### PR TITLE
[#275] Add XML output flag for gtest.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,7 +75,8 @@ foreach(test_src ${test_srcs} )
 	
 	# add test
     add_test(${test_name} ${MEMORYCHECK_COMMAND} ${MEMORYCHECK_COMMAND_OPTIONS}
-        --suppressions=${MEMORYCHECK_SUPPRESSIONS_FILE} ${CMAKE_BINARY_DIR}/test/${test_name})
+        --suppressions=${MEMORYCHECK_SUPPRESSIONS_FILE} ${CMAKE_BINARY_DIR}/test/${test_name}
+        --gtest_output=xml:${CMAKE_BINARY_DIR}/test/unit_${test_name}.xml)
 	
 endforeach(test_src ${test_srcs})
 
@@ -107,6 +108,7 @@ foreach(perf_src ${perf_srcs} )
 	)   
 	
 	# add test
-	add_test(${perf_name} ${CMAKE_BINARY_DIR}/test/${perf_name})
+	add_test(${perf_name} ${CMAKE_BINARY_DIR}/test/${perf_name}
+        --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${perf_name}.xml)
 	
 endforeach(perf_src ${perf_srcs})


### PR DESCRIPTION
Adding this flag will generate one XML output for every gtest target. I didn't find the documentation of generating a single XML file for all the tests. #275 