### PR TITLE
Change plan copy interface 

### DIFF
--- a/src/backend/planner/abstract_join_plan.h
+++ b/src/backend/planner/abstract_join_plan.h
@@ -62,7 +62,7 @@ class AbstractJoinPlan : public AbstractPlan {
 
   const catalog::Schema *GetSchema() const { return proj_schema_.get(); }
 
-  AbstractPlan *Copy() const = 0;
+  std::unique_ptr<AbstractPlan> Copy() const = 0;
 
  private:
   /** @brief The type of join that we're going to perform */

--- a/src/backend/planner/abstract_plan.h
+++ b/src/backend/planner/abstract_plan.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <iostream>
+#include <memory>
 #include <cstdint>
 #include <vector>
 #include <map>
@@ -71,10 +73,9 @@ class AbstractPlan : public Printable {
   // Get a string representation for debugging
   const std::string GetInfo() const;
 
-
   virtual std::unique_ptr<AbstractPlan> Copy() const = 0;
 
-private:
+ private:
   // A plan node can have multiple children
   std::vector<const AbstractPlan *> children_;
 

--- a/src/backend/planner/abstract_plan.h
+++ b/src/backend/planner/abstract_plan.h
@@ -72,7 +72,7 @@ class AbstractPlan : public Printable {
   const std::string GetInfo() const;
 
 
-  virtual AbstractPlan *Copy() const = 0;
+  virtual std::unique_ptr<AbstractPlan> Copy() const = 0;
 
 private:
   // A plan node can have multiple children

--- a/src/backend/planner/abstract_scan_plan.h
+++ b/src/backend/planner/abstract_scan_plan.h
@@ -54,7 +54,7 @@ class AbstractScan : public AbstractPlan {
 
   storage::DataTable *GetTable() const { return target_table_; }
 
-  AbstractPlan *Copy() const = 0;
+  std::unique_ptr<AbstractPlan> Copy() const = 0;
 
  private:
   /** @brief Pointer to table to scan from. */

--- a/src/backend/planner/aggregate_plan.h
+++ b/src/backend/planner/aggregate_plan.h
@@ -97,7 +97,7 @@ class AggregatePlan : public AbstractPlan {
 
   const std::vector<oid_t> &GetColumnIds() const { return column_ids_; }
 
-  AbstractPlan *Copy() const {
+  std::unique_ptr<AbstractPlan>Copy() const {
     std::vector<AggTerm> copied_agg_terms;
     for (const AggTerm &term : unique_agg_terms_) {
       copied_agg_terms.push_back(term.Copy());
@@ -107,7 +107,7 @@ class AggregatePlan : public AbstractPlan {
       project_info_->Copy(), predicate_->Copy(), std::move(copied_agg_terms),
       std::move(copied_groupby_col_ids),
       catalog::Schema::CopySchema(output_schema_.get()), agg_strategy_);
-    return new_plan;
+    return std::unique_ptr<AbstractPlan>(new_plan);
   }
 
  private:

--- a/src/backend/planner/aggregate_plan.h
+++ b/src/backend/planner/aggregate_plan.h
@@ -97,16 +97,16 @@ class AggregatePlan : public AbstractPlan {
 
   const std::vector<oid_t> &GetColumnIds() const { return column_ids_; }
 
-  std::unique_ptr<AbstractPlan>Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const {
     std::vector<AggTerm> copied_agg_terms;
     for (const AggTerm &term : unique_agg_terms_) {
       copied_agg_terms.push_back(term.Copy());
     }
     std::vector<oid_t> copied_groupby_col_ids(groupby_col_ids_);
     AggregatePlan *new_plan = new AggregatePlan(
-      project_info_->Copy(), predicate_->Copy(), std::move(copied_agg_terms),
-      std::move(copied_groupby_col_ids),
-      catalog::Schema::CopySchema(output_schema_.get()), agg_strategy_);
+        project_info_->Copy(), predicate_->Copy(), std::move(copied_agg_terms),
+        std::move(copied_groupby_col_ids),
+        catalog::Schema::CopySchema(output_schema_.get()), agg_strategy_);
     return std::unique_ptr<AbstractPlan>(new_plan);
   }
 

--- a/src/backend/planner/append_plan.h
+++ b/src/backend/planner/append_plan.h
@@ -34,9 +34,11 @@ class AppendPlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "Append"; }
 
-  std::unique_ptr<AbstractPlan> Copy() const { return std::unique_ptr<AbstractPlan>(new AppendPlan()); }
+  std::unique_ptr<AbstractPlan> Copy() const {
+    return std::unique_ptr<AbstractPlan>(new AppendPlan());
+  }
 
-private:
+ private:
   // nothing
 };
 }

--- a/src/backend/planner/append_plan.h
+++ b/src/backend/planner/append_plan.h
@@ -34,7 +34,7 @@ class AppendPlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "Append"; }
 
-  AbstractPlan *Copy() const { return new AppendPlan(); }
+  std::unique_ptr<AbstractPlan> Copy() const { return std::unique_ptr<AbstractPlan>(new AppendPlan()); }
 
 private:
   // nothing

--- a/src/backend/planner/delete_plan.h
+++ b/src/backend/planner/delete_plan.h
@@ -42,8 +42,8 @@ class DeletePlan : public AbstractPlan {
 
   bool GetTruncate() const { return truncate; }
 
-  AbstractPlan *Copy() const {
-    return new DeletePlan(target_table_, truncate);
+  std::unique_ptr<AbstractPlan> Copy() const {
+    return std::unique_ptr<AbstractPlan>(new DeletePlan(target_table_, truncate));
   }
 
  private:

--- a/src/backend/planner/delete_plan.h
+++ b/src/backend/planner/delete_plan.h
@@ -43,7 +43,8 @@ class DeletePlan : public AbstractPlan {
   bool GetTruncate() const { return truncate; }
 
   std::unique_ptr<AbstractPlan> Copy() const {
-    return std::unique_ptr<AbstractPlan>(new DeletePlan(target_table_, truncate));
+    return std::unique_ptr<AbstractPlan>(
+        new DeletePlan(target_table_, truncate));
   }
 
  private:

--- a/src/backend/planner/hash_join_plan.h
+++ b/src/backend/planner/hash_join_plan.h
@@ -57,8 +57,8 @@ class HashJoinPlan : public AbstractJoinPlan {
 
   std::unique_ptr<AbstractPlan> Copy() const {
     HashJoinPlan *new_plan = new HashJoinPlan(
-      GetJoinType(), GetPredicate()->Copy(), GetProjInfo()->Copy(),
-      catalog::Schema::CopySchema(GetSchema()), outer_column_ids_);
+        GetJoinType(), GetPredicate()->Copy(), GetProjInfo()->Copy(),
+        catalog::Schema::CopySchema(GetSchema()), outer_column_ids_);
     return std::unique_ptr<AbstractPlan>(new_plan);
   }
 

--- a/src/backend/planner/hash_join_plan.h
+++ b/src/backend/planner/hash_join_plan.h
@@ -55,11 +55,11 @@ class HashJoinPlan : public AbstractJoinPlan {
     return outer_column_ids_;
   }
 
-  AbstractPlan *Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const {
     HashJoinPlan *new_plan = new HashJoinPlan(
       GetJoinType(), GetPredicate()->Copy(), GetProjInfo()->Copy(),
       catalog::Schema::CopySchema(GetSchema()), outer_column_ids_);
-    return new_plan;
+    return std::unique_ptr<AbstractPlan>(new_plan);
   }
 
  private:

--- a/src/backend/planner/hash_plan.h
+++ b/src/backend/planner/hash_plan.h
@@ -44,12 +44,12 @@ class HashPlan : public AbstractPlan {
     return this->hash_keys_;
   }
 
-  AbstractPlan *Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const {
     std::vector<HashKeyPtrType> copied_hash_keys;
     for (const auto &key : hash_keys_) {
       copied_hash_keys.push_back(std::unique_ptr<HashKeyType>(key->Copy()));
     }
-    return new HashPlan(copied_hash_keys);
+    return std::unique_ptr<AbstractPlan>(new HashPlan(copied_hash_keys));
   }
 
  private:

--- a/src/backend/planner/index_scan_plan.h
+++ b/src/backend/planner/index_scan_plan.h
@@ -105,7 +105,7 @@ class IndexScanPlan : public AbstractScan {
 
   const std::string GetInfo() const { return "IndexScan"; }
 
-  AbstractPlan *Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const {
     std::vector<expression::AbstractExpression *> new_runtime_keys;
     for (auto *key : runtime_keys_) {
       new_runtime_keys.push_back(key->Copy());
@@ -115,7 +115,7 @@ class IndexScanPlan : public AbstractScan {
                        new_runtime_keys);
     IndexScanPlan *new_plan = new IndexScanPlan(
       GetTable(), GetPredicate()->Copy(), GetColumnIds(), desc);
-    return new_plan;
+    return std::unique_ptr<AbstractPlan>(new_plan);
   }
 
  private:

--- a/src/backend/planner/index_scan_plan.h
+++ b/src/backend/planner/index_scan_plan.h
@@ -114,7 +114,7 @@ class IndexScanPlan : public AbstractScan {
     IndexScanDesc desc(index_, key_column_ids_, expr_types_, values_,
                        new_runtime_keys);
     IndexScanPlan *new_plan = new IndexScanPlan(
-      GetTable(), GetPredicate()->Copy(), GetColumnIds(), desc);
+        GetTable(), GetPredicate()->Copy(), GetColumnIds(), desc);
     return std::unique_ptr<AbstractPlan>(new_plan);
   }
 

--- a/src/backend/planner/insert_plan.h
+++ b/src/backend/planner/insert_plan.h
@@ -51,8 +51,8 @@ class InsertPlan : public AbstractPlan {
   const std::string GetInfo() const { return "InsertPlan"; }
 
   std::unique_ptr<AbstractPlan> Copy() const {
-    return std::unique_ptr<AbstractPlan>(new InsertPlan(target_table_, project_info_->Copy(),
-                          bulk_insert_count));
+    return std::unique_ptr<AbstractPlan>(new InsertPlan(
+        target_table_, project_info_->Copy(), bulk_insert_count));
   }
 
  private:

--- a/src/backend/planner/insert_plan.h
+++ b/src/backend/planner/insert_plan.h
@@ -50,9 +50,9 @@ class InsertPlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "InsertPlan"; }
 
-  AbstractPlan *Copy() const {
-    return new InsertPlan(target_table_, project_info_->Copy(),
-                          bulk_insert_count);
+  std::unique_ptr<AbstractPlan> Copy() const {
+    return std::unique_ptr<AbstractPlan>(new InsertPlan(target_table_, project_info_->Copy(),
+                          bulk_insert_count));
   }
 
  private:

--- a/src/backend/planner/limit_plan.h
+++ b/src/backend/planner/limit_plan.h
@@ -45,7 +45,7 @@ class LimitPlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "Limit"; }
 
-  AbstractPlan *Copy() const { return new LimitPlan(limit_, offset_); }
+  std::unique_ptr<AbstractPlan> Copy() const { return std::unique_ptr<AbstractPlan>(new LimitPlan(limit_, offset_)); }
 
 private:
   const size_t limit_;   // as LIMIT in SQL standard

--- a/src/backend/planner/limit_plan.h
+++ b/src/backend/planner/limit_plan.h
@@ -45,9 +45,11 @@ class LimitPlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "Limit"; }
 
-  std::unique_ptr<AbstractPlan> Copy() const { return std::unique_ptr<AbstractPlan>(new LimitPlan(limit_, offset_)); }
+  std::unique_ptr<AbstractPlan> Copy() const {
+    return std::unique_ptr<AbstractPlan>(new LimitPlan(limit_, offset_));
+  }
 
-private:
+ private:
   const size_t limit_;   // as LIMIT in SQL standard
   const size_t offset_;  // as OFFSET in SQL standard
 };

--- a/src/backend/planner/materialization_plan.h
+++ b/src/backend/planner/materialization_plan.h
@@ -62,7 +62,7 @@ class MaterializationPlan : public AbstractPlan {
 
   std::unique_ptr<AbstractPlan> Copy() const {
     return std::unique_ptr<AbstractPlan>(new MaterializationPlan(
-      old_to_new_cols_, catalog::Schema::CopySchema(schema_), physify_flag_));
+        old_to_new_cols_, catalog::Schema::CopySchema(schema_), physify_flag_));
   }
 
  private:

--- a/src/backend/planner/materialization_plan.h
+++ b/src/backend/planner/materialization_plan.h
@@ -60,9 +60,9 @@ class MaterializationPlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "Materialize"; }
 
-  AbstractPlan *Copy() const {
-    return new MaterializationPlan(
-      old_to_new_cols_, catalog::Schema::CopySchema(schema_), physify_flag_);
+  std::unique_ptr<AbstractPlan> Copy() const {
+    return std::unique_ptr<AbstractPlan>(new MaterializationPlan(
+      old_to_new_cols_, catalog::Schema::CopySchema(schema_), physify_flag_));
   }
 
  private:

--- a/src/backend/planner/merge_join_plan.h
+++ b/src/backend/planner/merge_join_plan.h
@@ -77,8 +77,8 @@ class MergeJoinPlan : public AbstractJoinPlan {
     }
 
     MergeJoinPlan *new_plan = new MergeJoinPlan(
-      GetJoinType(), GetPredicate()->Copy(), GetProjInfo()->Copy(),
-      catalog::Schema::CopySchema(GetSchema()), new_join_clauses);
+        GetJoinType(), GetPredicate()->Copy(), GetProjInfo()->Copy(),
+        catalog::Schema::CopySchema(GetSchema()), new_join_clauses);
     return std::unique_ptr<AbstractPlan>(new_plan);
   }
 

--- a/src/backend/planner/merge_join_plan.h
+++ b/src/backend/planner/merge_join_plan.h
@@ -68,7 +68,7 @@ class MergeJoinPlan : public AbstractJoinPlan {
 
   const std::string GetInfo() const { return "MergeJoin"; }
 
-  AbstractPlan *Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const {
     std::vector<JoinClause> new_join_clauses;
     for (size_t i = 0; i < join_clauses_.size(); i++) {
       new_join_clauses.push_back(JoinClause(join_clauses_[i].left_->Copy(),
@@ -79,7 +79,7 @@ class MergeJoinPlan : public AbstractJoinPlan {
     MergeJoinPlan *new_plan = new MergeJoinPlan(
       GetJoinType(), GetPredicate()->Copy(), GetProjInfo()->Copy(),
       catalog::Schema::CopySchema(GetSchema()), new_join_clauses);
-    return new_plan;
+    return std::unique_ptr<AbstractPlan>(new_plan);
   }
 
  private:

--- a/src/backend/planner/mock_plan.h
+++ b/src/backend/planner/mock_plan.h
@@ -39,7 +39,7 @@ class MockPlan : public planner::AbstractPlan {
 
   inline const std::string GetInfo() const { return "Mock"; }
 
-  planner::AbstractPlan *Copy() const { return new MockPlan(); }
+  std::unique_ptr<planner::AbstractPlan> Copy() const { return std::unique_ptr<AbstractPlan>(new MockPlan()); }
 
 };
 

--- a/src/backend/planner/mock_plan.h
+++ b/src/backend/planner/mock_plan.h
@@ -39,8 +39,9 @@ class MockPlan : public planner::AbstractPlan {
 
   inline const std::string GetInfo() const { return "Mock"; }
 
-  std::unique_ptr<planner::AbstractPlan> Copy() const { return std::unique_ptr<AbstractPlan>(new MockPlan()); }
-
+  std::unique_ptr<planner::AbstractPlan> Copy() const {
+    return std::unique_ptr<AbstractPlan>(new MockPlan());
+  }
 };
 
 }  // namespace test

--- a/src/backend/planner/nested_loop_join_plan.h
+++ b/src/backend/planner/nested_loop_join_plan.h
@@ -58,11 +58,11 @@ class NestedLoopJoinPlan : public AbstractJoinPlan {
     return nl_;
   }  // added to support IN+subquery
 
-  AbstractPlan *Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const {
     NestedLoopJoinPlan *new_plan = new NestedLoopJoinPlan(
       GetJoinType(), GetPredicate()->Copy(), GetProjInfo()->Copy(),
       catalog::Schema::CopySchema(GetSchema()), nl_);
-    return new_plan;
+    return std::unique_ptr<AbstractPlan>(new_plan);
   }
 
 private:

--- a/src/backend/planner/nested_loop_join_plan.h
+++ b/src/backend/planner/nested_loop_join_plan.h
@@ -60,12 +60,12 @@ class NestedLoopJoinPlan : public AbstractJoinPlan {
 
   std::unique_ptr<AbstractPlan> Copy() const {
     NestedLoopJoinPlan *new_plan = new NestedLoopJoinPlan(
-      GetJoinType(), GetPredicate()->Copy(), GetProjInfo()->Copy(),
-      catalog::Schema::CopySchema(GetSchema()), nl_);
+        GetJoinType(), GetPredicate()->Copy(), GetProjInfo()->Copy(),
+        catalog::Schema::CopySchema(GetSchema()), nl_);
     return std::unique_ptr<AbstractPlan>(new_plan);
   }
 
-private:
+ private:
   NestLoop *nl_;  // added to support IN+subquery
 };
 

--- a/src/backend/planner/order_by_plan.h
+++ b/src/backend/planner/order_by_plan.h
@@ -54,7 +54,8 @@ class OrderByPlan : public AbstractPlan {
   const std::string GetInfo() const { return "OrderBy"; }
 
   std::unique_ptr<AbstractPlan> Copy() const {
-    return std::unique_ptr<AbstractPlan>(new OrderByPlan(sort_keys_, descend_flags_, output_column_ids_));
+    return std::unique_ptr<AbstractPlan>(
+        new OrderByPlan(sort_keys_, descend_flags_, output_column_ids_));
   }
 
  private:

--- a/src/backend/planner/order_by_plan.h
+++ b/src/backend/planner/order_by_plan.h
@@ -53,8 +53,8 @@ class OrderByPlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "OrderBy"; }
 
-  AbstractPlan *Copy() const {
-    return new OrderByPlan(sort_keys_, descend_flags_, output_column_ids_);
+  std::unique_ptr<AbstractPlan> Copy() const {
+    return std::unique_ptr<AbstractPlan>(new OrderByPlan(sort_keys_, descend_flags_, output_column_ids_));
   }
 
  private:

--- a/src/backend/planner/project_info.h
+++ b/src/backend/planner/project_info.h
@@ -85,19 +85,19 @@ class ProjectInfo {
     std::vector<Target> new_target_list;
     for (const Target &target : target_list_) {
       new_target_list.push_back(
-        std::pair<oid_t, const expression::AbstractExpression *>(
-          target.first, target.second->Copy()));
+          std::pair<oid_t, const expression::AbstractExpression *>(
+              target.first, target.second->Copy()));
     }
 
     std::vector<DirectMap> new_map_list;
     for (const DirectMap &aMap : direct_map_list_) {
       new_map_list.push_back(std::pair<oid_t, std::pair<oid_t, oid_t>>(
-        aMap.first,
-        std::pair<oid_t, oid_t>(aMap.second.first, aMap.second.second)));
+          aMap.first,
+          std::pair<oid_t, oid_t>(aMap.second.first, aMap.second.second)));
     }
 
     ProjectInfo *ret =
-      new ProjectInfo(std::move(new_target_list), std::move(new_map_list));
+        new ProjectInfo(std::move(new_target_list), std::move(new_map_list));
     return ret;
   }
 

--- a/src/backend/planner/projection_plan.h
+++ b/src/backend/planner/projection_plan.h
@@ -57,7 +57,7 @@ class ProjectionPlan : public AbstractPlan {
 
   std::unique_ptr<AbstractPlan> Copy() const {
     ProjectionPlan *new_plan = new ProjectionPlan(
-      project_info_->Copy(), catalog::Schema::CopySchema(schema_.get()));
+        project_info_->Copy(), catalog::Schema::CopySchema(schema_.get()));
     new_plan->SetColumnIds(column_ids_);
     return std::unique_ptr<AbstractPlan>(new_plan);
   }

--- a/src/backend/planner/projection_plan.h
+++ b/src/backend/planner/projection_plan.h
@@ -55,11 +55,11 @@ class ProjectionPlan : public AbstractPlan {
 
   const std::vector<oid_t> &GetColumnIds() const { return column_ids_; }
 
-  AbstractPlan *Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const {
     ProjectionPlan *new_plan = new ProjectionPlan(
       project_info_->Copy(), catalog::Schema::CopySchema(schema_.get()));
     new_plan->SetColumnIds(column_ids_);
-    return new_plan;
+    return std::unique_ptr<AbstractPlan>(new_plan);
   }
 
  private:

--- a/src/backend/planner/result_plan.h
+++ b/src/backend/planner/result_plan.h
@@ -48,7 +48,8 @@ class ResultPlan : public AbstractPlan {
   inline std::string GetInfo() const { return "Result"; }
 
   std::unique_ptr<AbstractPlan> Copy() const {
-    return std::unique_ptr<AbstractPlan>(new ResultPlan(new storage::Tuple(*tuple_), backend_));
+    return std::unique_ptr<AbstractPlan>(
+        new ResultPlan(new storage::Tuple(*tuple_), backend_));
   }
 
  private:

--- a/src/backend/planner/result_plan.h
+++ b/src/backend/planner/result_plan.h
@@ -47,8 +47,8 @@ class ResultPlan : public AbstractPlan {
 
   inline std::string GetInfo() const { return "Result"; }
 
-  AbstractPlan *Copy() const {
-    return new ResultPlan(new storage::Tuple(*tuple_), backend_);
+  std::unique_ptr<AbstractPlan> Copy() const {
+    return std::unique_ptr<AbstractPlan>(new ResultPlan(new storage::Tuple(*tuple_), backend_));
   }
 
  private:

--- a/src/backend/planner/seq_scan_plan.h
+++ b/src/backend/planner/seq_scan_plan.h
@@ -44,10 +44,10 @@ class SeqScanPlan : public AbstractScan {
 
   const std::string GetInfo() const { return "SeqScan"; }
 
-  AbstractPlan *Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const {
     AbstractPlan *new_plan = new SeqScanPlan(
       this->GetTable(), this->GetPredicate()->Copy(), this->GetColumnIds());
-    return new_plan;
+    return std::unique_ptr<AbstractPlan>(new_plan);
   }
 };
 

--- a/src/backend/planner/seq_scan_plan.h
+++ b/src/backend/planner/seq_scan_plan.h
@@ -46,7 +46,7 @@ class SeqScanPlan : public AbstractScan {
 
   std::unique_ptr<AbstractPlan> Copy() const {
     AbstractPlan *new_plan = new SeqScanPlan(
-      this->GetTable(), this->GetPredicate()->Copy(), this->GetColumnIds());
+        this->GetTable(), this->GetPredicate()->Copy(), this->GetColumnIds());
     return std::unique_ptr<AbstractPlan>(new_plan);
   }
 };

--- a/src/backend/planner/set_op_plan.h
+++ b/src/backend/planner/set_op_plan.h
@@ -40,7 +40,7 @@ class SetOpPlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "SetOp"; }
 
-  AbstractPlan *Copy() const { return new SetOpPlan(set_op_); }
+  std::unique_ptr<AbstractPlan> Copy() const { return std::unique_ptr<AbstractPlan>(new SetOpPlan(set_op_)); }
 
 private:
   /** @brief Set Operation of this node */

--- a/src/backend/planner/set_op_plan.h
+++ b/src/backend/planner/set_op_plan.h
@@ -40,9 +40,11 @@ class SetOpPlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "SetOp"; }
 
-  std::unique_ptr<AbstractPlan> Copy() const { return std::unique_ptr<AbstractPlan>(new SetOpPlan(set_op_)); }
+  std::unique_ptr<AbstractPlan> Copy() const {
+    return std::unique_ptr<AbstractPlan>(new SetOpPlan(set_op_));
+  }
 
-private:
+ private:
   /** @brief Set Operation of this node */
   SetOpType set_op_;
 };

--- a/src/backend/planner/update_plan.h
+++ b/src/backend/planner/update_plan.h
@@ -51,7 +51,8 @@ class UpdatePlan : public AbstractPlan {
   const std::string GetInfo() const { return "UpdatePlan"; }
 
   std::unique_ptr<AbstractPlan> Copy() const {
-    return std::unique_ptr<AbstractPlan>(new UpdatePlan(target_table_, project_info_->Copy()));
+    return std::unique_ptr<AbstractPlan>(
+        new UpdatePlan(target_table_, project_info_->Copy()));
   }
 
  private:

--- a/src/backend/planner/update_plan.h
+++ b/src/backend/planner/update_plan.h
@@ -50,8 +50,8 @@ class UpdatePlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "UpdatePlan"; }
 
-  AbstractPlan *Copy() const {
-    return new UpdatePlan(target_table_, project_info_->Copy());
+  std::unique_ptr<AbstractPlan> Copy() const {
+    return std::unique_ptr<AbstractPlan>(new UpdatePlan(target_table_, project_info_->Copy()));
   }
 
  private:


### PR DESCRIPTION
As we discussed in #110, the interface changed as follow:

`std::unique_ptr<AbstractPlan> Copy() const = 0`


