### PR TITLE
fix bug in transforming empty strings in scan key

### DIFF
--- a/src/backend/bridge/dml/expr/expr_transformer.cpp
+++ b/src/backend/bridge/dml/expr/expr_transformer.cpp
@@ -76,6 +76,10 @@ expression::AbstractExpression *ExprTransformer::TransformExpr(
       peloton_expr = TransformScalarArrayOp(expr_state);
       break;
 
+    case T_ArrayExpr:
+      peloton_expr = TransformArray(expr_state);
+      break;
+
     case T_Var:
       peloton_expr = TransformVar(expr_state);
       break;
@@ -140,6 +144,10 @@ expression::AbstractExpression *ExprTransformer::TransformExpr(
 
     case T_RelabelType:
       peloton_expr = TransformRelabelType(expr);
+      break;
+
+    case T_Param:
+      peloton_expr = TransformParam(expr);
       break;
 
     default:
@@ -298,6 +306,29 @@ expression::AbstractExpression *ExprTransformer::TransformScalarArrayOp(
       EXPRESSION_TYPE_COMPARE_IN, lc, rc);
   // return expression::ComparisonFactory(EXPRESSION_TYPE_COMPARE_EQUAL, lc,
   // rc);
+}
+
+expression::AbstractExpression *ExprTransformer::TransformArray(
+    const ExprState *es) {
+  LOG_TRACE("Transform ScalarArrayOp ");
+
+  auto array_expr = reinterpret_cast<const ArrayExpr *>(es->expr);
+
+  // Can only handle one dimension array now
+  if (array_expr->multidims)
+    LOG_ERROR("Do not support multi-dimension array");
+
+  std::vector<expression::AbstractExpression *> vals;
+  ListCell *arg;
+  foreach (arg, array_expr->elements) {
+    Expr *arg_expr = (Expr *)lfirst(arg);
+    vals.push_back(TransformExpr(arg_expr));
+  }
+  PostgresValueType pt =
+    static_cast<PostgresValueType>(array_expr->element_typeid);
+  ValueType vt = PostgresValueTypeToPelotonValueType(pt);
+
+  return expression::ExpressionUtil::VectorFactory(vt, vals);
 }
 
 expression::AbstractExpression *ExprTransformer::TransformFunc(
@@ -515,9 +546,15 @@ expression::AbstractExpression *ExprTransformer::TransformBool(
   return nullptr;
 }
 
+// Backward compatible for expr state
 expression::AbstractExpression *ExprTransformer::TransformParam(
     const ExprState *es) {
-  auto param_expr = reinterpret_cast<const Param *>(es->expr);
+  return TransformParam(es->expr);
+}
+
+expression::AbstractExpression *ExprTransformer::TransformParam(
+    const Expr *expr) {
+  auto param_expr = reinterpret_cast<const Param *>(expr);
 
   switch (param_expr->paramkind) {
     case PARAM_EXTERN: {

--- a/src/backend/bridge/dml/expr/expr_transformer.h
+++ b/src/backend/bridge/dml/expr/expr_transformer.h
@@ -50,6 +50,7 @@ class ExprTransformer {
   static expression::AbstractExpression *TransformOp(const ExprState *es);
   static expression::AbstractExpression *TransformScalarArrayOp(
       const ExprState *es);  // added by michael for IN operator
+  static expression::AbstractExpression *TransformArray(const ExprState *es);
   static expression::AbstractExpression *TransformVar(const ExprState *es);
   static expression::AbstractExpression *TransformBool(const ExprState *es);
   static expression::AbstractExpression *TransformParam(const ExprState *es);

--- a/src/backend/bridge/dml/mapper/dml_utils.cpp
+++ b/src/backend/bridge/dml/mapper/dml_utils.cpp
@@ -40,7 +40,7 @@ namespace bridge {
 // DML Utils
 //===--------------------------------------------------------------------===//
 
-ExprState *CopyExprState(ExprState *expr_state);
+ExprState *CopyExprState(const ExprState *expr_state);
 List *CopyExprStateList(List *from);
 
 ScanKeyData *CopyScanKey(ScanKeyData *scan_key, int num_keys,
@@ -53,7 +53,7 @@ MergeJoinClauseData *CopyMergeJoinClause(MergeJoinClauseData *from,
                                          int numClauses);
 
 AbstractPlanState *DMLUtils::PreparePlanState(AbstractPlanState *root,
-                                              PlanState *planstate,
+                                              const PlanState *planstate,
                                               bool left_child) {
   // Base case
   if (planstate == nullptr) return root;
@@ -64,67 +64,67 @@ AbstractPlanState *DMLUtils::PreparePlanState(AbstractPlanState *root,
   switch (planstate_type) {
     case T_ModifyTableState:
       child_planstate = PrepareModifyTableState(
-          reinterpret_cast<ModifyTableState *>(planstate));
+          reinterpret_cast<const ModifyTableState *>(planstate));
       break;
 
     case T_SeqScanState:
-      child_planstate =
-          PrepareSeqScanState(reinterpret_cast<SeqScanState *>(planstate));
+      child_planstate = PrepareSeqScanState(
+          reinterpret_cast<const SeqScanState *>(planstate));
       break;
     case T_IndexScanState:
-      child_planstate =
-          PrepareIndexScanState(reinterpret_cast<IndexScanState *>(planstate));
+      child_planstate = PrepareIndexScanState(
+          reinterpret_cast<const IndexScanState *>(planstate));
       break;
     case T_IndexOnlyScanState:
       child_planstate = PrepareIndexOnlyScanState(
-          reinterpret_cast<IndexOnlyScanState *>(planstate));
+          reinterpret_cast<const IndexOnlyScanState *>(planstate));
       break;
     case T_BitmapHeapScanState:
       child_planstate = PrepareBitmapHeapScanState(
-          reinterpret_cast<BitmapHeapScanState *>(planstate));
+          reinterpret_cast<const BitmapHeapScanState *>(planstate));
       break;
     case T_BitmapIndexScanState:
       child_planstate = PrepareBitmapIndexScanState(
-          reinterpret_cast<BitmapIndexScanState *>(planstate));
+          reinterpret_cast<const BitmapIndexScanState *>(planstate));
       break;
 
     case T_LockRowsState:
-      child_planstate =
-          PrepareLockRowsState(reinterpret_cast<LockRowsState *>(planstate));
+      child_planstate = PrepareLockRowsState(
+          reinterpret_cast<const LockRowsState *>(planstate));
       break;
     case T_LimitState:
       child_planstate =
-          PrepareLimitState(reinterpret_cast<LimitState *>(planstate));
+          PrepareLimitState(reinterpret_cast<const LimitState *>(planstate));
       break;
 
     case T_MaterialState:
-      child_planstate =
-          PrepareMaterialState(reinterpret_cast<MaterialState *>(planstate));
+      child_planstate = PrepareMaterialState(
+          reinterpret_cast<const MaterialState *>(planstate));
       break;
 
     case T_MergeJoinState:
-      child_planstate =
-          PrepareMergeJoinState(reinterpret_cast<MergeJoinState *>(planstate));
+      child_planstate = PrepareMergeJoinState(
+          reinterpret_cast<const MergeJoinState *>(planstate));
       break;
 
     case T_HashJoinState:
-      child_planstate =
-          PrepareHashJoinState(reinterpret_cast<HashJoinState *>(planstate));
+      child_planstate = PrepareHashJoinState(
+          reinterpret_cast<const HashJoinState *>(planstate));
       break;
 
     case T_NestLoopState:
-      child_planstate =
-          PrepareNestLoopState(reinterpret_cast<NestLoopState *>(planstate));
+      child_planstate = PrepareNestLoopState(
+          reinterpret_cast<const NestLoopState *>(planstate));
       break;
 
     case T_SortState:
       child_planstate =
-          PrepareSortState(reinterpret_cast<SortState *>(planstate));
+          PrepareSortState(reinterpret_cast<const SortState *>(planstate));
       break;
 
     case T_AggState:
       child_planstate =
-          PrepareAggState(reinterpret_cast<AggState *>(planstate));
+          PrepareAggState(reinterpret_cast<const AggState *>(planstate));
       break;
 
     case T_ResultState:
@@ -133,12 +133,12 @@ AbstractPlanState *DMLUtils::PreparePlanState(AbstractPlanState *root,
 
     case T_HashState:
       child_planstate =
-          PrepareHashState(reinterpret_cast<HashState *>(planstate));
+          PrepareHashState(reinterpret_cast<const HashState *>(planstate));
       break;
 
     case T_UniqueState: {
       child_planstate =
-          PrepareUniqueState(reinterpret_cast<UniqueState *>(planstate));
+          PrepareUniqueState(reinterpret_cast<const UniqueState *>(planstate));
     } break;
 
     default:
@@ -174,7 +174,7 @@ AbstractPlanState *DMLUtils::PreparePlanState(AbstractPlanState *root,
 }
 
 ModifyTablePlanState *DMLUtils::PrepareModifyTableState(
-    ModifyTableState *mt_plan_state) {
+    const ModifyTableState *mt_plan_state) {
   ModifyTablePlanState *info =
       (ModifyTablePlanState *)palloc(sizeof(ModifyTablePlanState));
   info->type = mt_plan_state->ps.type;
@@ -218,7 +218,7 @@ ModifyTablePlanState *DMLUtils::PrepareModifyTableState(
 }
 
 void DMLUtils::PrepareInsertState(ModifyTablePlanState *info,
-                                  ModifyTableState *mt_plan_state) {
+                                  const ModifyTableState *mt_plan_state) {
   // Should be only one sub plan which is a Result
   assert(mt_plan_state->mt_nplans == 1);
   assert(mt_plan_state->mt_plans != nullptr);
@@ -249,7 +249,7 @@ void DMLUtils::PrepareInsertState(ModifyTablePlanState *info,
 }
 
 void DMLUtils::PrepareUpdateState(ModifyTablePlanState *info,
-                                  ModifyTableState *mt_plan_state) {
+                                  const ModifyTableState *mt_plan_state) {
   // Should be only one sub plan which is a SeqScan
   assert(mt_plan_state->mt_nplans == 1);
   assert(mt_plan_state->mt_plans != nullptr);
@@ -286,7 +286,7 @@ void DMLUtils::PrepareUpdateState(ModifyTablePlanState *info,
 }
 
 void DMLUtils::PrepareDeleteState(ModifyTablePlanState *info,
-                                  ModifyTableState *mt_plan_state) {
+                                  const ModifyTableState *mt_plan_state) {
   // Grab Database ID and Table ID
   // Input must come from a subplan
   assert(mt_plan_state->resultRelInfo);
@@ -302,14 +302,16 @@ void DMLUtils::PrepareDeleteState(ModifyTablePlanState *info,
   info->mt_plans[0] = child_planstate;
 }
 
-ResultPlanState *DMLUtils::PrepareResultState(ResultState *result_plan_state) {
+ResultPlanState *DMLUtils::PrepareResultState(
+    const ResultState *result_plan_state) {
   ResultPlanState *info = (ResultPlanState *)palloc(sizeof(ResultPlanState));
   info->type = result_plan_state->ps.type;
 
   return info;
 }
 
-UniquePlanState *DMLUtils::PrepareUniqueState(UniqueState *unique_plan_state) {
+UniquePlanState *DMLUtils::PrepareUniqueState(
+    const UniqueState *unique_plan_state) {
   UniquePlanState *info = (UniquePlanState *)palloc(sizeof(UniquePlanState));
   info->type = unique_plan_state->ps.type;
 
@@ -329,7 +331,7 @@ UniquePlanState *DMLUtils::PrepareUniqueState(UniqueState *unique_plan_state) {
 }
 
 LockRowsPlanState *DMLUtils::PrepareLockRowsState(
-    LockRowsState *lr_plan_state) {
+    const LockRowsState *lr_plan_state) {
   LockRowsPlanState *info =
       (LockRowsPlanState *)palloc(sizeof(LockRowsPlanState));
   info->type = lr_plan_state->ps.type;
@@ -342,7 +344,8 @@ LockRowsPlanState *DMLUtils::PrepareLockRowsState(
   return info;
 }
 
-LimitPlanState *DMLUtils::PrepareLimitState(LimitState *limit_plan_state) {
+LimitPlanState *DMLUtils::PrepareLimitState(
+    const LimitState *limit_plan_state) {
   LimitPlanState *info = (LimitPlanState *)palloc(sizeof(LimitPlanState));
   info->type = limit_plan_state->ps.type;
 
@@ -429,7 +432,8 @@ void DMLUtils::PrepareAbstractJoinPlanState(AbstractJoinPlanState *j_plan_state,
       BuildProjectInfo(j_state.ps.ps_ProjInfo, tup_desc->natts);
 }
 
-NestLoopPlanState *DMLUtils::PrepareNestLoopState(NestLoopState *nl_state) {
+NestLoopPlanState *DMLUtils::PrepareNestLoopState(
+    const NestLoopState *nl_state) {
   NestLoopPlanState *info =
       (NestLoopPlanState *)palloc(sizeof(NestLoopPlanState));
 
@@ -442,7 +446,8 @@ NestLoopPlanState *DMLUtils::PrepareNestLoopState(NestLoopState *nl_state) {
   return info;
 }
 
-MergeJoinPlanState *DMLUtils::PrepareMergeJoinState(MergeJoinState *mj_state) {
+MergeJoinPlanState *DMLUtils::PrepareMergeJoinState(
+    const MergeJoinState *mj_state) {
   MergeJoinPlanState *info =
       (MergeJoinPlanState *)palloc(sizeof(MergeJoinPlanState));
 
@@ -458,7 +463,8 @@ MergeJoinPlanState *DMLUtils::PrepareMergeJoinState(MergeJoinState *mj_state) {
   return info;
 }
 
-HashJoinPlanState *DMLUtils::PrepareHashJoinState(HashJoinState *hj_state) {
+HashJoinPlanState *DMLUtils::PrepareHashJoinState(
+    const HashJoinState *hj_state) {
   HashJoinPlanState *info =
       (HashJoinPlanState *)palloc(sizeof(HashJoinPlanState));
   info->type = hj_state->js.ps.type;
@@ -470,7 +476,7 @@ HashJoinPlanState *DMLUtils::PrepareHashJoinState(HashJoinState *hj_state) {
   return info;
 }
 
-HashPlanState *DMLUtils::PrepareHashState(HashState *hash_state) {
+HashPlanState *DMLUtils::PrepareHashState(const HashState *hash_state) {
   HashPlanState *info = (HashPlanState *)palloc(sizeof(HashPlanState));
   info->type = hash_state->ps.type;
   info->hashkeys = CopyExprStateList(hash_state->hashkeys);
@@ -504,7 +510,8 @@ void DMLUtils::PrepareAbstractScanState(AbstractScanPlanState *ss_plan_state,
   ss_plan_state->tts_tupleDescriptor = CreateTupleDescCopy(tup_desc);
 }
 
-SeqScanPlanState *DMLUtils::PrepareSeqScanState(SeqScanState *ss_plan_state) {
+SeqScanPlanState *DMLUtils::PrepareSeqScanState(
+    const SeqScanState *ss_plan_state) {
   SeqScanPlanState *info = (SeqScanPlanState *)palloc(sizeof(SeqScanPlanState));
   info->type = ss_plan_state->ps.type;
 
@@ -521,7 +528,7 @@ SeqScanPlanState *DMLUtils::PrepareSeqScanState(SeqScanState *ss_plan_state) {
 }
 
 IndexScanPlanState *DMLUtils::PrepareIndexScanState(
-    IndexScanState *iss_plan_state) {
+    const IndexScanState *iss_plan_state) {
   IndexScanPlanState *info =
       (IndexScanPlanState *)palloc(sizeof(IndexScanPlanState));
   info->type = iss_plan_state->ss.ps.type;
@@ -551,7 +558,7 @@ IndexScanPlanState *DMLUtils::PrepareIndexScanState(
 }
 
 IndexOnlyScanPlanState *DMLUtils::PrepareIndexOnlyScanState(
-    IndexOnlyScanState *ioss_plan_state) {
+    const IndexOnlyScanState *ioss_plan_state) {
   IndexOnlyScanPlanState *info =
       (IndexOnlyScanPlanState *)palloc(sizeof(IndexOnlyScanPlanState));
   info->type = ioss_plan_state->ss.ps.type;
@@ -578,7 +585,7 @@ IndexOnlyScanPlanState *DMLUtils::PrepareIndexOnlyScanState(
 }
 
 BitmapHeapScanPlanState *DMLUtils::PrepareBitmapHeapScanState(
-    BitmapHeapScanState *bhss_plan_state) {
+    const BitmapHeapScanState *bhss_plan_state) {
   BitmapHeapScanPlanState *info =
       (BitmapHeapScanPlanState *)palloc(sizeof(BitmapHeapScanPlanState));
   info->type = bhss_plan_state->ss.ps.type;
@@ -593,7 +600,7 @@ BitmapHeapScanPlanState *DMLUtils::PrepareBitmapHeapScanState(
 }
 
 BitmapIndexScanPlanState *DMLUtils::PrepareBitmapIndexScanState(
-    BitmapIndexScanState *biss_state) {
+    const BitmapIndexScanState *biss_state) {
   BitmapIndexScanPlanState *info =
       (BitmapIndexScanPlanState *)palloc(sizeof(BitmapIndexScanPlanState));
   info->type = biss_state->ss.ps.type;
@@ -616,7 +623,7 @@ BitmapIndexScanPlanState *DMLUtils::PrepareBitmapIndexScanState(
 }
 
 MaterialPlanState *DMLUtils::PrepareMaterialState(
-    MaterialState *material_plan_state) {
+    const MaterialState *material_plan_state) {
   MaterialPlanState *info =
       (MaterialPlanState *)palloc(sizeof(MaterialPlanState));
   info->type = material_plan_state->ss.ps.type;
@@ -630,7 +637,7 @@ MaterialPlanState *DMLUtils::PrepareMaterialState(
   return info;
 }
 
-AggPlanState *DMLUtils::PrepareAggState(AggState *agg_plan_state) {
+AggPlanState *DMLUtils::PrepareAggState(const AggState *agg_plan_state) {
   AggPlanState *info = (AggPlanState *)palloc(sizeof(AggPlanState));
   info->type = agg_plan_state->ss.ps.type;
 
@@ -674,7 +681,7 @@ AggPlanState *DMLUtils::PrepareAggState(AggState *agg_plan_state) {
  * @brief preparing data
  * @param planstate
  */
-AbstractPlanState *DMLUtils::peloton_prepare_data(PlanState *planstate) {
+AbstractPlanState *DMLUtils::peloton_prepare_data(const PlanState *planstate) {
   auto peloton_planstate = PreparePlanState(nullptr, planstate, false);
 
   return peloton_planstate;
@@ -776,7 +783,7 @@ List *CopyExprStateList(List *fromlist) {
   return copylist;
 }
 
-ExprState *CopyExprState(ExprState *expr_state) {
+ExprState *CopyExprState(const ExprState *expr_state) {
   ExprState *expr_state_copy = nullptr;
 
   // We do a shallow copy first,

--- a/src/backend/bridge/dml/mapper/dml_utils.h
+++ b/src/backend/bridge/dml/mapper/dml_utils.h
@@ -35,62 +35,65 @@ class DMLUtils {
   DMLUtils &operator=(DMLUtils &&) = delete;
 
   static AbstractPlanState *PreparePlanState(AbstractPlanState *root,
-                                             PlanState *planstate,
+                                             const PlanState *planstate,
                                              bool left_child);
 
-  static AbstractPlanState *peloton_prepare_data(PlanState *planstate);
+  static AbstractPlanState *peloton_prepare_data(const PlanState *planstate);
 
  private:
   static ModifyTablePlanState *PrepareModifyTableState(
-      ModifyTableState *mt_planstate);
+      const ModifyTableState *mt_planstate);
 
   static void PrepareInsertState(ModifyTablePlanState *info,
-                                 ModifyTableState *mt_state);
+                                 const ModifyTableState *mt_state);
 
   static void PrepareUpdateState(ModifyTablePlanState *info,
-                                 ModifyTableState *mt_state);
+                                 const ModifyTableState *mt_state);
 
   static void PrepareDeleteState(ModifyTablePlanState *info,
-                                 ModifyTableState *mt_state);
+                                 const ModifyTableState *mt_state);
 
-  static ResultPlanState *PrepareResultState(ResultState *result_state);
+  static ResultPlanState *PrepareResultState(const ResultState *result_state);
 
-  static UniquePlanState *PrepareUniqueState(UniqueState *result_state);
+  static UniquePlanState *PrepareUniqueState(const UniqueState *result_state);
 
   static void PrepareAbstractScanState(AbstractScanPlanState *ss_plan_state,
                                        const ScanState &ss_state);
 
-  static SeqScanPlanState *PrepareSeqScanState(SeqScanState *ss_state);
+  static SeqScanPlanState *PrepareSeqScanState(const SeqScanState *ss_state);
 
-  static IndexScanPlanState *PrepareIndexScanState(IndexScanState *iss_state);
+  static IndexScanPlanState *PrepareIndexScanState(
+      const IndexScanState *iss_state);
 
   static IndexOnlyScanPlanState *PrepareIndexOnlyScanState(
-      IndexOnlyScanState *ioss_state);
+      const IndexOnlyScanState *ioss_state);
 
   static BitmapHeapScanPlanState *PrepareBitmapHeapScanState(
-      BitmapHeapScanState *bhss_state);
+      const BitmapHeapScanState *bhss_state);
 
   static BitmapIndexScanPlanState *PrepareBitmapIndexScanState(
-      BitmapIndexScanState *biss_state);
+      const BitmapIndexScanState *biss_state);
 
-  static LockRowsPlanState *PrepareLockRowsState(LockRowsState *lr_state);
+  static LockRowsPlanState *PrepareLockRowsState(const LockRowsState *lr_state);
 
-  static LimitPlanState *PrepareLimitState(LimitState *limit_state);
+  static LimitPlanState *PrepareLimitState(const LimitState *limit_state);
 
-  static MaterialPlanState *PrepareMaterialState(MaterialState *material_state);
+  static MaterialPlanState *PrepareMaterialState(
+      const MaterialState *material_state);
 
   static void PrepareAbstractJoinPlanState(AbstractJoinPlanState *j_plan_state,
                                            const JoinState &j_state);
 
-  static NestLoopPlanState *PrepareNestLoopState(NestLoopState *nl_state);
+  static NestLoopPlanState *PrepareNestLoopState(const NestLoopState *nl_state);
 
-  static MergeJoinPlanState *PrepareMergeJoinState(MergeJoinState *mj_state);
+  static MergeJoinPlanState *PrepareMergeJoinState(
+      const MergeJoinState *mj_state);
 
-  static HashJoinPlanState *PrepareHashJoinState(HashJoinState *hj_state);
+  static HashJoinPlanState *PrepareHashJoinState(const HashJoinState *hj_state);
 
-  static AggPlanState *PrepareAggState(AggState *agg_state);
+  static AggPlanState *PrepareAggState(const AggState *agg_state);
 
-  static SortPlanState *PrepareSortState(SortState *sort_plan_state) {
+  static SortPlanState *PrepareSortState(const SortState *sort_plan_state) {
     SortPlanState *info = (SortPlanState *)(palloc(sizeof(SortPlanState)));
     info->type = sort_plan_state->ss.ps.type;
     info->sort = (const Sort *)(copyObject(sort_plan_state->ss.ps.plan));
@@ -115,7 +118,7 @@ class DMLUtils {
     return info;
   }
 
-  static HashPlanState *PrepareHashState(HashState *hash_state);
+  static HashPlanState *PrepareHashState(const HashState *hash_state);
 
   static PelotonProjectionInfo *BuildProjectInfo(ProjectionInfo *proj_info,
                                                  int column_count);

--- a/src/backend/bridge/dml/tuple/tuple_transformer.cpp
+++ b/src/backend/bridge/dml/tuple/tuple_transformer.cpp
@@ -220,6 +220,11 @@ Value TupleTransformer::GetValue(Datum datum, Oid atttypid) {
     } break;
 
     case POSTGRES_VALUE_TYPE_INT4_ARRAY: {
+      if (datum == 0) {
+        value = ValueFactory::GetArrayValueFromSizeAndType(0, VALUE_TYPE_ARRAY);
+        std::vector<Value> vecValue;
+        value.SetArrayElements(vecValue);
+      } else {
       ArrayType *arr = DatumGetArrayTypeP(datum);
       int nelems = ArrayGetNItems(ARR_NDIM(arr), ARR_DIMS(arr));
       // Datum *elems;
@@ -243,6 +248,8 @@ Value TupleTransformer::GetValue(Datum datum, Oid atttypid) {
       }
 
       value.SetArrayElements(vecValue);
+
+      }
 
     } break;
 

--- a/src/backend/bridge/dml/tuple/tuple_transformer.cpp
+++ b/src/backend/bridge/dml/tuple/tuple_transformer.cpp
@@ -79,12 +79,17 @@ Value TupleTransformer::GetValue(Datum datum, Oid atttypid) {
      */
     case POSTGRES_VALUE_TYPE_BPCHAR: {
       struct varlena *bpcharptr = reinterpret_cast<struct varlena *>(datum);
-      int len = VARSIZE(bpcharptr) - VARHDRSZ;
-      char *varchar = static_cast<char *>(VARDATA(bpcharptr));
-      VarlenPool *data_pool = nullptr;
-      std::string str(varchar, len);
-      LOG_TRACE("len = %d , bpchar = \"%s\"", len, str.c_str());
-      value = ValueFactory::GetStringValue(str, data_pool);
+      if (bpcharptr != nullptr) {
+        int len = VARSIZE(bpcharptr) - VARHDRSZ;
+        char *varchar = static_cast<char *>(VARDATA(bpcharptr));
+        VarlenPool *data_pool = nullptr;
+        std::string str(varchar, len);
+        LOG_TRACE("len = %d , bpchar = \"%s\"", len, str.c_str());
+        value = ValueFactory::GetStringValue(str, data_pool);
+      } else {
+        LOG_TRACE("empty bpchar");
+        value = ValueFactory::GetStringValue("", nullptr);
+      }
 
     } break;
 
@@ -130,22 +135,32 @@ Value TupleTransformer::GetValue(Datum datum, Oid atttypid) {
 
     case POSTGRES_VALUE_TYPE_VARCHAR2: {
       struct varlena *varlenptr = reinterpret_cast<struct varlena *>(datum);
-      int len = VARSIZE(varlenptr) - VARHDRSZ;
-      char *varchar = static_cast<char *>(VARDATA(varlenptr));
-      VarlenPool *data_pool = nullptr;
-      std::string str(varchar, len);
-      LOG_TRACE("len = %u , varchar = \"%s\"", len, str.c_str());
-      value = ValueFactory::GetStringValue(str, data_pool);
+      if (varlenptr != nullptr) {
+        int len = VARSIZE(varlenptr) - VARHDRSZ;
+        char *varchar = static_cast<char *>(VARDATA(varlenptr));
+        VarlenPool *data_pool = nullptr;
+        std::string str(varchar, len);
+        LOG_TRACE("len = %u , varchar = \"%s\"", len, str.c_str());
+        value = ValueFactory::GetStringValue(str, data_pool);
+      } else {
+        LOG_TRACE("empty varchar");
+        value = ValueFactory::GetStringValue("", nullptr);
+      }
     } break;
 
     case POSTGRES_VALUE_TYPE_TEXT: {
       struct varlena *textptr = reinterpret_cast<struct varlena *>(datum);
-      int len = VARSIZE(textptr) - VARHDRSZ;
-      char *varchar = static_cast<char *>(VARDATA(textptr));
-      VarlenPool *data_pool = nullptr;
-      std::string str(varchar, len);
-      LOG_TRACE("len = %u , text = \"%s\"", len, str.c_str());
-      value = ValueFactory::GetStringValue(str, data_pool);
+      if (textptr != nullptr) {
+        int len = VARSIZE(textptr) - VARHDRSZ;
+        char *varchar = static_cast<char *>(VARDATA(textptr));
+        VarlenPool *data_pool = nullptr;
+        std::string str(varchar, len);
+        LOG_TRACE("len = %u , text = \"%s\"", len, str.c_str());
+        value = ValueFactory::GetStringValue(str, data_pool);
+      } else {
+        LOG_TRACE("empty text");
+        value = ValueFactory::GetStringValue("", nullptr);
+      }
     } break;
 
     case POSTGRES_VALUE_TYPE_TEXT_ARRAY: {

--- a/src/backend/bridge/dml/tuple/tuple_transformer.cpp
+++ b/src/backend/bridge/dml/tuple/tuple_transformer.cpp
@@ -164,59 +164,71 @@ Value TupleTransformer::GetValue(Datum datum, Oid atttypid) {
     } break;
 
     case POSTGRES_VALUE_TYPE_TEXT_ARRAY: {
-      ArrayType *arr = DatumGetArrayTypeP(datum);
-      int nelems = ArrayGetNItems(ARR_NDIM(arr), ARR_DIMS(arr));
-      Datum *elems = nullptr;
-      int i;
-      if (ARR_NDIM(arr) != 1 || ARR_HASNULL(arr) ||
-          ARR_ELEMTYPE(arr) != POSTGRES_VALUE_TYPE_TEXT)
-        LOG_ERROR("expected 1-D text array");
+      if (datum == 0) {
+        value = ValueFactory::GetArrayValueFromSizeAndType(0, VALUE_TYPE_ARRAY);
+        std::vector<Value> vecValue;
+        value.SetArrayElements(vecValue);
+      } else {
+        ArrayType *arr = DatumGetArrayTypeP(datum);
+        int nelems = ArrayGetNItems(ARR_NDIM(arr), ARR_DIMS(arr));
+        Datum *elems = nullptr;
+        int i;
+        if (ARR_NDIM(arr) != 1 || ARR_HASNULL(arr) ||
+            ARR_ELEMTYPE(arr) != POSTGRES_VALUE_TYPE_TEXT)
+          LOG_ERROR("expected 1-D text array");
 
-      deconstruct_array(arr, POSTGRES_VALUE_TYPE_TEXT, -1, false, 'i', &elems,
-                        NULL, &nelems);
+        deconstruct_array(arr, POSTGRES_VALUE_TYPE_TEXT, -1, false, 'i', &elems,
+            NULL, &nelems);
 
-      value =
+        value =
           ValueFactory::GetArrayValueFromSizeAndType(nelems, VALUE_TYPE_ARRAY);
 
-      std::vector<Value> vecValue;
+        std::vector<Value> vecValue;
 
-      for (i = 0; i < nelems; ++i) {
-        char *pText = TextDatumGetCString(elems[i]);
-        std::string str(pText);
-        LOG_TRACE("%s %u", pText, ARR_ELEMTYPE(arr));
-        VarlenPool *data_pool = nullptr;
-        LOG_TRACE("len = %lu , text = \"%s\"", str.length(), str.c_str());
-        Value val = ValueFactory::GetStringValue(str, data_pool);
-        vecValue.push_back(val);
+        for (i = 0; i < nelems; ++i) {
+          char *pText = TextDatumGetCString(elems[i]);
+          std::string str(pText);
+          LOG_TRACE("%s %u", pText, ARR_ELEMTYPE(arr));
+          VarlenPool *data_pool = nullptr;
+          LOG_TRACE("len = %lu , text = \"%s\"", str.length(), str.c_str());
+          Value val = ValueFactory::GetStringValue(str, data_pool);
+          vecValue.push_back(val);
+        }
+
+        value.SetArrayElements(vecValue);
+
       }
-
-      value.SetArrayElements(vecValue);
-
     } break;
 
     case POSTGRES_VALUE_TYPE_INT2_ARRAY: {
-      ArrayType *arr = DatumGetArrayTypeP(datum);
-      int nelems = ArrayGetNItems(ARR_NDIM(arr), ARR_DIMS(arr));
-      int i;
-      if (ARR_NDIM(arr) != 1 || ARR_HASNULL(arr) ||
-          ARR_ELEMTYPE(arr) != POSTGRES_VALUE_TYPE_SMALLINT)
-        LOG_ERROR("expected 1-D int2 array");
+      if (datum == 0) {
+        value = ValueFactory::GetArrayValueFromSizeAndType(0, VALUE_TYPE_ARRAY);
+        std::vector<Value> vecValue;
+        value.SetArrayElements(vecValue);
+      } else {
+        ArrayType *arr = DatumGetArrayTypeP(datum);
+        int nelems = ArrayGetNItems(ARR_NDIM(arr), ARR_DIMS(arr));
+        int i;
+        if (ARR_NDIM(arr) != 1 || ARR_HASNULL(arr) ||
+            ARR_ELEMTYPE(arr) != POSTGRES_VALUE_TYPE_SMALLINT)
+          LOG_ERROR("expected 1-D int2 array");
 
-      int16_t *pdata = (int16_t *)ARR_DATA_PTR(arr);
-      value =
+        int16_t *pdata = (int16_t *)ARR_DATA_PTR(arr);
+        value =
           ValueFactory::GetArrayValueFromSizeAndType(nelems, VALUE_TYPE_ARRAY);
 
-      std::vector<Value> vecValue;
+        std::vector<Value> vecValue;
 
-      for (i = 0; i < nelems; ++i) {
-        int16_t smallint = pdata[i];
-        LOG_TRACE("%d", smallint);
-        Value val = ValueFactory::GetSmallIntValue(smallint);
-        vecValue.push_back(val);
+        for (i = 0; i < nelems; ++i) {
+          int16_t smallint = pdata[i];
+          LOG_TRACE("%d", smallint);
+          Value val = ValueFactory::GetSmallIntValue(smallint);
+          vecValue.push_back(val);
+        }
+
+        value.SetArrayElements(vecValue);
+
       }
-
-      value.SetArrayElements(vecValue);
-
     } break;
 
     case POSTGRES_VALUE_TYPE_INT4_ARRAY: {
@@ -225,29 +237,29 @@ Value TupleTransformer::GetValue(Datum datum, Oid atttypid) {
         std::vector<Value> vecValue;
         value.SetArrayElements(vecValue);
       } else {
-      ArrayType *arr = DatumGetArrayTypeP(datum);
-      int nelems = ArrayGetNItems(ARR_NDIM(arr), ARR_DIMS(arr));
-      // Datum *elems;
-      int i;
-      if (ARR_NDIM(arr) != 1 || ARR_HASNULL(arr) ||
-          ARR_ELEMTYPE(arr) != POSTGRES_VALUE_TYPE_INTEGER)
-        LOG_ERROR("expected 1-D int4 array");
+        ArrayType *arr = DatumGetArrayTypeP(datum);
+        int nelems = ArrayGetNItems(ARR_NDIM(arr), ARR_DIMS(arr));
+        // Datum *elems;
+        int i;
+        if (ARR_NDIM(arr) != 1 || ARR_HASNULL(arr) ||
+            ARR_ELEMTYPE(arr) != POSTGRES_VALUE_TYPE_INTEGER)
+          LOG_ERROR("expected 1-D int4 array");
 
-      int32_t *pdata = (int32_t *)ARR_DATA_PTR(arr);
-      value =
+        int32_t *pdata = (int32_t *)ARR_DATA_PTR(arr);
+        value =
           ValueFactory::GetArrayValueFromSizeAndType(nelems, VALUE_TYPE_ARRAY);
 
-      std::vector<Value> vecValue;
+        std::vector<Value> vecValue;
 
-      for (i = 0; i < nelems; ++i) {
-        // int32_t integer = DatumGetInt32(elems[i]);
-        int32_t integer = pdata[i];
-        LOG_TRACE("%d", integer);
-        Value val = ValueFactory::GetIntegerValue(integer);
-        vecValue.push_back(val);
-      }
+        for (i = 0; i < nelems; ++i) {
+          // int32_t integer = DatumGetInt32(elems[i]);
+          int32_t integer = pdata[i];
+          LOG_TRACE("%d", integer);
+          Value val = ValueFactory::GetIntegerValue(integer);
+          vecValue.push_back(val);
+        }
 
-      value.SetArrayElements(vecValue);
+        value.SetArrayElements(vecValue);
 
       }
 
@@ -255,31 +267,37 @@ Value TupleTransformer::GetValue(Datum datum, Oid atttypid) {
 
     // FLOADT4 is same with double (8 bytes) ?
     case POSTGRES_VALUE_TYPE_FLOADT4_ARRAY: {
-      ArrayType *arr = DatumGetArrayTypeP(datum);
-      int nelems = ArrayGetNItems(ARR_NDIM(arr), ARR_DIMS(arr));
-      int i;
-      if (ARR_NDIM(arr) != 1 || ARR_HASNULL(arr) ||
-          ARR_ELEMTYPE(arr) != POSTGRES_VALUE_TYPE_DOUBLE)
-        LOG_ERROR("expected 1-D floadt4 array");
+      if (datum == 0) {
+        value = ValueFactory::GetArrayValueFromSizeAndType(0, VALUE_TYPE_ARRAY);
+        std::vector<Value> vecValue;
+        value.SetArrayElements(vecValue);
+      } else {
+        ArrayType *arr = DatumGetArrayTypeP(datum);
+        int nelems = ArrayGetNItems(ARR_NDIM(arr), ARR_DIMS(arr));
+        int i;
+        if (ARR_NDIM(arr) != 1 || ARR_HASNULL(arr) ||
+            ARR_ELEMTYPE(arr) != POSTGRES_VALUE_TYPE_DOUBLE)
+          LOG_ERROR("expected 1-D floadt4 array");
 
-      value =
+        value =
           ValueFactory::GetArrayValueFromSizeAndType(nelems, VALUE_TYPE_ARRAY);
 
-      double *pdata = (double *)ARR_DATA_PTR(arr);
-      value =
+        double *pdata = (double *)ARR_DATA_PTR(arr);
+        value =
           ValueFactory::GetArrayValueFromSizeAndType(nelems, VALUE_TYPE_ARRAY);
 
-      std::vector<Value> vecValue;
+        std::vector<Value> vecValue;
 
-      for (i = 0; i < nelems; ++i) {
-        double fpnum = pdata[i];
-        LOG_TRACE("%f", fpnum);
-        Value val = ValueFactory::GetDoubleValue(fpnum);
-        vecValue.push_back(val);
+        for (i = 0; i < nelems; ++i) {
+          double fpnum = pdata[i];
+          LOG_TRACE("%f", fpnum);
+          Value val = ValueFactory::GetDoubleValue(fpnum);
+          vecValue.push_back(val);
+        }
+
+        value.SetArrayElements(vecValue);
+
       }
-
-      value.SetArrayElements(vecValue);
-
     } break;
 
     // In Postgres, dates are 4-byte values representing the number of days

--- a/src/backend/expression/date_functions.h
+++ b/src/backend/expression/date_functions.h
@@ -94,7 +94,7 @@ namespace peloton {
 
 static const long COUNTER_BITS = 9;
 static const long PARTITIONID_BITS = 14;
-static const int64_t VOLT_EPOCH = epoch_microseconds_from_components(2008);
+//static const int64_t VOLT_EPOCH = epoch_microseconds_from_components(2008);
 
 /** implement the timestamp YEAR extract function **/
 template <>

--- a/src/postgres/backend/postmaster/peloton.cpp
+++ b/src/postgres/backend/postmaster/peloton.cpp
@@ -70,7 +70,7 @@ bool logging_module_check = false;
 
 bool syncronization_commit = false;
 
-static void peloton_process_status(const peloton_status& status, PlanState *planstate);
+static void peloton_process_status(const peloton_status& status, const PlanState *planstate);
 
 static void peloton_send_output(const peloton_status&  status,
                                 bool sendTuples,
@@ -166,7 +166,7 @@ peloton_ddl(Node *parsetree) {
  * ----------
  */
 void
-peloton_dml(PlanState *planstate,
+peloton_dml(const PlanState *planstate,
             bool sendTuples,
             DestReceiver *dest,
             TupleDesc tuple_desc,
@@ -234,7 +234,7 @@ peloton_dml(PlanState *planstate,
  * ----------
  */
 static void
-peloton_process_status(const peloton_status& status, PlanState *planstate) {
+peloton_process_status(const peloton_status& status, const PlanState *planstate) {
   int code;
 
   // Process the status code

--- a/src/postgres/include/postmaster/peloton.h
+++ b/src/postgres/include/postmaster/peloton.h
@@ -64,7 +64,7 @@ extern void peloton_bootstrap();
 
 extern void peloton_ddl(Node *parsetree);
 
-extern void peloton_dml(PlanState *planstate,
+extern void peloton_dml(const PlanState *planstate,
                         bool sendTuples,
                         DestReceiver *dest,
                         TupleDesc tuple_desc,


### PR DESCRIPTION
This PR mainly fixes the bug in issue #143.

As mentioned in that post, Postgres uses generic plan after several rounds of execution. In a generic plan, a parameter will be filled with a `Param` node rather than a `Const` node, and will be replaced by runtime_key in executor. However, Peloton does not handle some data types correctly (like strings and lists) when transforming the `Param` node.

This PR first fixes the bug in handling text, varchar, bpchar. What we do here is to simply transform it to an empty Value, since it will be replaced by runtime key anyway.

Things are more complicated for arrays. An `ArrayExpr` is passed as `runtime_key`, and Peloton does not support transforming `ArrayExpr` now. <del>Since this is sort of independent issue, I will send a separate PR when I finish it.</del> I added a `TransformArrayExpr` to transform `ArrayExpr` to `VectorExpression` in our VoltDB-like expression system.