### PR TITLE
[#241] Fix the copying of values when binding IndexScanPlan.

### DIFF
--- a/script/testing/jdbc/src/PelotonTest.java
+++ b/script/testing/jdbc/src/PelotonTest.java
@@ -504,10 +504,10 @@ public class PelotonTest {
     pt.Init();
     pt.ShowTable();
     pt.SeqScan();
-    // pt.Scan_Test();
-    // pt.Batch_Insert();
-    // pt.Batch_Update();
-    // pt.Batch_Delete();
+    pt.Scan_Test();
+    pt.Batch_Insert();
+    pt.Batch_Update();
+    pt.Batch_Delete();
     pt.Close();
   }
 }

--- a/script/testing/jdbc/src/PelotonTest.java
+++ b/script/testing/jdbc/src/PelotonTest.java
@@ -505,9 +505,9 @@ public class PelotonTest {
     pt.ShowTable();
     pt.SeqScan();
     pt.Scan_Test();
-    pt.Batch_Insert();
-    pt.Batch_Update();
-    pt.Batch_Delete();
+    //pt.Batch_Insert();
+    //pt.Batch_Update();
+    //pt.Batch_Delete();
     pt.Close();
   }
 }


### PR DESCRIPTION
The values of a IndexScanPlan are copied when binding a new query. That was implicitly done when copying a vector with value objects.

Now since we're using value pointers, we need to do deep copy manually.