### PR TITLE
Memory issues

### DIFF
--- a/src/include/storage/indirection_array.h
+++ b/src/include/storage/indirection_array.h
@@ -20,7 +20,7 @@ const size_t INVALID_INDIRECTION_OFFSET = std::numeric_limits<size_t>::max();
 
 class IndirectionArray {
  public:
-  IndirectionArray() {
+  IndirectionArray(oid_t oid) : oid_(oid) {
     indirections_.reset(new indirection_array_t());
   }
 
@@ -31,8 +31,9 @@ class IndirectionArray {
       return INVALID_INDIRECTION_OFFSET;
     }
 
-    size_t indirection_id = indirection_counter_.fetch_add(1, std::memory_order_relaxed);
-    
+    size_t indirection_id =
+        indirection_counter_.fetch_add(1, std::memory_order_relaxed);
+
     if (indirection_id >= INDIRECTION_ARRAY_MAX_SIZE) {
       return INVALID_INDIRECTION_OFFSET;
     }
@@ -43,15 +44,17 @@ class IndirectionArray {
     return &(indirections_->at(offset));
   }
 
- private:
+  inline oid_t GetOid() { return oid_; }
 
-  typedef std::array<ItemPointer, INDIRECTION_ARRAY_MAX_SIZE> indirection_array_t;
+ private:
+  typedef std::array<ItemPointer, INDIRECTION_ARRAY_MAX_SIZE>
+      indirection_array_t;
 
   std::unique_ptr<indirection_array_t> indirections_;
-  
+
   std::atomic<size_t> indirection_counter_ = ATOMIC_VAR_INIT(0);
+
+  oid_t oid_;
 };
-
-
 }
 }

--- a/src/include/wire/libevent_server.h
+++ b/src/include/wire/libevent_server.h
@@ -216,18 +216,18 @@ class LibeventMasterThread : public LibeventThread {
  */
 class LibeventSocket {
  public:
-  int sock_fd;           // socket file descriptor
-  struct event *event;   // libevent handle
-  short event_flags;     // event flags mask
+  int sock_fd;                    // socket file descriptor
+  struct event *event = nullptr;  // libevent handle
+  short event_flags;              // event flags mask
 
-  LibeventThread *thread;  // reference to the libevent thread
-  PacketManager pkt_manager;  // Stores state for this socket
+  LibeventThread *thread;          // reference to the libevent thread
+  PacketManager pkt_manager;       // Stores state for this socket
   ConnState state = CONN_INVALID;  // Initial state of connection
-  InputPacket rpkt;        // Used for reading a single Postgres packet
+  InputPacket rpkt;                // Used for reading a single Postgres packet
 
  private:
-  Buffer rbuf_;                      // Socket's read buffer
-  Buffer wbuf_;                      // Socket's write buffer
+  Buffer rbuf_;                     // Socket's read buffer
+  Buffer wbuf_;                     // Socket's write buffer
   unsigned int next_response_ = 0;  // The next response in the response buffer
 
  private:

--- a/src/include/wire/libevent_server.h
+++ b/src/include/wire/libevent_server.h
@@ -231,8 +231,6 @@ class LibeventSocket {
   unsigned int next_response_ = 0;  // The next response in the response buffer
 
  private:
-  void Init(short event_flags, LibeventThread *thread, ConnState init_state);
-
   // Is the requested amount of data available from the current position in
   // the reader buffer?
   bool IsReadDataAvailable(size_t bytes);
@@ -246,6 +244,11 @@ class LibeventSocket {
       : sock_fd(sock_fd) {
     Init(event_flags, thread, init_state);
   }
+
+  /* Reuse this object for a new connection. We could be assigned to a
+   * new thread, change thread reference.
+   */
+  void Init(short event_flags, LibeventThread *thread, ConnState init_state);
 
   /* refill_read_buffer - Used to repopulate read buffer with a fresh
    * batch of data from the socket
@@ -270,10 +273,7 @@ class LibeventSocket {
 
   void CloseSocket();
 
-  /* Resuse this object for a new connection. We could be assigned to a
-   * new thread, change thread reference.
-   */
-  void Reset(short event_flags, LibeventThread *thread, ConnState init_state);
+  void Reset();
 
  private:
   // Writes a packet's header (type, size) into the write buffer

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -104,6 +104,12 @@ DataTable::~DataTable() {
     delete foreign_key;
   }
 
+  // drop all indirection arrays
+  for (auto indirection_array : active_indirection_arrays_) {
+    auto oid = indirection_array->GetOid();
+    catalog_manager.DropIndirectionArray(oid);
+  }
+
   // AbstractTable cleans up the schema
 }
 
@@ -631,11 +637,12 @@ column_map_type DataTable::GetTileGroupLayout(LayoutType layout_type) {
 
 oid_t DataTable::AddDefaultIndirectionArray(
     const size_t &active_indirection_array_id) {
-  std::shared_ptr<IndirectionArray> indirection_array(new IndirectionArray());
 
   auto &manager = catalog::Manager::GetInstance();
-
   oid_t indirection_array_id = manager.GetNextIndirectionArrayId();
+
+  std::shared_ptr<IndirectionArray> indirection_array(
+      new IndirectionArray(indirection_array_id));
   manager.AddIndirectionArray(indirection_array_id, indirection_array);
 
   COMPILER_MEMORY_FENCE;

--- a/src/wire/libevent_callbacks.cpp
+++ b/src/wire/libevent_callbacks.cpp
@@ -51,7 +51,8 @@ void WorkerHandleNewConn(evutil_socket_t new_conn_recv_fd,
       } else {
         LOG_DEBUG("Reusing socket fd:%d", item->new_conn_fd);
         /* otherwise reset and reuse the existing conn object */
-        conn->Reset(item->event_flags, static_cast<LibeventThread *>(thread),
+        conn->Reset();
+        conn->Init(item->event_flags, static_cast<LibeventThread *>(thread),
                     CONN_READ);
       }
       break;

--- a/src/wire/libevent_socket.cpp
+++ b/src/wire/libevent_socket.cpp
@@ -483,7 +483,7 @@ void LibeventSocket::CloseSocket() {
   event_del(event);
 
   TransitState(CONN_CLOSED);
-
+  Reset();
   for (;;) {
     int status = close(sock_fd);
     if (status < 0) {
@@ -497,15 +497,13 @@ void LibeventSocket::CloseSocket() {
   }
 }
 
-void LibeventSocket::Reset(short event_flags, LibeventThread *thread,
-                           ConnState init_state) {
+void LibeventSocket::Reset() {
   rbuf_.Reset();
   wbuf_.Reset();
   pkt_manager.Reset();
   state = CONN_INVALID;
   rpkt.Reset();
   next_response_ = 0;
-  Init(event_flags, thread, init_state);
 }
 
 }  // End wire namespace


### PR DESCRIPTION
Profiled peloton's memory usage with `valgrind massif` and found a few memory issues in peloton:

* When @sid1607 and I were measuring tpcc performance last week, the stat mode was turned on by default, which doubles memory usage. This was fixed in PR #342. 
* The associated **indirection array** is not dropped when the table is destructed. In this PR, it's freed as soon as its table is dropped. 
* The **packet manager** keeps the per connection query statement & plan caches, but it's not cleaned up immediately after the connection is closed. This leads to references to un-freed **indexes** which takes lots of space. 
* A minor memory leak in libevent where event objects are new'ed but not freed.  

Another issue not directly related to memory is the use `lock_free_array` to store tile group ids for each table (and many other things). The size of the array is fixed. Peloton runs out of tile group ids after 25 minutes of TPCC execution (1 terminal). 

With these fixes we should be able to run peloton with multiple experiments back-to-back. 