### PR TITLE
Disable stat cuckoomap initialization

### DIFF
--- a/src/include/statistics/backend_stats_context.h
+++ b/src/include/statistics/backend_stats_context.h
@@ -168,10 +168,6 @@ class BackendStatsContext {
   // Whether this context is registered to the global aggregator
   bool is_registered_to_aggregator_;
 
-  // The mapping table of backend stat context for each thread
-  static CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>>
-      stats_context_map_;
-
   // The total number of queries aggregated
   oid_t aggregated_query_count_ = 0;
 
@@ -181,6 +177,11 @@ class BackendStatsContext {
 
   // Mark the on going query as completed and move it to completed query queue
   void CompleteQueryMetric();
+
+  // Get the mapping table of backend stat context for each thread
+  static CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>> &
+    GetBackendContextMap(void);
+
 };
 
 }  // namespace stats

--- a/src/statistics/backend_stats_context.cpp
+++ b/src/statistics/backend_stats_context.cpp
@@ -24,17 +24,22 @@
 namespace peloton {
 namespace stats {
 
-CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>>
-    BackendStatsContext::stats_context_map_;
+CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>> &
+  BackendStatsContext::GetBackendContextMap() {
+  static CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>>
+      stats_context_map;
+  return stats_context_map;
+}
 
 BackendStatsContext* BackendStatsContext::GetInstance() {
 
   // Each thread gets a backend stats context
   std::thread::id this_id = std::this_thread::get_id();
   std::shared_ptr<BackendStatsContext> result(nullptr);
-  if (stats_context_map_.Find(this_id, result) == false) {
+  auto &stats_context_map = GetBackendContextMap();
+  if (stats_context_map.Find(this_id, result) == false) {
     result.reset(new BackendStatsContext(LATENCY_MAX_HISTORY_THREAD, true));
-    stats_context_map_.Insert(this_id, result);
+    stats_context_map.Insert(this_id, result);
   }
   return result.get();
 }


### PR DESCRIPTION
Callgrind reports that stat cuckoomap constructor & destructor have high cost (even just called once). Removed it temporarily so that we can benchmark tpcc first. 
