### PR TITLE
Refactor the binding mechanism

### DIFF
--- a/src/common/portal.cpp
+++ b/src/common/portal.cpp
@@ -10,33 +10,25 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "common/portal.h"
 #include "common/logger.h"
 #include "common/statement.h"
 
 namespace peloton {
 
-
 Portal::Portal(const std::string& portal_name,
                std::shared_ptr<Statement> statement,
-               const std::vector<std::pair<int, std::string>>& bind_parameters)
-: portal_name(portal_name),
-  statement(statement),
-  bind_parameters(bind_parameters) {
+               std::vector<common::Value> bind_parameters)
+    : portal_name(portal_name),
+      statement(statement),
+      bind_parameters(std::move(bind_parameters)) {}
 
+Portal::~Portal() { statement.reset(); }
 
+std::shared_ptr<Statement> Portal::GetStatement() const { return statement; }
+
+const std::vector<common::Value>& Portal::GetParameters() const {
+  return bind_parameters;
 }
-
-Portal::~Portal() {
-
-  statement.reset();
-
-}
-
-std::shared_ptr<Statement> Portal::GetStatement() const {
-  return statement;
-}
-
 
 }  // namespace peloton

--- a/src/include/common/portal.h
+++ b/src/include/common/portal.h
@@ -10,46 +10,44 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
+
+#include "common/value.h"
 
 namespace peloton {
 
 class Statement;
 
 class Portal {
-
  public:
-
   Portal() = delete;
   Portal(const Portal &) = delete;
   Portal &operator=(const Portal &) = delete;
   Portal(Portal &&) = delete;
   Portal &operator=(Portal &&) = delete;
 
-  Portal(const std::string& portal_name,
-         std::shared_ptr<Statement> statement,
-         const std::vector<std::pair<int, std::string>>& bind_parameters);
+  Portal(const std::string &portal_name, std::shared_ptr<Statement> statement,
+         std::vector<common::Value> bind_parameters);
 
   ~Portal();
 
   std::shared_ptr<Statement> GetStatement() const;
 
- private:
+  const std::vector<common::Value> &GetParameters() const;
 
+ private:
   // Portal name
   std::string portal_name;
 
   // Prepared statement
   std::shared_ptr<Statement> statement;
 
-  // Group the parameter types and the parameters in this vector
-  std::vector<std::pair<int, std::string>> bind_parameters;
-
+  // Values bound to the statement of this portal
+  std::vector<common::Value> bind_parameters;
 };
 
 }  // namespace peloton

--- a/src/include/planner/abstract_scan_plan.h
+++ b/src/include/planner/abstract_scan_plan.h
@@ -57,8 +57,7 @@ class AbstractScan : public AbstractPlan {
 
   inline storage::DataTable *GetTable() const { return target_table_; }
 
-  inline bool IsForUpdate() const { return is_for_update;}
-  
+  inline bool IsForUpdate() const { return is_for_update; }
 
  protected:
   // These methods only used by its derived classes (when deserialization)
@@ -69,12 +68,7 @@ class AbstractScan : public AbstractPlan {
   void SetPredicate(expression::AbstractExpression *predicate) {
     predicate_ = std::unique_ptr<expression::AbstractExpression>(predicate);
   }
-  void SetForUpdateFlag(bool flag){is_for_update = flag;}
-
-  /** @brief Predicate with ValueParameters inside. Needed to be binded at
-   * the binding stage to generate the "real" predicate.
-   */
-  std::unique_ptr<expression::AbstractExpression> predicate_with_params_;
+  void SetForUpdateFlag(bool flag) { is_for_update = flag; }
 
  private:
   /** @brief Pointer to table to scan from. */

--- a/src/include/planner/project_info.h
+++ b/src/include/planner/project_info.h
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include <utility>
@@ -51,7 +50,7 @@ class ProjectInfo {
   ProjectInfo(TargetList &tl, DirectMapList &dml) = delete;
 
   ProjectInfo(TargetList &&tl, DirectMapList &&dml)
-      : target_list_(tl), direct_map_list_(dml) { }
+      : target_list_(tl), direct_map_list_(dml) {}
 
   const TargetList &GetTargetList() const { return target_list_; }
 
@@ -59,19 +58,15 @@ class ProjectInfo {
 
   bool isNonTrivial() const { return target_list_.size() > 0; };
 
-  bool Evaluate(storage::Tuple *dest, 
-                const AbstractTuple *tuple1,
+  bool Evaluate(storage::Tuple *dest, const AbstractTuple *tuple1,
                 const AbstractTuple *tuple2,
                 executor::ExecutorContext *econtext) const;
 
-  bool Evaluate(AbstractTuple *dest, 
-                const AbstractTuple *tuple1,
+  bool Evaluate(AbstractTuple *dest, const AbstractTuple *tuple1,
                 const AbstractTuple *tuple2,
                 executor::ExecutorContext *econtext) const;
 
   std::string Debug() const;
-
-  void transformParameterToConstantValueExpression(std::vector<common::Value>* values, catalog::Schema* schema);
 
   ~ProjectInfo();
 

--- a/src/include/planner/seq_scan_plan.h
+++ b/src/include/planner/seq_scan_plan.h
@@ -17,10 +17,10 @@
 #include <vector>
 
 #include "abstract_scan_plan.h"
-#include "common/types.h"
-#include "common/serializer.h"
-#include "expression/abstract_expression.h"
 #include "common/logger.h"
+#include "common/serializer.h"
+#include "common/types.h"
+#include "expression/abstract_expression.h"
 
 namespace peloton {
 
@@ -45,12 +45,6 @@ class SeqScanPlan : public AbstractScan {
               const std::vector<oid_t> &column_ids, bool is_for_update = false)
       : AbstractScan(table, predicate, column_ids) {
     LOG_DEBUG("Creating a Sequential Scan Plan");
-
-    // Store a copy of the original expression for binding multiple queries.
-    if (predicate != nullptr) {
-      predicate_with_params_ =
-          std::unique_ptr<expression::AbstractExpression>(predicate->Copy());
-    }
 
     SetForUpdateFlag(is_for_update);
   }

--- a/src/include/tcop/tcop.h
+++ b/src/include/tcop/tcop.h
@@ -47,6 +47,7 @@ class TrafficCop {
 
   // ExecPrepStmt - Execute a statement from a prepared and bound statement
   Result ExecuteStatement(const std::shared_ptr<Statement> &statement,
+                          const std::vector<common::Value> &params,
                           const bool unnamed,
                           const std::vector<int> &result_format,
                           std::vector<ResultType> &result, int &rows_change,

--- a/src/networking/protocol.cpp
+++ b/src/networking/protocol.cpp
@@ -634,9 +634,6 @@ void PacketManager::ExecExecuteMessage(Packet *pkt, ResponseBuffer &responses) {
   auto statement_name = statement->GetStatementName();
   bool unnamed = statement_name.empty();
   auto param_values = portal->GetParameters();
-  // for (auto &value : param_values) {
-  //  LOG_ERROR("%s", value.GetInfo().c_str());
-  //}
 
   auto &tcop = tcop::TrafficCop::GetInstance();
   auto status =

--- a/src/networking/protocol.cpp
+++ b/src/networking/protocol.cpp
@@ -451,7 +451,7 @@ void PacketManager::ExecBindMessage(Packet *pkt, ResponseBuffer &responses) {
           param_values.push_back(
               (common::ValueFactory::GetVarcharValue(param_str))
                   .CastAs(PostgresValueTypeToPelotonValueType(
-                       (PostgresValueType)param_types[param_idx])));
+                      (PostgresValueType)param_types[param_idx])));
         }
       } else {
         // BINARY mode
@@ -492,8 +492,9 @@ void PacketManager::ExecBindMessage(Packet *pkt, ResponseBuffer &responses) {
             bind_parameters.push_back(std::make_pair(
                 common::Type::VARBINARY,
                 std::string(reinterpret_cast<char *>(&param[0]), param_len)));
-            param_values.push_back(common::ValueFactory::GetVarbinaryValue(
-                &param[0], param_len).Copy());
+            param_values.push_back(
+                common::ValueFactory::GetVarbinaryValue(&param[0], param_len)
+                    .Copy());
           } break;
           default: {
             LOG_ERROR("Do not support data type: %d", param_types[param_idx]);
@@ -525,15 +526,18 @@ void PacketManager::ExecBindMessage(Packet *pkt, ResponseBuffer &responses) {
     }
   }
 
+  /*
   if (param_values.size() > 0) {
     statement->GetPlanTree()->SetParameterValues(&param_values);
   }
 
   // clean up param_values
   param_values.clear();
+  */
 
   // Construct a portal
-  auto portal = new Portal(portal_name, statement, bind_parameters);
+  auto portal = new Portal(portal_name, statement, std::move(param_values));
+  // LOG_ERROR("size after move: %ld", param_values.size());
   std::shared_ptr<Portal> portal_reference(portal);
 
   auto itr = portals_.find(portal_name);
@@ -634,10 +638,15 @@ void PacketManager::ExecExecuteMessage(Packet *pkt, ResponseBuffer &responses) {
 
   auto statement_name = statement->GetStatementName();
   bool unnamed = statement_name.empty();
+  auto param_values = portal->GetParameters();
+  // for (auto &value : param_values) {
+  //  LOG_ERROR("%s", value.GetInfo().c_str());
+  //}
 
   auto &tcop = tcop::TrafficCop::GetInstance();
-  auto status = tcop.ExecuteStatement(statement, unnamed, result_format_,
-                                      results, rows_affected, error_message);
+  auto status =
+      tcop.ExecuteStatement(statement, param_values, unnamed, result_format_,
+                            results, rows_affected, error_message);
 
   if (status == Result::RESULT_FAILURE) {
     LOG_ERROR("Failed to execute: %s", error_message.c_str());

--- a/src/networking/protocol.cpp
+++ b/src/networking/protocol.cpp
@@ -526,18 +526,13 @@ void PacketManager::ExecBindMessage(Packet *pkt, ResponseBuffer &responses) {
     }
   }
 
-  /*
   if (param_values.size() > 0) {
     statement->GetPlanTree()->SetParameterValues(&param_values);
   }
 
-  // clean up param_values
-  param_values.clear();
-  */
-
-  // Construct a portal
+  // Construct a portal.
+  // Notice that this will move param_values so no value will be left there.
   auto portal = new Portal(portal_name, statement, std::move(param_values));
-  // LOG_ERROR("size after move: %ld", param_values.size());
   std::shared_ptr<Portal> portal_reference(portal);
 
   auto itr = portals_.find(portal_name);

--- a/src/planner/index_scan_plan.cpp
+++ b/src/planner/index_scan_plan.cpp
@@ -47,6 +47,7 @@ IndexScanPlan::IndexScanPlan(storage::DataTable *table,
     predicate = predicate->Copy();
     expression::ExpressionUtil::ReplaceColumnExpressions(table->GetSchema(),
                                                          predicate);
+    SetPredicate(predicate);
   }
 
   // copy the value over for binding purpose

--- a/src/planner/index_scan_plan.cpp
+++ b/src/planner/index_scan_plan.cpp
@@ -45,10 +45,8 @@ IndexScanPlan::IndexScanPlan(storage::DataTable *table,
     // we need to copy it here because eventually predicate will be destroyed by
     // its owner...
     predicate = predicate->Copy();
-    expression::ExpressionUtil::ReplaceColumnExpressions(table->GetSchema(), predicate);
-    predicate_with_params_ =
-        std::unique_ptr<expression::AbstractExpression>(predicate);
-    SetPredicate(predicate_with_params_->Copy());
+    expression::ExpressionUtil::ReplaceColumnExpressions(table->GetSchema(),
+                                                         predicate);
   }
 
   // copy the value over for binding purpose
@@ -67,11 +65,6 @@ IndexScanPlan::IndexScanPlan(storage::DataTable *table,
 void IndexScanPlan::SetParameterValues(std::vector<common::Value> *values) {
   LOG_TRACE("Setting parameter values in Index Scans");
 
-  auto where = predicate_with_params_->Copy();
-  expression::ExpressionUtil::ConvertParameterExpressions(
-      where, values, GetTable()->GetSchema());
-  SetPredicate(where);
-
   // Destroy the values of the last plan and copy the original values over for
   // binding
   values_.clear();
@@ -85,8 +78,8 @@ void IndexScanPlan::SetParameterValues(std::vector<common::Value> *values) {
     if (value.GetTypeId() == common::Type::PARAMETER_OFFSET) {
       int offset = value.GetAs<int32_t>();
       values_[i] =
-          (values->at(offset)).
-              CastAs(GetTable()->GetSchema()->GetColumn(column_id).GetType());
+          (values->at(offset))
+              .CastAs(GetTable()->GetSchema()->GetColumn(column_id).GetType());
     }
   }
 

--- a/src/planner/seq_scan_plan.cpp
+++ b/src/planner/seq_scan_plan.cpp
@@ -144,9 +144,6 @@ bool SeqScanPlan::SerializeTo(SerializeOutput &output) {
     // Write the expression type
     ExpressionType expr_type = GetPredicate()->GetExpressionType();
     output.WriteByte(static_cast<int8_t>(expr_type));
-
-    // Write predicate
-    // GetPredicate()->SerializeTo(output);
   }
 
   // Write parent, but parent seems never be set or used right now

--- a/src/planner/seq_scan_plan.cpp
+++ b/src/planner/seq_scan_plan.cpp
@@ -11,14 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "planner/seq_scan_plan.h"
-#include "storage/data_table.h"
-#include "catalog/manager.h"
-#include "common/types.h"
-#include "common/macros.h"
-#include "common/logger.h"
-#include "expression/expression_util.h"
-#include "catalog/schema.h"
 #include "catalog/catalog.h"
+#include "catalog/manager.h"
+#include "catalog/schema.h"
+#include "common/logger.h"
+#include "common/macros.h"
+#include "common/types.h"
+#include "expression/expression_util.h"
+#include "storage/data_table.h"
 
 #include "parser/statement_select.h"
 
@@ -92,7 +92,7 @@ SeqScanPlan::SeqScanPlan(parser::SelectStatement *select_node) {
   }
 
   // Check for "For Update" flag
-  if(select_node->is_for_update == true){
+  if (select_node->is_for_update == true) {
     SetForUpdateFlag(true);
   }
 
@@ -100,9 +100,8 @@ SeqScanPlan::SeqScanPlan(parser::SelectStatement *select_node) {
   if (select_node->where_clause != NULL) {
     auto predicate = select_node->where_clause->Copy();
     // Replace COLUMN_REF expressions with TupleValue expressions
-    expression::ExpressionUtil::ReplaceColumnExpressions(GetTable()->GetSchema(), predicate);
-    predicate_with_params_ =
-        std::unique_ptr<expression::AbstractExpression>(predicate->Copy());
+    expression::ExpressionUtil::ReplaceColumnExpressions(
+        GetTable()->GetSchema(), predicate);
     SetPredicate(predicate);
   }
 }
@@ -147,7 +146,7 @@ bool SeqScanPlan::SerializeTo(SerializeOutput &output) {
     output.WriteByte(static_cast<int8_t>(expr_type));
 
     // Write predicate
-    //GetPredicate()->SerializeTo(output);
+    // GetPredicate()->SerializeTo(output);
   }
 
   // Write parent, but parent seems never be set or used right now
@@ -201,7 +200,8 @@ bool SeqScanPlan::DeserializeFrom(SerializeInput &input) {
 
   // Get table and set it to the member
   storage::DataTable *target_table = static_cast<storage::DataTable *>(
-      catalog::Catalog::GetInstance()->GetTableWithOid(database_oid, table_oid));
+      catalog::Catalog::GetInstance()->GetTableWithOid(database_oid,
+                                                       table_oid));
   SetTargetTable(target_table);
 
   // Read the number of column_id and set them to column_ids_
@@ -313,10 +313,6 @@ oid_t SeqScanPlan::GetColumnID(std::string col_name) {
 
 void SeqScanPlan::SetParameterValues(std::vector<common::Value> *values) {
   LOG_TRACE("Setting parameter values in Sequential Scan");
-  auto predicate = predicate_with_params_->Copy();
-  expression::ExpressionUtil::ConvertParameterExpressions(
-      predicate, values, GetTable()->GetSchema());
-  SetPredicate(predicate);
 
   for (auto &child_plan : GetChildren()) {
     child_plan->SetParameterValues(values);


### PR DESCRIPTION
The old binding mechanism was copying parameter values into predicates and changing plans in place. That was unclean software engineering and could introduce extra copies of parameters.

After this refactoring, Peloton is going to save parameters values in the per-connection cache, and pass that to the executor context for the evaluation in the execution.

**Note:** There're still two places where we're modifying the plan in-place right now: inserted tuples in the insert plan and index scan keys in in the index scan plan. We may also want to refactor those two places in the future.