### PR TITLE
Set the objects as nullptr in destructor

### DIFF
--- a/src/backend/expression/abstract_expression.cpp
+++ b/src/backend/expression/abstract_expression.cpp
@@ -40,7 +40,9 @@ AbstractExpression::AbstractExpression(ExpressionType type,
 
 AbstractExpression::~AbstractExpression() {
   delete m_left;
+  m_left = nullptr;
   delete m_right;
+  m_right = nullptr;
 }
 
 bool AbstractExpression::HasParameter() const {

--- a/src/backend/expression/case_expression.h
+++ b/src/backend/expression/case_expression.h
@@ -28,10 +28,14 @@ class CaseExpression : public AbstractExpression {
         case_type(vt) {}
 
   ~CaseExpression() {
-    for (auto clause : clauses)
+    for (auto clause : clauses) {
       delete clause;
-    if (default_result != nullptr)
+      clause = nullptr;
+    }
+    if (default_result != nullptr) {
       delete default_result;
+      default_result = nullptr;
+    }
   }
 
   Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,


### PR DESCRIPTION
See discussion in #80 
A better approach would be using shared_ptr. I have already changed it in expression part. However the logic of transforming CaseExpr disappears in master branch, therefore I did not push this update.