### PR TITLE
#229: added CI test for psql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ script:
     - make check -j2
     # install peloton
     - make install
+    # run psql tests
+    - bash ../script/testing/psql/psql_test.sh
     # run jdbc tests
     - python ../script/validators/jdbc_validator.py
     # upload coverage info

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -16,4 +16,5 @@ apt-get --ignore-missing -y install \
     libboost-filesystem-dev \
     libjemalloc-dev \
     valgrind \
-    lcov
+    lcov \
+    postgresql-client

--- a/script/testing/dml/basic1.sql
+++ b/script/testing/dml/basic1.sql
@@ -1,3 +1,6 @@
+-- WARNING: DO NOT MODIFY THIS FILE
+-- psql tests use the exact output from this file for CI
+
 -- create the table
 -- 2 columns, 1 primary key
 

--- a/script/testing/psql/psql_ref_out.txt
+++ b/script/testing/psql/psql_ref_out.txt
@@ -1,0 +1,106 @@
+drop table if exists foo 0
+create table foo(id integer PRIMARY KEY, year integer) 0
+insert into foo values(1, 100) 1
+insert into foo values(1, 200) 0
+insert into foo values(2, 200) 1
+insert into foo values(3, 300) 1
+insert into foo values(4, 400) 1
+insert into foo values(5, 400) 1
+insert into foo values(5, 500) 0
+ id | year 
+----+------
+  1 |  100
+  2 |  200
+  3 |  300
+  4 |  400
+  5 |  400
+(5 rows)
+
+ id | year 
+----+------
+  1 |  100
+  2 |  200
+(2 rows)
+
+ id | year 
+----+------
+  3 |  300
+  4 |  400
+  5 |  400
+(3 rows)
+
+delete from foo where year = 200 1
+ id | year 
+----+------
+  1 |  100
+  3 |  300
+  4 |  400
+  5 |  400
+(4 rows)
+
+update foo set year = 3000 where id = 3 1
+ id | year 
+----+------
+  1 |  100
+  4 |  400
+  5 |  400
+  3 | 3000
+(4 rows)
+
+update foo set year = 1000 where year = 100 1
+ id | year 
+----+------
+  4 |  400
+  5 |  400
+  3 | 3000
+  1 | 1000
+(4 rows)
+
+update foo set id = 3 where year = 1000 1
+ id | year 
+----+------
+  4 |  400
+  5 |  400
+  3 | 3000
+  3 | 1000
+(4 rows)
+
+update foo set id= 10 where year = 1000 1
+ id | year 
+----+------
+  4 |  400
+  5 |  400
+  3 | 3000
+ 10 | 1000
+(4 rows)
+
+insert into foo values (2, 2000) 1
+ id | year 
+----+------
+  4 |  400
+  5 |  400
+  3 | 3000
+ 10 | 1000
+  2 | 2000
+(5 rows)
+
+insert into foo values (4, 4000) 0
+ id | year 
+----+------
+  4 |  400
+  5 |  400
+  3 | 3000
+ 10 | 1000
+  2 | 2000
+(5 rows)
+
+insert into foo values (1, 1000) 0
+ id | year 
+----+------
+  4 |  400
+  5 |  400
+  3 | 3000
+ 10 | 1000
+  2 | 2000
+(5 rows)
+

--- a/script/testing/psql/psql_test.sh
+++ b/script/testing/psql/psql_test.sh
@@ -13,12 +13,12 @@ TEMP_OUT_FILE="/tmp/psql_out"
 cd $PELOTON_DIR/build
 
 # start peloton
-bin/peloton > /dev/null &
+bin/peloton -port 57721 > /dev/null &
 PELOTON_PID=$!
 sleep 3
 
 # run psql
-echo "\i ../script/testing/dml/basic1.sql" | psql "sslmode=disable" -U postgres -h 0.0.0.0 -p 5432 > $TEMP_OUT_FILE 2>&1
+echo "\i ../script/testing/dml/basic1.sql" | psql "sslmode=disable" -U postgres -h localhost -p 57721 > $TEMP_OUT_FILE 2>&1
 
 # compute diff against reference output
 diff_res=$(diff $TEMP_OUT_FILE $REF_OUT_FILE 2>&1)

--- a/script/testing/psql/psql_test.sh
+++ b/script/testing/psql/psql_test.sh
@@ -1,0 +1,37 @@
+# This script tests if psql is working correctly.
+#!/bin/bash
+
+# NOTE: absolute path to peloton directory is calculated from current directory
+# directory structure: peloton/scripts/testing/psql/<this_file>
+CODE_SOURCE_DIR=`dirname $0`
+PELOTON_DIR="$CODE_SOURCE_DIR/../../.."
+REF_OUT_FILE="$CODE_SOURCE_DIR/psql_ref_out.txt"
+TEMP_OUT_FILE="/tmp/psql_out"
+
+
+# assume that build director is called 'build'
+cd $PELOTON_DIR/build
+
+# start peloton
+bin/peloton > /dev/null &
+PELOTON_PID=$!
+sleep 3
+
+# run psql
+echo "\i ../script/testing/dml/basic1.sql" | psql "sslmode=disable" -U postgres -h 0.0.0.0 -p 5432 > $TEMP_OUT_FILE 2>&1
+
+# compute diff against reference output
+diff_res=$(diff $TEMP_OUT_FILE $REF_OUT_FILE 2>&1)
+if [[ -z $diff_res ]]; then
+    echo "PSQL TEST PASS"
+    exit 0
+else
+    echo "$diff_res"
+    exit -1
+fi
+
+# delete test output file
+rm $TEMP_OUT_FILE
+
+# kill peloton
+kill -9 $PELOTON_PID


### PR DESCRIPTION
I have added tests into CI to test if PSQL works.

1. The installation script has been updated to install the postgresql-client apt package to get psql "out-of-the-box"

2. The test_jdbc.sh script runs script/testing/dml/basic1.sql and diff's the output with the reference output for validation

3. Travis has been updated to include this test script into CI

EDIT: I also changed test ports because Travis has postgres installed by default and Peloton and Postgres currently use the same default port.