### PR TITLE
support scalable tile group allocation

### DIFF
--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -15,6 +15,7 @@
 #include "common/config.h"
 
 #include "gc/gc_manager_factory.h"
+#include "storage/data_table.h"
 
 #include "libcds/cds/init.h"
 
@@ -31,12 +32,17 @@ void PelotonInit::Initialize() {
   // Initialize CDS library
   cds::Initialize();
 
+
   // FIXME: A number for the available threads other than
   // std::thread::hardware_concurrency() should be
   // chosen. Assigning new task after reaching maximum will
   // block.
   thread_pool.Initialize(std::thread::hardware_concurrency(), 0);
 
+  int parallelism = (std::thread::hardware_concurrency() + 1) / 2;
+  storage::DataTable::SetActiveTileGroupCount(parallelism);
+  storage::DataTable::SetActiveIndirectionArrayCount(parallelism);
+  
   // the garbage collector is assigned to dedicated threads.
   auto &gc_manager = gc::GCManagerFactory::GetInstance();
   gc_manager.StartGC();

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -36,10 +36,6 @@ extern LayoutType peloton_layout_mode;
 
 extern std::vector<peloton::oid_t> sdbench_column_ids;
 
-const int ACTIVE_TILEGROUP_COUNT = 1;
-
-const int ACTIVE_INDIRECTION_ARRAY_COUNT = 1;
-
 
 namespace peloton {
 
@@ -70,6 +66,7 @@ namespace storage {
 class Tuple;
 class TileGroup;
 class IndirectionArray;
+
 
 
 //===--------------------------------------------------------------------===//
@@ -245,6 +242,16 @@ class DataTable : public AbstractTable {
                        concurrency::Transaction *transaction, 
                        ItemPointer **index_entry_ptr);
 
+
+
+  static void SetActiveTileGroupCount(const size_t active_tile_group_count) {
+    active_tilegroup_count_ = active_tile_group_count;
+  }
+
+  static void SetActiveIndirectionArrayCount(const size_t active_indirection_array_count) {
+    active_indirection_array_count_ = active_indirection_array_count;
+  }
+
  protected:
 
   //===--------------------------------------------------------------------===//
@@ -282,6 +289,11 @@ class DataTable : public AbstractTable {
   // check the foreign key constraints
   bool CheckForeignKeyConstraints(const storage::Tuple *tuple);
 
+public:
+  static size_t active_tilegroup_count_;
+
+  static size_t active_indirection_array_count_;
+
  private:
   //===--------------------------------------------------------------------===//
   // MEMBERS
@@ -293,12 +305,12 @@ class DataTable : public AbstractTable {
   // TILE GROUPS
   LockFreeArray<oid_t> tile_groups_;
 
-  std::shared_ptr<storage::TileGroup> active_tile_groups_[ACTIVE_TILEGROUP_COUNT];
+  std::vector<std::shared_ptr<storage::TileGroup>> active_tile_groups_;
 
   std::atomic<size_t> tile_group_count_ = ATOMIC_VAR_INIT(0);
 
   // INDIRECTIONS
-  std::shared_ptr<storage::IndirectionArray> active_indirection_arrays_[ACTIVE_INDIRECTION_ARRAY_COUNT];
+  std::vector<std::shared_ptr<storage::IndirectionArray>> active_indirection_arrays_;
 
   // data table mutex
   std::mutex data_table_mutex_;

--- a/test/executor/loader_test.cpp
+++ b/test/executor/loader_test.cpp
@@ -132,22 +132,22 @@ TEST_F(LoaderTests, LoadingTest) {
   auto expected_tile_group_count = 0;
 
   int total_tuple_count = loader_threads_count * tilegroup_count_per_loader * TEST_TUPLES_PER_TILEGROUP;
-  int max_cached_tuple_count = TEST_TUPLES_PER_TILEGROUP * ACTIVE_TILEGROUP_COUNT;
-  int max_unfill_cached_tuple_count = (TEST_TUPLES_PER_TILEGROUP - 1) * ACTIVE_TILEGROUP_COUNT;
+  int max_cached_tuple_count = TEST_TUPLES_PER_TILEGROUP * storage::DataTable::active_tilegroup_count_;
+  int max_unfill_cached_tuple_count = (TEST_TUPLES_PER_TILEGROUP - 1) * storage::DataTable::active_tilegroup_count_;
 
   if (total_tuple_count - max_cached_tuple_count <= 0) {
     if (total_tuple_count <= max_unfill_cached_tuple_count) {
-      expected_tile_group_count = ACTIVE_TILEGROUP_COUNT;
+      expected_tile_group_count = storage::DataTable::active_tilegroup_count_;
     } else {
-      expected_tile_group_count = ACTIVE_TILEGROUP_COUNT + total_tuple_count - max_unfill_cached_tuple_count; 
+      expected_tile_group_count = storage::DataTable::active_tilegroup_count_ + total_tuple_count - max_unfill_cached_tuple_count; 
     }
   } else {
-    int filled_tile_group_count = total_tuple_count / max_cached_tuple_count * ACTIVE_TILEGROUP_COUNT;
+    int filled_tile_group_count = total_tuple_count / max_cached_tuple_count * storage::DataTable::active_tilegroup_count_;
     
     if (total_tuple_count - filled_tile_group_count * TEST_TUPLES_PER_TILEGROUP - max_unfill_cached_tuple_count <= 0) {
-      expected_tile_group_count = filled_tile_group_count + ACTIVE_TILEGROUP_COUNT;
+      expected_tile_group_count = filled_tile_group_count + storage::DataTable::active_tilegroup_count_;
     } else {
-      expected_tile_group_count = filled_tile_group_count + ACTIVE_TILEGROUP_COUNT + (total_tuple_count - filled_tile_group_count - max_unfill_cached_tuple_count); 
+      expected_tile_group_count = filled_tile_group_count + storage::DataTable::active_tilegroup_count_ + (total_tuple_count - filled_tile_group_count - max_unfill_cached_tuple_count); 
     }
   }
 

--- a/test/include/common/harness.h
+++ b/test/include/common/harness.h
@@ -28,6 +28,11 @@
 #include "gtest/gtest.h"
 
 
+#include "libcds/cds/init.h"
+
+#include <google/protobuf/stubs/common.h>
+#include <gflags/gflags.h>
+
 namespace peloton {
 
 namespace common{
@@ -103,18 +108,25 @@ class PelotonTest : public ::testing::Test {
  protected:
 
   virtual void SetUp() {
+    // Initialize CDS library
+    cds::Initialize();
 
-    PelotonInit::Initialize();
-
-    PelotonInit::SetUpThread();
-
+    // Attach thread to cds
+    cds::threading::Manager::attachThread();
   }
 
   virtual void TearDown() {
+    // Detach thread from cds
+    cds::threading::Manager::detachThread();
 
-    PelotonInit::TearDownThread();
+    // Terminate CDS library
+    cds::Terminate();
 
-    PelotonInit::Shutdown();
+    // shutdown protocol buf library
+    google::protobuf::ShutdownProtobufLibrary();
+
+    // Shut down GFLAGS.
+    ::google::ShutDownCommandLineFlags();
 
   }
 };

--- a/test/performance/insert_performance_test.cpp
+++ b/test/performance/insert_performance_test.cpp
@@ -120,22 +120,22 @@ TEST_F(InsertTests, LoadingTest) {
   auto expected_tile_group_count = 0;
 
   int total_tuple_count = loader_threads_count * tilegroup_count_per_loader * TEST_TUPLES_PER_TILEGROUP;
-  int max_cached_tuple_count = TEST_TUPLES_PER_TILEGROUP * ACTIVE_TILEGROUP_COUNT;
-  int max_unfill_cached_tuple_count = (TEST_TUPLES_PER_TILEGROUP - 1) * ACTIVE_TILEGROUP_COUNT;
+  int max_cached_tuple_count = TEST_TUPLES_PER_TILEGROUP * storage::DataTable::active_tilegroup_count_;
+  int max_unfill_cached_tuple_count = (TEST_TUPLES_PER_TILEGROUP - 1) * storage::DataTable::active_tilegroup_count_;
 
   if (total_tuple_count - max_cached_tuple_count <= 0) {
     if (total_tuple_count <= max_unfill_cached_tuple_count) {
-      expected_tile_group_count = ACTIVE_TILEGROUP_COUNT;
+      expected_tile_group_count = storage::DataTable::active_tilegroup_count_;
     } else {
-      expected_tile_group_count = ACTIVE_TILEGROUP_COUNT + total_tuple_count - max_unfill_cached_tuple_count; 
+      expected_tile_group_count = storage::DataTable::active_tilegroup_count_ + total_tuple_count - max_unfill_cached_tuple_count; 
     }
   } else {
-    int filled_tile_group_count = total_tuple_count / max_cached_tuple_count * ACTIVE_TILEGROUP_COUNT;
+    int filled_tile_group_count = total_tuple_count / max_cached_tuple_count * storage::DataTable::active_tilegroup_count_;
     
     if (total_tuple_count - filled_tile_group_count * TEST_TUPLES_PER_TILEGROUP - max_unfill_cached_tuple_count <= 0) {
-      expected_tile_group_count = filled_tile_group_count + ACTIVE_TILEGROUP_COUNT;
+      expected_tile_group_count = filled_tile_group_count + storage::DataTable::active_tilegroup_count_;
     } else {
-      expected_tile_group_count = filled_tile_group_count + ACTIVE_TILEGROUP_COUNT + (total_tuple_count - filled_tile_group_count - max_unfill_cached_tuple_count); 
+      expected_tile_group_count = filled_tile_group_count + storage::DataTable::active_tilegroup_count_ + (total_tuple_count - filled_tile_group_count - max_unfill_cached_tuple_count); 
     }
   }
 


### PR DESCRIPTION
for now, the number of preallocated group is set to the number of threads / 2.