### PR TITLE
reduce memory allocation

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -643,9 +643,6 @@ std::string IndexTypeToString(IndexType type) {
     case INDEX_TYPE_BWTREE: {
       return "BWTREE";
     }
-    case INDEX_TYPE_SKIPLIST: {
-      return "SKIPLIST";
-    }
     case INDEX_TYPE_HASH: {
       return "HASH";
     }
@@ -660,8 +657,6 @@ IndexType StringToIndexType(const std::string& str) {
     return INDEX_TYPE_BTREE;
   } else if (str == "BWTREE") {
     return INDEX_TYPE_BWTREE;
-  } else if (str == "SKIPLIST") {
-    return INDEX_TYPE_SKIPLIST;
   } else if (str == "HASH") {
     return INDEX_TYPE_HASH;
   }

--- a/src/executor/delete_executor.cpp
+++ b/src/executor/delete_executor.cpp
@@ -129,16 +129,8 @@ bool DeleteExecutor::DExecute() {
           return false;
         }
         // if it is the latest version and not locked by other threads, then
-        // insert a new version.
-        std::unique_ptr<storage::Tuple> new_tuple(
-            new storage::Tuple(target_table_->GetSchema(), true));
-
-        // Make a copy of the original tuple and allocate a new tuple
-        expression::ContainerTuple<storage::TileGroup> old_tuple(
-            tile_group, physical_tuple_id);
-
-        // finally insert updated tuple into the table
-        ItemPointer new_location = target_table_->InsertEmptyVersion(new_tuple.get());
+        // insert an empty version.
+        ItemPointer new_location = target_table_->InsertEmptyVersion();
 
         // PerformUpdate() will not be executed if the insertion failed.
         // There is a write lock acquired, but since it is not in the write set,

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -391,8 +391,6 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
         }
 
         break;
-
-        break;
       }
       // if the tuple is not visible.
       else {

--- a/src/executor/logical_tile.cpp
+++ b/src/executor/logical_tile.cpp
@@ -179,6 +179,13 @@ Value LogicalTile::GetValue(oid_t tuple_id, oid_t column_id) {
   }
 }
 
+// this function is designed for overriding pure virtual function.
+void LogicalTile::SetValue(Value &value UNUSED_ATTRIBUTE, 
+                           oid_t tuple_id UNUSED_ATTRIBUTE, 
+                           oid_t column_id UNUSED_ATTRIBUTE) {
+  PL_ASSERT(false);
+}
+
 /**
  * @brief Returns the number of visible tuples in this logical tile.
  *

--- a/src/executor/update_executor.cpp
+++ b/src/executor/update_executor.cpp
@@ -101,16 +101,9 @@ bool UpdateExecutor::DExecute() {
       // Make a copy of the original tuple and allocate a new tuple
       expression::ContainerTuple<storage::TileGroup> old_tuple(
           tile_group, physical_tuple_id);
-      // Create a temp copy
-      std::unique_ptr<storage::Tuple> new_tuple(
-          new storage::Tuple(target_table_->GetSchema(), true));
       // Execute the projections
-      // TODO: reduce memory copy by doing inplace update
-      project_info_->Evaluate(new_tuple.get(), &old_tuple, nullptr,
+      project_info_->Evaluate(&old_tuple, &old_tuple, nullptr,
                               executor_context_);
-
-      // overwrite the tuple in place.
-      tile_group->CopyTuple(new_tuple.get(), physical_tuple_id);
       
       transaction_manager.PerformUpdate(current_txn, old_location);
 

--- a/src/include/common/abstract_tuple.h
+++ b/src/include/common/abstract_tuple.h
@@ -33,6 +33,9 @@ class AbstractTuple {
   /** @brief Get the value at the given column id. */
   virtual Value GetValue(oid_t column_id) const = 0;
 
+  /** @brief Set the value at the given column id. */
+  virtual void SetValue(oid_t column_id, Value &value) = 0;
+
   /** @brief Get the raw location of the tuple's contents i.e. tuple.value_data.
    */
   virtual char *GetData() const = 0;

--- a/src/include/common/types.h
+++ b/src/include/common/types.h
@@ -429,8 +429,7 @@ enum IndexType {
   INDEX_TYPE_INVALID = 0,   // invalid index type
   INDEX_TYPE_BTREE = 1,     // btree
   INDEX_TYPE_BWTREE = 2,    // bwtree
-  INDEX_TYPE_SKIPLIST = 3,  // skip list
-  INDEX_TYPE_HASH = 4       // hash
+  INDEX_TYPE_HASH = 3       // hash
 };
 
 enum IndexConstraintType {

--- a/src/include/executor/logical_tile.h
+++ b/src/include/executor/logical_tile.h
@@ -84,6 +84,8 @@ class LogicalTile : public Printable {
 
   Value GetValue(oid_t tuple_id, oid_t column_id);
 
+  void SetValue(Value &value, oid_t tuple_id, oid_t column_id);
+
   size_t GetTupleCount();
 
   size_t GetColumnCount();

--- a/src/include/expression/container_tuple.h
+++ b/src/include/expression/container_tuple.h
@@ -58,6 +58,14 @@ class ContainerTuple : public AbstractTuple {
     return container_->GetValue(tuple_id_, column_id);
   }
 
+
+  /** @brief Set the value at the given column id. */
+  void SetValue(oid_t column_id, Value &value) override {
+    PL_ASSERT(container_ != nullptr);
+
+    container_->SetValue(value, tuple_id_, column_id);
+  }
+
   /** @brief Get the raw location of the tuple's contents. */
   inline char *GetData() const override {
     // NOTE: We can't.Get a table tuple from a tilegroup or logical tile
@@ -174,6 +182,12 @@ class ContainerTuple<std::vector<Value>> : public AbstractTuple {
     PL_ASSERT(column_id < container_->size());
 
     return (*container_)[column_id];
+  }
+  
+  /** @brief Set the value at the given column id. */
+  // for override pure virtual function only.
+  void SetValue(oid_t column_id UNUSED_ATTRIBUTE, Value &value UNUSED_ATTRIBUTE) override {
+    PL_ASSERT(false);
   }
 
   /** @brief Get the raw location of the tuple's contents. */

--- a/src/include/planner/project_info.h
+++ b/src/include/planner/project_info.h
@@ -59,7 +59,13 @@ class ProjectInfo {
 
   bool isNonTrivial() const { return target_list_.size() > 0; };
 
-  bool Evaluate(storage::Tuple *dest, const AbstractTuple *tuple1,
+  bool Evaluate(storage::Tuple *dest, 
+                const AbstractTuple *tuple1,
+                const AbstractTuple *tuple2,
+                executor::ExecutorContext *econtext) const;
+
+  bool Evaluate(AbstractTuple *dest, 
+                const AbstractTuple *tuple1,
                 const AbstractTuple *tuple2,
                 executor::ExecutorContext *econtext) const;
 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -101,7 +101,7 @@ class DataTable : public AbstractTable {
   // TUPLE OPERATIONS
   //===--------------------------------------------------------------------===//
   // insert an empty version in table. designed for delete operation.
-  ItemPointer InsertEmptyVersion(const Tuple *tuple);
+  ItemPointer InsertEmptyVersion();
   // insert an version in table. designed for update operation.
   // as we implement logical-pointer indexing mechanism, targets_ptr is required.
   ItemPointer InsertVersion(const storage::Tuple *tuple, const TargetList *targets_ptr, ItemPointer *index_entry_ptr);
@@ -242,8 +242,7 @@ class DataTable : public AbstractTable {
   bool CheckConstraints(const storage::Tuple *tuple) const;
 
   // Claim a tuple slot in a tile group
-  ItemPointer GetEmptyTupleSlot(const storage::Tuple *tuple,
-                                bool check_constraint = true);
+  ItemPointer GetEmptyTupleSlot(const storage::Tuple *tuple);
 
   // add a tile group to the table
   oid_t AddDefaultTileGroup();

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -105,6 +105,14 @@ class DataTable : public AbstractTable {
   // insert an version in table. designed for update operation.
   // as we implement logical-pointer indexing mechanism, targets_ptr is required.
   ItemPointer InsertVersion(const storage::Tuple *tuple, const TargetList *targets_ptr, ItemPointer *index_entry_ptr);
+
+  // these two functions are designed for reducing memory allocation by performing in-place update.
+  // in the update executor, we first acquire a version slot from the data table, and then
+  // copy the content into the version. after that, we need to check constraints and then install the version
+  // into all the corresponding indexes.
+  ItemPointer AcquireVersion();
+  bool InstallVersion(const storage::Tuple *tuple, const TargetList *targets_ptr, ItemPointer *index_entry_ptr);
+
   // insert tuple in table. the pointer to the index entry is returned as index_entry_ptr.
   ItemPointer InsertTuple(const Tuple *tuple, concurrency::Transaction *transaction, ItemPointer **index_entry_ptr = nullptr);
   // designed for tables without primary key. e.g., output table used by aggregate_executor.

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -102,15 +102,14 @@ class DataTable : public AbstractTable {
   //===--------------------------------------------------------------------===//
   // insert an empty version in table. designed for delete operation.
   ItemPointer InsertEmptyVersion();
-  // insert an version in table. designed for update operation.
-  // as we implement logical-pointer indexing mechanism, targets_ptr is required.
-  ItemPointer InsertVersion(const storage::Tuple *tuple, const TargetList *targets_ptr, ItemPointer *index_entry_ptr);
-
+  
   // these two functions are designed for reducing memory allocation by performing in-place update.
   // in the update executor, we first acquire a version slot from the data table, and then
   // copy the content into the version. after that, we need to check constraints and then install the version
   // into all the corresponding indexes.
   ItemPointer AcquireVersion();
+  // install an version in table. designed for update operation.
+  // as we implement logical-pointer indexing mechanism, targets_ptr is required.
   bool InstallVersion(const AbstractTuple *tuple, const TargetList *targets_ptr, ItemPointer *index_entry_ptr);
 
   // insert tuple in table. the pointer to the index entry is returned as index_entry_ptr.
@@ -266,10 +265,6 @@ class DataTable : public AbstractTable {
   //===--------------------------------------------------------------------===//
   // INDEX HELPERS
   //===--------------------------------------------------------------------===//
-
-  // bool InsertInSecondaryIndexes(const storage::Tuple *tuple, 
-  //                               const TargetList *targets_ptr, 
-  //                               ItemPointer *index_entry_ptr);
 
   bool InsertInSecondaryIndexes(const AbstractTuple *tuple, 
                                 const TargetList *targets_ptr, 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -267,9 +267,9 @@ class DataTable : public AbstractTable {
   // INDEX HELPERS
   //===--------------------------------------------------------------------===//
 
-  bool InsertInSecondaryIndexes(const storage::Tuple *tuple, 
-                                const TargetList *targets_ptr, 
-                                ItemPointer *index_entry_ptr);
+  // bool InsertInSecondaryIndexes(const storage::Tuple *tuple, 
+  //                               const TargetList *targets_ptr, 
+  //                               ItemPointer *index_entry_ptr);
 
   bool InsertInSecondaryIndexes(const AbstractTuple *tuple, 
                                 const TargetList *targets_ptr, 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -111,7 +111,7 @@ class DataTable : public AbstractTable {
   // copy the content into the version. after that, we need to check constraints and then install the version
   // into all the corresponding indexes.
   ItemPointer AcquireVersion();
-  bool InstallVersion(const storage::Tuple *tuple, const TargetList *targets_ptr, ItemPointer *index_entry_ptr);
+  bool InstallVersion(const AbstractTuple *tuple, const TargetList *targets_ptr, ItemPointer *index_entry_ptr);
 
   // insert tuple in table. the pointer to the index entry is returned as index_entry_ptr.
   ItemPointer InsertTuple(const Tuple *tuple, concurrency::Transaction *transaction, ItemPointer **index_entry_ptr = nullptr);
@@ -268,6 +268,10 @@ class DataTable : public AbstractTable {
   //===--------------------------------------------------------------------===//
 
   bool InsertInSecondaryIndexes(const storage::Tuple *tuple, 
+                                const TargetList *targets_ptr, 
+                                ItemPointer *index_entry_ptr);
+
+  bool InsertInSecondaryIndexes(const AbstractTuple *tuple, 
                                 const TargetList *targets_ptr, 
                                 ItemPointer *index_entry_ptr);
 

--- a/src/include/storage/tile_group.h
+++ b/src/include/storage/tile_group.h
@@ -165,6 +165,8 @@ class TileGroup : public Printable {
 
   Value GetValue(oid_t tuple_id, oid_t column_id);
 
+  void SetValue(Value &value, oid_t tuple_id, oid_t column_id);
+
   double GetSchemaDifference(const storage::column_map_type &new_column_map);
 
   // Sync the contents

--- a/src/include/storage/tuple.h
+++ b/src/include/storage/tuple.h
@@ -163,7 +163,7 @@ class Tuple : public AbstractTuple {
   size_t GetUninlinedMemorySize() const;
 
   // This sets the relevant columns from the source tuple
-  void SetFromTuple(const storage::Tuple *tuple,
+  void SetFromTuple(const AbstractTuple *tuple,
                     const std::vector<oid_t> &columns, VarlenPool *pool);
 
   // Used to wrap read only tuples in indexing code.

--- a/src/include/storage/tuple.h
+++ b/src/include/storage/tuple.h
@@ -102,7 +102,7 @@ class Tuple : public AbstractTuple {
 
   // Get the value of a specified column (const)
   // (expensive) checks the schema to see how to return the Value.
-  Value GetValue(const oid_t column_id) const;
+  Value GetValue(oid_t column_id) const;
 
   /**
    * Allocate space to copy strings that can't be inlined rather
@@ -115,6 +115,9 @@ class Tuple : public AbstractTuple {
    */
   void SetValue(const oid_t column_id, const Value &value,
                 VarlenPool *dataPool);
+
+  // set value without data pool.
+  void SetValue(oid_t column_id, Value &value);
 
   inline int GetLength() const { return tuple_schema->GetLength(); }
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -397,10 +397,8 @@ bool DataTable::InsertInSecondaryIndexes(const AbstractTuple *tuple,
 
     // Key attributes are updated, insert a new entry in all secondary index
     std::unique_ptr<storage::Tuple> key(new storage::Tuple(index_schema, true));
-    for (auto indexed_column : indexed_columns) {
-      auto value = tuple->GetValue(indexed_column);
-      key->SetValue(indexed_column, value, index->GetPool());
-    }
+
+    key->SetFromTuple(tuple, indexed_columns, index->GetPool());
     
     switch (index->GetIndexType()) {
       case INDEX_CONSTRAINT_TYPE_PRIMARY_KEY:

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -188,29 +188,6 @@ ItemPointer DataTable::InsertEmptyVersion() {
   return location;
 }
 
-ItemPointer DataTable::InsertVersion(const storage::Tuple *tuple, 
-                                     const TargetList *targets_ptr, 
-                                     ItemPointer *index_entry_ptr) {
-  // First, claim a slot
-  ItemPointer location = GetEmptyTupleSlot(tuple);
-  if (location.block == INVALID_OID) {
-    LOG_TRACE("Failed to get tuple slot.");
-    return INVALID_ITEMPOINTER;
-  }
-
-  // Index checks and updates
-  if (InsertInSecondaryIndexes(tuple, targets_ptr, index_entry_ptr) == false) {
-    LOG_TRACE("Index constraint violated");
-    return INVALID_ITEMPOINTER;
-  }
-
-  LOG_TRACE("Location: %u, %u", location.block, location.offset);
-
-  IncreaseTupleCount(1);
-
-  return location;
-}
-
 ItemPointer DataTable::AcquireVersion() {
   // First, claim a slot
   ItemPointer location = GetEmptyTupleSlot(nullptr);
@@ -319,7 +296,7 @@ bool DataTable::InsertInIndexes(const storage::Tuple *tuple,
   
   int index_count = GetIndexCount();
 
-  *index_entry_ptr = nullptr;
+  *index_entry_ptr = new ItemPointer(location);
 
   auto &transaction_manager =
       concurrency::TransactionManagerFactory::GetInstance();
@@ -344,7 +321,6 @@ bool DataTable::InsertInIndexes(const storage::Tuple *tuple,
         // get unique tuple from primary index.
         // if in this index there has been a visible or uncommitted
         // <key, location> pair, this constraint is violated
-        *index_entry_ptr = new ItemPointer(location);
         res = index->CondInsertEntry(key.get(), *index_entry_ptr, fn);
       }
         break;
@@ -379,81 +355,6 @@ bool DataTable::InsertInIndexes(const storage::Tuple *tuple,
 
   return true;
 }
-
-// bool DataTable::InsertInSecondaryIndexes(const storage::Tuple *tuple,
-//               const TargetList *targets_ptr, ItemPointer *index_entry_ptr) {
-//   int index_count = GetIndexCount();
-//   // auto &transaction_manager = concurrency::TransactionManagerFactory::GetInstance();
-
-//   // this function is used for conditional insertion.
-//   // this helps avoid duplicated insertion caused by concurrent transactions.
-
-//   // TODO: handle unique index.
-//   // std::function<bool(const ItemPointer &)> fn =
-//   //   std::bind(&concurrency::TransactionManager::IsOccupied,
-//   //             &transaction_manager, std::placeholders::_1);
-
-//   // Transaform the target list into a hash set
-//   // when attempting to perform insertion to a secondary index,
-//   // we must check whether the updated column is a secondary index column.
-//   // insertion happens only if the updated column is a secondary index column.
-//   std::unordered_set<oid_t> targets_set;
-//   for (auto target : *targets_ptr) {
-//     targets_set.insert(target.first);
-//   }
-
-
-//   // Check existence for primary/unique indexes
-//   // Since this is NOT protected by a lock, concurrent insert may happen.
-//   for (int index_itr = index_count - 1; index_itr >= 0; --index_itr) {
-//     auto index = GetIndex(index_itr);
-//     auto index_schema = index->GetKeySchema();
-//     auto indexed_columns = index_schema->GetIndexedColumns();
-
-//     if (index->GetIndexType() == INDEX_CONSTRAINT_TYPE_PRIMARY_KEY) {
-//       continue;
-//     }
-
-//     // Check if we need to update the secondary index
-//     bool updated = false;
-//     for (auto col : indexed_columns) {
-//       if (targets_set.find(col) != targets_set.end()) {
-//         updated = true;
-//         break;
-//       }
-//     }
-
-//     // If attributes on key are not updated, skip the index update
-//     if (updated == false) {
-//       continue;
-//     }
-
-//     // Key attributes are updated, insert a new entry in all secondary index
-//     std::unique_ptr<storage::Tuple> key(new storage::Tuple(index_schema, true));
-//     key->SetFromTuple(tuple, indexed_columns, index->GetPool());
-
-//     switch (index->GetIndexType()) {
-//       case INDEX_CONSTRAINT_TYPE_PRIMARY_KEY:
-//         break;
-//       case INDEX_CONSTRAINT_TYPE_UNIQUE: {
-//         // if in this index there has been a visible or uncommitted
-//         // <key, location> pair, this constraint is violated
-//         // if (index->CondInsertEntry(key.get(), master_ptr, fn) == false) {
-//           // return false;
-//         // }
-//       } break;
-
-//       case INDEX_CONSTRAINT_TYPE_DEFAULT:
-//       default:
-//         index->InsertEntry(key.get(), index_entry_ptr);
-//         break;
-//     }
-//     LOG_TRACE("Index constraint check on %s passed.", index->GetName().c_str());
-//   }
-//   return true;
-// }
-
-
 
 
 bool DataTable::InsertInSecondaryIndexes(const AbstractTuple *tuple,

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -137,7 +137,6 @@ bool DataTable::CheckConstraints(const storage::Tuple *tuple) const {
 // we just wait until a new tuple slot in the newly allocated tile group is
 // available.
 ItemPointer DataTable::GetEmptyTupleSlot(const storage::Tuple *tuple) {
-  PL_ASSERT(tuple);
 
   size_t active_tile_group_id = number_of_tuples_ % ACTIVE_TILEGROUP_COUNT;
   std::shared_ptr<storage::TileGroup> tile_group;

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -136,8 +136,7 @@ bool DataTable::CheckConstraints(const storage::Tuple *tuple) const {
 // new tile group.
 // we just wait until a new tuple slot in the newly allocated tile group is
 // available.
-ItemPointer DataTable::GetEmptyTupleSlot(const storage::Tuple *tuple,
-                                         UNUSED_ATTRIBUTE bool check_constraint) {
+ItemPointer DataTable::GetEmptyTupleSlot(const storage::Tuple *tuple) {
   PL_ASSERT(tuple);
 
   size_t active_tile_group_id = number_of_tuples_ % ACTIVE_TILEGROUP_COUNT;
@@ -178,19 +177,13 @@ ItemPointer DataTable::GetEmptyTupleSlot(const storage::Tuple *tuple,
 //===--------------------------------------------------------------------===//
 // INSERT
 //===--------------------------------------------------------------------===//
-ItemPointer DataTable::InsertEmptyVersion(const storage::Tuple *tuple) {
+ItemPointer DataTable::InsertEmptyVersion() {
   // First, do integrity checks and claim a slot
-  ItemPointer location = GetEmptyTupleSlot(tuple, false);
+  ItemPointer location = GetEmptyTupleSlot(nullptr);
   if (location.block == INVALID_OID) {
     LOG_TRACE("Failed to get tuple slot.");
     return INVALID_ITEMPOINTER;
   }
-
-  // Index checks and updates
-  // if (InsertInSecondaryIndexes(tuple, location) == false) {
-  //   LOG_TRACE("Index constraint violated");
-  //   return INVALID_ITEMPOINTER;
-  // }
 
   LOG_TRACE("Location: %u, %u", location.block, location.offset);
 
@@ -202,7 +195,7 @@ ItemPointer DataTable::InsertVersion(const storage::Tuple *tuple,
                                      const TargetList *targets_ptr, 
                                      ItemPointer *index_entry_ptr) {
   // First, do integrity checks and claim a slot
-  ItemPointer location = GetEmptyTupleSlot(tuple, true);
+  ItemPointer location = GetEmptyTupleSlot(tuple);
   if (location.block == INVALID_OID) {
     LOG_TRACE("Failed to get tuple slot.");
     return INVALID_ITEMPOINTER;

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -319,7 +319,6 @@ bool DataTable::InsertInIndexes(const storage::Tuple *tuple,
   
   int index_count = GetIndexCount();
 
-  // *index_entry_ptr = new ItemPointer(location);
   *index_entry_ptr = nullptr;
 
   auto &transaction_manager =
@@ -345,7 +344,7 @@ bool DataTable::InsertInIndexes(const storage::Tuple *tuple,
         // get unique tuple from primary index.
         // if in this index there has been a visible or uncommitted
         // <key, location> pair, this constraint is violated
-        index_entry_ptr = new ItemPointer(location);
+        *index_entry_ptr = new ItemPointer(location);
         res = index->CondInsertEntry(key.get(), *index_entry_ptr, fn);
       }
         break;

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -86,8 +86,6 @@ DataTable::~DataTable() {
     }
   }
 
-  // indices will be automatically cleaned up
-
   // clean up foreign keys
   for (auto foreign_key : foreign_keys_) {
     delete foreign_key;
@@ -321,8 +319,9 @@ bool DataTable::InsertInIndexes(const storage::Tuple *tuple,
   
   int index_count = GetIndexCount();
 
-  *index_entry_ptr = new ItemPointer(location);
-  
+  // *index_entry_ptr = new ItemPointer(location);
+  *index_entry_ptr = nullptr;
+
   auto &transaction_manager =
       concurrency::TransactionManagerFactory::GetInstance();
 
@@ -346,6 +345,7 @@ bool DataTable::InsertInIndexes(const storage::Tuple *tuple,
         // get unique tuple from primary index.
         // if in this index there has been a visible or uncommitted
         // <key, location> pair, this constraint is violated
+        index_entry_ptr = new ItemPointer(location);
         res = index->CondInsertEntry(key.get(), *index_entry_ptr, fn);
       }
         break;

--- a/src/storage/tile_group.cpp
+++ b/src/storage/tile_group.cpp
@@ -357,6 +357,14 @@ Value TileGroup::GetValue(oid_t tuple_id, oid_t column_id) {
   return GetTile(tile_offset)->GetValue(tuple_id, tile_column_id);
 }
 
+void TileGroup::SetValue(Value &value, oid_t tuple_id, oid_t column_id) {
+  PL_ASSERT(tuple_id < GetNextTupleSlot());
+  oid_t tile_column_id, tile_offset;
+  LocateTileAndColumn(column_id, tile_offset, tile_column_id);
+  GetTile(tile_offset)->SetValue(value, tuple_id, tile_column_id);
+}
+
+
 Tile *TileGroup::GetTile(const oid_t tile_offset) const {
   PL_ASSERT(tile_offset < tile_count);
   Tile *tile = tiles[tile_offset].get();

--- a/src/storage/tuple.cpp
+++ b/src/storage/tuple.cpp
@@ -32,7 +32,7 @@ Tuple::~Tuple() {
 }
 
 // Get the value of a specified column (const)
-Value Tuple::GetValue(const oid_t column_id) const {
+Value Tuple::GetValue(oid_t column_id) const {
   PL_ASSERT(tuple_schema);
   PL_ASSERT(tuple_data);
   const ValueType column_type = tuple_schema->GetType(column_id);
@@ -78,6 +78,35 @@ void Tuple::SetValue(const oid_t column_offset, const Value &value,
       value.CastAs(type).SerializeToTupleStorageAllocateForObjects(
           value_location, is_inlined, column_length, is_in_bytes, data_pool);
     }
+  }
+}
+
+
+// Set all columns by value into this tuple.
+void Tuple::SetValue(oid_t column_offset, Value &value) {
+  PL_ASSERT(tuple_schema);
+  PL_ASSERT(tuple_data);
+
+  const ValueType type = tuple_schema->GetType(column_offset);
+
+  const bool is_inlined = tuple_schema->IsInlined(column_offset);
+  char *value_location = GetDataPtr(column_offset);
+  int32_t column_length = tuple_schema->GetLength(column_offset);
+  if (is_inlined == false)
+    column_length = tuple_schema->GetVariableLength(column_offset);
+
+  const bool is_in_bytes = false;
+  // Allocate in heap or given data pool depending on whether a pool is provided
+  // Skip casting if type is same
+  if (type == value.GetValueType()) {
+    value.SerializeToTupleStorage(value_location, is_inlined, column_length,
+                                  is_in_bytes);
+  } else {
+    Value casted_value = value.CastAs(type);
+    casted_value.SerializeToTupleStorage(value_location, is_inlined,
+                                         column_length, is_in_bytes);
+    // Do not clean up immediately
+    casted_value.SetCleanUp(false);
   }
 }
 

--- a/src/storage/tuple.cpp
+++ b/src/storage/tuple.cpp
@@ -110,7 +110,7 @@ void Tuple::SetValue(oid_t column_offset, Value &value) {
   }
 }
 
-void Tuple::SetFromTuple(const storage::Tuple *tuple,
+void Tuple::SetFromTuple(const AbstractTuple *tuple,
                          const std::vector<oid_t> &columns, VarlenPool *pool) {
   // We don't do any checks here about the source tuple and
   // this tuple's schema

--- a/test/concurrency/isolation_level_test.cpp
+++ b/test/concurrency/isolation_level_test.cpp
@@ -388,23 +388,6 @@ void SIAnomalyTest1() {
   }
 }
 
-// This is another version of the SI Anomaly described in this paper:
-// http://cs.nyu.edu/courses/fall15/CSCI-GA.2434-001/p729-cahill.pdf
-// void SIAnomalyTest2() {
-//   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-//   std::unique_ptr<storage::DataTable> table(
-//       TransactionTestsUtil::CreateTable());
-//   int X = 0, Y = 1, Z = 2;
-//   {
-
-//     TransactionScheduler scheduler(3, table.get(), &txn_manager);
-//     scheduler.Txn(1).Update(Y, 1);
-//     scheduler.Txn(1).Update(Z, 1);
-//     scheduler.Txn(0).Read(Y);
-//     scheduler.Txn(0).Write(X, 1);
-//   }
-// }
-
 TEST_F(IsolationLevelTest, SerializableTest) {
   for (auto test_type : TEST_TYPES) {
     concurrency::TransactionManagerFactory::Configure(
@@ -419,7 +402,6 @@ TEST_F(IsolationLevelTest, SerializableTest) {
   }
 }
 
-// FIXME: CONCURRENCY_TYPE_SPECULATIVE_READ can't pass it for now
 TEST_F(IsolationLevelTest, StressTest) {
 
   const int num_txn = 2;    // 16


### PR DESCRIPTION
currently, Peloton suffers from high memory allocation overhead when performing update operations. The key reason is that `update_executor` will always create a temporal copy for holding results obtained from tuple projection. This PR avoids creating such copy by directly performing in-place update on tuple versions. Every time the DBMS updates a tuple, it will (1) acquire a version slot from data table; (2) perform projection; (3) install the version back to data table.

btw, our itempointer pointer design is not the key factor for high memory allocation overhead. In fact, such allocation is cheap.