### PR TITLE
fix bug in tpcc benchmark

### DIFF
--- a/src/main/tpcc/tpcc_delivery.cpp
+++ b/src/main/tpcc/tpcc_delivery.cpp
@@ -323,9 +323,20 @@ bool RunDelivery(const size_t &thread_id){
     // Construct index scan executor
     std::vector<oid_t> orders_update_column_ids = {COL_IDX_O_CARRIER_ID};
 
+
+    std::vector<common::Value *> orders_update_key_values;
+
+    orders_update_key_values.push_back(no_o_id);
+    orders_update_key_values.push_back(common::ValueFactory::GetIntegerValue(d_id).Copy());
+    orders_update_key_values.push_back(common::ValueFactory::GetIntegerValue(warehouse_id).Copy());
+    
+    planner::IndexScanPlan::IndexScanDesc orders_update_index_scan_desc(
+      orders_pkey_index, orders_key_column_ids, orders_expr_types,
+      orders_update_key_values, runtime_keys);
+
     // Reuse the index scan desc created above since nothing different
     planner::IndexScanPlan orders_update_index_scan_node(
-      orders_table, nullptr, orders_update_column_ids, orders_index_scan_desc);
+      orders_table, nullptr, orders_update_column_ids, orders_update_index_scan_desc);
 
     executor::IndexScanExecutor orders_update_index_scan_executor(&orders_update_index_scan_node, context.get());
 
@@ -370,8 +381,19 @@ bool RunDelivery(const size_t &thread_id){
     // Construct index scan executor
     std::vector<oid_t> order_line_update_column_ids = {COL_IDX_OL_DELIVERY_D};
 
+
+    std::vector<common::Value *> order_line_update_key_values;
+
+    order_line_update_key_values.push_back(no_o_id);
+    order_line_update_key_values.push_back(common::ValueFactory::GetIntegerValue(d_id).Copy());
+    order_line_update_key_values.push_back(common::ValueFactory::GetIntegerValue(warehouse_id).Copy());
+    
+    planner::IndexScanPlan::IndexScanDesc order_line_update_index_scan_desc(
+      order_line_pkey_index, order_line_key_column_ids, order_line_expr_types,
+      order_line_update_key_values, runtime_keys);
+
     planner::IndexScanPlan order_line_update_index_scan_node(
-      order_line_table, nullptr, order_line_update_column_ids, order_line_index_scan_desc);
+      order_line_table, nullptr, order_line_update_column_ids, order_line_update_index_scan_desc);
 
     executor::IndexScanExecutor order_line_update_index_scan_executor(&order_line_update_index_scan_node, context.get());
 

--- a/src/main/tpcc/tpcc_loader.cpp
+++ b/src/main/tpcc/tpcc_loader.cpp
@@ -1745,7 +1745,6 @@ void LoadTPCCDatabase() {
   LOG_INFO("orders count = %lu", orders_table->GetTupleCount());
   LOG_INFO("new order count = %lu", new_order_table->GetTupleCount());
   LOG_INFO("order line count = %lu", order_line_table->GetTupleCount());
-  printf("here\n");
 }
 
 }  // namespace tpcc

--- a/src/main/tpcc/tpcc_loader.cpp
+++ b/src/main/tpcc/tpcc_loader.cpp
@@ -1745,6 +1745,7 @@ void LoadTPCCDatabase() {
   LOG_INFO("orders count = %lu", orders_table->GetTupleCount());
   LOG_INFO("new order count = %lu", new_order_table->GetTupleCount());
   LOG_INFO("order line count = %lu", order_line_table->GetTupleCount());
+  printf("here\n");
 }
 
 }  // namespace tpcc

--- a/src/main/tpcc/tpcc_new_order.cpp
+++ b/src/main/tpcc/tpcc_new_order.cpp
@@ -240,12 +240,12 @@ bool RunNewOrder(const size_t &thread_id){
   district_expr_types.push_back(
       ExpressionType::EXPRESSION_TYPE_COMPARE_EQUAL);
   
+  auto district_pkey_index = district_table->GetIndexWithOid(
+      district_table_pkey_index_oid);
+
   std::vector<common::Value *> district_key_values;
   district_key_values.push_back(common::ValueFactory::GetIntegerValue(district_id).Copy());
   district_key_values.push_back(common::ValueFactory::GetIntegerValue(warehouse_id).Copy());
-
-  auto district_pkey_index = district_table->GetIndexWithOid(
-      district_table_pkey_index_oid);
 
   planner::IndexScanPlan::IndexScanDesc district_index_scan_desc(
       district_pkey_index, district_key_column_ids, district_expr_types,
@@ -343,10 +343,18 @@ bool RunNewOrder(const size_t &thread_id){
 
   std::vector<oid_t> district_update_column_ids = {10}; // D_NEXT_O_ID
 
+  std::vector<common::Value *> district_update_key_values;
+  district_update_key_values.push_back(common::ValueFactory::GetIntegerValue(district_id).Copy());
+  district_update_key_values.push_back(common::ValueFactory::GetIntegerValue(warehouse_id).Copy());
+
+  planner::IndexScanPlan::IndexScanDesc district_update_index_scan_desc(
+      district_pkey_index, district_key_column_ids, district_expr_types,
+      district_update_key_values, runtime_keys);
+
   // Create plan node.
   planner::IndexScanPlan district_update_index_scan_node(district_table, nullptr,
                                                   district_update_column_ids,
-                                                  district_index_scan_desc);
+                                                  district_update_index_scan_desc);
 
   executor::IndexScanExecutor district_update_index_scan_executor(&district_update_index_scan_node, context.get());
 
@@ -472,6 +480,16 @@ bool RunNewOrder(const size_t &thread_id){
         stock_pkey_index, stock_key_column_ids, stock_expr_types,
         stock_key_values, runtime_keys);
 
+    std::vector<common::Value *> stock_update_key_values;
+    
+    stock_update_key_values.push_back(common::ValueFactory::GetIntegerValue(item_id).Copy());
+    stock_update_key_values.push_back(common::ValueFactory::GetIntegerValue(ol_w_id).Copy());
+
+    planner::IndexScanPlan::IndexScanDesc stock_index_scan_desc(
+        stock_pkey_index, stock_key_column_ids, stock_expr_types,
+        stock_update_key_values, runtime_keys);
+
+
     // Create plan node.
     planner::IndexScanPlan stock_index_scan_node(stock_table, nullptr,
                                                  stock_column_ids,
@@ -517,7 +535,7 @@ bool RunNewOrder(const size_t &thread_id){
     // Create plan node.
     planner::IndexScanPlan stock_update_index_scan_node(stock_table, nullptr,
                                                         stock_update_column_ids,
-                                                        stock_index_scan_desc);
+                                                        stock_update_index_scan_desc);
     
     executor::IndexScanExecutor stock_update_index_scan_executor(&stock_update_index_scan_node, context.get());
 

--- a/src/main/tpcc/tpcc_workload.cpp
+++ b/src/main/tpcc/tpcc_workload.cpp
@@ -82,10 +82,10 @@ namespace tpcc {
 // WORKLOAD
 /////////////////////////////////////////////////////////
 
-#define STOCK_LEVEL_RATIO     0.00
-#define ORDER_STATUS_RATIO    0.00
-#define PAYMENT_RATIO         0.00
-#define NEW_ORDER_RATIO       1.00
+#define STOCK_LEVEL_RATIO     0.04
+#define ORDER_STATUS_RATIO    0.04
+#define PAYMENT_RATIO         0.44
+#define NEW_ORDER_RATIO       0.44
 
 volatile bool is_running = true;
 

--- a/src/main/tpcc/tpcc_workload.cpp
+++ b/src/main/tpcc/tpcc_workload.cpp
@@ -84,8 +84,8 @@ namespace tpcc {
 
 #define STOCK_LEVEL_RATIO     0.00
 #define ORDER_STATUS_RATIO    0.00
-#define PAYMENT_RATIO         0.50
-#define NEW_ORDER_RATIO       0.50
+#define PAYMENT_RATIO         0.00
+#define NEW_ORDER_RATIO       1.00
 
 volatile bool is_running = true;
 

--- a/src/main/tpcc/tpcc_workload.cpp
+++ b/src/main/tpcc/tpcc_workload.cpp
@@ -84,8 +84,8 @@ namespace tpcc {
 
 #define STOCK_LEVEL_RATIO     0.04
 #define ORDER_STATUS_RATIO    0.04
-#define PAYMENT_RATIO         0.44
-#define NEW_ORDER_RATIO       0.44
+#define PAYMENT_RATIO         0.43
+#define NEW_ORDER_RATIO       0.45
 
 volatile bool is_running = true;
 


### PR DESCRIPTION
In this PR, I fixed a type-system-related problem in the hard-coded version of TPC-C benchmark. In our current implementation, the data value is created outside of the `IndexScanPlan` but deleted by the deconstructor of the `IndexScanPlan` (which is not a very good habit). This forbids us from reusing the created values.