### PR TITLE
Build broke on a fresh Ubuntu 14.04 with missing readline.h error. It…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ DBMS designed for next-generation storage technologies, like non-volatile memory
 > - **pkg-config** 
 > - **tbb** [Thread Building Blocks parallelism library]
 > - **json-spirit** [C++ JSON parser/generator]
+> - **readline** [Commandline editing library]
 > - **flex** [ Lexical analyzer generator ]
 > - **bison 3.0.4** [ Parser generator ]
 
@@ -17,7 +18,7 @@ DBMS designed for next-generation storage technologies, like non-volatile memory
  
 ###	Ubuntu Quick Setup
 
-    sudo apt-get install g++ pkg-config libtool libboost1.54-dev libtbb-dev libjson-spirit-dev flex bison
+    sudo apt-get install g++ pkg-config libtool libboost1.54-dev libtbb-dev libjson-spirit-dev libreadline-dev flex bison
 
 ### OS X Setup
 


### PR DESCRIPTION
… It seems that the readline library wasn't mentioned in the dependencies and configure also did not make any checks for it. Just adding the dependency in README.md

Build failure:
-----------------
```
  CC       common/pg_ctl-dumputils.o
  CC       common/pg_ctl-fe_memutils.o
  CC       common/pg_ctl-keywords.o
  CC       scripts/pg_ctl-pg_ctl.o
  CC       common/psql-dumputils.o
  CC       common/psql-fe_memutils.o
  CC       common/psql-keywords.o
  CC       pg_psql/psql-command.o
  CC       pg_psql/psql-common.o
  CC       pg_psql/psql-copy.o
In file included from ../../tools/pg_psql/command.c:44:0:
../../tools/pg_psql/input.h:21:31: fatal error: readline/readline.h: No such file or directory
 #include <readline/readline.h>
                               ^
compilation terminated.
  CC       pg_psql/psql-describe.o
make[2]: *** [pg_psql/psql-command.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory `/home/ghatage/peloton/build/tools'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/home/ghatage/peloton/build'
make: *** [all] Error 2
ghatage@ubuntu:~/peloton/build$ 
```
