### PR TITLE
Fixed memory leak in UDF expressions

### DIFF
--- a/src/backend/benchmark/tpcc/tpcc_workload.cpp
+++ b/src/backend/benchmark/tpcc/tpcc_workload.cpp
@@ -723,8 +723,8 @@ bool RunNewOrder(){
   auto result = txn_manager.CommitTransaction();
 
   if (result == Result::RESULT_SUCCESS) {
-    LOG_TRACE("D_TAX: %d", gd_lists_values[0][0]);
-    LOG_TRACE("D_NEXT_O_ID: %d", gd_lists_values[0][1]);
+    LOG_TRACE("D_TAX: %s", gd_lists_values[0][0].GetInfo().c_str());
+    LOG_TRACE("D_NEXT_O_ID: %s", gd_lists_values[0][1].GetInfo().c_str());
 
     return true;
   } else {

--- a/src/backend/bridge/dml/expr/expr_transformer.cpp
+++ b/src/backend/bridge/dml/expr/expr_transformer.cpp
@@ -362,24 +362,24 @@ expression::AbstractExpression *ExprTransformer::TransformFunc(
 
       auto function_id = fn_expr->funcid;
       auto collation = fn_es->fcinfo_data.fncollation;
-      auto args = fn_es->args;
+      //auto args = fn_es->args;
 
-      std::vector<expression::AbstractExpression *> m_args;
+      std::vector<std::unique_ptr<expression::AbstractExpression>> args;
 
       // Convert arguments to Peloton's expression
       int i = 0;
       ListCell *arg;
-      foreach (arg, args) {
+      foreach (arg, fn_es->args) {
         ExprState *argstate = (ExprState *)lfirst(arg);
-        m_args.push_back(TransformExpr(argstate));
+        args.emplace_back(TransformExpr(argstate));
         i++;
       }
 
       // Check if the number of arguments are less then maximum allowed.
-      assert(m_args.size() < EXPRESSION_MAX_ARG_NUM);
+      assert(args.size() < EXPRESSION_MAX_ARG_NUM);
 
       return expression::ExpressionUtil::UDFExpressionFactory(
-          function_id, collation, rettype, m_args);
+          function_id, collation, rettype, args);
     } else {
       // FIXME It will generate incorrect results.
       assert(list_length(fn_es->args) > 0);

--- a/src/backend/expression/expression_util.cpp
+++ b/src/backend/expression/expression_util.cpp
@@ -747,7 +747,7 @@ AbstractExpression *ExpressionUtil::ConjunctionFactory(
 
 AbstractExpression *ExpressionUtil::UDFExpressionFactory(
     Oid function_id, Oid collation, Oid return_type,
-    std::vector<expression::AbstractExpression *> args) {
+    std::vector<std::unique_ptr<expression::AbstractExpression>> &args) {
   return new expression::UDFExpression(function_id, collation, return_type,
                                        args);
 }

--- a/src/backend/expression/expression_util.h
+++ b/src/backend/expression/expression_util.h
@@ -124,7 +124,7 @@ class ExpressionUtil {
 
   static AbstractExpression *UDFExpressionFactory(
       Oid function_id, Oid collation, Oid return_type,
-      std::vector<expression::AbstractExpression *> args);
+      std::vector<std::unique_ptr<expression::AbstractExpression>> &args);
 };
 
 }  // End expression namespace

--- a/src/backend/logging/checkpoint/simple_checkpoint.cpp
+++ b/src/backend/logging/checkpoint/simple_checkpoint.cpp
@@ -206,7 +206,7 @@ void SimpleCheckpoint::InsertTuple(cid_t commit_id) {
   if (max_oid_ < target_location.block) {
     max_oid_ = tile_group_id;
   }
-  LOG_TRACE("Inserted a tuple from checkpoint: (%lu, %lu)",
+  LOG_TRACE("Inserted a tuple from checkpoint: (%u, %u)",
             target_location.block, target_location.offset);
 }
 

--- a/src/backend/logging/loggers/wal_frontend_logger.cpp
+++ b/src/backend/logging/loggers/wal_frontend_logger.cpp
@@ -438,7 +438,7 @@ bool WriteAheadFrontendLogger::RecoverTableIndexHelper(
     auto tile_group_id = logical_tile->GetColumnInfo(0)
                              .base_tile->GetTileGroup()
                              ->GetTileGroupId();
-    LOG_TRACE("Retrieved tile group %lu", tile_group_id);
+    LOG_TRACE("Retrieved tile group %u", tile_group_id);
 
     // Go over the logical tile
     for (oid_t tuple_id : *logical_tile) {
@@ -469,7 +469,7 @@ void WriteAheadFrontendLogger::InsertIndexEntry(storage::Tuple *tuple,
   assert(tuple);
   assert(table);
   auto index_count = table->GetIndexCount();
-  LOG_TRACE("Insert tuple (%lu, %lu) into %lu indexes", target_location.block,
+  LOG_TRACE("Insert tuple (%u, %u) into %u indexes", target_location.block,
             target_location.offset, index_count);
 
   for (int index_itr = index_count - 1; index_itr >= 0; --index_itr) {

--- a/src/backend/storage/data_table.cpp
+++ b/src/backend/storage/data_table.cpp
@@ -644,7 +644,7 @@ void DataTable::DropTileGroups() {
   for (auto tile_group_id : tile_groups_) {
     // add tile group in catalog
     catalog_manager.DropTileGroup(tile_group_id);
-    LOG_TRACE("Dropping tile group : %lu ", tile_group_id);
+    LOG_TRACE("Dropping tile group : %u ", tile_group_id);
   }
   tile_groups_.clear();
 }

--- a/tests/logging/recovery_test.cpp
+++ b/tests/logging/recovery_test.cpp
@@ -130,6 +130,7 @@ TEST_F(RecoveryTests, RestartTest) {
 
   auto status = logging::LoggingUtil::CreateDirectory(dir_name.c_str(), 0700);
   EXPECT_EQ(status, true);
+  logging::LogManager::GetInstance().SetLogDirectoryName("./");
 
   for (int i = 0; i < num_files; i++) {
     std::string file_name = dir_name + "/" + std::string("peloton_log_") +


### PR DESCRIPTION
Three things are fixed in this PR:

1. UDF expressions do not clean up their argument expressions. Fixed by using `unique_ptr`. This should've been caught in code review. 
2. Fixed more LOG_TRACE statement formats.
3. Explicitly set logging directory in recovery test so that is passes in debug builds.

Let me know if anything is amiss.