### PR TITLE
optimize tuple allocation from data table

### DIFF
--- a/src/backend/concurrency/optimistic_txn_manager.h
+++ b/src/backend/concurrency/optimistic_txn_manager.h
@@ -86,18 +86,18 @@ class OptimisticTxnManager : public TransactionManager {
   }
 
   virtual cid_t GetMaxCommittedCid() {
-    cid_t min_running_cid = 0;
+    cid_t min_running_cid = MAX_CID;
     for (size_t i = 0; i < RUNNING_TXN_BUCKET_NUM; ++i) {
       {
         auto iter = running_txn_buckets_[i].lock_table();
         for (auto &it : iter) {
-          if (min_running_cid == 0 || it.second < min_running_cid) {
+          if (it.second < min_running_cid) {
             min_running_cid = it.second;
           }
         }
       }
     }
-    assert(min_running_cid > 0);
+    assert(min_running_cid > 0 && min_running_cid != MAX_CID);
     return min_running_cid - 1;
   }
   

--- a/src/backend/concurrency/pessimistic_txn_manager.h
+++ b/src/backend/concurrency/pessimistic_txn_manager.h
@@ -85,18 +85,18 @@ class PessimisticTxnManager : public TransactionManager {
   }
 
   virtual cid_t GetMaxCommittedCid() {
-    cid_t min_running_cid = 0;
+    cid_t min_running_cid = MAX_CID;
     for (size_t i = 0; i < RUNNING_TXN_BUCKET_NUM; ++i) {
       {
         auto iter = running_txn_buckets_[i].lock_table();
         for (auto &it : iter) {
-          if (min_running_cid == 0 || it.second < min_running_cid) {
+          if (it.second < min_running_cid) {
             min_running_cid = it.second;
           }
         }
       }
     }
-    assert(min_running_cid > 0);
+    assert(min_running_cid > 0 && min_running_cid != MAX_CID);
     return min_running_cid - 1;
   }
 

--- a/src/backend/concurrency/speculative_read_txn_manager.cpp
+++ b/src/backend/concurrency/speculative_read_txn_manager.cpp
@@ -137,8 +137,9 @@ bool SpeculativeReadTxnManager::PerformRead(const oid_t &tile_group_id,
   // if the tuple is owned by other transaction, then register dependency.
   if (tuple_txn_id != INITIAL_TXN_ID && tuple_txn_id != INVALID_TXN_ID &&
       tuple_txn_id != current_txn_id) {
-    RegisterRetType ret_type = RegisterDependency(tuple_txn_id);
-    if (ret_type == REGISTER_RET_TYPE_NOT_FOUND) {
+    bool ret_type = RegisterDependency(tuple_txn_id);
+    if (ret_type == false) {
+      // we did not find the dependent txn.
       // actually, we can now validate whether this speculative read succeeds.
     }
   }

--- a/src/backend/concurrency/speculative_read_txn_manager.h
+++ b/src/backend/concurrency/speculative_read_txn_manager.h
@@ -21,26 +21,29 @@ namespace concurrency {
 struct SpecTxnContext {
   SpecTxnContext() : outer_dep_count_(0), is_cascading_abort_(false) {}
 
+  void SetBeginCid(const cid_t &begin_cid) {
+    begin_cid_ = begin_cid;
+  }
+
   void Clear() {
+    begin_cid_ = MAX_CID;
     inner_dep_set_.clear();
     outer_dep_set_.clear();
     outer_dep_count_ = 0;
     is_cascading_abort_ = false;
   }
 
+  cid_t begin_cid_;
+  Spinlock inner_dep_set_lock_;
+  // inner_dep_set is modified by other transactions. so lock is required.
   std::unordered_set<txn_id_t> inner_dep_set_;
+  // outer_dep_set is thread_local, and is safe to modify it.
   std::unordered_set<txn_id_t> outer_dep_set_;
-  std::atomic<size_t> outer_dep_count_;   // default: 0
-  std::atomic<bool> is_cascading_abort_;  // default: false
+  volatile std::atomic<size_t> outer_dep_count_;   // default: 0
+  volatile std::atomic<bool> is_cascading_abort_;  // default: false
 };
 
 extern thread_local SpecTxnContext spec_txn_context;
-
-enum RegisterRetType {
-  REGISTER_RET_TYPE_DUPLICATE = 0,
-  REGISTER_RET_TYPE_SUCCESS = 1,
-  REGISTER_RET_TYPE_NOT_FOUND = 2
-};
 
 //===--------------------------------------------------------------------===//
 // optimistic concurrency control with speculative reads
@@ -89,21 +92,21 @@ class SpeculativeReadTxnManager : public TransactionManager {
     cid_t begin_cid = GetNextCommitId();
     Transaction *txn = new Transaction(txn_id, begin_cid);
     current_txn = txn;
-    {
-      std::lock_guard<std::mutex> lock(running_txns_mutex_);
-      assert(running_txns_.find(txn->GetTransactionId()) ==
-             running_txns_.end());
-      running_txns_[txn->GetTransactionId()] = &spec_txn_context;
-    }
+    spec_txn_context.SetBeginCid(begin_cid);
+    
+    cid_t bucket_id = txn_id % RUNNING_TXN_BUCKET_NUM;
+    assert(running_txn_buckets_[bucket_id].contains(txn_id) == false);
+    running_txn_buckets_[bucket_id][txn_id] = &spec_txn_context;
     return txn;
   }
 
   virtual void EndTransaction() {
-    {
-      std::lock_guard<std::mutex> lock(running_txns_mutex_);
-      assert(running_txns_.find(current_txn->GetTransactionId()) !=
-             running_txns_.end());
-      running_txns_.erase(current_txn->GetTransactionId());
+    txn_id_t txn_id = current_txn->GetTransactionId();
+
+    cid_t bucket_id = txn_id % RUNNING_TXN_BUCKET_NUM;
+    bool ret = running_txn_buckets_[bucket_id].erase(txn_id);
+    if (ret == false) {
+      assert(false);
     }
     spec_txn_context.Clear();
 
@@ -112,33 +115,51 @@ class SpeculativeReadTxnManager : public TransactionManager {
   }
 
   virtual cid_t GetMaxCommittedCid() {
-    return 1;
+    cid_t min_running_cid = MAX_CID;
+    for (size_t i = 0; i < RUNNING_TXN_BUCKET_NUM; ++i) {
+      {
+        auto iter = running_txn_buckets_[i].lock_table();
+        for (auto &it : iter) {
+          if (it.second->begin_cid_ < min_running_cid) {
+            min_running_cid = it.second->begin_cid_;
+          }
+        }
+      }
+    }
+    assert(min_running_cid > 0 && min_running_cid != MAX_CID);
+    return min_running_cid - 1;
   }
 
   // is it because this dependency has been registered before?
   // or the dst txn does not exist?
-  RegisterRetType RegisterDependency(const txn_id_t &dst_txn_id) {
+  bool RegisterDependency(const txn_id_t &dst_txn_id) {
     txn_id_t src_txn_id = current_txn->GetTransactionId();
     // if this dependency has been registered before, then return.
     if (spec_txn_context.outer_dep_set_.find(dst_txn_id) !=
         spec_txn_context.outer_dep_set_.end()) {
-      return REGISTER_RET_TYPE_DUPLICATE;
+      return true;
     }
 
     // critical section.
-    {
-      std::lock_guard<std::mutex> lock(running_txns_mutex_);
-      // the dst txn has been committed.
-      if (running_txns_.find(dst_txn_id) == running_txns_.end()) {
-        return REGISTER_RET_TYPE_NOT_FOUND;
-      }
-      auto &dst_txn_context = *(running_txns_.at(dst_txn_id));
-      dst_txn_context.inner_dep_set_.insert(src_txn_id);
-    }
+    // {
+    //   std::lock_guard<std::mutex> lock(running_txns_mutex_);
+    //   // the dst txn has been committed.
+    //   if (running_txns_.find(dst_txn_id) == running_txns_.end()) {
+    //     return false;
+    //   }
+    //   auto &dst_txn_context = *(running_txns_.at(dst_txn_id));
+    //   dst_txn_context.inner_dep_set_.insert(src_txn_id);
+    // }
+
+    running_txn_buckets_[dst_txn_id % RUNNING_TXN_BUCKET_NUM].update_fn(dst_txn_id, [&src_txn_id](SpecTxnContext *context){
+      context->inner_dep_set_lock_.Lock();
+      context->inner_dep_set_.insert(src_txn_id);
+      context->inner_dep_set_lock_.Unlock();
+    });
 
     spec_txn_context.outer_dep_set_.insert(dst_txn_id);
     spec_txn_context.outer_dep_count_++;
-    return REGISTER_RET_TYPE_SUCCESS;
+    return true;
   }
 
   bool IsCommittable() {
@@ -153,32 +174,53 @@ class SpeculativeReadTxnManager : public TransactionManager {
   }
 
   void NotifyCommit() {
-    {
-      std::lock_guard<std::mutex> lock(running_txns_mutex_);
-      // some other transactions may also modify my inner dep set.
-      for (auto &child_txn_id : spec_txn_context.inner_dep_set_) {
-        if (running_txns_.find(child_txn_id) == running_txns_.end()) {
-          continue;
-        }
-        auto &child_txn_context = *(running_txns_.at(child_txn_id));
-        assert(child_txn_context.outer_dep_count_ > 0);
-        child_txn_context.outer_dep_count_--;
-      }
+    //{
+      // std::lock_guard<std::mutex> lock(running_txns_mutex_);
+      // // some other transactions may also modify my inner dep set.
+      // for (auto &child_txn_id : spec_txn_context.inner_dep_set_) {
+      //   if (running_txns_.find(child_txn_id) == running_txns_.end()) {
+      //     continue;
+      //   }
+      //   auto &child_txn_context = *(running_txns_.at(child_txn_id));
+      //   assert(child_txn_context.outer_dep_count_ > 0);
+      //   child_txn_context.outer_dep_count_--;
+      // }
+    //}
+
+    // some other transactions may also modify my inner dep set.
+    // so lock first.
+    spec_txn_context.inner_dep_set_lock_.Lock();
+    for (auto &child_txn_id : spec_txn_context.inner_dep_set_) {
+      running_txn_buckets_[child_txn_id % RUNNING_TXN_BUCKET_NUM].update_fn(child_txn_id, [](SpecTxnContext *context){
+        assert(context->outer_dep_count_ > 0);
+        context->outer_dep_count_--;
+      });
     }
+    spec_txn_context.inner_dep_set_lock_.Unlock();
   }
 
   void NotifyAbort() {
-    {
-      std::lock_guard<std::mutex> lock(running_txns_mutex_);
-      // some other transactions may also modify my inner dep set.
-      for (auto &child_txn_id : spec_txn_context.inner_dep_set_) {
-        if (running_txns_.find(child_txn_id) == running_txns_.end()) {
-          continue;
-        }
-        auto &child_txn_context = *(running_txns_.at(child_txn_id));
-        child_txn_context.is_cascading_abort_ = true;
-      }
+    //{
+      // std::lock_guard<std::mutex> lock(running_txns_mutex_);
+      // // some other transactions may also modify my inner dep set.
+      // for (auto &child_txn_id : spec_txn_context.inner_dep_set_) {
+      //   if (running_txns_.find(child_txn_id) == running_txns_.end()) {
+      //     continue;
+      //   }
+      //   auto &child_txn_context = *(running_txns_.at(child_txn_id));
+      //   child_txn_context.is_cascading_abort_ = true;
+      // }
+    //}
+
+    // some other transactions may also modify my inner dep set.
+    // so lock first.
+    spec_txn_context.inner_dep_set_lock_.Lock();
+    for (auto &child_txn_id : spec_txn_context.inner_dep_set_) {
+      running_txn_buckets_[child_txn_id % RUNNING_TXN_BUCKET_NUM].update_fn(child_txn_id, [](SpecTxnContext *context){
+        context->is_cascading_abort_ = true;
+      });
     }
+    spec_txn_context.inner_dep_set_lock_.Unlock();
   }
 
   virtual Result CommitTransaction();
@@ -186,10 +228,8 @@ class SpeculativeReadTxnManager : public TransactionManager {
   virtual Result AbortTransaction();
 
  private:
-  // should be changed to libcuckoo.
-  std::mutex running_txns_mutex_;
   // records all running transactions.
-  std::unordered_map<txn_id_t, SpecTxnContext *> running_txns_;
+  cuckoohash_map<txn_id_t, SpecTxnContext *> running_txn_buckets_[RUNNING_TXN_BUCKET_NUM];
 };
 }
 }

--- a/src/backend/storage/data_table.cpp
+++ b/src/backend/storage/data_table.cpp
@@ -48,12 +48,12 @@ DataTable::DataTable(catalog::Schema *schema, const std::string &table_name,
                      const size_t &tuples_per_tilegroup, const bool own_schema,
                      const bool adapt_table)
     : AbstractTable(database_oid, table_oid, table_name, schema, own_schema),
-      tuples_per_tilegroup(tuples_per_tilegroup),
-      adapt_table(adapt_table) {
+      tuples_per_tilegroup_(tuples_per_tilegroup), 
+      adapt_table_(adapt_table) {
   // Init default partition
   auto col_count = schema->GetColumnCount();
   for (oid_t col_itr = 0; col_itr < col_count; col_itr++) {
-    default_partition[col_itr] = std::make_pair(0, col_itr);
+    default_partition_[col_itr] = std::make_pair(0, col_itr);
   }
 
   // Create a tile group.
@@ -65,17 +65,17 @@ DataTable::~DataTable() {
   oid_t tile_group_count = GetTileGroupCount();
   for (oid_t tile_group_itr = 0; tile_group_itr < tile_group_count;
        tile_group_itr++) {
-    auto tile_group_id = tile_groups[tile_group_itr];
+    auto tile_group_id = tile_groups_[tile_group_itr];
     catalog::Manager::GetInstance().DropTileGroup(tile_group_id);
   }
 
   // clean up indices
-  for (auto index : indexes) {
+  for (auto index : indexes_) {
     delete index;
   }
 
   // clean up foreign keys
-  for (auto foreign_key : foreign_keys) {
+  for (auto foreign_key : foreign_keys_) {
     delete foreign_key;
   }
 
@@ -122,32 +122,60 @@ ItemPointer DataTable::GetEmptyTupleSlot(const storage::Tuple *tuple,
 
   std::shared_ptr<storage::TileGroup> tile_group;
   oid_t tuple_slot = INVALID_OID;
-  oid_t tile_group_offset = INVALID_OID;
+  //oid_t tile_group_offset = INVALID_OID;
   oid_t tile_group_id = INVALID_OID;
 
-  while (tuple_slot == INVALID_OID) {
-    // First, figure out last tile group
-    {
-      std::lock_guard<std::mutex> lock(table_mutex);
-      assert(GetTileGroupCount() > 0);
-      tile_group_offset = GetTileGroupCount() - 1;
-      LOG_TRACE("Tile group offset :: %lu ", tile_group_offset);
-    }
+  // while (tuple_slot == INVALID_OID) {
+  //   // First, figure out last tile group
+  //   //{
+  //     //std::lock_guard<std::mutex> lock(tile_group_mutex_);
+  //     tile_group_lock_.Lock();
+  //     assert(GetTileGroupCount() > 0);
+  //     tile_group_offset = GetTileGroupCount() - 1;
+  //     tile_group_lock_.Unlock();
+  //     LOG_TRACE("Tile group offset :: %lu ", tile_group_offset);
+  //   //}
 
-    // Then, try to grab a slot in the tile group header
-    tile_group = GetTileGroup(tile_group_offset);
+  //   // Then, try to grab a slot in the tile group header
+  //   tile_group = GetTileGroup(tile_group_offset);
+
+  //   tuple_slot = tile_group->InsertTuple(tuple);
+  //   tile_group_id = tile_group->GetTileGroupId();
+
+  //   if (tuple_slot == INVALID_OID) {
+  //     // attempt to grab a lock.
+  //     // if successful, then add new tile group.
+  //     // else, someone else has already created a new tile.
+
+
+  //     // XXX Should we put this in a critical section?
+  //     AddDefaultTileGroup();
+  //   }
+  // }
+
+  // get valid tuple.
+  while (true) {
+    // get the last tile group.
+    tile_group = GetTileGroup(tile_group_count_ - 1);
 
     tuple_slot = tile_group->InsertTuple(tuple);
-    tile_group_id = tile_group->GetTileGroupId();
 
-    if (tuple_slot == INVALID_OID) {
-      // XXX Should we put this in a critical section?
-      AddDefaultTileGroup();
+    // now we have already obtained a new tuple slot.
+    if (tuple_slot != INVALID_OID) {
+      tile_group_id = tile_group->GetTileGroupId();
+      break;
     }
+
+  }
+  // if this is the last tuple slot we can get
+  // then create a new tile group
+  if (tuple_slot == tile_group->GetAllocatedTupleCount() - 1) {
+    AddDefaultTileGroup();
   }
 
-  LOG_TRACE("tile group offset: %lu, tile group id: %lu, address: %p",
-            tile_group_offset, tile_group->GetTileGroupId(), tile_group.get());
+
+  LOG_TRACE("tile group count: %lu, tile group id: %lu, address: %p",
+            tile_group_count_, tile_group->GetTileGroupId(), tile_group.get());
 
   // Set tuple location
   ItemPointer location(tile_group_id, tuple_slot);
@@ -217,7 +245,7 @@ ItemPointer DataTable::InsertTuple(const storage::Tuple *tuple) {
   // Increase the table's number of tuples by 1
   IncreaseNumberOfTuplesBy(1);
   // Increase the indexes' number of tuples by 1 as well
-  for (auto index : indexes) index->IncreaseNumberOfTuplesBy(1);
+  for (auto index : indexes_) index->IncreaseNumberOfTuplesBy(1);
 
   return location;
 }
@@ -335,8 +363,8 @@ bool DataTable::InsertInSecondaryIndexes(const storage::Tuple *tuple,
  * @param amount amount to increase
  */
 void DataTable::IncreaseNumberOfTuplesBy(const float &amount) {
-  number_of_tuples += amount;
-  dirty = true;
+  number_of_tuples_ += amount;
+  dirty_ = true;
 }
 
 /**
@@ -344,8 +372,8 @@ void DataTable::IncreaseNumberOfTuplesBy(const float &amount) {
  * @param amount amount to decrease
  */
 void DataTable::DecreaseNumberOfTuplesBy(const float &amount) {
-  number_of_tuples -= amount;
-  dirty = true;
+  number_of_tuples_ -= amount;
+  dirty_ = true;
 }
 
 /**
@@ -353,26 +381,26 @@ void DataTable::DecreaseNumberOfTuplesBy(const float &amount) {
  * @param num_tuples number of tuples
  */
 void DataTable::SetNumberOfTuples(const float &num_tuples) {
-  number_of_tuples = num_tuples;
-  dirty = true;
+  number_of_tuples_ = num_tuples;
+  dirty_ = true;
 }
 
 /**
  * @brief Get the number of tuples in this table
  * @return number of tuples
  */
-float DataTable::GetNumberOfTuples() const { return number_of_tuples; }
+float DataTable::GetNumberOfTuples() const { return number_of_tuples_; }
 
 /**
  * @brief return dirty flag
  * @return dirty flag
  */
-bool DataTable::IsDirty() const { return dirty; }
+bool DataTable::IsDirty() const { return dirty_; }
 
 /**
  * @brief Reset dirty flag
  */
-void DataTable::ResetDirty() { dirty = false; }
+void DataTable::ResetDirty() { dirty_ = false; }
 
 //===--------------------------------------------------------------------===//
 // TILE GROUP
@@ -403,7 +431,7 @@ TileGroup *DataTable::GetTileGroupWithLayout(
 
   TileGroup *tile_group = TileGroupFactory::GetTileGroup(
       database_oid, table_oid, tile_group_id, this, schemas, partitioning,
-      tuples_per_tilegroup);
+      tuples_per_tilegroup_);
 
   return tile_group;
 }
@@ -412,7 +440,7 @@ column_map_type DataTable::GetTileGroupLayout(LayoutType layout_type) {
   column_map_type column_map;
 
   auto col_count = schema->GetColumnCount();
-  if (adapt_table == false) layout_type = LAYOUT_ROW;
+  if (adapt_table_ == false) layout_type = LAYOUT_ROW;
 
   // pure row layout map
   if (layout_type == LAYOUT_ROW) {
@@ -458,43 +486,57 @@ oid_t DataTable::AddDefaultTileGroup() {
 
   LOG_TRACE("Trying to add a tile group ");
   {
-    std::lock_guard<std::mutex> lock(table_mutex);
+    //std::lock_guard<std::mutex> lock(tile_group_mutex_);
 
     // Check if we actually need to allocate a tile group
 
     // (A) no tile groups in table
-    if (tile_groups.empty()) {
-      LOG_TRACE("Added first tile group ");
-      tile_groups.push_back(tile_group->GetTileGroupId());
-      // add tile group metadata in locator
-      catalog::Manager::GetInstance().AddTileGroup(tile_group_id, tile_group);
-      LOG_TRACE("Recording tile group : %lu ", tile_group_id);
-      return tile_group_id;
-    }
+    // if (tile_groups_.empty()) {
+    //   LOG_TRACE("Added first tile group ");
+    //   tile_groups_.push_back(tile_group->GetTileGroupId());
+    //   // add tile group metadata in locator
+    //   catalog::Manager::GetInstance().AddTileGroup(tile_group_id, tile_group);
+      
+    //   // do we need this fence?
+    //   // we must guarantee that the compiler always add tile group before adding tile_group_count_.
+    //   COMPILER_MEMORY_FENCE;
+      
+    //   tile_group_count_++;
+      
+    //   LOG_TRACE("Recording tile group : %lu ", tile_group_id);
+    //   return tile_group_id;
+    // }
 
     // (B) no slots in last tile group in table
-    auto last_tile_group_offset = GetTileGroupCount() - 1;
-    auto last_tile_group = GetTileGroup(last_tile_group_offset);
+    //auto last_tile_group_offset = GetTileGroupCount() - 1;
+    //auto last_tile_group = GetTileGroup(last_tile_group_offset);
 
-    oid_t active_tuple_count = last_tile_group->GetNextTupleSlot();
-    oid_t allocated_tuple_count = last_tile_group->GetAllocatedTupleCount();
-    if (active_tuple_count < allocated_tuple_count) {
-      LOG_TRACE("Slot exists in last tile group :: %lu %lu ",
-                active_tuple_count, allocated_tuple_count);
-      return INVALID_OID;
-    }
+    //oid_t active_tuple_count = last_tile_group->GetNextTupleSlot();
+    //oid_t allocated_tuple_count = last_tile_group->GetAllocatedTupleCount();
+    // if (active_tuple_count < allocated_tuple_count) {
+    //   LOG_TRACE("Slot exists in last tile group :: %lu %lu ",
+    //             active_tuple_count, allocated_tuple_count);
+    //   return INVALID_OID;
+    // }
 
     LOG_TRACE("Added a tile group ");
-    tile_groups.push_back(tile_group->GetTileGroupId());
+    tile_groups_.push_back(tile_group->GetTileGroupId());
 
     // add tile group metadata in locator
     catalog::Manager::GetInstance().AddTileGroup(tile_group_id, tile_group);
+    
+    // we must guarantee that the compiler always add tile group before adding tile_group_count_.
+    COMPILER_MEMORY_FENCE;
+
+    tile_group_count_++;
+
     LOG_TRACE("Recording tile group : %lu ", tile_group_id);
   }
 
   return tile_group_id;
 }
 
+// TODO: who calls this function? do we need mutex??
 oid_t DataTable::AddTileGroupWithOid(const oid_t &tile_group_id) {
   assert(tile_group_id);
 
@@ -510,45 +552,59 @@ oid_t DataTable::AddTileGroupWithOid(const oid_t &tile_group_id) {
 
   std::shared_ptr<TileGroup> tile_group(TileGroupFactory::GetTileGroup(
       database_oid, table_oid, tile_group_id, this, schemas, column_map,
-      tuples_per_tilegroup));
+      tuples_per_tilegroup_));
 
   LOG_TRACE("Trying to add a tile group ");
   {
-    std::lock_guard<std::mutex> lock(table_mutex);
+    //std::lock_guard<std::mutex> lock(tile_group_mutex_);
 
     LOG_TRACE("Added a tile group ");
-    tile_groups.push_back(tile_group->GetTileGroupId());
+    tile_groups_.push_back(tile_group->GetTileGroupId());
 
     // add tile group metadata in locator
     catalog::Manager::GetInstance().AddTileGroup(tile_group_id, tile_group);
+
+    // we must guarantee that the compiler always add tile group before adding tile_group_count_.
+    COMPILER_MEMORY_FENCE;
+
+    tile_group_count_++;
+
     LOG_TRACE("Recording tile group : %lu ", tile_group_id);
   }
 
   return tile_group_id;
 }
 
+// TODO: who calls this function? do we need mutex??
 void DataTable::AddTileGroup(const std::shared_ptr<TileGroup> &tile_group) {
   {
-    std::lock_guard<std::mutex> lock(table_mutex);
+    //std::lock_guard<std::mutex> lock(tile_group_mutex_);
 
-    tile_groups.push_back(tile_group->GetTileGroupId());
+    tile_groups_.push_back(tile_group->GetTileGroupId());
     oid_t tile_group_id = tile_group->GetTileGroupId();
 
     // add tile group in catalog
     catalog::Manager::GetInstance().AddTileGroup(tile_group_id, tile_group);
+    
+    // we must guarantee that the compiler always add tile group before adding tile_group_count_.
+    COMPILER_MEMORY_FENCE;
+
+    tile_group_count_++;
+
+
     LOG_TRACE("Recording tile group : %lu ", tile_group_id);
   }
 }
 
 size_t DataTable::GetTileGroupCount() const {
-  size_t size = tile_groups.size();
+  size_t size = tile_groups_.size();
   return size;
 }
 
 std::shared_ptr<storage::TileGroup> DataTable::GetTileGroup(
     const oid_t &tile_group_offset) const {
   assert(tile_group_offset < GetTileGroupCount());
-  auto tile_group_id = tile_groups[tile_group_offset];
+  auto tile_group_id = tile_groups_[tile_group_offset];
   return GetTileGroupById(tile_group_id);
 }
 
@@ -593,21 +649,21 @@ const std::string DataTable::GetInfo() const {
 
 void DataTable::AddIndex(index::Index *index) {
   {
-    std::lock_guard<std::mutex> lock(table_mutex);
-    indexes.push_back(index);
+    std::lock_guard<std::mutex> lock(tile_group_mutex_);
+    indexes_.push_back(index);
   }
 
   // Update index stats
   auto index_type = index->GetIndexType();
   if (index_type == INDEX_CONSTRAINT_TYPE_PRIMARY_KEY) {
-    has_primary_key = true;
+    has_primary_key_ = true;
   } else if (index_type == INDEX_CONSTRAINT_TYPE_UNIQUE) {
-    unique_constraint_count++;
+    unique_constraint_count_++;
   }
 }
 
 index::Index *DataTable::GetIndexWithOid(const oid_t &index_oid) const {
-  for (auto index : indexes)
+  for (auto index : indexes_)
     if (index->GetOid() == index_oid) return index;
 
   return nullptr;
@@ -615,27 +671,27 @@ index::Index *DataTable::GetIndexWithOid(const oid_t &index_oid) const {
 
 void DataTable::DropIndexWithOid(const oid_t &index_id) {
   {
-    std::lock_guard<std::mutex> lock(table_mutex);
+    std::lock_guard<std::mutex> lock(tile_group_mutex_);
 
     oid_t index_offset = 0;
-    for (auto index : indexes) {
+    for (auto index : indexes_) {
       if (index->GetOid() == index_id) break;
       index_offset++;
     }
-    assert(index_offset < indexes.size());
+    assert(index_offset < indexes_.size());
 
     // Drop the index
-    indexes.erase(indexes.begin() + index_offset);
+    indexes_.erase(indexes_.begin() + index_offset);
   }
 }
 
 index::Index *DataTable::GetIndex(const oid_t &index_offset) const {
-  assert(index_offset < indexes.size());
-  auto index = indexes.at(index_offset);
+  assert(index_offset < indexes_.size());
+  auto index = indexes_.at(index_offset);
   return index;
 }
 
-oid_t DataTable::GetIndexCount() const { return indexes.size(); }
+oid_t DataTable::GetIndexCount() const { return indexes_.size(); }
 
 //===--------------------------------------------------------------------===//
 // FOREIGN KEYS
@@ -643,7 +699,7 @@ oid_t DataTable::GetIndexCount() const { return indexes.size(); }
 
 void DataTable::AddForeignKey(catalog::ForeignKey *key) {
   {
-    std::lock_guard<std::mutex> lock(table_mutex);
+    std::lock_guard<std::mutex> lock(tile_group_mutex_);
     catalog::Schema *schema = this->GetSchema();
     catalog::Constraint constraint(CONSTRAINT_TYPE_FOREIGN,
                                    key->GetConstraintName());
@@ -653,25 +709,25 @@ void DataTable::AddForeignKey(catalog::ForeignKey *key) {
     }
     // TODO :: We need this one..
     catalog::ForeignKey *fk = new catalog::ForeignKey(*key);
-    foreign_keys.push_back(fk);
+    foreign_keys_.push_back(fk);
   }
 }
 
 catalog::ForeignKey *DataTable::GetForeignKey(const oid_t &key_offset) const {
   catalog::ForeignKey *key = nullptr;
-  key = foreign_keys.at(key_offset);
+  key = foreign_keys_.at(key_offset);
   return key;
 }
 
 void DataTable::DropForeignKey(const oid_t &key_offset) {
   {
-    std::lock_guard<std::mutex> lock(table_mutex);
-    assert(key_offset < foreign_keys.size());
-    foreign_keys.erase(foreign_keys.begin() + key_offset);
+    std::lock_guard<std::mutex> lock(tile_group_mutex_);
+    assert(key_offset < foreign_keys_.size());
+    foreign_keys_.erase(foreign_keys_.begin() + key_offset);
   }
 }
 
-oid_t DataTable::GetForeignKeyCount() const { return foreign_keys.size(); }
+oid_t DataTable::GetForeignKeyCount() const { return foreign_keys_.size(); }
 
 // Get the schema for the new transformed tile group
 std::vector<catalog::Schema> TransformTileGroupSchema(
@@ -751,17 +807,17 @@ void SetTransformedTileGroup(storage::TileGroup *orig_tile_group,
 storage::TileGroup *DataTable::TransformTileGroup(
     const oid_t &tile_group_offset, const double &theta) {
   // First, check if the tile group is in this table
-  if (tile_group_offset >= tile_groups.size()) {
+  if (tile_group_offset >= tile_groups_.size()) {
     LOG_ERROR("Tile group offset not found in table : %lu ", tile_group_offset);
     return nullptr;
   }
 
-  auto tile_group_id = tile_groups[tile_group_offset];
+  auto tile_group_id = tile_groups_[tile_group_offset];
 
   // Get orig tile group from catalog
   auto &catalog_manager = catalog::Manager::GetInstance();
   auto tile_group = catalog_manager.GetTileGroup(tile_group_id);
-  auto diff = tile_group->GetSchemaDifference(default_partition);
+  auto diff = tile_group->GetSchemaDifference(default_partition_);
 
   // Check threshold for transformation
   if (diff < theta) {
@@ -770,14 +826,14 @@ storage::TileGroup *DataTable::TransformTileGroup(
 
   // Get the schema for the new transformed tile group
   auto new_schema =
-      TransformTileGroupSchema(tile_group.get(), default_partition);
+      TransformTileGroupSchema(tile_group.get(), default_partition_);
 
   // Allocate space for the transformed tile group
   std::shared_ptr<storage::TileGroup> new_tile_group(
       TileGroupFactory::GetTileGroup(
           tile_group->GetDatabaseId(), tile_group->GetTableId(),
           tile_group->GetTileGroupId(), tile_group->GetAbstractTable(),
-          new_schema, default_partition, tile_group->GetAllocatedTupleCount()));
+          new_schema, default_partition_, tile_group->GetAllocatedTupleCount()));
 
   // Set the transformed tile group column-at-a-time
   SetTransformedTileGroup(tile_group.get(), new_tile_group.get());
@@ -792,20 +848,20 @@ storage::TileGroup *DataTable::TransformTileGroup(
 void DataTable::RecordSample(const brain::Sample &sample) {
   // Add sample
   {
-    std::lock_guard<std::mutex> lock(clustering_mutex);
-    samples.push_back(sample);
+    std::lock_guard<std::mutex> lock(clustering_mutex_);
+    samples_.push_back(sample);
   }
 }
 
 const column_map_type &DataTable::GetDefaultPartition() {
-  return default_partition;
+  return default_partition_;
 }
 
 std::map<oid_t, oid_t> DataTable::GetColumnMapStats() {
   std::map<oid_t, oid_t> column_map_stats;
 
   // Cluster per-tile column count
-  for (auto entry : default_partition) {
+  for (auto entry : default_partition_) {
     auto tile_id = entry.second.first;
     auto column_map_itr = column_map_stats.find(tile_id);
     if (column_map_itr == column_map_stats.end())
@@ -828,20 +884,20 @@ void DataTable::UpdateDefaultPartition() {
 
   // Process all samples
   {
-    std::lock_guard<std::mutex> lock(clustering_mutex);
+    std::lock_guard<std::mutex> lock(clustering_mutex_);
 
     // Check if we have any samples
-    if (samples.empty()) return;
+    if (samples_.empty()) return;
 
-    for (auto sample : samples) {
+    for (auto sample : samples_) {
       clusterer.ProcessSample(sample);
     }
 
-    samples.clear();
+    samples_.clear();
   }
 
   // TODO: Max number of tiles
-  default_partition = clusterer.GetPartitioning(2);
+  default_partition_ = clusterer.GetPartitioning(2);
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/backend/storage/data_table.h
+++ b/src/backend/storage/data_table.h
@@ -19,6 +19,7 @@
 #include "backend/catalog/foreign_key.h"
 #include "backend/storage/abstract_table.h"
 #include "backend/concurrency/transaction.h"
+#include "backend/common/platform.h"
 
 //===--------------------------------------------------------------------===//
 // GUC Variables
@@ -60,6 +61,7 @@ namespace storage {
 
 class Tuple;
 class TileGroup;
+
 
 //===--------------------------------------------------------------------===//
 // DataTable
@@ -190,9 +192,9 @@ class DataTable : public AbstractTable {
   // UTILITIES
   //===--------------------------------------------------------------------===//
 
-  bool HasPrimaryKey() { return has_primary_key; }
+  bool HasPrimaryKey() { return has_primary_key_; }
 
-  bool HasUniqueConstraints() { return (unique_constraint_count > 0); }
+  bool HasUniqueConstraints() { return (unique_constraint_count_ > 0); }
 
   bool HasForeignKeys() { return (GetForeignKeyCount() > 0); }
 
@@ -239,43 +241,49 @@ class DataTable : public AbstractTable {
 
   // TODO need some policy ?
   // number of tuples allocated per tilegroup
-  size_t tuples_per_tilegroup;
+  size_t tuples_per_tilegroup_;
 
+  // TILE GROUPS
   // set of tile groups
-  std::vector<oid_t> tile_groups;
+  std::vector<oid_t> tile_groups_;
+  std::atomic<size_t> tile_group_count_ = ATOMIC_VAR_INIT(0);
+  // current tile group
+  //size_t tile_group_offset_ = 0;
+
+  // tile group mutex
+  std::mutex tile_group_mutex_;
+  Spinlock tile_group_lock_;
 
   // INDEXES
-  std::vector<index::Index *> indexes;
+  std::vector<index::Index *> indexes_;
 
   // CONSTRAINTS
-  std::vector<catalog::ForeignKey *> foreign_keys;
+  std::vector<catalog::ForeignKey *> foreign_keys_;
 
-  // table mutex
-  std::mutex table_mutex;
 
   // has a primary key ?
-  std::atomic<bool> has_primary_key = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> has_primary_key_ = ATOMIC_VAR_INIT(false);
 
   // # of unique constraints
-  std::atomic<oid_t> unique_constraint_count = ATOMIC_VAR_INIT(START_OID);
+  std::atomic<oid_t> unique_constraint_count_ = ATOMIC_VAR_INIT(START_OID);
 
   // # of tuples
-  float number_of_tuples = 0.0;
+  float number_of_tuples_ = 0.0;
 
   // dirty flag
-  bool dirty = false;
+  bool dirty_ = false;
 
   // clustering mutex
-  std::mutex clustering_mutex;
+  std::mutex clustering_mutex_;
 
   // adapt table
-  bool adapt_table = true;
+  bool adapt_table_ = true;
 
   // default partition map for table
-  column_map_type default_partition;
+  column_map_type default_partition_;
 
   // samples for clustering
-  std::vector<brain::Sample> samples;
+  std::vector<brain::Sample> samples_;
 };
 
 }  // End storage namespace

--- a/tests/executor/loader_test.cpp
+++ b/tests/executor/loader_test.cpp
@@ -122,8 +122,9 @@ TEST_F(LoaderTests, LoadingTest) {
   LaunchParallelTest(loader_threads_count, InsertTuple, data_table.get(),
                      testing_pool, tilegroup_count_per_loader);
 
+  // NOTE: WE HAVE CHANGED TILE-GROUP ALLOCATION MECHANISM.
   auto expected_tile_group_count =
-      loader_threads_count * tilegroup_count_per_loader;
+      loader_threads_count * tilegroup_count_per_loader + 1;
   auto bytes_to_megabytes_converter = (1024 * 1024);
 
   EXPECT_EQ(data_table->GetTileGroupCount(), expected_tile_group_count);

--- a/tests/executor/mutate_test.cpp
+++ b/tests/executor/mutate_test.cpp
@@ -300,7 +300,9 @@ TEST_F(MutateTests, InsertTest) {
       ExecutorTestsUtil::CreateTable());
   const std::vector<storage::Tuple *> tuples;
 
-  EXPECT_EQ(source_data_table->GetTileGroupCount(), 3);
+  // NOTE: WE HAVE CHANGED TILE-GROUP ALLOCATION MECHANISM.
+  EXPECT_EQ(source_data_table->GetTileGroupCount(), 4);
+  //EXPECT_EQ(source_data_table->GetTileGroupCount(), 3);
   EXPECT_EQ(dest_data_table->GetTileGroupCount(), 1);
 
   auto txn = txn_manager.BeginTransaction();
@@ -343,7 +345,9 @@ TEST_F(MutateTests, InsertTest) {
   txn_manager.CommitTransaction();
 
   // We have inserted all the tuples in this logical tile
-  EXPECT_EQ(dest_data_table->GetTileGroupCount(), 1);
+  // NOTE: WE HAVE CHANGED TILE-GROUP ALLOCATION MECHANISM.
+  EXPECT_EQ(dest_data_table->GetTileGroupCount(), 2);
+  //EXPECT_EQ(dest_data_table->GetTileGroupCount(), 1);
 }
 
 TEST_F(MutateTests, DeleteTest) {

--- a/tests/storage/tile_group_iterator_test.cpp
+++ b/tests/storage/tile_group_iterator_test.cpp
@@ -52,7 +52,7 @@ TEST_F(TileGroupIteratorTests, BasicTest) {
     }
   }  // WHILE
 
-  EXPECT_EQ(expected_tilegroup_count, actual_tile_group_count);
+  EXPECT_EQ(expected_tilegroup_count + 1, actual_tile_group_count);
 }
 
 }  // End test namespace


### PR DESCRIPTION
Previous implementation leverages mutex to synchronize tuple allocation. In the worst case, three mutexes must be locked in one function call. This is quite inefficient, as mutex utilizes signals to achieve thread-level synchronization. Our new implementation adopts spinlocks (cas inside) to optimize tuple allocation. Our experiments on a 12-core machine confirms that our storage can scale well even under write-intensive workload.