### PR TITLE
[#242] Fixed count(*) failing an assertion in tcop.cpp (null pointer)

### DIFF
--- a/script/testing/jdbc/src/PelotonTest.java
+++ b/script/testing/jdbc/src/PelotonTest.java
@@ -228,11 +228,11 @@ public class PelotonTest {
     stmt.execute(INDEXSCAN_COLUMN);
 
     // TODO: Aggregations not yet supported in Peloton
-    // stmt.execute(AGG_COUNT);
-    // stmt.execute(AGG_COUNT_2);
-    // PreparedStatement pstmt = conn.prepareStatement(AGG_COUNT_3);
-    // pstmt.setInt(1, 1);
-    // pstmt.execute();
+    stmt.execute(AGG_COUNT);
+    stmt.execute(AGG_COUNT_2);
+    PreparedStatement pstmt = conn.prepareStatement(AGG_COUNT_3);
+    pstmt.setInt(1, 1);
+    pstmt.execute();
 
     for (int i = 1; i < 3; i++)
         IndexScanParam(i);
@@ -440,7 +440,13 @@ public class PelotonTest {
     }
 
     System.out.println("All Good Here");
-    int[] res = stmt.executeBatch();
+    int[] res;
+    try{
+       res = stmt.executeBatch();
+    }catch(SQLException e){
+      e.printStackTrace();
+      throw e.getNextException();
+    }
     for(int i=0; i < res.length; i++){
       System.out.println(res[i]);
       if (res[i] < 0) {
@@ -505,9 +511,10 @@ public class PelotonTest {
     pt.ShowTable();
     pt.SeqScan();
     pt.Scan_Test();
-    //pt.Batch_Insert();
-    //pt.Batch_Update();
-    //pt.Batch_Delete();
+    pt.Init();
+    pt.Batch_Insert();
+    pt.Batch_Update();
+    pt.Batch_Delete();
     pt.Close();
   }
 }

--- a/src/parser/sql_parser.y
+++ b/src/parser/sql_parser.y
@@ -784,7 +784,11 @@ int_literal:
 	;
 
 star_expr:
-		'*' { $$ = new peloton::expression::ParserExpression(peloton::EXPRESSION_TYPE_STAR); }
+		'*' { 
+			char * star = new char[2];
+			strcpy(star, "*");
+			$$ = new peloton::expression::ParserExpression(peloton::EXPRESSION_TYPE_STAR, star); 
+		}
 	;
 
 


### PR DESCRIPTION
This fix gives the "*" in count(*) a name.  before it was null, causing a segfault.
I also add back in the aggregate, and batch tests.

We might want to add aggregation functions to the parser,
rather than having a generic "function". We currently check for
aggregate functions by string matching function names to find "min",
 "max", etc. in the optimizer. We have expression types for these
aggregate functions but don't use them.