### PR TITLE
Add copy functions to expressions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,5 @@ local.properties
 
 # Code Recommenders
 .recommenders/
+
+CMakeLists.txt

--- a/src/backend/expression/abstract_expression.h
+++ b/src/backend/expression/abstract_expression.h
@@ -105,15 +105,14 @@ class AbstractExpression : public Printable {
   // Get a string representation for debugging
   const std::string GetInfo() const;
 
-    virtual AbstractExpression *Copy() const = 0;
+  virtual AbstractExpression *Copy() const = 0;
 
-    inline AbstractExpression *CopyUtil(
+  inline AbstractExpression *CopyUtil(
       const AbstractExpression *expression) const {
-      return (expression == nullptr) ? nullptr : expression->Copy();
-    }
+    return (expression == nullptr) ? nullptr : expression->Copy();
+  }
 
-
-protected:
+ protected:
   AbstractExpression();
   AbstractExpression(ExpressionType type);
   AbstractExpression(ExpressionType type, AbstractExpression *left,

--- a/src/backend/expression/abstract_expression.h
+++ b/src/backend/expression/abstract_expression.h
@@ -105,7 +105,15 @@ class AbstractExpression : public Printable {
   // Get a string representation for debugging
   const std::string GetInfo() const;
 
- protected:
+    virtual AbstractExpression *Copy() const = 0;
+
+    inline AbstractExpression *CopyUtil(
+      const AbstractExpression *expression) const {
+      return (expression == nullptr) ? nullptr : expression->Copy();
+    }
+
+
+protected:
   AbstractExpression();
   AbstractExpression(ExpressionType type);
   AbstractExpression(ExpressionType type, AbstractExpression *left,

--- a/src/backend/expression/case_expression.h
+++ b/src/backend/expression/case_expression.h
@@ -53,18 +53,18 @@ class CaseExpression : public AbstractExpression {
     return spacer + "CaseExpression";
   }
 
-    AbstractExpression *Copy() const {
-      std::vector<AbstractExpression *> copied_clauses;
-      for (AbstractExpression *clause : clauses) {
-        if (clause == nullptr) {
-          continue;
-        }
-        copied_clauses.push_back(clause->Copy());
+  AbstractExpression *Copy() const {
+    std::vector<AbstractExpression *> copied_clauses;
+    for (AbstractExpression *clause : clauses) {
+      if (clause == nullptr) {
+        continue;
       }
-
-      return new CaseExpression(case_type, copied_clauses,
-                                default_result->Copy());
+      copied_clauses.push_back(clause->Copy());
     }
+
+    return new CaseExpression(case_type, copied_clauses,
+                              default_result->Copy());
+  }
 
  private:
   // Case expression clauses

--- a/src/backend/expression/case_expression.h
+++ b/src/backend/expression/case_expression.h
@@ -53,6 +53,19 @@ class CaseExpression : public AbstractExpression {
     return spacer + "CaseExpression";
   }
 
+    AbstractExpression *Copy() const {
+      std::vector<AbstractExpression *> copied_clauses;
+      for (AbstractExpression *clause : clauses) {
+        if (clause == nullptr) {
+          continue;
+        }
+        copied_clauses.push_back(clause->Copy());
+      }
+
+      return new CaseExpression(case_type, copied_clauses,
+                                default_result->Copy());
+    }
+
  private:
   // Case expression clauses
   std::vector<AbstractExpression *> clauses;

--- a/src/backend/expression/cast_expression.h
+++ b/src/backend/expression/cast_expression.h
@@ -76,9 +76,9 @@ class CastExpression : public AbstractExpression {
     return (buffer.str());
   }
 
-    AbstractExpression *Copy() const {
-     return new CastExpression(type_, CopyUtil(child_));
-    }
+  AbstractExpression *Copy() const {
+    return new CastExpression(type_, CopyUtil(child_));
+  }
 
  private:
   PostgresValueType type_;

--- a/src/backend/expression/cast_expression.h
+++ b/src/backend/expression/cast_expression.h
@@ -76,6 +76,10 @@ class CastExpression : public AbstractExpression {
     return (buffer.str());
   }
 
+    AbstractExpression *Copy() const {
+     return new CastExpression(type_, CopyUtil(child_));
+    }
+
  private:
   PostgresValueType type_;
   AbstractExpression *child_;

--- a/src/backend/expression/coalesce_expression.h
+++ b/src/backend/expression/coalesce_expression.h
@@ -44,6 +44,18 @@ class CoalesceExpression : public AbstractExpression {
   std::string DebugInfo(const std::string &spacer) const {
     return spacer + "CoalesceExpression";
   }
+  
+    AbstractExpression *Copy() const {
+    std::vector<AbstractExpression *> copied_expression;
+    for (AbstractExpression *expression : expressions) {
+      if (expression == nullptr) {
+        continue;
+      }
+      copied_expression.push_back(expression->Copy());
+    }
+
+    return new CoalesceExpression(value_type, copied_expression);
+  }
 
  private:
   // Expression arguments

--- a/src/backend/expression/coalesce_expression.h
+++ b/src/backend/expression/coalesce_expression.h
@@ -44,8 +44,8 @@ class CoalesceExpression : public AbstractExpression {
   std::string DebugInfo(const std::string &spacer) const {
     return spacer + "CoalesceExpression";
   }
-  
-    AbstractExpression *Copy() const {
+
+  AbstractExpression *Copy() const {
     std::vector<AbstractExpression *> copied_expression;
     for (AbstractExpression *expression : expressions) {
       if (expression == nullptr) {

--- a/src/backend/expression/comparison_expression.h
+++ b/src/backend/expression/comparison_expression.h
@@ -247,8 +247,8 @@ class ComparisonExpression : public AbstractExpression {
   std::string DebugInfo(const std::string &spacer) const {
     return (spacer + "ComparisonExpression\n");
   }
-  
-    AbstractExpression *Copy() const {
+
+  AbstractExpression *Copy() const {
     AbstractExpression *copied_left =
         ((m_left == nullptr) ? nullptr : m_left->Copy());
     AbstractExpression *copied_right =

--- a/src/backend/expression/comparison_expression.h
+++ b/src/backend/expression/comparison_expression.h
@@ -247,6 +247,16 @@ class ComparisonExpression : public AbstractExpression {
   std::string DebugInfo(const std::string &spacer) const {
     return (spacer + "ComparisonExpression\n");
   }
+  
+    AbstractExpression *Copy() const {
+    AbstractExpression *copied_left =
+        ((m_left == nullptr) ? nullptr : m_left->Copy());
+    AbstractExpression *copied_right =
+        ((m_right == nullptr) ? nullptr : m_right->Copy());
+
+    return new ComparisonExpression<OP>(AbstractExpression::m_type, copied_left,
+                                        copied_right);
+  }
 
  private:
   AbstractExpression *m_left;
@@ -259,6 +269,19 @@ class InlinedComparisonExpression : public ComparisonExpression<C> {
   InlinedComparisonExpression(ExpressionType type, AbstractExpression *left,
                               AbstractExpression *right)
       : ComparisonExpression<C>(type, left, right) {}
+
+  AbstractExpression *Copy() const {
+    AbstractExpression *copied_left =
+        ((AbstractExpression::m_left == nullptr)
+             ? nullptr
+             : AbstractExpression::m_left->Copy());
+    AbstractExpression *copied_right =
+        ((AbstractExpression::m_right == nullptr)
+             ? nullptr
+             : AbstractExpression::m_right->Copy());
+    return new InlinedComparisonExpression<C, L, R>(AbstractExpression::m_type,
+                                                    copied_left, copied_right);
+  }
 };
 
 }  // End expression namespace

--- a/src/backend/expression/conjunction_expression.h
+++ b/src/backend/expression/conjunction_expression.h
@@ -41,10 +41,10 @@ class ConjunctionExpression : public AbstractExpression {
     return (spacer + "ConjunctionExpression\n");
   }
 
-    AbstractExpression *Copy() const {
-      return new ConjunctionExpression<C>(GetExpressionType(), CopyUtil(m_left),
-                                          CopyUtil(m_right));
-    }
+  AbstractExpression *Copy() const {
+    return new ConjunctionExpression<C>(GetExpressionType(), CopyUtil(m_left),
+                                        CopyUtil(m_right));
+  }
 
   AbstractExpression *m_left;
   AbstractExpression *m_right;

--- a/src/backend/expression/conjunction_expression.h
+++ b/src/backend/expression/conjunction_expression.h
@@ -41,6 +41,11 @@ class ConjunctionExpression : public AbstractExpression {
     return (spacer + "ConjunctionExpression\n");
   }
 
+    AbstractExpression *Copy() const {
+      return new ConjunctionExpression<C>(GetExpressionType(), CopyUtil(m_left),
+                                          CopyUtil(m_right));
+    }
+
   AbstractExpression *m_left;
   AbstractExpression *m_right;
 };

--- a/src/backend/expression/constant_value_expression.h
+++ b/src/backend/expression/constant_value_expression.h
@@ -49,7 +49,12 @@ class ConstantValueExpression : public AbstractExpression {
            "\n";
   }
 
- protected:
+    AbstractExpression *Copy() const {
+     return new ConstantValueExpression(value);
+    }
+
+
+protected:
   Value value;
 };
 

--- a/src/backend/expression/constant_value_expression.h
+++ b/src/backend/expression/constant_value_expression.h
@@ -49,12 +49,11 @@ class ConstantValueExpression : public AbstractExpression {
            "\n";
   }
 
-    AbstractExpression *Copy() const {
-     return new ConstantValueExpression(value);
-    }
+  AbstractExpression *Copy() const {
+    return new ConstantValueExpression(value);
+  }
 
-
-protected:
+ protected:
   Value value;
 };
 

--- a/src/backend/expression/date_expression.h
+++ b/src/backend/expression/date_expression.h
@@ -117,6 +117,11 @@ class ExtractExpression : public AbstractExpression {
     return (spacer + "ExtractExpression");
   }
 
+    AbstractExpression *Copy() const {
+      return new ExtractExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+    }
+
+
  private:
   TimestampSubfield subfield;
   static std::string const YEAR_STR;

--- a/src/backend/expression/date_expression.h
+++ b/src/backend/expression/date_expression.h
@@ -203,6 +203,10 @@ class DateToTimestampExpression : public AbstractExpression {
   std::string DebugInfo(const std::string &spacer) const {
     return (spacer + "DateToTimestampExpression");
   }
+
+    AbstractExpression *Copy() const {
+      return new DateToTimestampExpression(CopyUtil(GetLeft()));
+    }
 };
 
 }  // namespace expression

--- a/src/backend/expression/date_expression.h
+++ b/src/backend/expression/date_expression.h
@@ -117,10 +117,9 @@ class ExtractExpression : public AbstractExpression {
     return (spacer + "ExtractExpression");
   }
 
-    AbstractExpression *Copy() const {
-      return new ExtractExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
-    }
-
+  AbstractExpression *Copy() const {
+    return new ExtractExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+  }
 
  private:
   TimestampSubfield subfield;
@@ -204,9 +203,9 @@ class DateToTimestampExpression : public AbstractExpression {
     return (spacer + "DateToTimestampExpression");
   }
 
-    AbstractExpression *Copy() const {
-      return new DateToTimestampExpression(CopyUtil(GetLeft()));
-    }
+  AbstractExpression *Copy() const {
+    return new DateToTimestampExpression(CopyUtil(GetLeft()));
+  }
 };
 
 }  // namespace expression

--- a/src/backend/expression/expression_util.h
+++ b/src/backend/expression/expression_util.h
@@ -32,7 +32,7 @@ class ExpressionUtil {
   static AbstractExpression *ExpressionFactory(
       PlannerDomValue obj, ExpressionType et, ValueType vt, int vs,
       AbstractExpression *lc, AbstractExpression *rc,
-      const std::vector<AbstractExpression *>& arguments);
+      const std::vector<AbstractExpression *> &arguments);
 
   static AbstractExpression *ExpressionFactory(json_spirit::Object &obj,
                                                ExpressionType et, ValueType vt,
@@ -91,7 +91,7 @@ class ExpressionUtil {
   // Implemented in functionexpression.cpp because function expression
   // handling.Is a system unto itself.
   static AbstractExpression *FunctionFactory(
-      int functionId, const std::vector<AbstractExpression *>& arguments);
+      int functionId, const std::vector<AbstractExpression *> &arguments);
 
   static AbstractExpression *CastFactory(ValueType vt, AbstractExpression *lc);
 
@@ -100,7 +100,7 @@ class ExpressionUtil {
       AbstractExpression *child = nullptr);
 
   static AbstractExpression *VectorFactory(
-      ValueType vt, const std::vector<AbstractExpression *>& args);
+      ValueType vt, const std::vector<AbstractExpression *> &args);
   static AbstractExpression *ParameterValueFactory(int idx);
   static AbstractExpression *ParameterValueFactory(PlannerDomValue obj,
                                                    ExpressionType et,
@@ -127,7 +127,7 @@ class ExpressionUtil {
 
   static AbstractExpression *SubqueryFactory(
       ExpressionType subqueryType, PlannerDomValue obj,
-      const std::vector<AbstractExpression *>& rgs);
+      const std::vector<AbstractExpression *> &rgs);
 
   static AbstractExpression *CaseExprFactory(
       ValueType vt, const std::vector<AbstractExpression *> &clauses,

--- a/src/backend/expression/function_expression.cpp
+++ b/src/backend/expression/function_expression.cpp
@@ -111,6 +111,10 @@ class ConstantFunctionExpression : public expression::AbstractExpression {
     buffer << spacer << "ConstantFunctionExpression " << F << std::endl;
     return (buffer.str());
   }
+
+    expression::AbstractExpression *Copy() const {
+      return new ConstantFunctionExpression<F>();
+    }
 };
 
 /*
@@ -140,6 +144,11 @@ class UnaryFunctionExpression : public expression::AbstractExpression {
     buffer << spacer << "UnaryFunctionExpression " << F << std::endl;
     return (buffer.str());
   }
+
+    expression::AbstractExpression *Copy() const {
+      assert(m_child != nullptr);
+      return new UnaryFunctionExpression<F>(m_child->Copy());
+    }
 };
 
 /*
@@ -189,6 +198,15 @@ class GeneralFunctionExpression : public expression::AbstractExpression {
     buffer << spacer << "GeneralFunctionExpression " << F << std::endl;
     return (buffer.str());
   }
+
+    expression::AbstractExpression *Copy() const {
+      std::vector<expression::AbstractExpression *> args;
+      for (auto arg : m_args) {
+        args.push_back(arg->Copy());
+      }
+
+      return new GeneralFunctionExpression<F>(args);
+    }
 
  private:
   const std::vector<AbstractExpression *> &m_args;

--- a/src/backend/expression/hash_range_expression.h
+++ b/src/backend/expression/hash_range_expression.h
@@ -111,12 +111,12 @@ class HashRangeExpression : public AbstractExpression {
 
   int GetColumnId() const { return this->value_idx; }
 
-    AbstractExpression *Copy() const {
-      srange_type *copied_ranges = new srange_type();
-      copied_ranges->first = ranges.get()->first;
-      copied_ranges->second = ranges.get()->second;
-      return new HashRangeExpression(value_idx, copied_ranges, num_ranges);
-    }
+  AbstractExpression *Copy() const {
+    srange_type *copied_ranges = new srange_type();
+    copied_ranges->first = ranges.get()->first;
+    copied_ranges->second = ranges.get()->second;
+    return new HashRangeExpression(value_idx, copied_ranges, num_ranges);
+  }
 
  private:
   const int value_idx;  // which (offset) column of the tuple

--- a/src/backend/expression/hash_range_expression.h
+++ b/src/backend/expression/hash_range_expression.h
@@ -111,6 +111,13 @@ class HashRangeExpression : public AbstractExpression {
 
   int GetColumnId() const { return this->value_idx; }
 
+    AbstractExpression *Copy() const {
+      srange_type *copied_ranges = new srange_type();
+      copied_ranges->first = ranges.get()->first;
+      copied_ranges->second = ranges.get()->second;
+      return new HashRangeExpression(value_idx, copied_ranges, num_ranges);
+    }
+
  private:
   const int value_idx;  // which (offset) column of the tuple
   boost::scoped_array<srange_type> ranges;

--- a/src/backend/expression/nullif_expression.h
+++ b/src/backend/expression/nullif_expression.h
@@ -49,17 +49,17 @@ class NullIfExpression : public AbstractExpression {
     return spacer + "NullIfExpression";
   }
 
-    AbstractExpression *Copy() const {
-      std::vector<AbstractExpression *> copied_expression;
-      for (AbstractExpression *expression : expressions) {
-        if (expression == nullptr) {
-          continue;
-        }
-        copied_expression.push_back(expression->Copy());
+  AbstractExpression *Copy() const {
+    std::vector<AbstractExpression *> copied_expression;
+    for (AbstractExpression *expression : expressions) {
+      if (expression == nullptr) {
+        continue;
       }
-
-      return new NullIfExpression(value_type, copied_expression);
+      copied_expression.push_back(expression->Copy());
     }
+
+    return new NullIfExpression(value_type, copied_expression);
+  }
 
  private:
   // Specified expressions

--- a/src/backend/expression/nullif_expression.h
+++ b/src/backend/expression/nullif_expression.h
@@ -49,6 +49,18 @@ class NullIfExpression : public AbstractExpression {
     return spacer + "NullIfExpression";
   }
 
+    AbstractExpression *Copy() const {
+      std::vector<AbstractExpression *> copied_expression;
+      for (AbstractExpression *expression : expressions) {
+        if (expression == nullptr) {
+          continue;
+        }
+        copied_expression.push_back(expression->Copy());
+      }
+
+      return new NullIfExpression(value_type, copied_expression);
+    }
+
  private:
   // Specified expressions
   std::vector<AbstractExpression *> expressions;

--- a/src/backend/expression/operator_expression.h
+++ b/src/backend/expression/operator_expression.h
@@ -20,239 +20,239 @@
 #include <cassert>
 
 namespace peloton {
-    namespace expression {
+namespace expression {
 
 /*
  * Unary operators. (NOT and IS_NULL)
  */
 
-        class OperatorNotExpression : public AbstractExpression {
-        public:
-            OperatorNotExpression(AbstractExpression *left)
-              : AbstractExpression(EXPRESSION_TYPE_OPERATOR_NOT) {
-             m_left = left;
-            };
+class OperatorNotExpression : public AbstractExpression {
+ public:
+  OperatorNotExpression(AbstractExpression *left)
+      : AbstractExpression(EXPRESSION_TYPE_OPERATOR_NOT) {
+    m_left = left;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-             assert(m_left);
-             Value operand = m_left->Evaluate(tuple1, tuple2, context);
-             // NOT TRUE.Is FALSE
-             if (operand.IsTrue()) {
-              return Value::GetFalse();
-             }
-             // NOT FALSE.Is TRUE
-             if (operand.IsFalse()) {
-              return Value::GetTrue();
-             }
-             // NOT NULL.Is NULL
-             return operand;
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    Value operand = m_left->Evaluate(tuple1, tuple2, context);
+    // NOT TRUE.Is FALSE
+    if (operand.IsTrue()) {
+      return Value::GetFalse();
+    }
+    // NOT FALSE.Is TRUE
+    if (operand.IsFalse()) {
+      return Value::GetTrue();
+    }
+    // NOT NULL.Is NULL
+    return operand;
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-             return (spacer + "OperatorNotExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorNotExpression");
+  }
 
-            AbstractExpression *Copy() const {
-             return new OperatorNotExpression(CopyUtil(m_left));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new OperatorNotExpression(CopyUtil(m_left));
+  }
+};
 
-        class OperatorIsNullExpression : public AbstractExpression {
-        public:
-            OperatorIsNullExpression(AbstractExpression *left)
-              : AbstractExpression(EXPRESSION_TYPE_OPERATOR_IS_NULL) {
-             m_left = left;
-            };
+class OperatorIsNullExpression : public AbstractExpression {
+ public:
+  OperatorIsNullExpression(AbstractExpression *left)
+      : AbstractExpression(EXPRESSION_TYPE_OPERATOR_IS_NULL) {
+    m_left = left;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-             assert(m_left);
-             Value tmp = m_left->Evaluate(tuple1, tuple2, context);
-             if (tmp.IsNull()) {
-              return Value::GetTrue();
-             } else {
-              return Value::GetFalse();
-             }
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    Value tmp = m_left->Evaluate(tuple1, tuple2, context);
+    if (tmp.IsNull()) {
+      return Value::GetTrue();
+    } else {
+      return Value::GetFalse();
+    }
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-             return (spacer + "OperatorIsNullExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorIsNullExpression");
+  }
 
-            AbstractExpression *Copy() const {
-             return new OperatorIsNullExpression(CopyUtil(m_left));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new OperatorIsNullExpression(CopyUtil(m_left));
+  }
+};
 
-        class OperatorCastExpression : public AbstractExpression {
-        public:
-            OperatorCastExpression(ValueType vt, AbstractExpression *left)
-              : AbstractExpression(EXPRESSION_TYPE_OPERATOR_CAST), m_targetType(vt) {
-             m_left = left;
-            };
+class OperatorCastExpression : public AbstractExpression {
+ public:
+  OperatorCastExpression(ValueType vt, AbstractExpression *left)
+      : AbstractExpression(EXPRESSION_TYPE_OPERATOR_CAST), m_targetType(vt) {
+    m_left = left;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-             assert(m_left);
-             return m_left->Evaluate(tuple1, tuple2, context).CastAs(m_targetType);
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    return m_left->Evaluate(tuple1, tuple2, context).CastAs(m_targetType);
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-             return (spacer + "CastExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "CastExpression");
+  }
 
-            AbstractExpression *Copy() const {
-             return new OperatorCastExpression(m_targetType, CopyUtil(m_left));
-            }
+  AbstractExpression *Copy() const {
+    return new OperatorCastExpression(m_targetType, CopyUtil(m_left));
+  }
 
-        private:
-            ValueType m_targetType;
-        };
+ private:
+  ValueType m_targetType;
+};
 
-        class OperatorUnaryMinusExpression : public AbstractExpression {
-        public:
-            OperatorUnaryMinusExpression(AbstractExpression *left)
-              : AbstractExpression(EXPRESSION_TYPE_OPERATOR_UNARY_MINUS) {
-             m_left = left;
-            };
+class OperatorUnaryMinusExpression : public AbstractExpression {
+ public:
+  OperatorUnaryMinusExpression(AbstractExpression *left)
+      : AbstractExpression(EXPRESSION_TYPE_OPERATOR_UNARY_MINUS) {
+    m_left = left;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-             assert(m_left);
-             Value operand = m_left->Evaluate(tuple1, tuple2, context);
-             // NOT TRUE.Is FALSE
-             return Value::GetUnaryMinus(operand);
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    Value operand = m_left->Evaluate(tuple1, tuple2, context);
+    // NOT TRUE.Is FALSE
+    return Value::GetUnaryMinus(operand);
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-             return (spacer + "OperatorNotExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorNotExpression");
+  }
 
-            AbstractExpression *Copy() const {
-             return new OperatorUnaryMinusExpression(CopyUtil(m_left));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new OperatorUnaryMinusExpression(CopyUtil(m_left));
+  }
+};
 
-        class OperatorCaseWhenExpression : public AbstractExpression {
-        public:
-            OperatorCaseWhenExpression(ValueType vt, AbstractExpression *left,
-                                       AbstractExpression *right)
-              : AbstractExpression(EXPRESSION_TYPE_OPERATOR_CASE_WHEN, left, right),
-                m_returnType(vt){};
+class OperatorCaseWhenExpression : public AbstractExpression {
+ public:
+  OperatorCaseWhenExpression(ValueType vt, AbstractExpression *left,
+                             AbstractExpression *right)
+      : AbstractExpression(EXPRESSION_TYPE_OPERATOR_CASE_WHEN, left, right),
+        m_returnType(vt){};
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-             assert(m_left);
-             assert(m_right);
-             Value thenClause = m_left->Evaluate(tuple1, tuple2, context);
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    assert(m_right);
+    Value thenClause = m_left->Evaluate(tuple1, tuple2, context);
 
-             if (thenClause.IsTrue()) {
-              return m_right->Evaluate(tuple1, tuple2, context).CastAs(m_returnType);
-             } else {
-              // the condition value is not true
-              // this statement shouldn't be executed
-              throw 0;
-             }
-            }
+    if (thenClause.IsTrue()) {
+      return m_right->Evaluate(tuple1, tuple2, context).CastAs(m_returnType);
+    } else {
+      // the condition value is not true
+      // this statement shouldn't be executed
+      throw 0;
+    }
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-             return (spacer + "Operator CASE WHEN Expression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "Operator CASE WHEN Expression");
+  }
 
-            AbstractExpression *Copy() const {
-             return new OperatorCaseWhenExpression(m_returnType, CopyUtil(GetLeft()),
-                                                   CopyUtil(GetRight()));
-            }
+  AbstractExpression *Copy() const {
+    return new OperatorCaseWhenExpression(m_returnType, CopyUtil(GetLeft()),
+                                          CopyUtil(GetRight()));
+  }
 
-        private:
-            ValueType m_returnType;
-        };
+ private:
+  ValueType m_returnType;
+};
 
 /*
  * Binary operators.
  */
 
-        class OpPlus {
-        public:
-            inline Value op(Value left, Value right) const { return left.OpAdd(right); }
-        };
+class OpPlus {
+ public:
+  inline Value op(Value left, Value right) const { return left.OpAdd(right); }
+};
 
-        class OpMinus {
-        public:
-            inline Value op(Value left, Value right) const {
-             return left.OpSubtract(right);
-            }
-        };
+class OpMinus {
+ public:
+  inline Value op(Value left, Value right) const {
+    return left.OpSubtract(right);
+  }
+};
 
-        class OpMultiply {
-        public:
-            inline Value op(Value left, Value right) const {
-             return left.OpMultiply(right);
-            }
-        };
+class OpMultiply {
+ public:
+  inline Value op(Value left, Value right) const {
+    return left.OpMultiply(right);
+  }
+};
 
-        class OpDivide {
-        public:
-            inline Value op(Value left, Value right) const {
-             return left.OpDivide(right);
-            }
-        };
+class OpDivide {
+ public:
+  inline Value op(Value left, Value right) const {
+    return left.OpDivide(right);
+  }
+};
 
-        class OpMod {
-        public:
-            inline Value op(Value left, Value right) const { return left.OpMod(right); }
-        };
+class OpMod {
+ public:
+  inline Value op(Value left, Value right) const { return left.OpMod(right); }
+};
 
 /*
  * Expressions templated on binary operator types
  */
 
-        template <typename OPER>
-        class OperatorExpression : public AbstractExpression {
-        public:
-            OperatorExpression(ExpressionType type, AbstractExpression *left,
-                               AbstractExpression *right)
-              : AbstractExpression(type, left, right) {}
+template <typename OPER>
+class OperatorExpression : public AbstractExpression {
+ public:
+  OperatorExpression(ExpressionType type, AbstractExpression *left,
+                     AbstractExpression *right)
+      : AbstractExpression(type, left, right) {}
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-             assert(m_left);
-             assert(m_right);
-             return oper.op(m_left->Evaluate(tuple1, tuple2, context),
-                            m_right->Evaluate(tuple1, tuple2, context));
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    assert(m_right);
+    return oper.op(m_left->Evaluate(tuple1, tuple2, context),
+                   m_right->Evaluate(tuple1, tuple2, context));
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-             return (spacer + "OptimizedOperatorExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OptimizedOperatorExpression");
+  }
 
-            AbstractExpression *Copy() const {
-             // TODO: How about OPER oper?
-             return new OperatorExpression<OPER>(
-               GetExpressionType(), CopyUtil(GetLeft()), CopyUtil(GetRight()));
-            }
+  AbstractExpression *Copy() const {
+    // TODO: How about OPER oper?
+    return new OperatorExpression<OPER>(
+        GetExpressionType(), CopyUtil(GetLeft()), CopyUtil(GetRight()));
+  }
 
-        private:
-            OPER oper;
-        };
+ private:
+  OPER oper;
+};
 
-        class OperatorExistsExpression : public AbstractExpression {
-        public:
-            OperatorExistsExpression(AbstractExpression *left)
-              : AbstractExpression(EXPRESSION_TYPE_OPERATOR_EXISTS, left, NULL) {}
+class OperatorExistsExpression : public AbstractExpression {
+ public:
+  OperatorExistsExpression(AbstractExpression *left)
+      : AbstractExpression(EXPRESSION_TYPE_OPERATOR_EXISTS, left, NULL) {}
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const;
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const;
 
-            std::string DebugInfo(const std::string &spacer) const {
-             return (spacer + "OperatorE.IstsExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorE.IstsExpression");
+  }
 
-            AbstractExpression *Copy() const {
-             return new OperatorExistsExpression(CopyUtil(GetLeft()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new OperatorExistsExpression(CopyUtil(GetLeft()));
+  }
+};
 
-    }  // End expression namespace
+}  // End expression namespace
 }  // End peloton namespace

--- a/src/backend/expression/operator_expression.h
+++ b/src/backend/expression/operator_expression.h
@@ -20,208 +20,239 @@
 #include <cassert>
 
 namespace peloton {
-namespace expression {
+    namespace expression {
 
 /*
  * Unary operators. (NOT and IS_NULL)
  */
 
-class OperatorNotExpression : public AbstractExpression {
- public:
-  OperatorNotExpression(AbstractExpression *left)
-      : AbstractExpression(EXPRESSION_TYPE_OPERATOR_NOT) {
-    m_left = left;
-  };
+        class OperatorNotExpression : public AbstractExpression {
+        public:
+            OperatorNotExpression(AbstractExpression *left)
+              : AbstractExpression(EXPRESSION_TYPE_OPERATOR_NOT) {
+             m_left = left;
+            };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    Value operand = m_left->Evaluate(tuple1, tuple2, context);
-    // NOT TRUE.Is FALSE
-    if (operand.IsTrue()) {
-      return Value::GetFalse();
-    }
-    // NOT FALSE.Is TRUE
-    if (operand.IsFalse()) {
-      return Value::GetTrue();
-    }
-    // NOT NULL.Is NULL
-    return operand;
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+             assert(m_left);
+             Value operand = m_left->Evaluate(tuple1, tuple2, context);
+             // NOT TRUE.Is FALSE
+             if (operand.IsTrue()) {
+              return Value::GetFalse();
+             }
+             // NOT FALSE.Is TRUE
+             if (operand.IsFalse()) {
+              return Value::GetTrue();
+             }
+             // NOT NULL.Is NULL
+             return operand;
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorNotExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+             return (spacer + "OperatorNotExpression");
+            }
 
-class OperatorIsNullExpression : public AbstractExpression {
- public:
-  OperatorIsNullExpression(AbstractExpression *left)
-      : AbstractExpression(EXPRESSION_TYPE_OPERATOR_IS_NULL) {
-    m_left = left;
-  };
+            AbstractExpression *Copy() const {
+             return new OperatorNotExpression(CopyUtil(m_left));
+            }
+        };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    Value tmp = m_left->Evaluate(tuple1, tuple2, context);
-    if (tmp.IsNull()) {
-      return Value::GetTrue();
-    } else {
-      return Value::GetFalse();
-    }
-  }
+        class OperatorIsNullExpression : public AbstractExpression {
+        public:
+            OperatorIsNullExpression(AbstractExpression *left)
+              : AbstractExpression(EXPRESSION_TYPE_OPERATOR_IS_NULL) {
+             m_left = left;
+            };
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorIsNullExpression");
-  }
-};
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+             assert(m_left);
+             Value tmp = m_left->Evaluate(tuple1, tuple2, context);
+             if (tmp.IsNull()) {
+              return Value::GetTrue();
+             } else {
+              return Value::GetFalse();
+             }
+            }
 
-class OperatorCastExpression : public AbstractExpression {
- public:
-  OperatorCastExpression(ValueType vt, AbstractExpression *left)
-      : AbstractExpression(EXPRESSION_TYPE_OPERATOR_CAST), m_targetType(vt) {
-    m_left = left;
-  };
+            std::string DebugInfo(const std::string &spacer) const {
+             return (spacer + "OperatorIsNullExpression");
+            }
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    return m_left->Evaluate(tuple1, tuple2, context).CastAs(m_targetType);
-  }
+            AbstractExpression *Copy() const {
+             return new OperatorIsNullExpression(CopyUtil(m_left));
+            }
+        };
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "CastExpression");
-  }
+        class OperatorCastExpression : public AbstractExpression {
+        public:
+            OperatorCastExpression(ValueType vt, AbstractExpression *left)
+              : AbstractExpression(EXPRESSION_TYPE_OPERATOR_CAST), m_targetType(vt) {
+             m_left = left;
+            };
 
- private:
-  ValueType m_targetType;
-};
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+             assert(m_left);
+             return m_left->Evaluate(tuple1, tuple2, context).CastAs(m_targetType);
+            }
 
-class OperatorUnaryMinusExpression : public AbstractExpression {
- public:
-  OperatorUnaryMinusExpression(AbstractExpression *left)
-      : AbstractExpression(EXPRESSION_TYPE_OPERATOR_UNARY_MINUS) {
-    m_left = left;
-  };
+            std::string DebugInfo(const std::string &spacer) const {
+             return (spacer + "CastExpression");
+            }
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    Value operand = m_left->Evaluate(tuple1, tuple2, context);
-    // NOT TRUE.Is FALSE
-    return Value::GetUnaryMinus(operand);
-  }
+            AbstractExpression *Copy() const {
+             return new OperatorCastExpression(m_targetType, CopyUtil(m_left));
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorNotExpression");
-  }
-};
+        private:
+            ValueType m_targetType;
+        };
 
-class OperatorCaseWhenExpression : public AbstractExpression {
- public:
-  OperatorCaseWhenExpression(ValueType vt, AbstractExpression *left,
-                             AbstractExpression *right)
-      : AbstractExpression(EXPRESSION_TYPE_OPERATOR_CASE_WHEN, left, right),
-        m_returnType(vt){};
+        class OperatorUnaryMinusExpression : public AbstractExpression {
+        public:
+            OperatorUnaryMinusExpression(AbstractExpression *left)
+              : AbstractExpression(EXPRESSION_TYPE_OPERATOR_UNARY_MINUS) {
+             m_left = left;
+            };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    assert(m_right);
-    Value thenClause = m_left->Evaluate(tuple1, tuple2, context);
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+             assert(m_left);
+             Value operand = m_left->Evaluate(tuple1, tuple2, context);
+             // NOT TRUE.Is FALSE
+             return Value::GetUnaryMinus(operand);
+            }
 
-    if (thenClause.IsTrue()) {
-      return m_right->Evaluate(tuple1, tuple2, context).CastAs(m_returnType);
-    } else {
-      // the condition value is not true
-      // this statement shouldn't be executed
-      throw 0;
-    }
-  }
+            std::string DebugInfo(const std::string &spacer) const {
+             return (spacer + "OperatorNotExpression");
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "Operator CASE WHEN Expression");
-  }
+            AbstractExpression *Copy() const {
+             return new OperatorUnaryMinusExpression(CopyUtil(m_left));
+            }
+        };
 
- private:
-  ValueType m_returnType;
-};
+        class OperatorCaseWhenExpression : public AbstractExpression {
+        public:
+            OperatorCaseWhenExpression(ValueType vt, AbstractExpression *left,
+                                       AbstractExpression *right)
+              : AbstractExpression(EXPRESSION_TYPE_OPERATOR_CASE_WHEN, left, right),
+                m_returnType(vt){};
+
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+             assert(m_left);
+             assert(m_right);
+             Value thenClause = m_left->Evaluate(tuple1, tuple2, context);
+
+             if (thenClause.IsTrue()) {
+              return m_right->Evaluate(tuple1, tuple2, context).CastAs(m_returnType);
+             } else {
+              // the condition value is not true
+              // this statement shouldn't be executed
+              throw 0;
+             }
+            }
+
+            std::string DebugInfo(const std::string &spacer) const {
+             return (spacer + "Operator CASE WHEN Expression");
+            }
+
+            AbstractExpression *Copy() const {
+             return new OperatorCaseWhenExpression(m_returnType, CopyUtil(GetLeft()),
+                                                   CopyUtil(GetRight()));
+            }
+
+        private:
+            ValueType m_returnType;
+        };
 
 /*
  * Binary operators.
  */
 
-class OpPlus {
- public:
-  inline Value op(Value left, Value right) const { return left.OpAdd(right); }
-};
+        class OpPlus {
+        public:
+            inline Value op(Value left, Value right) const { return left.OpAdd(right); }
+        };
 
-class OpMinus {
- public:
-  inline Value op(Value left, Value right) const {
-    return left.OpSubtract(right);
-  }
-};
+        class OpMinus {
+        public:
+            inline Value op(Value left, Value right) const {
+             return left.OpSubtract(right);
+            }
+        };
 
-class OpMultiply {
- public:
-  inline Value op(Value left, Value right) const {
-    return left.OpMultiply(right);
-  }
-};
+        class OpMultiply {
+        public:
+            inline Value op(Value left, Value right) const {
+             return left.OpMultiply(right);
+            }
+        };
 
-class OpDivide {
- public:
-  inline Value op(Value left, Value right) const {
-    return left.OpDivide(right);
-  }
-};
+        class OpDivide {
+        public:
+            inline Value op(Value left, Value right) const {
+             return left.OpDivide(right);
+            }
+        };
 
-class OpMod {
- public:
-  inline Value op(Value left, Value right) const { return left.OpMod(right); }
-};
+        class OpMod {
+        public:
+            inline Value op(Value left, Value right) const { return left.OpMod(right); }
+        };
 
 /*
  * Expressions templated on binary operator types
  */
 
-template <typename OPER>
-class OperatorExpression : public AbstractExpression {
- public:
-  OperatorExpression(ExpressionType type, AbstractExpression *left,
-                     AbstractExpression *right)
-      : AbstractExpression(type, left, right) {}
+        template <typename OPER>
+        class OperatorExpression : public AbstractExpression {
+        public:
+            OperatorExpression(ExpressionType type, AbstractExpression *left,
+                               AbstractExpression *right)
+              : AbstractExpression(type, left, right) {}
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    assert(m_right);
-    return oper.op(m_left->Evaluate(tuple1, tuple2, context),
-                   m_right->Evaluate(tuple1, tuple2, context));
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+             assert(m_left);
+             assert(m_right);
+             return oper.op(m_left->Evaluate(tuple1, tuple2, context),
+                            m_right->Evaluate(tuple1, tuple2, context));
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OptimizedOperatorExpression");
-  }
+            std::string DebugInfo(const std::string &spacer) const {
+             return (spacer + "OptimizedOperatorExpression");
+            }
 
- private:
-  OPER oper;
-};
+            AbstractExpression *Copy() const {
+             // TODO: How about OPER oper?
+             return new OperatorExpression<OPER>(
+               GetExpressionType(), CopyUtil(GetLeft()), CopyUtil(GetRight()));
+            }
 
-class OperatorExistsExpression : public AbstractExpression {
- public:
-  OperatorExistsExpression(AbstractExpression *left)
-      : AbstractExpression(EXPRESSION_TYPE_OPERATOR_EXISTS, left, NULL) {}
+        private:
+            OPER oper;
+        };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const;
+        class OperatorExistsExpression : public AbstractExpression {
+        public:
+            OperatorExistsExpression(AbstractExpression *left)
+              : AbstractExpression(EXPRESSION_TYPE_OPERATOR_EXISTS, left, NULL) {}
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorE.IstsExpression");
-  }
-};
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const;
 
-}  // End expression namespace
+            std::string DebugInfo(const std::string &spacer) const {
+             return (spacer + "OperatorE.IstsExpression");
+            }
+
+            AbstractExpression *Copy() const {
+             return new OperatorExistsExpression(CopyUtil(GetLeft()));
+            }
+        };
+
+    }  // End expression namespace
 }  // End peloton namespace

--- a/src/backend/expression/parameter_value_expression.h
+++ b/src/backend/expression/parameter_value_expression.h
@@ -52,9 +52,9 @@ class ParameterValueExpression : public AbstractExpression {
 
   int GetParameterId() const { return this->m_valueIdx; }
 
-    AbstractExpression *Copy() const {
-      return new ParameterValueExpression(m_valueIdx, m_paramValue);
-    }
+  AbstractExpression *Copy() const {
+    return new ParameterValueExpression(m_valueIdx, m_paramValue);
+  }
 
  private:
   size_t m_valueIdx;

--- a/src/backend/expression/parameter_value_expression.h
+++ b/src/backend/expression/parameter_value_expression.h
@@ -52,6 +52,10 @@ class ParameterValueExpression : public AbstractExpression {
 
   int GetParameterId() const { return this->m_valueIdx; }
 
+    AbstractExpression *Copy() const {
+      return new ParameterValueExpression(m_valueIdx, m_paramValue);
+    }
+
  private:
   size_t m_valueIdx;
 

--- a/src/backend/expression/scalar_value_expression.h
+++ b/src/backend/expression/scalar_value_expression.h
@@ -29,10 +29,9 @@ class ScalarValueExpression : public AbstractExpression {
 
   std::string DebugInfo(const std::string &spacer) const;
 
-    AbstractExpression *Copy() const {
-     return new ScalarValueExpression(CopyUtil(GetLeft()));
-    }
-
+  AbstractExpression *Copy() const {
+    return new ScalarValueExpression(CopyUtil(GetLeft()));
+  }
 };
 
 }  // End expression namespace

--- a/src/backend/expression/scalar_value_expression.h
+++ b/src/backend/expression/scalar_value_expression.h
@@ -28,6 +28,11 @@ class ScalarValueExpression : public AbstractExpression {
                  executor::ExecutorContext *context) const;
 
   std::string DebugInfo(const std::string &spacer) const;
+
+    AbstractExpression *Copy() const {
+     return new ScalarValueExpression(CopyUtil(GetLeft()));
+    }
+
 };
 
 }  // End expression namespace

--- a/src/backend/expression/string_expression.h
+++ b/src/backend/expression/string_expression.h
@@ -22,427 +22,490 @@
 #include <vector>
 
 namespace peloton {
-namespace expression {
+    namespace expression {
 
 /*
  * Substring expressoin
  */
 
-class SubstringExpression : public AbstractExpression {
- private:
-  AbstractExpression *len;  // length of substring to take (optional)
- public:
-  /*
-   * constructor
-   * string : string to take substring
-   * from : first position
-   * len : last position
-   */
-  SubstringExpression(AbstractExpression *string, AbstractExpression *from,
-                      AbstractExpression *len)
-      : AbstractExpression(EXPRESSION_TYPE_SUBSTR), len(len) {
-    m_left = string;
-    m_right = from;
-  };
+        class SubstringExpression : public AbstractExpression {
+        private:
+            AbstractExpression *len;  // length of substring to take (optional)
+        public:
+            /*
+             * constructor
+             * string : string to take substring
+             * from : first position
+             * len : last position
+             */
+            SubstringExpression(AbstractExpression *string, AbstractExpression *from,
+                                AbstractExpression *len)
+              : AbstractExpression(EXPRESSION_TYPE_SUBSTR), len(len) {
+              m_left = string;
+              m_right = from;
+            };
 
-  ~SubstringExpression() { delete len; }
+            ~SubstringExpression() { delete len; }
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    std::vector<Value> substr_args;
-    substr_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-    substr_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-    // if length not defined call 2 arg substring
-    if (len == nullptr) {
-      return Value::Call<FUNC_VOLT_SUBSTRING_CHAR_FROM>(substr_args);
-    } else {
-      substr_args.emplace_back(len->Evaluate(tuple1, tuple2, context));
-      return Value::Call<FUNC_SUBSTRING_CHAR>(substr_args);
-    }
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              assert(m_left);
+              std::vector<Value> substr_args;
+              substr_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+              substr_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+              // if length not defined call 2 arg substring
+              if (len == nullptr) {
+                return Value::Call<FUNC_VOLT_SUBSTRING_CHAR_FROM>(substr_args);
+              } else {
+                substr_args.emplace_back(len->Evaluate(tuple1, tuple2, context));
+                return Value::Call<FUNC_SUBSTRING_CHAR>(substr_args);
+              }
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorSubstringExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorSubstringExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new SubstringExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()),
+                                             CopyUtil(len));
+            }
+        };
 
 /*
  * Implements the 2 variable concat expression
  */
-class ConcatExpression : public AbstractExpression {
- private:
- public:
-  ConcatExpression(AbstractExpression *lc, AbstractExpression *rc)
-      : AbstractExpression(EXPRESSION_TYPE_CONCAT) {
-    m_left = lc;
-    m_right = rc;
-  };
+        class ConcatExpression : public AbstractExpression {
+        private:
+        public:
+            ConcatExpression(AbstractExpression *lc, AbstractExpression *rc)
+              : AbstractExpression(EXPRESSION_TYPE_CONCAT) {
+              m_left = lc;
+              m_right = rc;
+            };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    std::vector<Value> concat_args;
-    concat_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-    concat_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-    return Value::Call<FUNC_CONCAT>(concat_args);
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              assert(m_left);
+              std::vector<Value> concat_args;
+              concat_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+              concat_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+              return Value::Call<FUNC_CONCAT>(concat_args);
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorConcatExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorConcatExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new ConcatExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+            }
+        };
 
 /*
  * Implements the ascii expression
  * Currently does not handle unicode well
  */
-class AsciiExpression : public AbstractExpression {
- private:
- public:
-  AsciiExpression(AbstractExpression *lc)
-      : AbstractExpression(EXPRESSION_TYPE_ASCII) {
-    m_left = lc;
-  };
+        class AsciiExpression : public AbstractExpression {
+        private:
+        public:
+            AsciiExpression(AbstractExpression *lc)
+              : AbstractExpression(EXPRESSION_TYPE_ASCII) {
+              m_left = lc;
+            };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    return m_left->Evaluate(tuple1, tuple2, context).CallUnary<FUNC_ASCII>();
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              assert(m_left);
+              return m_left->Evaluate(tuple1, tuple2, context).CallUnary<FUNC_ASCII>();
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorAsciiExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorAsciiExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new AsciiExpression(CopyUtil(GetLeft()));
+            }
+        };
 
 /*
  * Implements the octet length expression
  */
-class OctetLengthExpression : public AbstractExpression {
- private:
- public:
-  OctetLengthExpression(AbstractExpression *lc)
-      : AbstractExpression(EXPRESSION_TYPE_OCTET_LEN) {
-    m_left = lc;
-  };
+        class OctetLengthExpression : public AbstractExpression {
+        private:
+        public:
+            OctetLengthExpression(AbstractExpression *lc)
+              : AbstractExpression(EXPRESSION_TYPE_OCTET_LEN) {
+              m_left = lc;
+            };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    return m_left->Evaluate(tuple1, tuple2, context)
-        .CallUnary<FUNC_OCTET_LENGTH>();
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              assert(m_left);
+              return m_left->Evaluate(tuple1, tuple2, context)
+                .CallUnary<FUNC_OCTET_LENGTH>();
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorOctetLengthExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorOctetLengthExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new OctetLengthExpression(CopyUtil(GetLeft()));
+            }
+        };
 
 /*
  * Implements the CHR expression
  */
-class CharExpression : public AbstractExpression {
- private:
- public:
-  CharExpression(AbstractExpression *lc)
-      : AbstractExpression(EXPRESSION_TYPE_CHAR) {
-    m_left = lc;
-  };
+        class CharExpression : public AbstractExpression {
+        private:
+        public:
+            CharExpression(AbstractExpression *lc)
+              : AbstractExpression(EXPRESSION_TYPE_CHAR) {
+              m_left = lc;
+            };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    return m_left->Evaluate(tuple1, tuple2, context).CallUnary<FUNC_CHAR>();
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              assert(m_left);
+              return m_left->Evaluate(tuple1, tuple2, context).CallUnary<FUNC_CHAR>();
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorCharExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorCharExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new CharExpression(CopyUtil(GetLeft()));
+            }
+        };
 
 /*
  * Implements the CHAR LENGTH Expression
  */
-class CharLengthExpression : public AbstractExpression {
- private:
- public:
-  CharLengthExpression(AbstractExpression *lc)
-      : AbstractExpression(EXPRESSION_TYPE_CHAR_LEN) {
-    m_left = lc;
-  };
+        class CharLengthExpression : public AbstractExpression {
+        private:
+        public:
+            CharLengthExpression(AbstractExpression *lc)
+              : AbstractExpression(EXPRESSION_TYPE_CHAR_LEN) {
+              m_left = lc;
+            };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    return m_left->Evaluate(tuple1, tuple2, context)
-        .CallUnary<FUNC_CHAR_LENGTH>();
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              assert(m_left);
+              return m_left->Evaluate(tuple1, tuple2, context)
+                .CallUnary<FUNC_CHAR_LENGTH>();
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorCharLengthExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorCharLengthExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new CharLengthExpression(CopyUtil(GetLeft()));
+            }
+        };
 
 /*
  * implements the repeat function
  */
-class RepeatExpression : public AbstractExpression {
- private:
- public:
-  RepeatExpression(AbstractExpression *string, AbstractExpression *num)
-      : AbstractExpression(EXPRESSION_TYPE_REPEAT) {
-    m_left = string;
-    m_right = num;
-  };
+        class RepeatExpression : public AbstractExpression {
+        private:
+        public:
+            RepeatExpression(AbstractExpression *string, AbstractExpression *num)
+              : AbstractExpression(EXPRESSION_TYPE_REPEAT) {
+              m_left = string;
+              m_right = num;
+            };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    assert(m_right);
-    std::vector<Value> repeat_args;
-    repeat_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-    repeat_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-    return Value::Call<FUNC_REPEAT>(repeat_args);
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              assert(m_left);
+              assert(m_right);
+              std::vector<Value> repeat_args;
+              repeat_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+              repeat_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+              return Value::Call<FUNC_REPEAT>(repeat_args);
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorRepeatExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorRepeatExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new RepeatExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+            }
+        };
 
 /*
  * implements left
  */
-class LeftExpression : public AbstractExpression {
- private:
- public:
-  LeftExpression(AbstractExpression *string, AbstractExpression *num)
-      : AbstractExpression(EXPRESSION_TYPE_LEFT) {
-    m_left = string;
-    m_right = num;
-  };
+        class LeftExpression : public AbstractExpression {
+        private:
+        public:
+            LeftExpression(AbstractExpression *string, AbstractExpression *num)
+              : AbstractExpression(EXPRESSION_TYPE_LEFT) {
+              m_left = string;
+              m_right = num;
+            };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    assert(m_right);
-    std::vector<Value> left_args;
-    left_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-    left_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-    return Value::Call<FUNC_LEFT>(left_args);
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              assert(m_left);
+              assert(m_right);
+              std::vector<Value> left_args;
+              left_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+              left_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+              return Value::Call<FUNC_LEFT>(left_args);
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorLeftExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorLeftExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new LeftExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+            }
+        };
 
 /*
  * implements right
  */
-class RightExpression : public AbstractExpression {
- private:
- public:
-  RightExpression(AbstractExpression *lc, AbstractExpression *rc)
-      : AbstractExpression(EXPRESSION_TYPE_RIGHT) {
-    m_left = lc;
-    m_right = rc;
-  };
+        class RightExpression : public AbstractExpression {
+        private:
+        public:
+            RightExpression(AbstractExpression *lc, AbstractExpression *rc)
+              : AbstractExpression(EXPRESSION_TYPE_RIGHT) {
+              m_left = lc;
+              m_right = rc;
+            };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    assert(m_right);
-    std::vector<Value> right_args;
-    right_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-    right_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-    return Value::Call<FUNC_RIGHT>(right_args);
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              assert(m_left);
+              assert(m_right);
+              std::vector<Value> right_args;
+              right_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+              right_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+              return Value::Call<FUNC_RIGHT>(right_args);
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorRightExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorRightExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new RightExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+            }
+        };
 
 /*
  * implements ltrim (leading trim)
  */
-class LTrimExpression : public AbstractExpression {
- public:
-  LTrimExpression(AbstractExpression *chars, AbstractExpression *string)
-      : AbstractExpression(EXPRESSION_TYPE_RTRIM) {
-    m_left = string;
-    m_right = chars;
-  }
+        class LTrimExpression : public AbstractExpression {
+        public:
+            LTrimExpression(AbstractExpression *string, AbstractExpression *chars)
+              : AbstractExpression(EXPRESSION_TYPE_RTRIM) {
+              m_left = string;
+              m_right = chars;
+            }
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    std::vector<Value> position_args;
-    // if null do not add to the arguments
-    if (m_left) {
-      position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-    }
-    position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              std::vector<Value> position_args;
+              // if null do not add to the arguments
+              if (m_left) {
+                position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+              }
+              position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
 
-    return Value::Call<FUNC_TRIM_LEADING_CHAR>(position_args);
-  }
+              return Value::Call<FUNC_TRIM_LEADING_CHAR>(position_args);
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorLTrimExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorLTrimExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new LTrimExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+            }
+        };
 
 /*
  * implements rtrim (trailing trim)
  */
-class RTrimExpression : public AbstractExpression {
- public:
-  RTrimExpression(AbstractExpression *chars, AbstractExpression *string)
-      : AbstractExpression(EXPRESSION_TYPE_RTRIM) {
-    m_left = string;
-    m_right = chars;
-  }
+        class RTrimExpression : public AbstractExpression {
+        public:
+            RTrimExpression(AbstractExpression *string, AbstractExpression *chars)
+              : AbstractExpression(EXPRESSION_TYPE_RTRIM) {
+              m_left = string;
+              m_right = chars;
+            }
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    std::vector<Value> position_args;
-    // if null do not add to the arguments
-    if (m_left) {
-      position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-    }
-    position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-    return Value::Call<FUNC_TRIM_TRAILING_CHAR>(position_args);
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              std::vector<Value> position_args;
+              // if null do not add to the arguments
+              if (m_left) {
+                position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+              }
+              position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+              return Value::Call<FUNC_TRIM_TRAILING_CHAR>(position_args);
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorRTrimExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorRTrimExpression");
+            }
 
-class BTrimExpression : public AbstractExpression {
- public:
-  BTrimExpression(AbstractExpression *chars, AbstractExpression *string)
-      : AbstractExpression(EXPRESSION_TYPE_BTRIM) {
-    m_left = string;
-    m_right = chars;
-  }
+            AbstractExpression *Copy() const {
+              return new RTrimExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+            }
+        };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    std::vector<Value> position_args;
-    // if null do not add to the arguments
-    if (m_left) {
-      position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-    }
-    position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+        class BTrimExpression : public AbstractExpression {
+        public:
+            BTrimExpression(AbstractExpression *string, AbstractExpression *chars)
+              : AbstractExpression(EXPRESSION_TYPE_BTRIM) {
+              m_left = string;
+              m_right = chars;
+            }
 
-    return Value::Call<FUNC_TRIM_BOTH_CHAR>(position_args);
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              std::vector<Value> position_args;
+              // if null do not add to the arguments
+              if (m_left) {
+                position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+              }
+              position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorBTrimExpression");
-  }
-};
+              return Value::Call<FUNC_TRIM_BOTH_CHAR>(position_args);
+            }
+
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorBTrimExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new BTrimExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+            }
+        };
 
 /*
  * implement position
  */
-class PositionExpression : public AbstractExpression {
- private:
- public:
-  PositionExpression(AbstractExpression *lc, AbstractExpression *rc)
-      : AbstractExpression(EXPRESSION_TYPE_POSITION) {
-    m_left = lc;
-    m_right = rc;
-  };
+        class PositionExpression : public AbstractExpression {
+        private:
+        public:
+            PositionExpression(AbstractExpression *lc, AbstractExpression *rc)
+              : AbstractExpression(EXPRESSION_TYPE_POSITION) {
+              m_left = lc;
+              m_right = rc;
+            };
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    assert(m_right);
-    std::vector<Value> position_args;
-    position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-    position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              assert(m_left);
+              assert(m_right);
+              std::vector<Value> position_args;
+              position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+              position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
 
-    return Value::Call<FUNC_POSITION_CHAR>(position_args);
-  }
+              return Value::Call<FUNC_POSITION_CHAR>(position_args);
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorPositionExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorPositionExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new PositionExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+            }
+        };
 
 /*
  * implements overlay (4 args)
  */
-class OverlayExpression : public AbstractExpression {
- private:
-  AbstractExpression *from;
-  AbstractExpression *len;
+        class OverlayExpression : public AbstractExpression {
+        private:
+            AbstractExpression *from;
+            AbstractExpression *len;
 
- public:
-  OverlayExpression(AbstractExpression *string1, AbstractExpression *string2,
-                    AbstractExpression *from, AbstractExpression *len)
-      : AbstractExpression(EXPRESSION_TYPE_OVERLAY), from(from), len(len) {
-    m_left = string1;
-    m_right = string2;
-  };
+        public:
+            OverlayExpression(AbstractExpression *string1, AbstractExpression *string2,
+                              AbstractExpression *from, AbstractExpression *len)
+              : AbstractExpression(EXPRESSION_TYPE_OVERLAY), from(from), len(len) {
+              m_left = string1;
+              m_right = string2;
+            };
 
-  ~OverlayExpression() {
-    delete from;
-    delete len;
-  }
+            ~OverlayExpression() {
+              delete from;
+              delete len;
+            }
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    std::vector<Value> overlay_args;
-    overlay_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-    overlay_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-    overlay_args.emplace_back(from->Evaluate(tuple1, tuple2, context));
-    if (len) {
-      overlay_args.emplace_back(len->Evaluate(tuple1, tuple2, context));
-    }
-    return Value::Call<FUNC_OVERLAY_CHAR>(overlay_args);
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              assert(m_left);
+              std::vector<Value> overlay_args;
+              overlay_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+              overlay_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+              overlay_args.emplace_back(from->Evaluate(tuple1, tuple2, context));
+              if (len) {
+                overlay_args.emplace_back(len->Evaluate(tuple1, tuple2, context));
+              }
+              return Value::Call<FUNC_OVERLAY_CHAR>(overlay_args);
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorOverlayExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorOverlayExpression");
+            }
+
+            AbstractExpression *Copy() const {
+              return new OverlayExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()),
+                                           CopyUtil(from), CopyUtil(len));
+            }
+        };
 
 /*
  * implements replace
  */
-class ReplaceExpression : public AbstractExpression {
- private:
-  AbstractExpression *to;
+        class ReplaceExpression : public AbstractExpression {
+        private:
+            AbstractExpression *to;
 
- public:
-  ReplaceExpression(AbstractExpression *string, AbstractExpression *from,
-                    AbstractExpression *to)
-      : AbstractExpression(EXPRESSION_TYPE_REPLACE), to(to) {
-    m_left = string;
-    m_right = from;
-  };
+        public:
+            ReplaceExpression(AbstractExpression *string, AbstractExpression *from,
+                              AbstractExpression *to)
+              : AbstractExpression(EXPRESSION_TYPE_REPLACE), to(to) {
+              m_left = string;
+              m_right = from;
+            };
 
-  ~ReplaceExpression() { delete to; }
+            ~ReplaceExpression() { delete to; }
 
-  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                 executor::ExecutorContext *context) const {
-    assert(m_left);
-    std::vector<Value> replace_args;
-    replace_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-    replace_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-    replace_args.emplace_back(to->Evaluate(tuple1, tuple2, context));
-    return Value::Call<FUNC_REPLACE>(replace_args);
-  }
+            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                           executor::ExecutorContext *context) const {
+              assert(m_left);
+              std::vector<Value> replace_args;
+              replace_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+              replace_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+              replace_args.emplace_back(to->Evaluate(tuple1, tuple2, context));
+              return Value::Call<FUNC_REPLACE>(replace_args);
+            }
 
-  std::string DebugInfo(const std::string &spacer) const {
-    return (spacer + "OperatorReplaceExpression");
-  }
-};
+            std::string DebugInfo(const std::string &spacer) const {
+              return (spacer + "OperatorReplaceExpression");
+            }
 
-}  // End expression namespace
+            AbstractExpression *Copy() const {
+              return new ReplaceExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()),
+                                           CopyUtil(to));
+            }
+        };
+
+    }  // End expression namespace
 }  // End peloton namespace

--- a/src/backend/expression/string_expression.h
+++ b/src/backend/expression/string_expression.h
@@ -22,490 +22,490 @@
 #include <vector>
 
 namespace peloton {
-    namespace expression {
+namespace expression {
 
 /*
  * Substring expressoin
  */
 
-        class SubstringExpression : public AbstractExpression {
-        private:
-            AbstractExpression *len;  // length of substring to take (optional)
-        public:
-            /*
-             * constructor
-             * string : string to take substring
-             * from : first position
-             * len : last position
-             */
-            SubstringExpression(AbstractExpression *string, AbstractExpression *from,
-                                AbstractExpression *len)
-              : AbstractExpression(EXPRESSION_TYPE_SUBSTR), len(len) {
-              m_left = string;
-              m_right = from;
-            };
+class SubstringExpression : public AbstractExpression {
+ private:
+  AbstractExpression *len;  // length of substring to take (optional)
+ public:
+  /*
+   * constructor
+   * string : string to take substring
+   * from : first position
+   * len : last position
+   */
+  SubstringExpression(AbstractExpression *string, AbstractExpression *from,
+                      AbstractExpression *len)
+      : AbstractExpression(EXPRESSION_TYPE_SUBSTR), len(len) {
+    m_left = string;
+    m_right = from;
+  };
 
-            ~SubstringExpression() { delete len; }
+  ~SubstringExpression() { delete len; }
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              assert(m_left);
-              std::vector<Value> substr_args;
-              substr_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-              substr_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-              // if length not defined call 2 arg substring
-              if (len == nullptr) {
-                return Value::Call<FUNC_VOLT_SUBSTRING_CHAR_FROM>(substr_args);
-              } else {
-                substr_args.emplace_back(len->Evaluate(tuple1, tuple2, context));
-                return Value::Call<FUNC_SUBSTRING_CHAR>(substr_args);
-              }
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    std::vector<Value> substr_args;
+    substr_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+    substr_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+    // if length not defined call 2 arg substring
+    if (len == nullptr) {
+      return Value::Call<FUNC_VOLT_SUBSTRING_CHAR_FROM>(substr_args);
+    } else {
+      substr_args.emplace_back(len->Evaluate(tuple1, tuple2, context));
+      return Value::Call<FUNC_SUBSTRING_CHAR>(substr_args);
+    }
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorSubstringExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorSubstringExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new SubstringExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()),
-                                             CopyUtil(len));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new SubstringExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()),
+                                   CopyUtil(len));
+  }
+};
 
 /*
  * Implements the 2 variable concat expression
  */
-        class ConcatExpression : public AbstractExpression {
-        private:
-        public:
-            ConcatExpression(AbstractExpression *lc, AbstractExpression *rc)
-              : AbstractExpression(EXPRESSION_TYPE_CONCAT) {
-              m_left = lc;
-              m_right = rc;
-            };
+class ConcatExpression : public AbstractExpression {
+ private:
+ public:
+  ConcatExpression(AbstractExpression *lc, AbstractExpression *rc)
+      : AbstractExpression(EXPRESSION_TYPE_CONCAT) {
+    m_left = lc;
+    m_right = rc;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              assert(m_left);
-              std::vector<Value> concat_args;
-              concat_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-              concat_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-              return Value::Call<FUNC_CONCAT>(concat_args);
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    std::vector<Value> concat_args;
+    concat_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+    concat_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+    return Value::Call<FUNC_CONCAT>(concat_args);
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorConcatExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorConcatExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new ConcatExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new ConcatExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+  }
+};
 
 /*
  * Implements the ascii expression
  * Currently does not handle unicode well
  */
-        class AsciiExpression : public AbstractExpression {
-        private:
-        public:
-            AsciiExpression(AbstractExpression *lc)
-              : AbstractExpression(EXPRESSION_TYPE_ASCII) {
-              m_left = lc;
-            };
+class AsciiExpression : public AbstractExpression {
+ private:
+ public:
+  AsciiExpression(AbstractExpression *lc)
+      : AbstractExpression(EXPRESSION_TYPE_ASCII) {
+    m_left = lc;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              assert(m_left);
-              return m_left->Evaluate(tuple1, tuple2, context).CallUnary<FUNC_ASCII>();
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    return m_left->Evaluate(tuple1, tuple2, context).CallUnary<FUNC_ASCII>();
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorAsciiExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorAsciiExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new AsciiExpression(CopyUtil(GetLeft()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new AsciiExpression(CopyUtil(GetLeft()));
+  }
+};
 
 /*
  * Implements the octet length expression
  */
-        class OctetLengthExpression : public AbstractExpression {
-        private:
-        public:
-            OctetLengthExpression(AbstractExpression *lc)
-              : AbstractExpression(EXPRESSION_TYPE_OCTET_LEN) {
-              m_left = lc;
-            };
+class OctetLengthExpression : public AbstractExpression {
+ private:
+ public:
+  OctetLengthExpression(AbstractExpression *lc)
+      : AbstractExpression(EXPRESSION_TYPE_OCTET_LEN) {
+    m_left = lc;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              assert(m_left);
-              return m_left->Evaluate(tuple1, tuple2, context)
-                .CallUnary<FUNC_OCTET_LENGTH>();
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    return m_left->Evaluate(tuple1, tuple2, context)
+        .CallUnary<FUNC_OCTET_LENGTH>();
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorOctetLengthExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorOctetLengthExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new OctetLengthExpression(CopyUtil(GetLeft()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new OctetLengthExpression(CopyUtil(GetLeft()));
+  }
+};
 
 /*
  * Implements the CHR expression
  */
-        class CharExpression : public AbstractExpression {
-        private:
-        public:
-            CharExpression(AbstractExpression *lc)
-              : AbstractExpression(EXPRESSION_TYPE_CHAR) {
-              m_left = lc;
-            };
+class CharExpression : public AbstractExpression {
+ private:
+ public:
+  CharExpression(AbstractExpression *lc)
+      : AbstractExpression(EXPRESSION_TYPE_CHAR) {
+    m_left = lc;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              assert(m_left);
-              return m_left->Evaluate(tuple1, tuple2, context).CallUnary<FUNC_CHAR>();
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    return m_left->Evaluate(tuple1, tuple2, context).CallUnary<FUNC_CHAR>();
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorCharExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorCharExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new CharExpression(CopyUtil(GetLeft()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new CharExpression(CopyUtil(GetLeft()));
+  }
+};
 
 /*
  * Implements the CHAR LENGTH Expression
  */
-        class CharLengthExpression : public AbstractExpression {
-        private:
-        public:
-            CharLengthExpression(AbstractExpression *lc)
-              : AbstractExpression(EXPRESSION_TYPE_CHAR_LEN) {
-              m_left = lc;
-            };
+class CharLengthExpression : public AbstractExpression {
+ private:
+ public:
+  CharLengthExpression(AbstractExpression *lc)
+      : AbstractExpression(EXPRESSION_TYPE_CHAR_LEN) {
+    m_left = lc;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              assert(m_left);
-              return m_left->Evaluate(tuple1, tuple2, context)
-                .CallUnary<FUNC_CHAR_LENGTH>();
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    return m_left->Evaluate(tuple1, tuple2, context)
+        .CallUnary<FUNC_CHAR_LENGTH>();
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorCharLengthExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorCharLengthExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new CharLengthExpression(CopyUtil(GetLeft()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new CharLengthExpression(CopyUtil(GetLeft()));
+  }
+};
 
 /*
  * implements the repeat function
  */
-        class RepeatExpression : public AbstractExpression {
-        private:
-        public:
-            RepeatExpression(AbstractExpression *string, AbstractExpression *num)
-              : AbstractExpression(EXPRESSION_TYPE_REPEAT) {
-              m_left = string;
-              m_right = num;
-            };
+class RepeatExpression : public AbstractExpression {
+ private:
+ public:
+  RepeatExpression(AbstractExpression *string, AbstractExpression *num)
+      : AbstractExpression(EXPRESSION_TYPE_REPEAT) {
+    m_left = string;
+    m_right = num;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              assert(m_left);
-              assert(m_right);
-              std::vector<Value> repeat_args;
-              repeat_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-              repeat_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-              return Value::Call<FUNC_REPEAT>(repeat_args);
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    assert(m_right);
+    std::vector<Value> repeat_args;
+    repeat_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+    repeat_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+    return Value::Call<FUNC_REPEAT>(repeat_args);
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorRepeatExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorRepeatExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new RepeatExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new RepeatExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+  }
+};
 
 /*
  * implements left
  */
-        class LeftExpression : public AbstractExpression {
-        private:
-        public:
-            LeftExpression(AbstractExpression *string, AbstractExpression *num)
-              : AbstractExpression(EXPRESSION_TYPE_LEFT) {
-              m_left = string;
-              m_right = num;
-            };
+class LeftExpression : public AbstractExpression {
+ private:
+ public:
+  LeftExpression(AbstractExpression *string, AbstractExpression *num)
+      : AbstractExpression(EXPRESSION_TYPE_LEFT) {
+    m_left = string;
+    m_right = num;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              assert(m_left);
-              assert(m_right);
-              std::vector<Value> left_args;
-              left_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-              left_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-              return Value::Call<FUNC_LEFT>(left_args);
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    assert(m_right);
+    std::vector<Value> left_args;
+    left_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+    left_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+    return Value::Call<FUNC_LEFT>(left_args);
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorLeftExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorLeftExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new LeftExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new LeftExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+  }
+};
 
 /*
  * implements right
  */
-        class RightExpression : public AbstractExpression {
-        private:
-        public:
-            RightExpression(AbstractExpression *lc, AbstractExpression *rc)
-              : AbstractExpression(EXPRESSION_TYPE_RIGHT) {
-              m_left = lc;
-              m_right = rc;
-            };
+class RightExpression : public AbstractExpression {
+ private:
+ public:
+  RightExpression(AbstractExpression *lc, AbstractExpression *rc)
+      : AbstractExpression(EXPRESSION_TYPE_RIGHT) {
+    m_left = lc;
+    m_right = rc;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              assert(m_left);
-              assert(m_right);
-              std::vector<Value> right_args;
-              right_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-              right_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-              return Value::Call<FUNC_RIGHT>(right_args);
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    assert(m_right);
+    std::vector<Value> right_args;
+    right_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+    right_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+    return Value::Call<FUNC_RIGHT>(right_args);
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorRightExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorRightExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new RightExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new RightExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+  }
+};
 
 /*
  * implements ltrim (leading trim)
  */
-        class LTrimExpression : public AbstractExpression {
-        public:
-            LTrimExpression(AbstractExpression *string, AbstractExpression *chars)
-              : AbstractExpression(EXPRESSION_TYPE_RTRIM) {
-              m_left = string;
-              m_right = chars;
-            }
+class LTrimExpression : public AbstractExpression {
+ public:
+  LTrimExpression(AbstractExpression *string, AbstractExpression *chars)
+      : AbstractExpression(EXPRESSION_TYPE_RTRIM) {
+    m_left = string;
+    m_right = chars;
+  }
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              std::vector<Value> position_args;
-              // if null do not add to the arguments
-              if (m_left) {
-                position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-              }
-              position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    std::vector<Value> position_args;
+    // if null do not add to the arguments
+    if (m_left) {
+      position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+    }
+    position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
 
-              return Value::Call<FUNC_TRIM_LEADING_CHAR>(position_args);
-            }
+    return Value::Call<FUNC_TRIM_LEADING_CHAR>(position_args);
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorLTrimExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorLTrimExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new LTrimExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new LTrimExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+  }
+};
 
 /*
  * implements rtrim (trailing trim)
  */
-        class RTrimExpression : public AbstractExpression {
-        public:
-            RTrimExpression(AbstractExpression *string, AbstractExpression *chars)
-              : AbstractExpression(EXPRESSION_TYPE_RTRIM) {
-              m_left = string;
-              m_right = chars;
-            }
+class RTrimExpression : public AbstractExpression {
+ public:
+  RTrimExpression(AbstractExpression *string, AbstractExpression *chars)
+      : AbstractExpression(EXPRESSION_TYPE_RTRIM) {
+    m_left = string;
+    m_right = chars;
+  }
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              std::vector<Value> position_args;
-              // if null do not add to the arguments
-              if (m_left) {
-                position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-              }
-              position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-              return Value::Call<FUNC_TRIM_TRAILING_CHAR>(position_args);
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    std::vector<Value> position_args;
+    // if null do not add to the arguments
+    if (m_left) {
+      position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+    }
+    position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+    return Value::Call<FUNC_TRIM_TRAILING_CHAR>(position_args);
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorRTrimExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorRTrimExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new RTrimExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new RTrimExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+  }
+};
 
-        class BTrimExpression : public AbstractExpression {
-        public:
-            BTrimExpression(AbstractExpression *string, AbstractExpression *chars)
-              : AbstractExpression(EXPRESSION_TYPE_BTRIM) {
-              m_left = string;
-              m_right = chars;
-            }
+class BTrimExpression : public AbstractExpression {
+ public:
+  BTrimExpression(AbstractExpression *string, AbstractExpression *chars)
+      : AbstractExpression(EXPRESSION_TYPE_BTRIM) {
+    m_left = string;
+    m_right = chars;
+  }
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              std::vector<Value> position_args;
-              // if null do not add to the arguments
-              if (m_left) {
-                position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-              }
-              position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    std::vector<Value> position_args;
+    // if null do not add to the arguments
+    if (m_left) {
+      position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+    }
+    position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
 
-              return Value::Call<FUNC_TRIM_BOTH_CHAR>(position_args);
-            }
+    return Value::Call<FUNC_TRIM_BOTH_CHAR>(position_args);
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorBTrimExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorBTrimExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new BTrimExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new BTrimExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+  }
+};
 
 /*
  * implement position
  */
-        class PositionExpression : public AbstractExpression {
-        private:
-        public:
-            PositionExpression(AbstractExpression *lc, AbstractExpression *rc)
-              : AbstractExpression(EXPRESSION_TYPE_POSITION) {
-              m_left = lc;
-              m_right = rc;
-            };
+class PositionExpression : public AbstractExpression {
+ private:
+ public:
+  PositionExpression(AbstractExpression *lc, AbstractExpression *rc)
+      : AbstractExpression(EXPRESSION_TYPE_POSITION) {
+    m_left = lc;
+    m_right = rc;
+  };
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              assert(m_left);
-              assert(m_right);
-              std::vector<Value> position_args;
-              position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-              position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    assert(m_right);
+    std::vector<Value> position_args;
+    position_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+    position_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
 
-              return Value::Call<FUNC_POSITION_CHAR>(position_args);
-            }
+    return Value::Call<FUNC_POSITION_CHAR>(position_args);
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorPositionExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorPositionExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new PositionExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new PositionExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()));
+  }
+};
 
 /*
  * implements overlay (4 args)
  */
-        class OverlayExpression : public AbstractExpression {
-        private:
-            AbstractExpression *from;
-            AbstractExpression *len;
+class OverlayExpression : public AbstractExpression {
+ private:
+  AbstractExpression *from;
+  AbstractExpression *len;
 
-        public:
-            OverlayExpression(AbstractExpression *string1, AbstractExpression *string2,
-                              AbstractExpression *from, AbstractExpression *len)
-              : AbstractExpression(EXPRESSION_TYPE_OVERLAY), from(from), len(len) {
-              m_left = string1;
-              m_right = string2;
-            };
+ public:
+  OverlayExpression(AbstractExpression *string1, AbstractExpression *string2,
+                    AbstractExpression *from, AbstractExpression *len)
+      : AbstractExpression(EXPRESSION_TYPE_OVERLAY), from(from), len(len) {
+    m_left = string1;
+    m_right = string2;
+  };
 
-            ~OverlayExpression() {
-              delete from;
-              delete len;
-            }
+  ~OverlayExpression() {
+    delete from;
+    delete len;
+  }
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              assert(m_left);
-              std::vector<Value> overlay_args;
-              overlay_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-              overlay_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-              overlay_args.emplace_back(from->Evaluate(tuple1, tuple2, context));
-              if (len) {
-                overlay_args.emplace_back(len->Evaluate(tuple1, tuple2, context));
-              }
-              return Value::Call<FUNC_OVERLAY_CHAR>(overlay_args);
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    std::vector<Value> overlay_args;
+    overlay_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+    overlay_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+    overlay_args.emplace_back(from->Evaluate(tuple1, tuple2, context));
+    if (len) {
+      overlay_args.emplace_back(len->Evaluate(tuple1, tuple2, context));
+    }
+    return Value::Call<FUNC_OVERLAY_CHAR>(overlay_args);
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorOverlayExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorOverlayExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new OverlayExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()),
-                                           CopyUtil(from), CopyUtil(len));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new OverlayExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()),
+                                 CopyUtil(from), CopyUtil(len));
+  }
+};
 
 /*
  * implements replace
  */
-        class ReplaceExpression : public AbstractExpression {
-        private:
-            AbstractExpression *to;
+class ReplaceExpression : public AbstractExpression {
+ private:
+  AbstractExpression *to;
 
-        public:
-            ReplaceExpression(AbstractExpression *string, AbstractExpression *from,
-                              AbstractExpression *to)
-              : AbstractExpression(EXPRESSION_TYPE_REPLACE), to(to) {
-              m_left = string;
-              m_right = from;
-            };
+ public:
+  ReplaceExpression(AbstractExpression *string, AbstractExpression *from,
+                    AbstractExpression *to)
+      : AbstractExpression(EXPRESSION_TYPE_REPLACE), to(to) {
+    m_left = string;
+    m_right = from;
+  };
 
-            ~ReplaceExpression() { delete to; }
+  ~ReplaceExpression() { delete to; }
 
-            Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
-                           executor::ExecutorContext *context) const {
-              assert(m_left);
-              std::vector<Value> replace_args;
-              replace_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
-              replace_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
-              replace_args.emplace_back(to->Evaluate(tuple1, tuple2, context));
-              return Value::Call<FUNC_REPLACE>(replace_args);
-            }
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                 executor::ExecutorContext *context) const {
+    assert(m_left);
+    std::vector<Value> replace_args;
+    replace_args.emplace_back(m_left->Evaluate(tuple1, tuple2, context));
+    replace_args.emplace_back(m_right->Evaluate(tuple1, tuple2, context));
+    replace_args.emplace_back(to->Evaluate(tuple1, tuple2, context));
+    return Value::Call<FUNC_REPLACE>(replace_args);
+  }
 
-            std::string DebugInfo(const std::string &spacer) const {
-              return (spacer + "OperatorReplaceExpression");
-            }
+  std::string DebugInfo(const std::string &spacer) const {
+    return (spacer + "OperatorReplaceExpression");
+  }
 
-            AbstractExpression *Copy() const {
-              return new ReplaceExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()),
-                                           CopyUtil(to));
-            }
-        };
+  AbstractExpression *Copy() const {
+    return new ReplaceExpression(CopyUtil(GetLeft()), CopyUtil(GetRight()),
+                                 CopyUtil(to));
+  }
+};
 
-    }  // End expression namespace
+}  // End expression namespace
 }  // End peloton namespace

--- a/src/backend/expression/string_functions.h
+++ b/src/backend/expression/string_functions.h
@@ -625,7 +625,8 @@ struct money_numpunct : std::numpunct<char> {
 template <>
 inline Value Value::Call<FUNC_VOLT_FORMAT_CURRENCY>(
     const std::vector<Value> &arguments) {
-  // TODO: Use the getloc of standart c out stream instead of std::locale() below
+  // TODO: Use the getloc of standart c out stream instead of std::locale()
+  // below
   static std::locale newloc(std::locale(), new money_numpunct);
   static std::locale nullloc(std::locale(), new std::numpunct<char>);
   static TTInt one("1");

--- a/src/backend/expression/subquery_expression.h
+++ b/src/backend/expression/subquery_expression.h
@@ -42,7 +42,14 @@ class SubqueryExpression : public AbstractExpression {
 
   std::string DebugInfo(const std::string &spacer) const;
 
- private:
+    AbstractExpression *Copy() const {
+      return new SubqueryExpression(GetExpressionType(), m_subqueryId,
+                                    m_paramIdxs, m_otherParamIdxs,
+                                    std::vector<AbstractExpression *>());
+    }
+
+
+private:
   const int m_subqueryId;
 
   // The .Ist of parameter indexes that need to be set by this subquery

--- a/src/backend/expression/subquery_expression.h
+++ b/src/backend/expression/subquery_expression.h
@@ -33,7 +33,7 @@ class SubqueryExpression : public AbstractExpression {
   SubqueryExpression(ExpressionType subqueryType, int subqueryId,
                      const std::vector<int> &paramIdxs,
                      const std::vector<int> &otherParamIdxs,
-                     const std::vector<AbstractExpression *>& tveParams);
+                     const std::vector<AbstractExpression *> &tveParams);
 
   ~SubqueryExpression();
 
@@ -42,14 +42,13 @@ class SubqueryExpression : public AbstractExpression {
 
   std::string DebugInfo(const std::string &spacer) const;
 
-    AbstractExpression *Copy() const {
-      return new SubqueryExpression(GetExpressionType(), m_subqueryId,
-                                    m_paramIdxs, m_otherParamIdxs,
-                                    std::vector<AbstractExpression *>());
-    }
+  AbstractExpression *Copy() const {
+    return new SubqueryExpression(GetExpressionType(), m_subqueryId,
+                                  m_paramIdxs, m_otherParamIdxs,
+                                  std::vector<AbstractExpression *>());
+  }
 
-
-private:
+ private:
   const int m_subqueryId;
 
   // The .Ist of parameter indexes that need to be set by this subquery
@@ -60,7 +59,6 @@ private:
   // also including its child subqueries.
   // T.Is originate at the grandparent levels.
   std::vector<int> m_otherParamIdxs;
-
 };
 
 }  // End expression namespace

--- a/src/backend/expression/tuple_address_expression.h
+++ b/src/backend/expression/tuple_address_expression.h
@@ -40,8 +40,7 @@ class TupleAddressExpression : public AbstractExpression {
     return spacer + "TupleAddressExpression\n";
   }
 
-    AbstractExpression *Copy() const { return new TupleAddressExpression(); }
-
+  AbstractExpression *Copy() const { return new TupleAddressExpression(); }
 };
 
 }  // End expression namespace

--- a/src/backend/expression/tuple_address_expression.h
+++ b/src/backend/expression/tuple_address_expression.h
@@ -39,6 +39,9 @@ class TupleAddressExpression : public AbstractExpression {
   std::string DebugInfo(const std::string &spacer) const {
     return spacer + "TupleAddressExpression\n";
   }
+
+    AbstractExpression *Copy() const { return new TupleAddressExpression(); }
+
 };
 
 }  // End expression namespace

--- a/src/backend/expression/tuple_value_expression.h
+++ b/src/backend/expression/tuple_value_expression.h
@@ -67,6 +67,10 @@ class TupleValueExpression : public AbstractExpression {
 
   int GetTupleIdx() const { return this->tuple_idx; }
 
+    AbstractExpression *Copy() const {
+      return new TupleValueExpression(tuple_idx, value_idx);
+    }
+
  protected:
   const int tuple_idx;  // which tuple. defaults to tuple1
   const int value_idx;  // which (offset) column of the tuple

--- a/src/backend/expression/tuple_value_expression.h
+++ b/src/backend/expression/tuple_value_expression.h
@@ -67,9 +67,9 @@ class TupleValueExpression : public AbstractExpression {
 
   int GetTupleIdx() const { return this->tuple_idx; }
 
-    AbstractExpression *Copy() const {
-      return new TupleValueExpression(tuple_idx, value_idx);
-    }
+  AbstractExpression *Copy() const {
+    return new TupleValueExpression(tuple_idx, value_idx);
+  }
 
  protected:
   const int tuple_idx;  // which tuple. defaults to tuple1

--- a/src/backend/expression/vector_comparison_expression.h
+++ b/src/backend/expression/vector_comparison_expression.h
@@ -109,6 +109,13 @@ class VectorComparisonExpression : public AbstractExpression {
     return (spacer + "VectorComparisonExpression\n");
   }
 
+    AbstractExpression *Copy() const {
+      return new VectorComparisonExpression<OP, ValueExtractorLeft,
+        ValueExtractorRight>(
+        GetExpressionType(), CopyUtil(GetLeft()), CopyUtil(GetRight()),
+        m_quantifier);
+    }
+
  private:
   QuantifierType m_quantifier = QUANTIFIER_TYPE_NONE;
 };

--- a/src/backend/expression/vector_comparison_expression.h
+++ b/src/backend/expression/vector_comparison_expression.h
@@ -109,12 +109,12 @@ class VectorComparisonExpression : public AbstractExpression {
     return (spacer + "VectorComparisonExpression\n");
   }
 
-    AbstractExpression *Copy() const {
-      return new VectorComparisonExpression<OP, ValueExtractorLeft,
-        ValueExtractorRight>(
+  AbstractExpression *Copy() const {
+    return new VectorComparisonExpression<OP, ValueExtractorLeft,
+                                          ValueExtractorRight>(
         GetExpressionType(), CopyUtil(GetLeft()), CopyUtil(GetRight()),
         m_quantifier);
-    }
+  }
 
  private:
   QuantifierType m_quantifier = QUANTIFIER_TYPE_NONE;

--- a/src/backend/expression/vector_expression.h
+++ b/src/backend/expression/vector_expression.h
@@ -30,14 +30,14 @@ namespace expression {
  */
 class VectorExpression : public AbstractExpression {
  public:
-    VectorExpression(ValueType elementType,
-                     const std::vector<AbstractExpression *> &arguments)
+  VectorExpression(ValueType elementType,
+                   const std::vector<AbstractExpression *> &arguments)
       : AbstractExpression(EXPRESSION_TYPE_VALUE_VECTOR),
         arguments(arguments),
         elementType_(elementType) {
-      in_list = ValueFactory::GetArrayValueFromSizeAndType(arguments.size(),
-                                                           elementType);
-    }
+    in_list = ValueFactory::GetArrayValueFromSizeAndType(arguments.size(),
+                                                         elementType);
+  }
 
   virtual ~VectorExpression() {
     for (auto argument : arguments) delete argument;
@@ -72,23 +72,23 @@ class VectorExpression : public AbstractExpression {
   // for test
   std::vector<AbstractExpression *> GetArgs() const { return arguments; }
 
-    AbstractExpression *Copy() const {
-      std::vector<AbstractExpression *> copied_expression;
-      for (AbstractExpression *expression : arguments) {
-        if (expression == nullptr) {
-          continue;
-        }
-        copied_expression.push_back(expression->Copy());
+  AbstractExpression *Copy() const {
+    std::vector<AbstractExpression *> copied_expression;
+    for (AbstractExpression *expression : arguments) {
+      if (expression == nullptr) {
+        continue;
       }
-      return new VectorExpression(elementType_, copied_expression);
+      copied_expression.push_back(expression->Copy());
     }
+    return new VectorExpression(elementType_, copied_expression);
+  }
 
  private:
   // Arguments
   std::vector<AbstractExpression *> arguments;
 
-    // In list value type
-    ValueType elementType_;
+  // In list value type
+  ValueType elementType_;
 
   // In list
   Value in_list;

--- a/src/backend/expression/vector_expression.h
+++ b/src/backend/expression/vector_expression.h
@@ -30,12 +30,14 @@ namespace expression {
  */
 class VectorExpression : public AbstractExpression {
  public:
-  VectorExpression(ValueType elementType,
-                   const std::vector<AbstractExpression *> &arguments)
-      : AbstractExpression(EXPRESSION_TYPE_VALUE_VECTOR), arguments(arguments) {
-    in_list = ValueFactory::GetArrayValueFromSizeAndType(arguments.size(),
-                                                         elementType);
-  }
+    VectorExpression(ValueType elementType,
+                     const std::vector<AbstractExpression *> &arguments)
+      : AbstractExpression(EXPRESSION_TYPE_VALUE_VECTOR),
+        arguments(arguments),
+        elementType_(elementType) {
+      in_list = ValueFactory::GetArrayValueFromSizeAndType(arguments.size(),
+                                                           elementType);
+    }
 
   virtual ~VectorExpression() {
     for (auto argument : arguments) delete argument;
@@ -70,9 +72,23 @@ class VectorExpression : public AbstractExpression {
   // for test
   std::vector<AbstractExpression *> GetArgs() const { return arguments; }
 
+    AbstractExpression *Copy() const {
+      std::vector<AbstractExpression *> copied_expression;
+      for (AbstractExpression *expression : arguments) {
+        if (expression == nullptr) {
+          continue;
+        }
+        copied_expression.push_back(expression->Copy());
+      }
+      return new VectorExpression(elementType_, copied_expression);
+    }
+
  private:
   // Arguments
   std::vector<AbstractExpression *> arguments;
+
+    // In list value type
+    ValueType elementType_;
 
   // In list
   Value in_list;

--- a/tests/expression/expression_test.cpp
+++ b/tests/expression/expression_test.cpp
@@ -29,13 +29,13 @@
 #include "backend/expression/case_expression.h"
 
 namespace peloton {
-namespace test {
+    namespace test {
 
 //===--------------------------------------------------------------------===//
 // Expression Tests
 //===--------------------------------------------------------------------===//
 
-class ExpressionTest : public PelotonTest {};
+        class ExpressionTest : public PelotonTest {};
 
 /*
    Description of test:
@@ -58,148 +58,148 @@ class ExpressionTest : public PelotonTest {};
 /*
  *  Abstract expression mock object
  */
-class AE {
- public:
-  AE(ExpressionType et, ValueType vt, int vs)
-      : m_type(et),
-        m_valueType(vt),
-        m_valueSize(vs),
-        left(nullptr),
-        right(nullptr) {}
+        class AE {
+        public:
+            AE(ExpressionType et, ValueType vt, int vs)
+              : m_type(et),
+                m_valueType(vt),
+                m_valueSize(vs),
+                left(nullptr),
+                right(nullptr) {}
 
-  virtual ~AE() {
-    delete left;
-    delete right;
-  }
+            virtual ~AE() {
+              delete left;
+              delete right;
+            }
 
-  virtual json_spirit::Object SerializeValue() {
-    json_spirit::Object json;
-    Serialize(json);
-    return json;
-  }
+            virtual json_spirit::Object SerializeValue() {
+              json_spirit::Object json;
+              Serialize(json);
+              return json;
+            }
 
-  // this is how java serializes..
-  // note derived class data follows the serialization of children
-  virtual void Serialize(json_spirit::Object &json) {
-    json.push_back(json_spirit::Pair(
-        "TYPE", json_spirit::Value(ExpressionTypeToString(m_type))));
-    json.push_back(json_spirit::Pair(
-        "VALUE_TYPE", json_spirit::Value(ValueTypeToString(m_valueType))));
-    json.push_back(
-        json_spirit::Pair("VALUE_SIZE", json_spirit::Value(m_valueSize)));
+            // this is how java serializes..
+            // note derived class data follows the serialization of children
+            virtual void Serialize(json_spirit::Object &json) {
+              json.push_back(json_spirit::Pair(
+                "TYPE", json_spirit::Value(ExpressionTypeToString(m_type))));
+              json.push_back(json_spirit::Pair(
+                "VALUE_TYPE", json_spirit::Value(ValueTypeToString(m_valueType))));
+              json.push_back(
+                json_spirit::Pair("VALUE_SIZE", json_spirit::Value(m_valueSize)));
 
-    if (left) json.push_back(json_spirit::Pair("LEFT", left->SerializeValue()));
-    if (right)
-      json.push_back(json_spirit::Pair("RIGHT", right->SerializeValue()));
-  }
+              if (left) json.push_back(json_spirit::Pair("LEFT", left->SerializeValue()));
+              if (right)
+                json.push_back(json_spirit::Pair("RIGHT", right->SerializeValue()));
+            }
 
-  ExpressionType m_type;  // TYPE
-  ValueType m_valueType;  // VALUE_TYPE
-  int m_valueSize;        // VALUE_SIZE
+            ExpressionType m_type;  // TYPE
+            ValueType m_valueType;  // VALUE_TYPE
+            int m_valueSize;        // VALUE_SIZE
 
-  // to build a tree
-  AE *left;
-  AE *right;
-};
+            // to build a tree
+            AE *left;
+            AE *right;
+        };
 
 /*
  * constant value expression mock object
  */
-class CV : public AE {
- public:
-  CV(ExpressionType et, ValueType vt, int vs, int64_t v)
-      : AE(et, vt, vs), m_jsontype(1), m_intValue(v) {
-    m_stringValue = nullptr;
-    m_doubleValue = 0.0;
-  }
+        class CV : public AE {
+        public:
+            CV(ExpressionType et, ValueType vt, int vs, int64_t v)
+              : AE(et, vt, vs), m_jsontype(1), m_intValue(v) {
+              m_stringValue = nullptr;
+              m_doubleValue = 0.0;
+            }
 
-  CV(ExpressionType et, ValueType vt, int vs, char *v)
-      : AE(et, vt, vs), m_jsontype(1), m_stringValue(strdup(v)) {
-    m_intValue = 0;
-    m_doubleValue = 0.0;
-  }
+            CV(ExpressionType et, ValueType vt, int vs, char *v)
+              : AE(et, vt, vs), m_jsontype(1), m_stringValue(strdup(v)) {
+              m_intValue = 0;
+              m_doubleValue = 0.0;
+            }
 
-  CV(ExpressionType et, ValueType vt, int vs, double v)
-      : AE(et, vt, vs), m_jsontype(1), m_doubleValue(v) {
-    m_stringValue = nullptr;
-    m_intValue = 0;
-  }
+            CV(ExpressionType et, ValueType vt, int vs, double v)
+              : AE(et, vt, vs), m_jsontype(1), m_doubleValue(v) {
+              m_stringValue = nullptr;
+              m_intValue = 0;
+            }
 
-  ~CV() {}
+            ~CV() {}
 
-  virtual void Serialize(json_spirit::Object &json) {
-    AE::Serialize(json);
-    if (m_jsontype == 0)
-      json.push_back(
-          json_spirit::Pair("VALUE", json_spirit::Value(m_stringValue)));
-    else if (m_jsontype == 1)
-      json.push_back(
-          json_spirit::Pair("VALUE", json_spirit::Value(m_intValue)));
-    else if (m_jsontype == 2)
-      json.push_back(
-          json_spirit::Pair("VALUE", json_spirit::Value(m_doubleValue)));
-  }
+            virtual void Serialize(json_spirit::Object &json) {
+              AE::Serialize(json);
+              if (m_jsontype == 0)
+                json.push_back(
+                  json_spirit::Pair("VALUE", json_spirit::Value(m_stringValue)));
+              else if (m_jsontype == 1)
+                json.push_back(
+                  json_spirit::Pair("VALUE", json_spirit::Value(m_intValue)));
+              else if (m_jsontype == 2)
+                json.push_back(
+                  json_spirit::Pair("VALUE", json_spirit::Value(m_doubleValue)));
+            }
 
-  int m_jsontype;  // 0 = string, 1 = int64_t, 2 = double
+            int m_jsontype;  // 0 = string, 1 = int64_t, 2 = double
 
-  int64_t m_intValue;    // VALUE
-  char *m_stringValue;   // VALUE
-  double m_doubleValue;  // VALUE
-};
+            int64_t m_intValue;    // VALUE
+            char *m_stringValue;   // VALUE
+            double m_doubleValue;  // VALUE
+        };
 
 /*
  * parameter value expression mock object
  */
-class PV : public AE {
- public:
-  PV(ExpressionType et, ValueType vt, int vs, int pi)
-      : AE(et, vt, vs), m_paramIdx(pi) {}
+        class PV : public AE {
+        public:
+            PV(ExpressionType et, ValueType vt, int vs, int pi)
+              : AE(et, vt, vs), m_paramIdx(pi) {}
 
-  virtual void Serialize(json_spirit::Object &json) {
-    AE::Serialize(json);
-    json.push_back(
-        json_spirit::Pair("PARAM_IDX", json_spirit::Value(m_paramIdx)));
-  }
+            virtual void Serialize(json_spirit::Object &json) {
+              AE::Serialize(json);
+              json.push_back(
+                json_spirit::Pair("PARAM_IDX", json_spirit::Value(m_paramIdx)));
+            }
 
-  int m_paramIdx;  // PARAM_IDX
-};
+            int m_paramIdx;  // PARAM_IDX
+        };
 
 /*
  * tuple value expression mock object
  */
-class TV : public AE {
- public:
-  TV(ExpressionType et, ValueType vt, int vs, int ci, const char *tn,
-     const char *cn, const char *ca)
-      : AE(et, vt, vs),
-        m_columnIdx(ci),
-        m_tableName(strdup(tn)),
-        m_colName(strdup(cn)),
-        m_colAlias(strdup(ca)) {}
+        class TV : public AE {
+        public:
+            TV(ExpressionType et, ValueType vt, int vs, int ci, const char *tn,
+               const char *cn, const char *ca)
+              : AE(et, vt, vs),
+                m_columnIdx(ci),
+                m_tableName(strdup(tn)),
+                m_colName(strdup(cn)),
+                m_colAlias(strdup(ca)) {}
 
-  ~TV() {
-    delete m_tableName;
-    delete m_colName;
-    delete m_colAlias;
-  }
+            ~TV() {
+              delete m_tableName;
+              delete m_colName;
+              delete m_colAlias;
+            }
 
-  virtual void Serialize(json_spirit::Object &json) {
-    AE::Serialize(json);
-    json.push_back(
-        json_spirit::Pair("COLUMN_IDX", json_spirit::Value(m_columnIdx)));
-    json.push_back(
-        json_spirit::Pair("TABLE_NAME", json_spirit::Value(m_tableName)));
-    json.push_back(
-        json_spirit::Pair("COLUMN_NAME", json_spirit::Value(m_colName)));
-    json.push_back(
-        json_spirit::Pair("COLUMN_ALIAS", json_spirit::Value(m_colAlias)));
-  }
+            virtual void Serialize(json_spirit::Object &json) {
+              AE::Serialize(json);
+              json.push_back(
+                json_spirit::Pair("COLUMN_IDX", json_spirit::Value(m_columnIdx)));
+              json.push_back(
+                json_spirit::Pair("TABLE_NAME", json_spirit::Value(m_tableName)));
+              json.push_back(
+                json_spirit::Pair("COLUMN_NAME", json_spirit::Value(m_colName)));
+              json.push_back(
+                json_spirit::Pair("COLUMN_ALIAS", json_spirit::Value(m_colAlias)));
+            }
 
-  int m_columnIdx;    // COLUMN_IDX
-  char *m_tableName;  // TABLE_NAME
-  char *m_colName;    // COLUMN_NAME
-  char *m_colAlias;   // COLUMN_ALIAS
-};
+            int m_columnIdx;    // COLUMN_IDX
+            char *m_tableName;  // TABLE_NAME
+            char *m_colName;    // COLUMN_NAME
+            char *m_colAlias;   // COLUMN_ALIAS
+        };
 
 /*
    helpers to build trivial left-associative trees
@@ -207,306 +207,596 @@ class TV : public AE {
    and (a, +, b, * c) returns (a + b) * c
  */
 
-AE *Join(AE *op, AE *left, AE *right) {
-  op->left = left;
-  op->right = right;
-  return op;
-}
+        AE *Join(AE *op, AE *left, AE *right) {
+          op->left = left;
+          op->right = right;
+          return op;
+        }
 
-AE *MakeTree(AE *tree, std::queue<AE *> &q) {
-  if (!q.empty()) {
-    AE *left, *right, *op;
-    if (tree) {
-      left = tree;
-    } else {
-      left = q.front();
-      q.pop();
-    }
+        AE *MakeTree(AE *tree, std::queue<AE *> &q) {
+          if (!q.empty()) {
+            AE *left, *right, *op;
+            if (tree) {
+              left = tree;
+            } else {
+              left = q.front();
+              q.pop();
+            }
 
-    op = q.front();
-    q.pop();
-    right = q.front();
-    q.pop();
+            op = q.front();
+            q.pop();
+            right = q.front();
+            q.pop();
 
-    tree = MakeTree(Join(op, left, right), q);
-  }
-  return tree;
-}
+            tree = MakeTree(Join(op, left, right), q);
+          }
+          return tree;
+        }
 
 // boilerplate to turn the queue into a real AbstractExpression tree;
 //   return the generated AE tree by reference to allow deletion (the queue
 //   is emptied by the tree building process)
-expression::AbstractExpression *ConvertToExpression(std::queue<AE *> &e) {
-  AE *tree = MakeTree(nullptr, e);
-  json_spirit::Object json = tree->SerializeValue();
-  expression::AbstractExpression *exp =
-      expression::AbstractExpression::CreateExpressionTree(json);
-  delete tree;
-  return exp;
-}
+        expression::AbstractExpression *ConvertToExpression(std::queue<AE *> &e) {
+          AE *tree = MakeTree(nullptr, e);
+          json_spirit::Object json = tree->SerializeValue();
+          expression::AbstractExpression *exp =
+            expression::AbstractExpression::CreateExpressionTree(json);
+          delete tree;
+          return exp;
+        }
 
 /*
  * Show that simple addition works with the framework
  */
-TEST_F(ExpressionTest, SimpleAddition) {
-  std::queue<AE *> e;
-  storage::Tuple junk;
+        TEST_F(ExpressionTest, SimpleAddition) {
+        std::queue<AE *> e;
+        storage::Tuple junk;
 
-  // 1 + 4
-  e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
-                (int64_t)1));
-  e.push(new AE(EXPRESSION_TYPE_OPERATOR_PLUS, VALUE_TYPE_TINYINT, 1));
-  e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
-                (int64_t)4));
-  std::unique_ptr<expression::AbstractExpression> testexp(
+        // 1 + 4
+        e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+        (int64_t)1));
+        e.push(new AE(EXPRESSION_TYPE_OPERATOR_PLUS, VALUE_TYPE_TINYINT, 1));
+        e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+        (int64_t)4));
+        std::unique_ptr<expression::AbstractExpression> testexp(
+          ConvertToExpression(e));
+
+        Value result = testexp->Evaluate(&junk, nullptr, nullptr);
+        LOG_INFO("%s", result.GetInfo().c_str());
+
+        EXPECT_EQ(ValuePeeker::PeekAsBigInt(result), 5LL);
+    }
+
+    TEST_F(ExpressionTest, SimpleAdditionCopyTest) {
+    std::queue<AE *> e;
+    storage::Tuple junk;
+
+    // 1 + 4
+    e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+    (int64_t)1));
+    e.push(new AE(EXPRESSION_TYPE_OPERATOR_PLUS, VALUE_TYPE_TINYINT, 1));
+    e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+    (int64_t)4));
+    std::unique_ptr<expression::AbstractExpression> testexp(
       ConvertToExpression(e));
+    std::unique_ptr<expression::AbstractExpression> copied_testexp(
+      testexp->Copy());
 
-  Value result = testexp->Evaluate(&junk, nullptr, nullptr);
-  LOG_INFO("%s", result.GetInfo().c_str());
+    Value result = copied_testexp->Evaluate(&junk, nullptr, nullptr);
+    LOG_INFO("%s", result.GetInfo().c_str());
 
-  EXPECT_EQ(ValuePeeker::PeekAsBigInt(result), 5LL);
+    EXPECT_EQ(ValuePeeker::PeekAsBigInt(result), 5LL);
 }
 
 /*
  * Show that the associative property is as expected
  */
 TEST_F(ExpressionTest, SimpleMultiplication) {
-  std::queue<AE *> e;
-  storage::Tuple junk;
+std::queue<AE *> e;
+storage::Tuple junk;
 
-  // (1 + 4) * 5
-  e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
-                (int64_t)1));
-  e.push(new AE(EXPRESSION_TYPE_OPERATOR_PLUS, VALUE_TYPE_TINYINT, 1));
-  e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
-                (int64_t)4));
-  e.push(new AE(EXPRESSION_TYPE_OPERATOR_MULTIPLY, VALUE_TYPE_TINYINT, 1));
-  e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
-                (int64_t)5));
+// (1 + 4) * 5
+e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+(int64_t)1));
+e.push(new AE(EXPRESSION_TYPE_OPERATOR_PLUS, VALUE_TYPE_TINYINT, 1));
+e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+(int64_t)4));
+e.push(new AE(EXPRESSION_TYPE_OPERATOR_MULTIPLY, VALUE_TYPE_TINYINT, 1));
+e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+(int64_t)5));
 
-  std::unique_ptr<expression::AbstractExpression> e1(ConvertToExpression(e));
-  Value r1 = e1->Evaluate(&junk, nullptr, nullptr);
-  LOG_INFO("%s", r1.GetInfo().c_str());
-  EXPECT_EQ(ValuePeeker::PeekAsBigInt(r1), 25LL);
+std::unique_ptr<expression::AbstractExpression> e1(ConvertToExpression(e));
 
-  // (2 * 5) + 3
-  e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
-                (int64_t)2));
-  e.push(new AE(EXPRESSION_TYPE_OPERATOR_MULTIPLY, VALUE_TYPE_TINYINT, 1));
-  e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
-                (int64_t)5));
-  e.push(new AE(EXPRESSION_TYPE_OPERATOR_PLUS, VALUE_TYPE_TINYINT, 1));
-  e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
-                (int64_t)3));
+Value r1 = e1->Evaluate(&junk, nullptr, nullptr);
+LOG_INFO("%s", r1.GetInfo().c_str());
+EXPECT_EQ(ValuePeeker::PeekAsBigInt(r1), 25LL);
 
-  std::unique_ptr<expression::AbstractExpression> e2(ConvertToExpression(e));
-  Value r2 = e2->Evaluate(&junk, nullptr, nullptr);
-  LOG_INFO("%s", r2.GetInfo().c_str());
-  EXPECT_EQ(ValuePeeker::PeekAsBigInt(r2), 13LL);
+// (2 * 5) + 3
+e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+(int64_t)2));
+e.push(new AE(EXPRESSION_TYPE_OPERATOR_MULTIPLY, VALUE_TYPE_TINYINT, 1));
+e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+(int64_t)5));
+e.push(new AE(EXPRESSION_TYPE_OPERATOR_PLUS, VALUE_TYPE_TINYINT, 1));
+e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+(int64_t)3));
+
+std::unique_ptr<expression::AbstractExpression> e2(ConvertToExpression(e));
+
+Value r2 = e2->Evaluate(&junk, nullptr, nullptr);
+LOG_INFO("%s", r2.GetInfo().c_str());
+EXPECT_EQ(ValuePeeker::PeekAsBigInt(r2), 13LL);
+}
+
+TEST_F(ExpressionTest, SimpleMultiplicationCopyTest) {
+std::queue<AE *> e;
+storage::Tuple junk;
+
+// (1 + 4) * 5
+e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+(int64_t)1));
+e.push(new AE(EXPRESSION_TYPE_OPERATOR_PLUS, VALUE_TYPE_TINYINT, 1));
+e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+(int64_t)4));
+e.push(new AE(EXPRESSION_TYPE_OPERATOR_MULTIPLY, VALUE_TYPE_TINYINT, 1));
+e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+(int64_t)5));
+
+std::unique_ptr<expression::AbstractExpression> e1(ConvertToExpression(e));
+std::unique_ptr<expression::AbstractExpression> c_e1(e1->Copy());
+Value r1 = c_e1->Evaluate(&junk, nullptr, nullptr);
+LOG_INFO("%s", r1.GetInfo().c_str());
+EXPECT_EQ(ValuePeeker::PeekAsBigInt(r1), 25LL);
+
+// (2 * 5) + 3
+e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+(int64_t)2));
+e.push(new AE(EXPRESSION_TYPE_OPERATOR_MULTIPLY, VALUE_TYPE_TINYINT, 1));
+e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+(int64_t)5));
+e.push(new AE(EXPRESSION_TYPE_OPERATOR_PLUS, VALUE_TYPE_TINYINT, 1));
+e.push(new CV(EXPRESSION_TYPE_VALUE_CONSTANT, VALUE_TYPE_TINYINT, 1,
+(int64_t)3));
+
+std::unique_ptr<expression::AbstractExpression> e2(ConvertToExpression(e));
+std::unique_ptr<expression::AbstractExpression> c_e2(e2->Copy());
+
+Value r2 = c_e2->Evaluate(&junk, nullptr, nullptr);
+LOG_INFO("%s", r2.GetInfo().c_str());
+EXPECT_EQ(ValuePeeker::PeekAsBigInt(r2), 13LL);
 }
 
 TEST_F(ExpressionTest, SimpleFilter) {
-  // WHERE id = 20
+// WHERE id = 20
 
-  // EXPRESSION
+// EXPRESSION
 
-  expression::TupleValueExpression *tup_val_exp =
-      new expression::TupleValueExpression(0, 0);
-  expression::ConstantValueExpression *const_val_exp =
-      new expression::ConstantValueExpression(
-          ValueFactory::GetIntegerValue(20));
-  expression::ComparisonExpression<expression::CmpEq> *equal =
-      new expression::ComparisonExpression<expression::CmpEq>(
-          EXPRESSION_TYPE_COMPARE_EQUAL, tup_val_exp, const_val_exp);
+expression::TupleValueExpression *tup_val_exp =
+  new expression::TupleValueExpression(0, 0);
+expression::ConstantValueExpression *const_val_exp =
+  new expression::ConstantValueExpression(
+    ValueFactory::GetIntegerValue(20));
+expression::ComparisonExpression<expression::CmpEq> *equal =
+  new expression::ComparisonExpression<expression::CmpEq>(
+    EXPRESSION_TYPE_COMPARE_EQUAL, tup_val_exp, const_val_exp);
 
-  // TUPLE
+// TUPLE
 
-  std::vector<catalog::Column> columns;
+std::vector<catalog::Column> columns;
 
-  catalog::Column column1(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
-                          "A", true);
-  catalog::Column column2(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
-                          "B", true);
-  columns.push_back(column1);
-  columns.push_back(column2);
-  catalog::Schema *schema(new catalog::Schema(columns));
+catalog::Column column1(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        "A", true);
+catalog::Column column2(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        "B", true);
+columns.push_back(column1);
+columns.push_back(column2);
+catalog::Schema *schema(new catalog::Schema(columns));
 
-  storage::Tuple *tuple(new storage::Tuple(schema, true));
+storage::Tuple *tuple(new storage::Tuple(schema, true));
 
-  tuple->SetValue(0, ValueFactory::GetIntegerValue(20), nullptr);
-  tuple->SetValue(1, ValueFactory::GetIntegerValue(45), nullptr);
+tuple->SetValue(0, ValueFactory::GetIntegerValue(20), nullptr);
+tuple->SetValue(1, ValueFactory::GetIntegerValue(45), nullptr);
 
-  LOG_INFO("%s", equal->GetInfo().c_str());
-  EXPECT_EQ(equal->Evaluate(tuple, NULL, NULL).IsTrue(), true);
+LOG_INFO("%s", equal->GetInfo().c_str());
+EXPECT_EQ(equal->Evaluate(tuple, NULL, NULL).IsTrue(), true);
 
-  tuple->SetValue(0, ValueFactory::GetIntegerValue(50), nullptr);
-  EXPECT_EQ(equal->Evaluate(tuple, NULL, NULL).IsTrue(), false);
+tuple->SetValue(0, ValueFactory::GetIntegerValue(50), nullptr);
+EXPECT_EQ(equal->Evaluate(tuple, NULL, NULL).IsTrue(), false);
 
-  // delete the root to destroy the full tree.
-  delete equal;
+// delete the root to destroy the full tree.
+delete equal;
 
-  delete schema;
-  delete tuple;
+delete schema;
+delete tuple;
+}
+
+TEST_F(ExpressionTest, SimpleFilterCopyTest) {
+// WHERE id = 20
+
+// EXPRESSION
+
+expression::TupleValueExpression *tup_val_exp =
+  new expression::TupleValueExpression(0, 0);
+expression::ConstantValueExpression *const_val_exp =
+  new expression::ConstantValueExpression(
+    ValueFactory::GetIntegerValue(20));
+expression::ComparisonExpression<expression::CmpEq> *o_equal =
+  new expression::ComparisonExpression<expression::CmpEq>(
+    EXPRESSION_TYPE_COMPARE_EQUAL, tup_val_exp, const_val_exp);
+
+expression::ComparisonExpression<expression::CmpEq> *equal =
+  dynamic_cast<expression::ComparisonExpression<expression::CmpEq> *>(
+    o_equal->Copy());
+
+// TUPLE
+
+std::vector<catalog::Column> columns;
+
+catalog::Column column1(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        "A", true);
+catalog::Column column2(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        "B", true);
+columns.push_back(column1);
+columns.push_back(column2);
+catalog::Schema *schema(new catalog::Schema(columns));
+
+storage::Tuple *tuple(new storage::Tuple(schema, true));
+
+tuple->SetValue(0, ValueFactory::GetIntegerValue(20), nullptr);
+tuple->SetValue(1, ValueFactory::GetIntegerValue(45), nullptr);
+
+LOG_INFO("%s", equal->GetInfo().c_str());
+EXPECT_EQ(equal->Evaluate(tuple, NULL, NULL).IsTrue(), true);
+
+tuple->SetValue(0, ValueFactory::GetIntegerValue(50), nullptr);
+EXPECT_EQ(equal->Evaluate(tuple, NULL, NULL).IsTrue(), false);
+
+// delete the root to destroy the full tree.
+delete equal;
+delete o_equal;
+
+delete schema;
+delete tuple;
 }
 
 TEST_F(ExpressionTest, SimpleInFilter) {
-  // WHERE id in (15, 20)
+// WHERE id in (15, 20)
 
-  // EXPRESSION
+// EXPRESSION
 
-  expression::TupleValueExpression *tup_val_exp =
-      new expression::TupleValueExpression(0, 0);
-  expression::ConstantValueExpression *const_val_exp1 =
-      new expression::ConstantValueExpression(
-          ValueFactory::GetIntegerValue(15));
-  expression::ConstantValueExpression *const_val_exp2 =
-      new expression::ConstantValueExpression(
-          ValueFactory::GetIntegerValue(20));
+expression::TupleValueExpression *tup_val_exp =
+  new expression::TupleValueExpression(0, 0);
+expression::ConstantValueExpression *const_val_exp1 =
+  new expression::ConstantValueExpression(
+    ValueFactory::GetIntegerValue(15));
+expression::ConstantValueExpression *const_val_exp2 =
+  new expression::ConstantValueExpression(
+    ValueFactory::GetIntegerValue(20));
 
-  std::vector<expression::AbstractExpression *> vec_const_exprs;
-  vec_const_exprs.push_back(const_val_exp1);
-  vec_const_exprs.push_back(const_val_exp2);
+std::vector<expression::AbstractExpression *> vec_const_exprs;
+vec_const_exprs.push_back(const_val_exp1);
+vec_const_exprs.push_back(const_val_exp2);
 
-  expression::VectorExpression *vec_exp =
-      new expression::VectorExpression(VALUE_TYPE_ARRAY, vec_const_exprs);
+expression::VectorExpression *vec_exp =
+  new expression::VectorExpression(VALUE_TYPE_ARRAY, vec_const_exprs);
 
-  expression::ComparisonExpression<expression::CmpIn> *equal =
-      new expression::ComparisonExpression<expression::CmpIn>(
-          EXPRESSION_TYPE_COMPARE_IN, tup_val_exp, vec_exp);
+expression::ComparisonExpression<expression::CmpIn> *equal =
+  new expression::ComparisonExpression<expression::CmpIn>(
+    EXPRESSION_TYPE_COMPARE_IN, tup_val_exp, vec_exp);
 
-  // TUPLE
+// TUPLE
 
-  std::vector<catalog::Column> columns;
+std::vector<catalog::Column> columns;
 
-  catalog::Column column1(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
-                          "A", true);
-  catalog::Column column2(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
-                          "B", true);
-  columns.push_back(column1);
-  columns.push_back(column2);
-  catalog::Schema *schema(new catalog::Schema(columns));
+catalog::Column column1(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        "A", true);
+catalog::Column column2(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        "B", true);
+columns.push_back(column1);
+columns.push_back(column2);
+catalog::Schema *schema(new catalog::Schema(columns));
 
-  storage::Tuple *tuple(new storage::Tuple(schema, true));
+storage::Tuple *tuple(new storage::Tuple(schema, true));
 
-  tuple->SetValue(0, ValueFactory::GetIntegerValue(20), nullptr);
-  tuple->SetValue(1, ValueFactory::GetIntegerValue(45), nullptr);
+tuple->SetValue(0, ValueFactory::GetIntegerValue(20), nullptr);
+tuple->SetValue(1, ValueFactory::GetIntegerValue(45), nullptr);
 
-  LOG_INFO("%s", equal->GetInfo().c_str());
-  EXPECT_EQ(equal->Evaluate(tuple, NULL, NULL).IsTrue(), true);
+LOG_INFO("%s", equal->GetInfo().c_str());
+EXPECT_EQ(equal->Evaluate(tuple, NULL, NULL).IsTrue(), true);
 
-  tuple->SetValue(0, ValueFactory::GetIntegerValue(50), nullptr);
-  EXPECT_EQ(equal->Evaluate(tuple, NULL, NULL).IsTrue(), false);
+tuple->SetValue(0, ValueFactory::GetIntegerValue(50), nullptr);
+EXPECT_EQ(equal->Evaluate(tuple, NULL, NULL).IsTrue(), false);
 
-  // delete the root to destroy the full tree.
-  delete equal;
+// delete the root to destroy the full tree.
+delete equal;
 
-  delete schema;
-  delete tuple;
+delete schema;
+delete tuple;
+}
+
+TEST_F(ExpressionTest, SimpleInFilterCopyTest) {
+// WHERE id in (15, 20)
+
+// EXPRESSION
+
+expression::TupleValueExpression *tup_val_exp =
+  new expression::TupleValueExpression(0, 0);
+expression::ConstantValueExpression *const_val_exp1 =
+  new expression::ConstantValueExpression(
+    ValueFactory::GetIntegerValue(15));
+expression::ConstantValueExpression *const_val_exp2 =
+  new expression::ConstantValueExpression(
+    ValueFactory::GetIntegerValue(20));
+
+std::vector<expression::AbstractExpression *> vec_const_exprs;
+vec_const_exprs.push_back(const_val_exp1);
+vec_const_exprs.push_back(const_val_exp2);
+
+expression::VectorExpression *vec_exp =
+  new expression::VectorExpression(VALUE_TYPE_ARRAY, vec_const_exprs);
+
+expression::ComparisonExpression<expression::CmpIn> *o_equal =
+  new expression::ComparisonExpression<expression::CmpIn>(
+    EXPRESSION_TYPE_COMPARE_IN, tup_val_exp, vec_exp);
+
+expression::ComparisonExpression<expression::CmpIn> *equal =
+  dynamic_cast<expression::ComparisonExpression<expression::CmpIn> *>(
+    o_equal->Copy());
+
+// TUPLE
+
+std::vector<catalog::Column> columns;
+
+catalog::Column column1(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        "A", true);
+catalog::Column column2(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        "B", true);
+columns.push_back(column1);
+columns.push_back(column2);
+catalog::Schema *schema(new catalog::Schema(columns));
+
+storage::Tuple *tuple(new storage::Tuple(schema, true));
+
+tuple->SetValue(0, ValueFactory::GetIntegerValue(20), nullptr);
+tuple->SetValue(1, ValueFactory::GetIntegerValue(45), nullptr);
+
+LOG_INFO("%s", equal->GetInfo().c_str());
+EXPECT_EQ(equal->Evaluate(tuple, NULL, NULL).IsTrue(), true);
+
+tuple->SetValue(0, ValueFactory::GetIntegerValue(50), nullptr);
+EXPECT_EQ(equal->Evaluate(tuple, NULL, NULL).IsTrue(), false);
+
+// delete the root to destroy the full tree.
+delete equal;
+delete o_equal;
+
+delete schema;
+delete tuple;
 }
 
 TEST_F(ExpressionTest, SimpleCase) {
-  // CASE WHEN i=1 THEN 2 ELSE 3 END
+// CASE WHEN i=1 THEN 2 ELSE 3 END
 
-  // EXPRESSION
+// EXPRESSION
 
-  expression::TupleValueExpression *tup_val_exp =
-      new expression::TupleValueExpression(0, 0);
-  expression::ConstantValueExpression *const_val_exp_1 =
-      new expression::ConstantValueExpression(ValueFactory::GetIntegerValue(1));
-  expression::ConstantValueExpression *const_val_exp_2 =
-      new expression::ConstantValueExpression(ValueFactory::GetIntegerValue(2));
-  expression::ConstantValueExpression *const_val_exp_3 =
-      new expression::ConstantValueExpression(ValueFactory::GetIntegerValue(3));
+expression::TupleValueExpression *tup_val_exp =
+  new expression::TupleValueExpression(0, 0);
+expression::ConstantValueExpression *const_val_exp_1 =
+  new expression::ConstantValueExpression(ValueFactory::GetIntegerValue(1));
+expression::ConstantValueExpression *const_val_exp_2 =
+  new expression::ConstantValueExpression(ValueFactory::GetIntegerValue(2));
+expression::ConstantValueExpression *const_val_exp_3 =
+  new expression::ConstantValueExpression(ValueFactory::GetIntegerValue(3));
 
-  expression::ComparisonExpression<expression::CmpEq> *case_when_cond =
-      new expression::ComparisonExpression<expression::CmpEq>(
-          EXPRESSION_TYPE_COMPARE_EQUAL, tup_val_exp, const_val_exp_1);
+expression::ComparisonExpression<expression::CmpEq> *case_when_cond =
+  new expression::ComparisonExpression<expression::CmpEq>(
+    EXPRESSION_TYPE_COMPARE_EQUAL, tup_val_exp, const_val_exp_1);
 
-  expression::OperatorCaseWhenExpression *case_when_clause =
-      new expression::OperatorCaseWhenExpression(
-          VALUE_TYPE_INTEGER, case_when_cond, const_val_exp_2);
+expression::OperatorCaseWhenExpression *case_when_clause =
+  new expression::OperatorCaseWhenExpression(
+    VALUE_TYPE_INTEGER, case_when_cond, const_val_exp_2);
 
-  std::vector<expression::AbstractExpression *> clauses;
-  clauses.push_back(case_when_clause);
+std::vector<expression::AbstractExpression *> clauses;
+clauses.push_back(case_when_clause);
 
-  expression::CaseExpression *case_expression = new expression::CaseExpression(
-      VALUE_TYPE_INTEGER, clauses, const_val_exp_3);
-  // TUPLE
+expression::CaseExpression *case_expression = new expression::CaseExpression(
+  VALUE_TYPE_INTEGER, clauses, const_val_exp_3);
+// TUPLE
 
-  std::vector<catalog::Column> columns;
+std::vector<catalog::Column> columns;
 
-  catalog::Column column1(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
-                          "i", true);
-  catalog::Column column2(VALUE_TYPE_DOUBLE, GetTypeSize(VALUE_TYPE_DOUBLE),
-                          "f", true);
-  columns.push_back(column1);
-  columns.push_back(column2);
-  catalog::Schema *schema(new catalog::Schema(columns));
+catalog::Column column1(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        "i", true);
+catalog::Column column2(VALUE_TYPE_DOUBLE, GetTypeSize(VALUE_TYPE_DOUBLE),
+                        "f", true);
+columns.push_back(column1);
+columns.push_back(column2);
+catalog::Schema *schema(new catalog::Schema(columns));
 
-  storage::Tuple *tuple(new storage::Tuple(schema, true));
+storage::Tuple *tuple(new storage::Tuple(schema, true));
 
-  tuple->SetValue(0, ValueFactory::GetIntegerValue(1), nullptr);
-  tuple->SetValue(1, ValueFactory::GetDoubleValue(1.5), nullptr);
+tuple->SetValue(0, ValueFactory::GetIntegerValue(1), nullptr);
+tuple->SetValue(1, ValueFactory::GetDoubleValue(1.5), nullptr);
 
-  Value result = case_expression->Evaluate(tuple, nullptr, nullptr);
+Value result = case_expression->Evaluate(tuple, nullptr, nullptr);
 
-  // Test with A = 1, should get 2
-  EXPECT_EQ(ValuePeeker::PeekAsInteger(result), 2);
+// Test with A = 1, should get 2
+EXPECT_EQ(ValuePeeker::PeekAsInteger(result), 2);
 
-  tuple->SetValue(0, ValueFactory::GetIntegerValue(2), nullptr);
-  tuple->SetValue(1, ValueFactory::GetDoubleValue(-1.5), nullptr);
+tuple->SetValue(0, ValueFactory::GetIntegerValue(2), nullptr);
+tuple->SetValue(1, ValueFactory::GetDoubleValue(-1.5), nullptr);
 
-  result = case_expression->Evaluate(tuple, nullptr, nullptr);
+result = case_expression->Evaluate(tuple, nullptr, nullptr);
 
-  // Test with A = 2, should get 3
-  EXPECT_EQ(ValuePeeker::PeekAsInteger(result), 3);
+// Test with A = 2, should get 3
+EXPECT_EQ(ValuePeeker::PeekAsInteger(result), 3);
 
-  delete case_expression;
-  delete schema;
-  delete tuple;
+delete case_expression;
+delete schema;
+delete tuple;
+}
+
+TEST_F(ExpressionTest, SimpleCaseCopyTest) {
+// CASE WHEN i=1 THEN 2 ELSE 3 END
+
+// EXPRESSION
+
+expression::TupleValueExpression *tup_val_exp =
+  new expression::TupleValueExpression(0, 0);
+expression::ConstantValueExpression *const_val_exp_1 =
+  new expression::ConstantValueExpression(ValueFactory::GetIntegerValue(1));
+expression::ConstantValueExpression *const_val_exp_2 =
+  new expression::ConstantValueExpression(ValueFactory::GetIntegerValue(2));
+expression::ConstantValueExpression *const_val_exp_3 =
+  new expression::ConstantValueExpression(ValueFactory::GetIntegerValue(3));
+
+expression::ComparisonExpression<expression::CmpEq> *case_when_cond =
+  new expression::ComparisonExpression<expression::CmpEq>(
+    EXPRESSION_TYPE_COMPARE_EQUAL, tup_val_exp, const_val_exp_1);
+
+expression::OperatorCaseWhenExpression *case_when_clause =
+  new expression::OperatorCaseWhenExpression(
+    VALUE_TYPE_INTEGER, case_when_cond, const_val_exp_2);
+
+std::vector<expression::AbstractExpression *> clauses;
+clauses.push_back(case_when_clause);
+
+expression::CaseExpression *o_case_expression =
+  new expression::CaseExpression(VALUE_TYPE_INTEGER, clauses,
+                                 const_val_exp_3);
+
+expression::CaseExpression *case_expression =
+  dynamic_cast<expression::CaseExpression *>(o_case_expression->Copy());
+// TUPLE
+
+std::vector<catalog::Column> columns;
+
+catalog::Column column1(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        "i", true);
+catalog::Column column2(VALUE_TYPE_DOUBLE, GetTypeSize(VALUE_TYPE_DOUBLE),
+                        "f", true);
+columns.push_back(column1);
+columns.push_back(column2);
+catalog::Schema *schema(new catalog::Schema(columns));
+
+storage::Tuple *tuple(new storage::Tuple(schema, true));
+
+tuple->SetValue(0, ValueFactory::GetIntegerValue(1), nullptr);
+tuple->SetValue(1, ValueFactory::GetDoubleValue(1.5), nullptr);
+
+Value result = case_expression->Evaluate(tuple, nullptr, nullptr);
+
+// Test with A = 1, should get 2
+EXPECT_EQ(ValuePeeker::PeekAsInteger(result), 2);
+
+tuple->SetValue(0, ValueFactory::GetIntegerValue(2), nullptr);
+tuple->SetValue(1, ValueFactory::GetDoubleValue(-1.5), nullptr);
+
+result = case_expression->Evaluate(tuple, nullptr, nullptr);
+
+// Test with A = 2, should get 3
+EXPECT_EQ(ValuePeeker::PeekAsInteger(result), 3);
+
+delete case_expression;
+delete o_case_expression;
+delete schema;
+delete tuple;
 }
 
 TEST_F(ExpressionTest, UnaryMinus) {
-  // EXPRESSION
+// EXPRESSION
 
-  expression::TupleValueExpression *tup_val_exp_int =
-      new expression::TupleValueExpression(0, 0);
-  expression::TupleValueExpression *tup_val_exp_double =
-      new expression::TupleValueExpression(0, 1);
+expression::TupleValueExpression *tup_val_exp_int =
+  new expression::TupleValueExpression(0, 0);
+expression::TupleValueExpression *tup_val_exp_double =
+  new expression::TupleValueExpression(0, 1);
 
-  // TUPLE
-  expression::OperatorUnaryMinusExpression *unary_minus_int =
-      new expression::OperatorUnaryMinusExpression(tup_val_exp_int);
+// TUPLE
+expression::OperatorUnaryMinusExpression *unary_minus_int =
+  new expression::OperatorUnaryMinusExpression(tup_val_exp_int);
 
-  expression::OperatorUnaryMinusExpression *unary_minus_double =
-      new expression::OperatorUnaryMinusExpression(tup_val_exp_double);
+expression::OperatorUnaryMinusExpression *unary_minus_double =
+  new expression::OperatorUnaryMinusExpression(tup_val_exp_double);
 
-  std::vector<catalog::Column> columns;
+std::vector<catalog::Column> columns;
 
-  catalog::Column column1(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
-                          "i", true);
-  catalog::Column column2(VALUE_TYPE_DOUBLE, GetTypeSize(VALUE_TYPE_DOUBLE),
-                          "f", true);
-  columns.push_back(column1);
-  columns.push_back(column2);
-  catalog::Schema *schema(new catalog::Schema(columns));
+catalog::Column column1(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        "i", true);
+catalog::Column column2(VALUE_TYPE_DOUBLE, GetTypeSize(VALUE_TYPE_DOUBLE),
+                        "f", true);
+columns.push_back(column1);
+columns.push_back(column2);
+catalog::Schema *schema(new catalog::Schema(columns));
 
-  storage::Tuple *tuple(new storage::Tuple(schema, true));
+storage::Tuple *tuple(new storage::Tuple(schema, true));
 
-  // Test with A = 1, should get -1
-  tuple->SetValue(0, ValueFactory::GetIntegerValue(1), nullptr);
-  Value result = unary_minus_int->Evaluate(tuple, nullptr, nullptr);
-  EXPECT_EQ(ValuePeeker::PeekAsInteger(result), -1);
+// Test with A = 1, should get -1
+tuple->SetValue(0, ValueFactory::GetIntegerValue(1), nullptr);
+Value result = unary_minus_int->Evaluate(tuple, nullptr, nullptr);
+EXPECT_EQ(ValuePeeker::PeekAsInteger(result), -1);
 
-  // Test with A = 1.5, should get -1.5
-  tuple->SetValue(1, ValueFactory::GetDoubleValue(1.5), nullptr);
-  result = unary_minus_double->Evaluate(tuple, nullptr, nullptr);
-  EXPECT_EQ(ValuePeeker::PeekDouble(result), -1.5);
+// Test with A = 1.5, should get -1.5
+tuple->SetValue(1, ValueFactory::GetDoubleValue(1.5), nullptr);
+result = unary_minus_double->Evaluate(tuple, nullptr, nullptr);
+EXPECT_EQ(ValuePeeker::PeekDouble(result), -1.5);
 
-  delete unary_minus_double;
-  delete unary_minus_int;
-  delete schema;
-  delete tuple;
+delete unary_minus_double;
+delete unary_minus_int;
+delete schema;
+delete tuple;
+}
+
+TEST_F(ExpressionTest, UnaryMinusCopyTest) {
+// EXPRESSION
+
+expression::TupleValueExpression *tup_val_exp_int =
+  new expression::TupleValueExpression(0, 0);
+expression::TupleValueExpression *tup_val_exp_double =
+  new expression::TupleValueExpression(0, 1);
+
+// TUPLE
+expression::OperatorUnaryMinusExpression *o_unary_minus_int =
+  new expression::OperatorUnaryMinusExpression(tup_val_exp_int);
+
+expression::OperatorUnaryMinusExpression *o_unary_minus_double =
+  new expression::OperatorUnaryMinusExpression(tup_val_exp_double);
+
+expression::OperatorUnaryMinusExpression *unary_minus_int =
+  dynamic_cast<expression::OperatorUnaryMinusExpression *>(
+    o_unary_minus_int->Copy());
+
+expression::OperatorUnaryMinusExpression *unary_minus_double =
+  dynamic_cast<expression::OperatorUnaryMinusExpression *>(
+    o_unary_minus_double->Copy());
+
+std::vector<catalog::Column> columns;
+
+catalog::Column column1(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        "i", true);
+catalog::Column column2(VALUE_TYPE_DOUBLE, GetTypeSize(VALUE_TYPE_DOUBLE),
+                        "f", true);
+columns.push_back(column1);
+columns.push_back(column2);
+catalog::Schema *schema(new catalog::Schema(columns));
+
+storage::Tuple *tuple(new storage::Tuple(schema, true));
+
+// Test with A = 1, should get -1
+tuple->SetValue(0, ValueFactory::GetIntegerValue(1), nullptr);
+Value result = unary_minus_int->Evaluate(tuple, nullptr, nullptr);
+EXPECT_EQ(ValuePeeker::PeekAsInteger(result), -1);
+
+// Test with A = 1.5, should get -1.5
+tuple->SetValue(1, ValueFactory::GetDoubleValue(1.5), nullptr);
+result = unary_minus_double->Evaluate(tuple, nullptr, nullptr);
+EXPECT_EQ(ValuePeeker::PeekDouble(result), -1.5);
+
+delete unary_minus_double;
+delete unary_minus_int;
+delete o_unary_minus_double;
+delete o_unary_minus_int;
+delete schema;
+delete tuple;
 }
 
 }  // End test namespace


### PR DESCRIPTION
In order to support intra-query parallelism, peloton plan tree has to be copied. During copy, the difficult but necessary part is to copy expression classes. 

In this commit, AbstractExpression is added a Copy interface, like following:

`  virtual AbstractExpression *Copy() const = 0;`

Each child class of AbstractExpression  implements this interface, and do recursively copy in a clean manner.

In expression_test, the old tests are extended, to test if copied expressions are correct.