### PR TITLE
psql & jdbc error message 

### DIFF
--- a/script/testing/jdbc/src/PelotonTest.java
+++ b/script/testing/jdbc/src/PelotonTest.java
@@ -119,6 +119,8 @@ public class PelotonTest {
 
   private final String UNSUPPORTED_INNER_JOIN_SQL = "SELECT * FROM A INNER JOIN B ON A.id = B.id;";
 
+  private final String UNSUPPORTED_SELECT_FOR_UPDATE_SQL = "SELECT id FROM A FOR UPDATE where A.id = 1;";
+
   public PelotonTest() throws SQLException {
     try {
       Class.forName("org.postgresql.Driver");
@@ -608,13 +610,14 @@ public class PelotonTest {
     Statement stmt = conn.createStatement();
 
     int validQueryIndex = -1;
-    String statements[] = new String[5];
+    String statements[] = new String[6];
     statements[0] = INVALID_TABLE_SQL;
     statements[1] = INVALID_DB_SQL;
     statements[2] = INVALID_SYNTAX_SQL;
     statements[3] = UNSUPPORTED_JOIN_SQL;
     statements[4] = UNSUPPORTED_INNER_JOIN_SQL;
-    for (int i = 0; i < 5; i++) {
+    statements[5] = UNSUPPORTED_SELECT_FOR_UPDATE_SQL;
+    for (int i = 0; i < 6; i++) {
       try {
         stmt.execute(statements[i]);
         validQueryIndex = i;

--- a/script/testing/jdbc/src/PelotonTest.java
+++ b/script/testing/jdbc/src/PelotonTest.java
@@ -108,7 +108,16 @@ public class PelotonTest {
 
   // To test the table stats colleced
   private final String SELECT_TABLE_METRIC = "SELECT * FROM catalog_db.table_metric;";
-  ;
+  
+  private final String INVALID_TABLE_SQL = "SELECT * FROM INVALID_TABLE;";
+
+  private final String INVALID_DB_SQL = "SELECT * FROM INVALID_DB.A;";
+
+  private final String INVALID_KEYWORD_SQL = "INVALIDKEYWORD * FROM A;";
+
+  private final String UNSUPPORTED_JOIN_SQL = "SELECT * FROM A, B;";
+
+  private final String UNSUPPORTED_INNER_JOIN_SQL = "SELECT * FROM A INNER JOIN B ON A.id = B.id;";
 
   public PelotonTest() throws SQLException {
     try {
@@ -594,6 +603,31 @@ public class PelotonTest {
     conn.commit();
   }
 
+  public void Invalid_SQL() throws SQLException {
+    conn.setAutoCommit(true);
+    Statement stmt = conn.createStatement();
+
+    int validQueryIndex = -1;
+    String statements[] = new String[5];
+    statements[0] = INVALID_TABLE_SQL;
+    statements[1] = INVALID_DB_SQL;
+    statements[2] = INVALID_KEYWORD_SQL;
+    statements[3] = UNSUPPORTED_JOIN_SQL;
+    statements[4] = UNSUPPORTED_INNER_JOIN_SQL;
+    for (int i = 0; i < 5; i++) {
+      try {
+        stmt.execute(statements[i]);
+        validQueryIndex = i;
+        break;
+      } catch (Exception e) {
+        // Great! Exception is expected!
+      }
+    }
+    if (validQueryIndex != -1) {
+      throw new SQLException(statements[validQueryIndex]);
+    }
+  }
+
   public void Batch_Update() throws SQLException{
     PreparedStatement stmt = conn.prepareStatement(UPDATE_BY_INDEXSCAN);
 
@@ -662,6 +696,7 @@ public class PelotonTest {
     pt.Batch_Insert();
     pt.Batch_Update();
     pt.Batch_Delete();
+    pt.Invalid_SQL();
     pt.Close();
   }
 

--- a/script/testing/jdbc/src/PelotonTest.java
+++ b/script/testing/jdbc/src/PelotonTest.java
@@ -2,7 +2,7 @@
 //
 //                         Peloton
 //
-// delete_plan.h
+// PelotonTest.java
 //
 // Identification: script/testing/jdbc/src/PelotonTest.java
 //
@@ -113,7 +113,7 @@ public class PelotonTest {
 
   private final String INVALID_DB_SQL = "SELECT * FROM INVALID_DB.A;";
 
-  private final String INVALID_KEYWORD_SQL = "INVALIDKEYWORD * FROM A;";
+  private final String INVALID_SYNTAX_SQL = "INVALIDKEYWORD * FROM A;";
 
   private final String UNSUPPORTED_JOIN_SQL = "SELECT * FROM A, B;";
 
@@ -611,7 +611,7 @@ public class PelotonTest {
     String statements[] = new String[5];
     statements[0] = INVALID_TABLE_SQL;
     statements[1] = INVALID_DB_SQL;
-    statements[2] = INVALID_KEYWORD_SQL;
+    statements[2] = INVALID_SYNTAX_SQL;
     statements[3] = UNSUPPORTED_JOIN_SQL;
     statements[4] = UNSUPPORTED_INNER_JOIN_SQL;
     for (int i = 0; i < 5; i++) {
@@ -624,7 +624,7 @@ public class PelotonTest {
       }
     }
     if (validQueryIndex != -1) {
-      throw new SQLException(statements[validQueryIndex]);
+      throw new SQLException("This should be an invalid SQL: " + statements[validQueryIndex]);
     }
   }
 

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -96,9 +96,11 @@ class Catalog {
                    concurrency::Transaction *txn);
 
   // Find a database using its id
+  // Throw CatalogException if not found
   storage::Database *GetDatabaseWithOid(const oid_t db_oid) const;
 
   // Find a database using its name
+  // Throw CatalogException if not found
   storage::Database *GetDatabaseWithName(const std::string db_name) const;
 
   // Find a database using vector offset

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -151,6 +151,7 @@ class DataTable : public AbstractTable {
 
   void AddIndex(std::shared_ptr<index::Index> index);
 
+  // Throw CatalogException if not such index is found
   std::shared_ptr<index::Index> GetIndexWithOid(const oid_t &index_oid);
 
   void DropIndexWithOid(const oid_t &index_oid);

--- a/src/include/storage/database.h
+++ b/src/include/storage/database.h
@@ -53,8 +53,10 @@ class Database : public Printable {
 
   storage::DataTable *GetTable(const oid_t table_offset) const;
 
+  // Throw CatalogException if such table is not found
   storage::DataTable *GetTableWithOid(const oid_t table_oid) const;
 
+  // Throw CatalogException if such table is not found
   storage::DataTable *GetTableWithName(const std::string table_name) const;
 
   oid_t GetTableCount() const;

--- a/src/networking/protocol.cpp
+++ b/src/networking/protocol.cpp
@@ -304,8 +304,9 @@ void PacketManager::ExecParseMessage(Packet *pkt, ResponseBuffer &responses) {
   statement =
       tcop.PrepareStatement(statement_name, query_string, error_message);
   if (statement.get() == nullptr) {
+    skipped_stmt_ = true;
     SendErrorResponse({{'M', error_message}}, responses);
-    SendReadyForQuery(txn_state_, responses);
+    LOG_TRACE("ExecParse Error");
     return;
   }
 

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -606,6 +606,8 @@ std::unique_ptr<planner::AbstractScan> SimpleOptimizer::CreateScanPlan(
 
   bool update_flag = false;
   if (select_stmt->is_for_update == true) {
+    throw NotImplementedException(
+        "Error: select .. for update is not implemented yet!");
     update_flag = true;
   }
   // Create index scan desc

--- a/src/planner/drop_plan.cpp
+++ b/src/planner/drop_plan.cpp
@@ -33,10 +33,19 @@ DropPlan::DropPlan(std::string name) {
 
 DropPlan::DropPlan(parser::DropStatement *parse_tree) {
   table_name = parse_tree->GetTableName();
-  target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
-      parse_tree->GetDatabaseName(), table_name);
   // Set it up for the moment , cannot seem to find it in DropStatement
   missing = parse_tree->missing;
+
+  try {
+    target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
+        parse_tree->GetDatabaseName(), table_name);
+  }
+  catch (CatalogException &e) {
+    // Dropping a table which doesn't exist
+    if (missing == false) {
+      throw e;
+    }
+  }
 }
 
 }  // namespace planner

--- a/src/statistics/index_metric.cpp
+++ b/src/statistics/index_metric.cpp
@@ -24,15 +24,15 @@ IndexMetric::IndexMetric(MetricType type, oid_t database_id, oid_t table_id,
       table_id_(table_id),
       index_id_(index_id) {
   index_name_ = "";
-  auto index = catalog::Catalog::GetInstance()->GetIndexWithOid(
-      database_id, table_id, index_id);
-  if (index == nullptr) {
-    index_name_ = "";
-  } else {
+  try {
+    auto index = catalog::Catalog::GetInstance()->GetIndexWithOid(
+        database_id, table_id, index_id);
     index_name_ = index->GetName();
     for (auto& ch : index_name_) {
       ch = toupper(ch);
     }
+  }
+  catch (CatalogException& e) {
   }
 }
 

--- a/src/statistics/table_metric.cpp
+++ b/src/statistics/table_metric.cpp
@@ -19,13 +19,14 @@ namespace stats {
 
 TableMetric::TableMetric(MetricType type, oid_t database_id, oid_t table_id)
     : AbstractMetric(type), database_id_(database_id), table_id_(table_id) {
-  auto table =
-      catalog::Catalog::GetInstance()->GetTableWithOid(database_id, table_id);
-  if (table == nullptr) {
-    table_name_ = "";
-  } else {
+  try {
+    auto table =
+        catalog::Catalog::GetInstance()->GetTableWithOid(database_id, table_id);
     table_name_ = table->GetName();
     for (auto& ch : table_name_) ch = toupper(ch);
+  }
+  catch (CatalogException& e) {
+    table_name_ = "";
   }
 }
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -18,6 +18,7 @@
 #include "common/exception.h"
 #include "common/logger.h"
 #include "common/platform.h"
+#include "common/exception.h"
 #include "catalog/foreign_key.h"
 #include "catalog/catalog.h"
 #include "concurrency/transaction_manager_factory.h"
@@ -828,7 +829,10 @@ std::shared_ptr<index::Index> DataTable::GetIndexWithOid(
       break;
     }
   }
-
+  if (ret_index == nullptr) {
+    throw CatalogException("No index with oid = " + std::to_string(index_oid) +
+                           " is found");
+  }
   return ret_index;
 }
 

--- a/src/storage/database.cpp
+++ b/src/storage/database.cpp
@@ -17,6 +17,7 @@
 #include "storage/table_factory.h"
 #include "common/logger.h"
 #include "index/index.h"
+#include "common/exception.h"
 
 namespace peloton {
 namespace storage {
@@ -45,7 +46,8 @@ void Database::AddTable(storage::DataTable *table) {
 storage::DataTable *Database::GetTableWithOid(const oid_t table_oid) const {
   for (auto table : tables)
     if (table->GetOid() == table_oid) return table;
-
+  throw CatalogException("Table with oid = " + std::to_string(table_oid) +
+                         " is not found");
   return nullptr;
 }
 
@@ -53,7 +55,7 @@ storage::DataTable *Database::GetTableWithName(const std::string table_name)
     const {
   for (auto table : tables)
     if (table->GetName() == table_name) return table;
-
+  throw CatalogException("Table " + table_name + " is not found");
   return nullptr;
 }
 

--- a/src/storage/table_factory.cpp
+++ b/src/storage/table_factory.cpp
@@ -37,13 +37,14 @@ DataTable *TableFactory::GetDataTable(oid_t database_id, oid_t relation_id,
 
 bool TableFactory::DropDataTable(oid_t database_oid, oid_t table_oid) {
   auto catalog = catalog::Catalog::GetInstance();
-
-  DataTable *table =
-      (DataTable *)catalog->GetTableWithOid(database_oid, table_oid);
-
-  if (table == nullptr) return false;
-
-  delete table;
+  try {
+    DataTable *table =
+        (DataTable *)catalog->GetTableWithOid(database_oid, table_oid);
+    delete table;
+  }
+  catch (CatalogException &e) {
+    return false;
+  }
   return true;
 }
 

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -103,7 +103,6 @@ Result TrafficCop::ExecuteStatement(
   }
   catch (Exception &e) {
     error_message = e.what();
-    e.PrintStackTrace();
     return Result::RESULT_FAILURE;
   }
 }
@@ -120,7 +119,9 @@ std::shared_ptr<Statement> TrafficCop::PrepareStatement(
   try {
     auto &peloton_parser = parser::Parser::GetInstance();
     auto sql_stmt = peloton_parser.BuildParseTree(query_string);
-
+    if (sql_stmt->is_valid == false) {
+      throw ParserException("Error parsing SQL statement");
+    }
     statement->SetPlanTree(
         optimizer::SimpleOptimizer::BuildPelotonPlanTree(sql_stmt));
 
@@ -138,7 +139,6 @@ std::shared_ptr<Statement> TrafficCop::PrepareStatement(
   }
   catch (Exception &e) {
     error_message = e.what();
-    e.PrintStackTrace();
     return nullptr;
   }
 }

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -143,8 +143,9 @@ TEST_F(CatalogTests, DroppingDatabase) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->DropDatabaseWithName("EMP_DB", txn);
-  EXPECT_EQ(catalog::Catalog::GetInstance()->GetDatabaseWithName("EMP_DB"),
-            nullptr);
+
+  EXPECT_THROW(catalog::Catalog::GetInstance()->GetDatabaseWithName("EMP_DB"),
+               CatalogException);
   txn_manager.CommitTransaction(txn);
 }
 

--- a/test/concurrency/transaction_tests_util.cpp
+++ b/test/concurrency/transaction_tests_util.cpp
@@ -182,9 +182,11 @@ storage::DataTable *TransactionTestsUtil::CreateTable(
 
   // add this table to current database
   auto catalog = catalog::Catalog::GetInstance();
-  storage::Database *db = catalog->GetDatabaseWithOid(database_id);
-  if (db != nullptr) {
+  try {
+    storage::Database *db = catalog->GetDatabaseWithOid(database_id);
     db->AddTable(table);
+  }
+  catch (CatalogException &e) {
   }
 
   // Insert tuple

--- a/test/statistics/stats_tests_util.cpp
+++ b/test/statistics/stats_tests_util.cpp
@@ -29,10 +29,7 @@ namespace test {
 
 void StatsTestsUtil::ShowTable(std::string database_name,
                                std::string table_name) {
-  UNUSED_ATTRIBUTE auto table =
-      catalog::Catalog::GetInstance()->GetTableWithName(database_name,
-                                                        table_name);
-  PL_ASSERT(table != nullptr);
+  catalog::Catalog::GetInstance()->GetTableWithName(database_name, table_name);
   std::unique_ptr<Statement> statement;
   auto &peloton_parser = parser::Parser::GetInstance();
   std::vector<common::Value *> params;


### PR DESCRIPTION
In this PR, error messages are propagated to the front end when 
* A query accesses a table/database which doesn't exist 
* It fails to parse the query 
* Query planner is unimplemented (e.g. join queries, select for update)

Now when accessing a table which doesn't exist, an exception will be thrown and possibly propagate up to the front end. Throwing an exception is slow, but this should not happen very often. 

End-to-end test cases are added to `PelotonTest.java`. 

However, it doesn't cover all the unimplemented features yet. It would take a while for me to figure out all features that are not implemented. **If you know some feature not supported off-hand and not covered by my code, please kindly leave a comment.** Thanks! 

@sid1607  Please review what I changed in the wire protocol code. 

TODO:
* also throw exception on columns that don't exist.