### PR TITLE
#291 Fixed multi-tile group output collection

### DIFF
--- a/script/testing/jdbc/src/PelotonTest.java
+++ b/script/testing/jdbc/src/PelotonTest.java
@@ -14,7 +14,7 @@ import java.sql.*;
 import org.postgresql.util.*;
 
 public class PelotonTest {
-  private final String url = "jdbc:postgresql://localhost:5432/";
+  private final String url = "jdbc:postgresql://localhost:54321/";
   private final String username = "postgres";
   private final String pass = "postgres";
 

--- a/script/testing/jdbc/src/PelotonTest.java
+++ b/script/testing/jdbc/src/PelotonTest.java
@@ -14,7 +14,7 @@ import java.sql.*;
 import org.postgresql.util.*;
 
 public class PelotonTest {
-  private final String url = "jdbc:postgresql://localhost:54321/";
+  private final String url = "jdbc:postgresql://localhost:5432/";
   private final String username = "postgres";
   private final String pass = "postgres";
 

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -103,8 +103,8 @@ peloton_status PlanExecutor::ExecutePlan(
     if (logical_tile.get() != nullptr) {
       LOG_TRACE("Final Answer: %s",
                 logical_tile->GetInfo().c_str());  // Printing the answers
-      auto output_schema =
-          logical_tile->GetPhysicalSchema();  // Physical schema of the tile
+      std::unique_ptr<catalog::Schema> output_schema(
+          logical_tile->GetPhysicalSchema());  // Physical schema of the tile
       std::vector<std::vector<std::string>> answer_tuples;
       answer_tuples =
           std::move(logical_tile->GetAllValuesAsStrings(result_format));
@@ -124,7 +124,6 @@ peloton_status PlanExecutor::ExecutePlan(
           result.push_back(res);
         }
       }
-      delete output_schema;
     }
   }
 

--- a/src/executor/seq_scan_executor.cpp
+++ b/src/executor/seq_scan_executor.cpp
@@ -104,10 +104,8 @@ bool SeqScanExecutor::DExecute() {
 
       /* Hopefully we needn't do projections here */
       SetOutput(tile.release());
-
       return true;
     }
-
     return false;
   }
   // Scanning a table


### PR DESCRIPTION
This diff pulls the output logical tiles even when Execute() status is true. This ensures that all the tiles will be returned for queries that generate output spanning over multiple logical tiles.