### PR TITLE
Add a setting up script for Fedora 24

### DIFF
--- a/script/installation/fedora-setup.sh
+++ b/script/installation/fedora-setup.sh
@@ -12,4 +12,5 @@ dnf install -y git \
 	boost-devel \
 	jemalloc-devel \
 	valgrind \
-	lcov
+	lcov \
+	postgresql-contrib

--- a/script/installation/fedora-setup.sh
+++ b/script/installation/fedora-setup.sh
@@ -13,4 +13,4 @@ dnf install -y git \
 	jemalloc-devel \
 	valgrind \
 	lcov \
-	postgresql-contrib
+	postgresql

--- a/script/installation/fedora-setup.sh
+++ b/script/installation/fedora-setup.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Install neccessary packages
+dnf install -y git \
+	gcc-c++ \
+	cmake \
+	gflags-devel \
+	protobuf-devel \
+	bison \
+	flex \
+	libevent-devel \
+	boost-devel \
+	jemalloc-devel \
+	valgrind \
+	lcov


### PR DESCRIPTION
I tried building Peloton on Fedora 24 and it built successfully. So I would like to provide my script for setting up necessary dependencies on Fedora 24 (64-bit).