### PR TITLE
quick fix compilation failure with g++ 5

### DIFF
--- a/src/executor/hybrid_scan_executor.cpp
+++ b/src/executor/hybrid_scan_executor.cpp
@@ -21,6 +21,7 @@
 #include <ctime>
 #include <cassert>
 #include <thread>
+#include <numeric>
 
 #include "common/timer.h"
 #include "common/types.h"

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <numeric>
 
 #include "common/types.h"
 #include "executor/logical_tile.h"

--- a/src/executor/seq_scan_executor.cpp
+++ b/src/executor/seq_scan_executor.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <numeric>
 
 #include "common/types.h"
 #include "executor/logical_tile.h"

--- a/src/logging/checkpoint/simple_checkpoint.cpp
+++ b/src/logging/checkpoint/simple_checkpoint.cpp
@@ -13,7 +13,8 @@
 #include <dirent.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
-#include <stdio.h>
+#include <cstdio>
+#include <numeric>
 
 #include "logging/checkpoint/simple_checkpoint.h"
 #include "logging/loggers/wal_frontend_logger.h"

--- a/src/logging/loggers/wal_frontend_logger.cpp
+++ b/src/logging/loggers/wal_frontend_logger.cpp
@@ -15,6 +15,7 @@
 #include <sys/mman.h>
 #include <algorithm>
 #include <dirent.h>
+#include <numeric>
 
 #include "catalog/catalog.h"
 #include "catalog/manager.h"

--- a/test/logging/checkpoint_test.cpp
+++ b/test/logging/checkpoint_test.cpp
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <numeric>
+
 #include "common/harness.h"
 #include "catalog/catalog.h"
 #include "logging/checkpoint.h"


### PR DESCRIPTION
The master branch failed to build with g++ 5. This is caused by the missing of `numeric` library. This PR fixes this problem.