### PR TITLE
Fix bug in cleaning plan

### DIFF
--- a/src/backend/bridge/dml/mapper/mapper.cpp
+++ b/src/backend/bridge/dml/mapper/mapper.cpp
@@ -186,8 +186,9 @@ void PlanTransformer::CleanPlan(const planner::AbstractPlan *root) {
 
   // Clean all children subtrees
   auto children = root->GetChildren();
-  for (auto child : children) {
+  for (auto &child : children) {
     CleanPlan(child);
+    child = nullptr;
   }
 
   // Clean the root


### PR DESCRIPTION
I got an exception when executing this query:
`SELECT 1 FROM A WHERE id IN (SELECT id FROM A)`
The reason is very similar to what we have discussed before: our code did not set to nullptr after deletion. 