### PR TITLE
Fix unused variable in stat test. #271

### DIFF
--- a/test/statistics/stats_tests_util.cpp
+++ b/test/statistics/stats_tests_util.cpp
@@ -29,8 +29,9 @@ namespace test {
 
 void StatsTestsUtil::ShowTable(std::string database_name,
                                std::string table_name) {
-  auto table = catalog::Catalog::GetInstance()->GetTableWithName(database_name,
-                                                                 table_name);
+  UNUSED_ATTRIBUTE auto table =
+      catalog::Catalog::GetInstance()->GetTableWithName(database_name,
+                                                        table_name);
   PL_ASSERT(table != nullptr);
   std::unique_ptr<Statement> statement;
   auto &peloton_parser = parser::Parser::GetInstance();


### PR DESCRIPTION
Annotate the unused variable which breaks the release jenkins build. 