### PR TITLE
Comment out the exception for "select for update".

### DIFF
--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -606,8 +606,10 @@ std::unique_ptr<planner::AbstractScan> SimpleOptimizer::CreateScanPlan(
 
   bool update_flag = false;
   if (select_stmt->is_for_update == true) {
-    throw NotImplementedException(
-        "Error: select .. for update is not implemented yet!");
+    // FIXME: These are commented out for now to profile TPC-C. Eventually we
+    // have to support select for update.
+    //throw NotImplementedException(
+    //    "Error: select .. for update is not implemented yet!");
     update_flag = true;
   }
   // Create index scan desc


### PR DESCRIPTION
After adding the error messages we will throw an exception when encountering an "select for update" statement, which prevents TPC-C from running successfully. I commented out that exception for now to allow us profiling the system first. Eventually we have to support that.