### PR TITLE
Fix bug in handling empty project_info in plan transformers

### DIFF
--- a/src/backend/bridge/dml/mapper/mapper_agg.cpp
+++ b/src/backend/bridge/dml/mapper/mapper_agg.cpp
@@ -39,7 +39,12 @@ std::unique_ptr<planner::AbstractPlan> PlanTransformer::TransformAgg(
   /* Get project info */
   std::unique_ptr<const planner::ProjectInfo> proj_info(
       BuildProjectInfoFromTLSkipJunk(targetlist));
-  LOG_INFO("proj_info : %s", proj_info->Debug().c_str());
+  if (proj_info.get() != nullptr) {
+    LOG_INFO("proj_info : %s", proj_info->Debug().c_str());
+  } else {
+    LOG_INFO("empty projection info");
+  }
+
 
   /* Get predicate */
   std::unique_ptr<const expression::AbstractExpression> predicate(

--- a/src/backend/bridge/dml/mapper/mapper_hash_join.cpp
+++ b/src/backend/bridge/dml/mapper/mapper_hash_join.cpp
@@ -65,7 +65,11 @@ std::unique_ptr<planner::AbstractPlan> PlanTransformer::TransformHashJoin(
 
   project_info.reset(BuildProjectInfoFromTLSkipJunk(hj_plan_state->targetlist));
 
-  LOG_INFO("%s", project_info.get()->Debug().c_str());
+  if (project_info.get() != nullptr) {
+    LOG_INFO("%s", project_info.get()->Debug().c_str());
+  } else {
+    LOG_INFO("empty projection info");
+  }
 
   std::shared_ptr<const catalog::Schema> project_schema(
       SchemaTransformer::GetSchemaFromTupleDesc(
@@ -74,7 +78,8 @@ std::unique_ptr<planner::AbstractPlan> PlanTransformer::TransformHashJoin(
   std::vector<oid_t> outer_hashkeys =
       BuildColumnListFromExpStateList(hj_plan_state->outer_hashkeys);
 
-  bool non_trivial = project_info.get()->isNonTrivial();
+  bool non_trivial = (project_info.get() != nullptr &&
+                      project_info.get()->isNonTrivial());
   if (non_trivial) {
     // we have non-trivial projection
     LOG_INFO("We have non-trivial projection");

--- a/src/backend/bridge/dml/mapper/mapper_merge_join.cpp
+++ b/src/backend/bridge/dml/mapper/mapper_merge_join.cpp
@@ -69,7 +69,8 @@ std::unique_ptr<planner::AbstractPlan> PlanTransformer::TransformMergeJoin(
 
   project_info.reset(BuildProjectInfoFromTLSkipJunk(mj_plan_state->targetlist));
 
-  bool non_trivial = project_info.get()->isNonTrivial();
+  bool non_trivial = (project_info.get() != nullptr &&
+                      project_info.get()->isNonTrivial());
   if (non_trivial) {
     // we have non-trivial projection
     LOG_INFO("We have non-trivial projection");

--- a/src/backend/bridge/dml/mapper/mapper_nested_loop_join.cpp
+++ b/src/backend/bridge/dml/mapper/mapper_nested_loop_join.cpp
@@ -60,14 +60,19 @@ std::unique_ptr<planner::AbstractPlan> PlanTransformer::TransformNestLoop(
 
   project_info.reset(BuildProjectInfo(nl_plan_state->ps_ProjInfo));
 
-  LOG_INFO("%s", project_info.get()->Debug().c_str());
+  if (project_info.get() != nullptr) {
+    LOG_INFO("%s", project_info.get()->Debug().c_str());
+  } else {
+    LOG_INFO("empty projection info");
+  }
 
   std::unique_ptr<planner::AbstractPlan> result;
   std::shared_ptr<const catalog::Schema> project_schema(
       SchemaTransformer::GetSchemaFromTupleDesc(
           nl_plan_state->tts_tupleDescriptor));
 
-  bool non_trivial = project_info.get()->isNonTrivial();
+  bool non_trivial = (project_info.get() != nullptr &&
+                      project_info.get()->isNonTrivial());
   if (non_trivial) {
     // we have non-trivial projection
     LOG_INFO("We have non-trivial projection");


### PR DESCRIPTION
This following statement fails:
```
SELECT count(*) FROM a, b, c, d
```
because `project_info` is a nullptr and our code did not handle it properly.