### PR TITLE
Initial ExpressionUtil enhancements

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -13,12 +13,12 @@
 #include "common/types.h"
 #include "common/exception.h"
 #include "common/logger.h"
-#include "common/value_factory.h"
 #include "common/macros.h"
+#include "common/value_factory.h"
 
-#include <sstream>
-#include <cstring>
 #include <algorithm>
+#include <cstring>
+#include <sstream>
 
 namespace peloton {
 
@@ -128,15 +128,15 @@ std::string BackendTypeToString(BackendType type) {
   std::string ret;
 
   switch (type) {
-    case(BACKEND_TYPE_MM) :
+    case (BACKEND_TYPE_MM):
       return "MM";
-    case(BACKEND_TYPE_NVM) :
+    case (BACKEND_TYPE_NVM):
       return "NVM";
-    case(BACKEND_TYPE_SSD) :
+    case (BACKEND_TYPE_SSD):
       return "SSD";
-    case(BACKEND_TYPE_HDD) :
+    case (BACKEND_TYPE_HDD):
       return "HDD";
-    case(BACKEND_TYPE_INVALID) :
+    case (BACKEND_TYPE_INVALID):
       return "INVALID";
     default: { return "UNKNOWN " + std::to_string(type); }
   }
@@ -161,93 +161,77 @@ BackendType StringToBackendType(std::string str) {
 //===--------------------------------------------------------------------===//
 // Value <--> String Utilities
 //===--------------------------------------------------------------------===//
-/*
-std::string ValueTypeToString(ValueType type) {
+
+std::string TypeIdToString(common::Type::TypeId type) {
   switch (type) {
-    case VALUE_TYPE_INVALID:
+    case common::Type::INVALID:
       return "INVALID";
-    case VALUE_TYPE_NULL:
-      return "NULL";
-    case VALUE_TYPE_TINYINT:
+    case common::Type::PARAMETER_OFFSET:
+      return "PARAMETER_OFFSET";
+    case common::Type::BOOLEAN:
+      return "BOOLEAN";
+    case common::Type::TINYINT:
       return "TINYINT";
-    case VALUE_TYPE_SMALLINT:
+    case common::Type::SMALLINT:
       return "SMALLINT";
-    case VALUE_TYPE_INTEGER:
+    case common::Type::INTEGER:
       return "INTEGER";
-    case VALUE_TYPE_BIGINT:
+    case common::Type::BIGINT:
       return "BIGINT";
-    case VALUE_TYPE_REAL:
-      return "REAL";
-    case VALUE_TYPE_DOUBLE:
-      return "DOUBLE";
-    case VALUE_TYPE_VARCHAR:
-      return "VARCHAR";
-    case VALUE_TYPE_VARBINARY:
-      return "VARBINARY";
-    case VALUE_TYPE_DATE:
-      return "DATE";
-    case VALUE_TYPE_TIMESTAMP:
-      return "TIMESTAMP";
-    case VALUE_TYPE_DECIMAL:
+    case common::Type::DECIMAL:
       return "DECIMAL";
+    case common::Type::TIMESTAMP:
+      return "TIMESTAMP";
+    case common::Type::DATE:
+      return "DATE";
+    case common::Type::VARCHAR:
+      return "VARCHAR";
+    case common::Type::VARBINARY:
+      return "VARBINARY";
+    case common::Type::ARRAY:
+      return "ARRAY";
+    case common::Type::UDT:
+      return "UDT";
     default:
       return "INVALID";
   }
 }
 
-ValueType StringToValueType(std::string str) {
+common::Type::TypeId StringToTypeId(std::string str) {
   if (str == "INVALID") {
-    return VALUE_TYPE_INVALID;
-  } else if (str == "NULL") {
-    return VALUE_TYPE_NULL;
+    return common::Type::INVALID;
+  } else if (str == "PARAMETER_OFFSET") {
+    return common::Type::PARAMETER_OFFSET;
+  } else if (str == "BOOLEAN") {
+    return common::Type::BOOLEAN;
   } else if (str == "TINYINT") {
-    return VALUE_TYPE_TINYINT;
+    return common::Type::TINYINT;
   } else if (str == "SMALLINT") {
-    return VALUE_TYPE_SMALLINT;
+    return common::Type::SMALLINT;
   } else if (str == "INTEGER") {
-    return VALUE_TYPE_INTEGER;
+    return common::Type::INTEGER;
   } else if (str == "BIGINT") {
-    return VALUE_TYPE_BIGINT;
-  } else if (str == "DOUBLE") {
-    return VALUE_TYPE_DOUBLE;
-  } else if (str == "STRING") {
-    return VALUE_TYPE_VARCHAR;
-  } else if (str == "VARBINARY") {
-    return VALUE_TYPE_VARBINARY;
-  } else if (str == "DATE") {
-    return VALUE_TYPE_DATE;
-  } else if (str == "TIMESTAMP") {
-    return VALUE_TYPE_TIMESTAMP;
+    return common::Type::BIGINT;
   } else if (str == "DECIMAL") {
-    return VALUE_TYPE_DECIMAL;
+    return common::Type::DECIMAL;
+  } else if (str == "TIMESTAMP") {
+    return common::Type::TIMESTAMP;
+  } else if (str == "DATE") {
+    return common::Type::DATE;
+  } else if (str == "VARCHAR") {
+    return common::Type::VARCHAR;
+  } else if (str == "VARBINARY") {
+    return common::Type::VARBINARY;
+  } else if (str == "ARRAY") {
+    return common::Type::ARRAY;
+  } else if (str == "UDT") {
+    return common::Type::UDT;
   } else {
     throw ConversionException("No conversion from string :" + str);
   }
-  return VALUE_TYPE_INVALID;
+  return common::Type::INVALID;
 }
 
-ValueType PostgresStringToValueType(std::string str) {
-  if (str == "int4" || str == "int")
-    return VALUE_TYPE_INTEGER;
-  else if (str == "int2" || str == "smallint")
-    return VALUE_TYPE_SMALLINT;
-  else if (str == "date")
-    return VALUE_TYPE_DATE;
-  else if (str == "timestamp" || str == "timestamptz")
-    return VALUE_TYPE_TIMESTAMP;
-  else if (str == "float" || str == "float4" || str == "float8" ||
-           str == "double")
-    return VALUE_TYPE_DOUBLE;
-  else if (str == "text" || str == "varchar" || str == "char")
-    return VALUE_TYPE_VARCHAR;
-  else if (str == "numeric" || str == "decimal")
-    return VALUE_TYPE_DECIMAL;
-  else
-    return VALUE_TYPE_INVALID;
-
-  return VALUE_TYPE_INVALID;
-}
-*/
 /** takes in 0-F, returns 0-15 */
 int32_t HexCharToInt(char c) {
   c = static_cast<char>(toupper(c));
@@ -351,7 +335,8 @@ bool AtomicUpdateItemPointer(ItemPointer* src_ptr, const ItemPointer& value) {
   PL_ASSERT(sizeof(ItemPointer) == sizeof(int64_t));
   int64_t* cast_src_ptr = reinterpret_cast<int64_t*>((void*)src_ptr);
   int64_t* cast_value_ptr = reinterpret_cast<int64_t*>((void*)&value);
-  return __sync_bool_compare_and_swap(cast_src_ptr, *cast_src_ptr, *cast_value_ptr);
+  return __sync_bool_compare_and_swap(cast_src_ptr, *cast_src_ptr,
+                                      *cast_value_ptr);
 }
 
 //===--------------------------------------------------------------------===//
@@ -360,19 +345,45 @@ bool AtomicUpdateItemPointer(ItemPointer* src_ptr, const ItemPointer& value) {
 
 std::string StatementTypeToString(StatementType type) {
   switch (type) {
-    case STATEMENT_TYPE_SELECT: { return "SELECT"; }
-    case STATEMENT_TYPE_ALTER: { return "ALTER"; }
-    case STATEMENT_TYPE_CREATE: { return "CREATE"; }
-    case STATEMENT_TYPE_DELETE: { return "DELETE"; }
-    case STATEMENT_TYPE_DROP: { return "DROP"; }
-    case STATEMENT_TYPE_EXECUTE: { return "EXECUTE"; }
-    case STATEMENT_TYPE_COPY: { return "COPY"; }
-    case STATEMENT_TYPE_INSERT: { return "INSERT"; }
-    case STATEMENT_TYPE_INVALID: { return "INVALID"; }
-    case STATEMENT_TYPE_PREPARE: { return "PREPARE"; }
-    case STATEMENT_TYPE_RENAME: { return "RENAME"; }
-    case STATEMENT_TYPE_TRANSACTION: { return "TRANSACTION"; }
-    case STATEMENT_TYPE_UPDATE: { return "UPDATE"; }
+    case STATEMENT_TYPE_SELECT: {
+      return "SELECT";
+    }
+    case STATEMENT_TYPE_ALTER: {
+      return "ALTER";
+    }
+    case STATEMENT_TYPE_CREATE: {
+      return "CREATE";
+    }
+    case STATEMENT_TYPE_DELETE: {
+      return "DELETE";
+    }
+    case STATEMENT_TYPE_DROP: {
+      return "DROP";
+    }
+    case STATEMENT_TYPE_EXECUTE: {
+      return "EXECUTE";
+    }
+    case STATEMENT_TYPE_COPY: {
+      return "COPY";
+    }
+    case STATEMENT_TYPE_INSERT: {
+      return "INSERT";
+    }
+    case STATEMENT_TYPE_INVALID: {
+      return "INVALID";
+    }
+    case STATEMENT_TYPE_PREPARE: {
+      return "PREPARE";
+    }
+    case STATEMENT_TYPE_RENAME: {
+      return "RENAME";
+    }
+    case STATEMENT_TYPE_TRANSACTION: {
+      return "TRANSACTION";
+    }
+    case STATEMENT_TYPE_UPDATE: {
+      return "UPDATE";
+    }
   }
   return "NOT A KNOWN TYPE - INVALID";
 }
@@ -383,68 +394,166 @@ std::string StatementTypeToString(StatementType type) {
 
 std::string ExpressionTypeToString(ExpressionType type) {
   switch (type) {
-    case EXPRESSION_TYPE_INVALID: { return "INVALID"; }
-    case EXPRESSION_TYPE_OPERATOR_PLUS: { return "OPERATOR_PLUS"; }
-    case EXPRESSION_TYPE_OPERATOR_MINUS: { return "OPERATOR_MINUS"; }
+    case EXPRESSION_TYPE_INVALID: {
+      return "INVALID";
+    }
+    case EXPRESSION_TYPE_OPERATOR_PLUS: {
+      return "OPERATOR_PLUS";
+    }
+    case EXPRESSION_TYPE_OPERATOR_MINUS: {
+      return "OPERATOR_MINUS";
+    }
     case EXPRESSION_TYPE_OPERATOR_UNARY_MINUS: {
       return "OPERATOR_UNARY_MINUS";
     }
 
-    case EXPRESSION_TYPE_OPERATOR_CASE_EXPR: { return "OPERATOR_CASE_EXPR"; }
-    case EXPRESSION_TYPE_OPERATOR_MULTIPLY: { return "OPERATOR_MULTIPLY"; }
-    case EXPRESSION_TYPE_OPERATOR_DIVIDE: { return "OPERATOR_DIVIDE"; }
-    case EXPRESSION_TYPE_OPERATOR_CONCAT: { return "OPERATOR_CONCAT"; }
-    case EXPRESSION_TYPE_OPERATOR_MOD: { return "OPERATOR_MOD"; }
-    case EXPRESSION_TYPE_OPERATOR_CAST: { return "OPERATOR_CAST"; }
-    case EXPRESSION_TYPE_OPERATOR_NOT: { return "OPERATOR_NOT"; }
-    case EXPRESSION_TYPE_OPERATOR_IS_NULL: { return "OPERATOR_IS_NULL"; }
-    case EXPRESSION_TYPE_OPERATOR_EXISTS: { return "OPERATOR_EXISTS"; }
-    case EXPRESSION_TYPE_COMPARE_EQUAL: { return "COMPARE_EQUAL"; }
-    case EXPRESSION_TYPE_COMPARE_NOTEQUAL: { return "COMPARE_NOT_EQUAL"; }
-    case EXPRESSION_TYPE_COMPARE_LESSTHAN: { return "COMPARE_LESSTHAN"; }
-    case EXPRESSION_TYPE_COMPARE_GREATERTHAN: { return "COMPARE_GREATERTHAN"; }
+    case EXPRESSION_TYPE_OPERATOR_CASE_EXPR: {
+      return "OPERATOR_CASE_EXPR";
+    }
+    case EXPRESSION_TYPE_OPERATOR_MULTIPLY: {
+      return "OPERATOR_MULTIPLY";
+    }
+    case EXPRESSION_TYPE_OPERATOR_DIVIDE: {
+      return "OPERATOR_DIVIDE";
+    }
+    case EXPRESSION_TYPE_OPERATOR_CONCAT: {
+      return "OPERATOR_CONCAT";
+    }
+    case EXPRESSION_TYPE_OPERATOR_MOD: {
+      return "OPERATOR_MOD";
+    }
+    case EXPRESSION_TYPE_OPERATOR_CAST: {
+      return "OPERATOR_CAST";
+    }
+    case EXPRESSION_TYPE_OPERATOR_NOT: {
+      return "OPERATOR_NOT";
+    }
+    case EXPRESSION_TYPE_OPERATOR_IS_NULL: {
+      return "OPERATOR_IS_NULL";
+    }
+    case EXPRESSION_TYPE_OPERATOR_EXISTS: {
+      return "OPERATOR_EXISTS";
+    }
+    case EXPRESSION_TYPE_COMPARE_EQUAL: {
+      return "COMPARE_EQUAL";
+    }
+    case EXPRESSION_TYPE_COMPARE_NOTEQUAL: {
+      return "COMPARE_NOT_EQUAL";
+    }
+    case EXPRESSION_TYPE_COMPARE_LESSTHAN: {
+      return "COMPARE_LESSTHAN";
+    }
+    case EXPRESSION_TYPE_COMPARE_GREATERTHAN: {
+      return "COMPARE_GREATERTHAN";
+    }
     case EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO: {
       return "COMPARE_LESSTHANOREQUALTO";
     }
     case EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO: {
       return "COMPARE_GREATERTHANOREQUALTO";
     }
-    case EXPRESSION_TYPE_CONJUNCTION_AND: { return "CONJUNCTION_AND"; }
-    case EXPRESSION_TYPE_CONJUNCTION_OR: { return "CONJUNCTION_OR"; }
-    case EXPRESSION_TYPE_VALUE_CONSTANT: { return "VALUE_CONSTANT"; }
-    case EXPRESSION_TYPE_VALUE_PARAMETER: { return "VALUE_PARAMETER"; }
-    case EXPRESSION_TYPE_VALUE_TUPLE: { return "VALUE_TUPLE"; }
-    case EXPRESSION_TYPE_AGGREGATE_COUNT: { return "AGGREGATE_COUNT"; }
+    case EXPRESSION_TYPE_CONJUNCTION_AND: {
+      return "CONJUNCTION_AND";
+    }
+    case EXPRESSION_TYPE_CONJUNCTION_OR: {
+      return "CONJUNCTION_OR";
+    }
+    case EXPRESSION_TYPE_VALUE_CONSTANT: {
+      return "VALUE_CONSTANT";
+    }
+    case EXPRESSION_TYPE_VALUE_PARAMETER: {
+      return "VALUE_PARAMETER";
+    }
+    case EXPRESSION_TYPE_VALUE_TUPLE: {
+      return "VALUE_TUPLE";
+    }
+    case EXPRESSION_TYPE_AGGREGATE_COUNT: {
+      return "AGGREGATE_COUNT";
+    }
     case EXPRESSION_TYPE_AGGREGATE_COUNT_STAR: {
       return "AGGREGATE_COUNT_STAR";
     }
-    case EXPRESSION_TYPE_AGGREGATE_SUM: { return "AGGREGATE_SUM"; }
-    case EXPRESSION_TYPE_AGGREGATE_MIN: { return "AGGREGATE_MIN"; }
-    case EXPRESSION_TYPE_AGGREGATE_MAX: { return "AGGREGATE_MAX"; }
-    case EXPRESSION_TYPE_AGGREGATE_AVG: { return "AGGREGATE_AVG"; }    
-    case EXPRESSION_TYPE_PLACEHOLDER: { return "PLACEHOLDER"; }
-    case EXPRESSION_TYPE_COLUMN_REF: { return "COLUMN_REF"; }
-    case EXPRESSION_TYPE_FUNCTION_REF: { return "FUNCTION_REF"; }
-    case EXPRESSION_TYPE_CAST: { return "CAST"; }
-    case EXPRESSION_TYPE_STAR: { return "STAR"; }
-    case EXPRESSION_TYPE_SUBSTR: { return "SUBSTRING"; }
-    case EXPRESSION_TYPE_ASCII: { return "ASCII"; }
-    case EXPRESSION_TYPE_OCTET_LEN: { return "OCTET_LENGTH"; }
-    case EXPRESSION_TYPE_CHAR: { return "CHAR"; }
-    case EXPRESSION_TYPE_CHAR_LEN: { return "CHAR_LEN"; }
-    case EXPRESSION_TYPE_SPACE: { return "SPACE"; }
-    case EXPRESSION_TYPE_REPEAT: { return "REPEAT"; }
-    case EXPRESSION_TYPE_POSITION: { return "POSITION"; }
-    case EXPRESSION_TYPE_LEFT: { return "LEFT"; }
-    case EXPRESSION_TYPE_RIGHT: { return "RIGHT"; }
-    case EXPRESSION_TYPE_CONCAT: { return "CONCAT"; }
-    case EXPRESSION_TYPE_LTRIM: { return "L_TRIM"; }
-    case EXPRESSION_TYPE_RTRIM: { return "R_TRIM"; }
-    case EXPRESSION_TYPE_BTRIM: { return "B_TRIM"; }
-    case EXPRESSION_TYPE_REPLACE: { return "REPLACE"; }
-    case EXPRESSION_TYPE_OVERLAY: { return "OVERLAY"; }
-    case EXPRESSION_TYPE_EXTRACT: { return "EXTRACT"; }
-    case EXPRESSION_TYPE_DATE_TO_TIMESTAMP: { return "DATE_TO_TIMESTAMP"; }
+    case EXPRESSION_TYPE_AGGREGATE_SUM: {
+      return "AGGREGATE_SUM";
+    }
+    case EXPRESSION_TYPE_AGGREGATE_MIN: {
+      return "AGGREGATE_MIN";
+    }
+    case EXPRESSION_TYPE_AGGREGATE_MAX: {
+      return "AGGREGATE_MAX";
+    }
+    case EXPRESSION_TYPE_AGGREGATE_AVG: {
+      return "AGGREGATE_AVG";
+    }
+    case EXPRESSION_TYPE_PLACEHOLDER: {
+      return "PLACEHOLDER";
+    }
+    case EXPRESSION_TYPE_COLUMN_REF: {
+      return "COLUMN_REF";
+    }
+    case EXPRESSION_TYPE_FUNCTION_REF: {
+      return "FUNCTION_REF";
+    }
+    case EXPRESSION_TYPE_CAST: {
+      return "CAST";
+    }
+    case EXPRESSION_TYPE_STAR: {
+      return "STAR";
+    }
+    case EXPRESSION_TYPE_SUBSTR: {
+      return "SUBSTRING";
+    }
+    case EXPRESSION_TYPE_ASCII: {
+      return "ASCII";
+    }
+    case EXPRESSION_TYPE_OCTET_LEN: {
+      return "OCTET_LENGTH";
+    }
+    case EXPRESSION_TYPE_CHAR: {
+      return "CHAR";
+    }
+    case EXPRESSION_TYPE_CHAR_LEN: {
+      return "CHAR_LEN";
+    }
+    case EXPRESSION_TYPE_SPACE: {
+      return "SPACE";
+    }
+    case EXPRESSION_TYPE_REPEAT: {
+      return "REPEAT";
+    }
+    case EXPRESSION_TYPE_POSITION: {
+      return "POSITION";
+    }
+    case EXPRESSION_TYPE_LEFT: {
+      return "LEFT";
+    }
+    case EXPRESSION_TYPE_RIGHT: {
+      return "RIGHT";
+    }
+    case EXPRESSION_TYPE_CONCAT: {
+      return "CONCAT";
+    }
+    case EXPRESSION_TYPE_LTRIM: {
+      return "L_TRIM";
+    }
+    case EXPRESSION_TYPE_RTRIM: {
+      return "R_TRIM";
+    }
+    case EXPRESSION_TYPE_BTRIM: {
+      return "B_TRIM";
+    }
+    case EXPRESSION_TYPE_REPLACE: {
+      return "REPLACE";
+    }
+    case EXPRESSION_TYPE_OVERLAY: {
+      return "OVERLAY";
+    }
+    case EXPRESSION_TYPE_EXTRACT: {
+      return "EXTRACT";
+    }
+    case EXPRESSION_TYPE_DATE_TO_TIMESTAMP: {
+      return "DATE_TO_TIMESTAMP";
+    }
     default:
       break;
   }
@@ -524,10 +633,18 @@ ExpressionType StringToExpressionType(const std::string& str) {
 
 std::string IndexTypeToString(IndexType type) {
   switch (type) {
-    case INDEX_TYPE_INVALID: { return "INVALID"; }
-    case INDEX_TYPE_BTREE: { return "BTREE"; }
-    case INDEX_TYPE_BWTREE: { return "BWTREE"; }
-    case INDEX_TYPE_HASH: { return "HASH"; }
+    case INDEX_TYPE_INVALID: {
+      return "INVALID";
+    }
+    case INDEX_TYPE_BTREE: {
+      return "BTREE";
+    }
+    case INDEX_TYPE_BWTREE: {
+      return "BWTREE";
+    }
+    case INDEX_TYPE_HASH: {
+      return "HASH";
+    }
   }
   return "INVALID";
 }
@@ -551,10 +668,18 @@ IndexType StringToIndexType(const std::string& str) {
 
 std::string IndexConstraintTypeToString(IndexConstraintType type) {
   switch (type) {
-    case INDEX_CONSTRAINT_TYPE_INVALID: { return "INVALID"; }
-    case INDEX_CONSTRAINT_TYPE_DEFAULT: { return "NORMAL"; }
-    case INDEX_CONSTRAINT_TYPE_PRIMARY_KEY: { return "PRIMARY_KEY"; }
-    case INDEX_CONSTRAINT_TYPE_UNIQUE: { return "UNIQUE"; }
+    case INDEX_CONSTRAINT_TYPE_INVALID: {
+      return "INVALID";
+    }
+    case INDEX_CONSTRAINT_TYPE_DEFAULT: {
+      return "NORMAL";
+    }
+    case INDEX_CONSTRAINT_TYPE_PRIMARY_KEY: {
+      return "PRIMARY_KEY";
+    }
+    case INDEX_CONSTRAINT_TYPE_UNIQUE: {
+      return "UNIQUE";
+    }
   }
   return "INVALID";
 }
@@ -577,36 +702,96 @@ IndexConstraintType StringToIndexConstraintType(const std::string& str) {
 
 std::string PlanNodeTypeToString(PlanNodeType type) {
   switch (type) {
-    case PLAN_NODE_TYPE_INVALID: { return "INVALID"; }
-    case PLAN_NODE_TYPE_ABSTRACT_SCAN: { return "ABSTRACT_SCAN"; }
-    case PLAN_NODE_TYPE_SEQSCAN: { return "SEQSCAN"; }
-    case PLAN_NODE_TYPE_INDEXSCAN: { return "INDEXSCAN"; }
-    case PLAN_NODE_TYPE_NESTLOOP: { return "NESTLOOP"; }
-    case PLAN_NODE_TYPE_NESTLOOPINDEX: { return "NESTLOOPINDEX"; }
-    case PLAN_NODE_TYPE_MERGEJOIN: { return "MERGEJOIN"; }
-    case PLAN_NODE_TYPE_HASHJOIN: { return "HASHJOIN"; }
-    case PLAN_NODE_TYPE_UPDATE: { return "UPDATE"; }
-    case PLAN_NODE_TYPE_INSERT: { return "INSERT"; }
-    case PLAN_NODE_TYPE_DELETE: { return "DELETE"; }
-    case PLAN_NODE_TYPE_COPY: { return "COPY"; }
-    case PLAN_NODE_TYPE_SEND: { return "SEND"; }
-    case PLAN_NODE_TYPE_RECEIVE: { return "RECEIVE"; }
-    case PLAN_NODE_TYPE_PRINT: { return "PRINT"; }
-    case PLAN_NODE_TYPE_AGGREGATE: { return "AGGREGATE"; }
-    case PLAN_NODE_TYPE_UNION: { return "UNION"; }
-    case PLAN_NODE_TYPE_ORDERBY: { return "RECEIVE"; }
-    case PLAN_NODE_TYPE_PROJECTION: { return "PROJECTION"; }
-    case PLAN_NODE_TYPE_MATERIALIZE: { return "MATERIALIZE"; }
-    case PLAN_NODE_TYPE_LIMIT: { return "LIMIT"; }
-    case PLAN_NODE_TYPE_DISTINCT: { return "DISTINCT"; }
-    case PLAN_NODE_TYPE_SETOP: { return "SETOP"; }
-    case PLAN_NODE_TYPE_APPEND: { return "APPEND"; }
-    case PLAN_NODE_TYPE_RESULT: { return "RESULT"; }
-    case PLAN_NODE_TYPE_AGGREGATE_V2: { return "AGGREGATE_V2"; }
-    case PLAN_NODE_TYPE_MOCK: { return "MOCK"; }
-    case PLAN_NODE_TYPE_HASH: { return "HASH"; }
-    case PLAN_NODE_TYPE_DROP: { return "DROP"; }
-    case PLAN_NODE_TYPE_CREATE: { return "CREATE"; }
+    case PLAN_NODE_TYPE_INVALID: {
+      return "INVALID";
+    }
+    case PLAN_NODE_TYPE_ABSTRACT_SCAN: {
+      return "ABSTRACT_SCAN";
+    }
+    case PLAN_NODE_TYPE_SEQSCAN: {
+      return "SEQSCAN";
+    }
+    case PLAN_NODE_TYPE_INDEXSCAN: {
+      return "INDEXSCAN";
+    }
+    case PLAN_NODE_TYPE_NESTLOOP: {
+      return "NESTLOOP";
+    }
+    case PLAN_NODE_TYPE_NESTLOOPINDEX: {
+      return "NESTLOOPINDEX";
+    }
+    case PLAN_NODE_TYPE_MERGEJOIN: {
+      return "MERGEJOIN";
+    }
+    case PLAN_NODE_TYPE_HASHJOIN: {
+      return "HASHJOIN";
+    }
+    case PLAN_NODE_TYPE_UPDATE: {
+      return "UPDATE";
+    }
+    case PLAN_NODE_TYPE_INSERT: {
+      return "INSERT";
+    }
+    case PLAN_NODE_TYPE_DELETE: {
+      return "DELETE";
+    }
+    case PLAN_NODE_TYPE_COPY: {
+      return "COPY";
+    }
+    case PLAN_NODE_TYPE_SEND: {
+      return "SEND";
+    }
+    case PLAN_NODE_TYPE_RECEIVE: {
+      return "RECEIVE";
+    }
+    case PLAN_NODE_TYPE_PRINT: {
+      return "PRINT";
+    }
+    case PLAN_NODE_TYPE_AGGREGATE: {
+      return "AGGREGATE";
+    }
+    case PLAN_NODE_TYPE_UNION: {
+      return "UNION";
+    }
+    case PLAN_NODE_TYPE_ORDERBY: {
+      return "RECEIVE";
+    }
+    case PLAN_NODE_TYPE_PROJECTION: {
+      return "PROJECTION";
+    }
+    case PLAN_NODE_TYPE_MATERIALIZE: {
+      return "MATERIALIZE";
+    }
+    case PLAN_NODE_TYPE_LIMIT: {
+      return "LIMIT";
+    }
+    case PLAN_NODE_TYPE_DISTINCT: {
+      return "DISTINCT";
+    }
+    case PLAN_NODE_TYPE_SETOP: {
+      return "SETOP";
+    }
+    case PLAN_NODE_TYPE_APPEND: {
+      return "APPEND";
+    }
+    case PLAN_NODE_TYPE_RESULT: {
+      return "RESULT";
+    }
+    case PLAN_NODE_TYPE_AGGREGATE_V2: {
+      return "AGGREGATE_V2";
+    }
+    case PLAN_NODE_TYPE_MOCK: {
+      return "MOCK";
+    }
+    case PLAN_NODE_TYPE_HASH: {
+      return "HASH";
+    }
+    case PLAN_NODE_TYPE_DROP: {
+      return "DROP";
+    }
+    case PLAN_NODE_TYPE_CREATE: {
+      return "CREATE";
+    }
   }
   return "INVALID";
 }
@@ -660,19 +845,45 @@ PlanNodeType StringToPlanNodeType(const std::string& str) {
 
 std::string ParseNodeTypeToString(ParseNodeType type) {
   switch (type) {
-    case PARSE_NODE_TYPE_INVALID: { return "INVALID"; }
-    case PARSE_NODE_TYPE_SCAN: { return "SCAN"; }
-    case PARSE_NODE_TYPE_CREATE: { return "CREATE"; }
-    case PARSE_NODE_TYPE_DROP: { return "DROP"; }
-    case PARSE_NODE_TYPE_UPDATE: { return "UPDATE"; }
-    case PARSE_NODE_TYPE_INSERT: { return "INSERT"; }
-    case PARSE_NODE_TYPE_DELETE: { return "DELETE"; }
-    case PARSE_NODE_TYPE_PREPARE: { return "PREPARE"; }
-    case PARSE_NODE_TYPE_EXECUTE: { return "EXECUTE"; }
-    case PARSE_NODE_TYPE_SELECT: { return "SELECT"; }
-    case PARSE_NODE_TYPE_JOIN_EXPR: { return "JOIN_EXPR"; }
-    case PARSE_NODE_TYPE_TABLE: { return "TABLE"; }
-    case PARSE_NODE_TYPE_MOCK: { return "MOCK"; }
+    case PARSE_NODE_TYPE_INVALID: {
+      return "INVALID";
+    }
+    case PARSE_NODE_TYPE_SCAN: {
+      return "SCAN";
+    }
+    case PARSE_NODE_TYPE_CREATE: {
+      return "CREATE";
+    }
+    case PARSE_NODE_TYPE_DROP: {
+      return "DROP";
+    }
+    case PARSE_NODE_TYPE_UPDATE: {
+      return "UPDATE";
+    }
+    case PARSE_NODE_TYPE_INSERT: {
+      return "INSERT";
+    }
+    case PARSE_NODE_TYPE_DELETE: {
+      return "DELETE";
+    }
+    case PARSE_NODE_TYPE_PREPARE: {
+      return "PREPARE";
+    }
+    case PARSE_NODE_TYPE_EXECUTE: {
+      return "EXECUTE";
+    }
+    case PARSE_NODE_TYPE_SELECT: {
+      return "SELECT";
+    }
+    case PARSE_NODE_TYPE_JOIN_EXPR: {
+      return "JOIN_EXPR";
+    }
+    case PARSE_NODE_TYPE_TABLE: {
+      return "TABLE";
+    }
+    case PARSE_NODE_TYPE_MOCK: {
+      return "MOCK";
+    }
   }
   return "INVALID";
 }
@@ -714,15 +925,33 @@ ParseNodeType StringToParseNodeType(const std::string& str) {
 
 std::string ConstraintTypeToString(ConstraintType type) {
   switch (type) {
-    case CONSTRAINT_TYPE_INVALID: { return "INVALID"; }
-    case CONSTRAINT_TYPE_NULL: { return "NULL"; }
-    case CONSTRAINT_TYPE_NOTNULL: { return "NOTNULL"; }
-    case CONSTRAINT_TYPE_DEFAULT: { return "DEFAULT"; }
-    case CONSTRAINT_TYPE_CHECK: { return "CHECK"; }
-    case CONSTRAINT_TYPE_PRIMARY: { return "PRIMARY_KEY"; }
-    case CONSTRAINT_TYPE_UNIQUE: { return "UNIQUE"; }
-    case CONSTRAINT_TYPE_FOREIGN: { return "FOREIGN_KEY"; }
-    case CONSTRAINT_TYPE_EXCLUSION: { return "EXCLUSION"; }
+    case CONSTRAINT_TYPE_INVALID: {
+      return "INVALID";
+    }
+    case CONSTRAINT_TYPE_NULL: {
+      return "NULL";
+    }
+    case CONSTRAINT_TYPE_NOTNULL: {
+      return "NOTNULL";
+    }
+    case CONSTRAINT_TYPE_DEFAULT: {
+      return "DEFAULT";
+    }
+    case CONSTRAINT_TYPE_CHECK: {
+      return "CHECK";
+    }
+    case CONSTRAINT_TYPE_PRIMARY: {
+      return "PRIMARY_KEY";
+    }
+    case CONSTRAINT_TYPE_UNIQUE: {
+      return "UNIQUE";
+    }
+    case CONSTRAINT_TYPE_FOREIGN: {
+      return "FOREIGN_KEY";
+    }
+    case CONSTRAINT_TYPE_EXCLUSION: {
+      return "EXCLUSION";
+    }
   }
   return "INVALID";
 }
@@ -785,32 +1014,48 @@ std::string LoggingTypeToString(LoggingType type) {
 
 std::string LoggingStatusToString(LoggingStatus type) {
   switch (type) {
-    case LOGGING_STATUS_TYPE_INVALID: { return "INVALID"; }
-    case LOGGING_STATUS_TYPE_STANDBY: { return "LOGGING_STATUS_TYPE_STANDBY"; }
+    case LOGGING_STATUS_TYPE_INVALID: {
+      return "INVALID";
+    }
+    case LOGGING_STATUS_TYPE_STANDBY: {
+      return "LOGGING_STATUS_TYPE_STANDBY";
+    }
     case LOGGING_STATUS_TYPE_RECOVERY: {
       return "LOGGING_STATUS_TYPE_RECOVERY";
     }
-    case LOGGING_STATUS_TYPE_LOGGING: { return "LOGGING_STATUS_TYPE_ONGOING"; }
+    case LOGGING_STATUS_TYPE_LOGGING: {
+      return "LOGGING_STATUS_TYPE_ONGOING";
+    }
     case LOGGING_STATUS_TYPE_TERMINATE: {
       return "LOGGING_STATUS_TYPE_TERMINATE";
     }
-    case LOGGING_STATUS_TYPE_SLEEP: { return "LOGGING_STATUS_TYPE_SLEEP"; }
+    case LOGGING_STATUS_TYPE_SLEEP: {
+      return "LOGGING_STATUS_TYPE_SLEEP";
+    }
   }
   return "INVALID";
 }
 
 std::string LoggerTypeToString(LoggerType type) {
   switch (type) {
-    case LOGGER_TYPE_INVALID: { return "INVALID"; }
-    case LOGGER_TYPE_FRONTEND: { return "LOGGER_TYPE_FRONTEND"; }
-    case LOGGER_TYPE_BACKEND: { return "LOGGER_TYPE_BACKEND"; }
+    case LOGGER_TYPE_INVALID: {
+      return "INVALID";
+    }
+    case LOGGER_TYPE_FRONTEND: {
+      return "LOGGER_TYPE_FRONTEND";
+    }
+    case LOGGER_TYPE_BACKEND: {
+      return "LOGGER_TYPE_BACKEND";
+    }
   }
   return "INVALID";
 }
 
 std::string LogRecordTypeToString(LogRecordType type) {
   switch (type) {
-    case LOGRECORD_TYPE_INVALID: { return "INVALID"; }
+    case LOGRECORD_TYPE_INVALID: {
+      return "INVALID";
+    }
     case LOGRECORD_TYPE_TRANSACTION_BEGIN: {
       return "LOGRECORD_TYPE_TRANSACTION_BEGIN";
     }
@@ -826,9 +1071,15 @@ std::string LogRecordTypeToString(LogRecordType type) {
     case LOGRECORD_TYPE_TRANSACTION_DONE: {
       return "LOGRECORD_TYPE_TRANSACTION_DONE";
     }
-    case LOGRECORD_TYPE_TUPLE_INSERT: { return "LOGRECORD_TYPE_TUPLE_INSERT"; }
-    case LOGRECORD_TYPE_TUPLE_DELETE: { return "LOGRECORD_TYPE_TUPLE_DELETE"; }
-    case LOGRECORD_TYPE_TUPLE_UPDATE: { return "LOGRECORD_TYPE_TUPLE_UPDATE"; }
+    case LOGRECORD_TYPE_TUPLE_INSERT: {
+      return "LOGRECORD_TYPE_TUPLE_INSERT";
+    }
+    case LOGRECORD_TYPE_TUPLE_DELETE: {
+      return "LOGRECORD_TYPE_TUPLE_DELETE";
+    }
+    case LOGRECORD_TYPE_TUPLE_UPDATE: {
+      return "LOGRECORD_TYPE_TUPLE_UPDATE";
+    }
     case LOGRECORD_TYPE_WAL_TUPLE_INSERT: {
       return "LOGRECORD_TYPE_WAL_TUPLE_INSERT";
     }
@@ -938,9 +1189,15 @@ ConstraintType PostgresConstraintTypeToPelotonConstraintType(
 
 std::string QuantifierTypeToString(QuantifierType type) {
   switch (type) {
-    case QUANTIFIER_TYPE_NONE: { return "NONE"; }
-    case QUANTIFIER_TYPE_ANY: { return "ANY"; }
-    case QUANTIFIER_TYPE_ALL: { return "ALL"; }
+    case QUANTIFIER_TYPE_NONE: {
+      return "NONE";
+    }
+    case QUANTIFIER_TYPE_ANY: {
+      return "ANY";
+    }
+    case QUANTIFIER_TYPE_ALL: {
+      return "ALL";
+    }
   }
   return "INVALID";
 }

--- a/src/common/value.cpp
+++ b/src/common/value.cpp
@@ -248,9 +248,9 @@ Value::~Value() {
 const std::string Value::GetInfo() const {
   std::ostringstream os;
 
-  os << "\tValue :: " << " type = "
+  os << "Value :: " << " type = "
       << Type::GetInstance(GetTypeId())->ToString() << "," << " value = "
-      << ToString() << std::endl;
+      << ToString();
 
   return os.str();
 }

--- a/src/include/common/types.h
+++ b/src/include/common/types.h
@@ -12,17 +12,17 @@
 
 #pragma once
 
-#include <string>
-#include <cstdint>
-#include <climits>
-#include <limits>
 #include <bitset>
-#include <vector>
+#include <climits>
+#include <cstdint>
 #include <functional>
+#include <limits>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include "common/type.h"
+#include <vector>
 #include "common/config.h"
+#include "common/type.h"
 
 //===--------------------------------------------------------------------===//
 // GUC Variables
@@ -75,7 +75,7 @@ enum ReplicationType {
 enum GarbageCollectionType {
   GARBAGE_COLLECTION_TYPE_INVALID = 0,
   GARBAGE_COLLECTION_TYPE_OFF = 1,  // turn off GC
-  GARBAGE_COLLECTION_TYPE_ON = 2  // turn on GC
+  GARBAGE_COLLECTION_TYPE_ON = 2    // turn on GC
 };
 
 //===--------------------------------------------------------------------===//
@@ -91,7 +91,7 @@ enum GarbageCollectionType {
 namespace peloton {
 
 // forward declare
-//class Value;
+// class Value;
 
 //===--------------------------------------------------------------------===//
 // NULL-related Constants
@@ -202,7 +202,7 @@ enum PostgresValueType {
 };
 
 enum ValueType {
-    // TODO
+  // TODO
 };
 
 //===--------------------------------------------------------------------===//
@@ -213,7 +213,7 @@ enum ExpressionType {
   EXPRESSION_TYPE_INVALID = 0,
 
   // TODO: Add the expression types that you implemented
-  
+
 
   // -----------------------------
   // String operators
@@ -470,7 +470,6 @@ enum IsolationLevelType {
 // Garbage Collection Types
 //===--------------------------------------------------------------------===//
 
-
 enum BackendType {
   BACKEND_TYPE_INVALID = 0,  // invalid backend type
   BACKEND_TYPE_MM = 1,       // on volatile memory
@@ -484,10 +483,10 @@ enum BackendType {
 //===--------------------------------------------------------------------===//
 
 enum IndexType {
-  INDEX_TYPE_INVALID = 0,   // invalid index type
-  INDEX_TYPE_BTREE = 1,     // btree
-  INDEX_TYPE_BWTREE = 2,    // bwtree
-  INDEX_TYPE_HASH = 3       // hash
+  INDEX_TYPE_INVALID = 0,  // invalid index type
+  INDEX_TYPE_BTREE = 1,    // btree
+  INDEX_TYPE_BWTREE = 2,   // bwtree
+  INDEX_TYPE_HASH = 3      // hash
 };
 
 enum IndexConstraintType {
@@ -901,10 +900,7 @@ enum EntityType {
 // Endianess
 // ------------------------------------------------------------------
 
-enum Endianess {
-  BYTE_ORDER_BIG_ENDIAN = 0,
-  BYTE_ORDER_LITTLE_ENDIAN = 1
-};
+enum Endianess { BYTE_ORDER_BIG_ENDIAN = 0, BYTE_ORDER_LITTLE_ENDIAN = 1 };
 
 //===--------------------------------------------------------------------===//
 // Type definitions.
@@ -945,13 +941,11 @@ static const cid_t MAX_CID = std::numeric_limits<cid_t>::max();
 // For epoch
 static const size_t EPOCH_LENGTH = 10;
 
-
 // For threads
 extern size_t QUERY_THREAD_COUNT;
 extern size_t LOGGING_THREAD_COUNT;
 extern size_t GC_THREAD_COUNT;
 extern size_t EPOCH_THREAD_COUNT;
-
 
 //===--------------------------------------------------------------------===//
 // TupleMetadata
@@ -1014,19 +1008,17 @@ struct ItemPointerHasher {
 enum RWType {
   RW_TYPE_INVALID,
   RW_TYPE_READ,
-  RW_TYPE_READ_OWN, // select for update
+  RW_TYPE_READ_OWN,  // select for update
   RW_TYPE_UPDATE,
   RW_TYPE_INSERT,
   RW_TYPE_DELETE,
   RW_TYPE_INS_DEL,  // delete after insert.
 };
 
-enum GCSetType {
-  GC_SET_TYPE_COMMITTED,
-  GC_SET_TYPE_ABORTED
-};
+enum GCSetType { GC_SET_TYPE_COMMITTED, GC_SET_TYPE_ABORTED };
 
-typedef std::unordered_map<oid_t, std::unordered_map<oid_t, RWType>> ReadWriteSet;
+typedef std::unordered_map<oid_t, std::unordered_map<oid_t, RWType>>
+    ReadWriteSet;
 
 //===--------------------------------------------------------------------===//
 // File Handle
@@ -1059,7 +1051,7 @@ bool IsNumeric(ValueType type);
 bool IsIntegralType(ValueType type);
 
 // for testing, obtain a random instance of the specified type
-//Value GetRandomValue(ValueType type);
+// Value GetRandomValue(ValueType type);
 
 int64_t GetMaxTypeValue(ValueType type);
 
@@ -1080,6 +1072,8 @@ bool AtomicUpdateItemPointer(ItemPointer *src_ptr, const ItemPointer &value);
 std::string BackendTypeToString(BackendType type);
 BackendType StringToBackendType(const std::string &str);
 
+std::string TypeIdToString(common::Type::TypeId type);
+common::Type::TypeId StringToTypeId(const std::string &str);
 std::string ValueTypeToString(ValueType type);
 ValueType StringToValueType(const std::string &str);
 ValueType PostgresStringToValueType(std::string str);
@@ -1132,7 +1126,6 @@ typedef std::vector<Target> TargetList;
 typedef std::pair<oid_t, std::pair<oid_t, oid_t>> DirectMap;
 
 typedef std::vector<DirectMap> DirectMapList;
-
 
 //===--------------------------------------------------------------------===//
 // Wire protocol typedefs

--- a/src/include/expression/expression_util.h
+++ b/src/include/expression/expression_util.h
@@ -15,13 +15,13 @@
 #include <string>
 #include <vector>
 
-#include "catalog/schema.h"
 #include "catalog/catalog.h"
+#include "catalog/schema.h"
 #include "expression/comparison_expression.h"
-#include "expression/function_expression.h"
 #include "expression/conjunction_expression.h"
 #include "expression/constant_value_expression.h"
 #include "expression/constant_value_expression.h"
+#include "expression/function_expression.h"
 #include "expression/operator_expression.h"
 #include "expression/parameter_value_expression.h"
 #include "expression/tuple_value_expression.h"
@@ -94,9 +94,7 @@ class ExpressionUtil {
         auto value =
             new ConstantValueExpression(values->at(right->GetValueIdx()));
         LOG_TRACE("Setting parameter %u to value %s", right->GetValueIdx(),
-                  value->GetValue()
-                      .GetInfo()
-                      .c_str());
+                  value->GetValue().GetInfo().c_str());
         expression->SetChild(1, value);
       } else {
         ConvertParameterExpressions(expression->GetModifiableChild(1), values,
@@ -137,7 +135,8 @@ class ExpressionUtil {
   static AbstractExpression *OperatorFactory(
       ExpressionType type, common::Type::TypeId value_type,
       AbstractExpression *expr1, AbstractExpression *expr2,
-      UNUSED_ATTRIBUTE AbstractExpression *expr3, UNUSED_ATTRIBUTE AbstractExpression *expr4) {
+      UNUSED_ATTRIBUTE AbstractExpression *expr3,
+      UNUSED_ATTRIBUTE AbstractExpression *expr4) {
     switch (type) {
       default:
         return new OperatorExpression(type, value_type, expr1, expr2);
@@ -148,7 +147,8 @@ class ExpressionUtil {
       ExpressionType type,
       const std::list<expression::AbstractExpression *> &child_exprs) {
     if (child_exprs.empty())
-      return new ConstantValueExpression(common::ValueFactory::GetBooleanValue(1));
+      return new ConstantValueExpression(
+          common::ValueFactory::GetBooleanValue(1));
     AbstractExpression *left = nullptr;
     AbstractExpression *right = nullptr;
     for (auto expr : child_exprs) {
@@ -160,46 +160,57 @@ class ExpressionUtil {
 
   inline static bool IsAggregateExpression(ExpressionType type) {
     switch (type) {
-    case EXPRESSION_TYPE_AGGREGATE_COUNT:
-    case EXPRESSION_TYPE_AGGREGATE_COUNT_STAR:
-    case EXPRESSION_TYPE_AGGREGATE_SUM:
-    case EXPRESSION_TYPE_AGGREGATE_MIN:
-    case EXPRESSION_TYPE_AGGREGATE_MAX:
-    case EXPRESSION_TYPE_AGGREGATE_AVG:
-    case EXPRESSION_TYPE_AGGREGATE_APPROX_COUNT_DISTINCT:
-    case EXPRESSION_TYPE_AGGREGATE_VALS_TO_HYPERLOGLOG:
-    case EXPRESSION_TYPE_AGGREGATE_HYPERLOGLOGS_TO_CARD:
-      return true;
-    default:
-      return false;
+      case EXPRESSION_TYPE_AGGREGATE_COUNT:
+      case EXPRESSION_TYPE_AGGREGATE_COUNT_STAR:
+      case EXPRESSION_TYPE_AGGREGATE_SUM:
+      case EXPRESSION_TYPE_AGGREGATE_MIN:
+      case EXPRESSION_TYPE_AGGREGATE_MAX:
+      case EXPRESSION_TYPE_AGGREGATE_AVG:
+      case EXPRESSION_TYPE_AGGREGATE_APPROX_COUNT_DISTINCT:
+      case EXPRESSION_TYPE_AGGREGATE_VALS_TO_HYPERLOGLOG:
+      case EXPRESSION_TYPE_AGGREGATE_HYPERLOGLOGS_TO_CARD:
+        return true;
+      default:
+        return false;
     }
   }
 
   inline static bool IsOperatorExpression(ExpressionType type) {
     switch (type) {
-    case EXPRESSION_TYPE_OPERATOR_PLUS:
-    case EXPRESSION_TYPE_OPERATOR_MINUS:
-    case EXPRESSION_TYPE_OPERATOR_MULTIPLY:
-    case EXPRESSION_TYPE_OPERATOR_DIVIDE:
-    case EXPRESSION_TYPE_OPERATOR_CONCAT:
-    case EXPRESSION_TYPE_OPERATOR_MOD:
-    case EXPRESSION_TYPE_OPERATOR_CAST:
-    case EXPRESSION_TYPE_OPERATOR_NOT:
-    case EXPRESSION_TYPE_OPERATOR_IS_NULL:
-    case EXPRESSION_TYPE_OPERATOR_EXISTS:
-    case EXPRESSION_TYPE_OPERATOR_UNARY_MINUS:
-      return true;
-    default:
-      return false;
+      case EXPRESSION_TYPE_OPERATOR_PLUS:
+      case EXPRESSION_TYPE_OPERATOR_MINUS:
+      case EXPRESSION_TYPE_OPERATOR_MULTIPLY:
+      case EXPRESSION_TYPE_OPERATOR_DIVIDE:
+      case EXPRESSION_TYPE_OPERATOR_CONCAT:
+      case EXPRESSION_TYPE_OPERATOR_MOD:
+      case EXPRESSION_TYPE_OPERATOR_CAST:
+      case EXPRESSION_TYPE_OPERATOR_NOT:
+      case EXPRESSION_TYPE_OPERATOR_IS_NULL:
+      case EXPRESSION_TYPE_OPERATOR_EXISTS:
+      case EXPRESSION_TYPE_OPERATOR_UNARY_MINUS:
+        return true;
+      default:
+        return false;
     }
+  }
+
+  /**
+   * Generate a pretty-printed string representation of the entire
+   * Expresssion tree
+   */
+  static std::string GetInfo(AbstractExpression *expr) {
+    std::ostringstream os;
+    std::string spacer("");
+    GetInfo(expr, os, spacer);
+    return os.str();
   }
 
   /**
    * Walks an expression tree and fills in information about
    * columns and functions in their respective obejects
    */
-  static void TransformExpression(
-      catalog::Schema *schema, AbstractExpression *expr) {
+  static void TransformExpression(catalog::Schema *schema,
+                                  AbstractExpression *expr) {
     bool dummy;
     TransformExpression(nullptr, nullptr, expr, schema, dummy, false);
   }
@@ -207,61 +218,99 @@ class ExpressionUtil {
   /**
    * This function walks an expression tree and fills in information about
    * columns and functions. Also generates a list of column ids we need to fetch
-   * from the base tile groups. Simultaniously generates a mapping of the original column
+   * from the base tile groups. Simultaniously generates a mapping of the
+   * original column
    * id to the id in the logical tiles returned by the base tile groups
    *
    * This function is useful in determining information used by projection plans
    */
-  static void TransformExpression(std::unordered_map<oid_t, oid_t> &column_mapping, std::vector<oid_t> &column_ids,
-        AbstractExpression *expr, const catalog::Schema& schema, bool &needs_projection) {
-    TransformExpression(&column_mapping, &column_ids, expr, &schema, needs_projection, true);
+  static void TransformExpression(
+      std::unordered_map<oid_t, oid_t> &column_mapping,
+      std::vector<oid_t> &column_ids, AbstractExpression *expr,
+      const catalog::Schema &schema, bool &needs_projection) {
+    TransformExpression(&column_mapping, &column_ids, expr, &schema,
+                        needs_projection, true);
   }
 
  private:
   /**
-   * this is a private function for transforming expressions as described above
    *
-   * find columns determines if we are building a column_mapping and column_ids or we are just transforming
+   */
+  static void GetInfo(const AbstractExpression *expr, std::ostringstream &os,
+                      std::string &spacer) {
+    std::string orig_spacer(spacer);
+    ExpressionType etype = expr->GetExpressionType();
+    Type::TypeId vtype = expr->GetValueType();
+
+    // spacer += "   ";
+    std::string info = ExpressionTypeToString(etype);
+
+    // Basic Information
+    os << spacer << "ValueType[" << TypeIdToString(vtype) << "]";
+    os << "[" << ExpressionTypeToString(etype) << "]";
+    os << "[NumChildren=" << expr->GetChildrenSize() << "]\n";
+
+    for (int i = 0, cnt = expr->GetChildrenSize(); i < cnt; i++) {
+      os << spacer << "[" << i << "]   ";
+      GetInfo(expr->GetChild(i), os, spacer);
+      os << "\n";
+    }
+    return;
+  }
+
+  /**
+   * this is a private function for transforming expressions as described
+   * above
+   *
+   * find columns determines if we are building a column_mapping and
+   * column_ids
+   * or we are just transforming
    * the expressions
    */
-  static void TransformExpression(std::unordered_map<oid_t, oid_t> *column_mapping, std::vector<oid_t> *column_ids,
-       AbstractExpression *expr, const catalog::Schema* schema, bool &needs_projection, bool find_columns) {
-    if (expr == nullptr){
+  static void TransformExpression(
+      std::unordered_map<oid_t, oid_t> *column_mapping,
+      std::vector<oid_t> *column_ids, AbstractExpression *expr,
+      const catalog::Schema *schema, bool &needs_projection,
+      bool find_columns) {
+    if (expr == nullptr) {
       return;
     }
     size_t num_children = expr->GetChildrenSize();
     // do dfs to transform all chilren
-    for(size_t child = 0; child < num_children; child++){
-      TransformExpression(column_mapping, column_ids, expr->GetModifiableChild(child), schema, needs_projection, find_columns);
+    for (size_t child = 0; child < num_children; child++) {
+      TransformExpression(column_mapping, column_ids,
+                          expr->GetModifiableChild(child), schema,
+                          needs_projection, find_columns);
     }
     // if this is a column, we need to find if it is exists in the scema
-    if (expr->GetExpressionType() == EXPRESSION_TYPE_VALUE_TUPLE && expr->GetValueType() == Type::INVALID) {
+    if (expr->GetExpressionType() == EXPRESSION_TYPE_VALUE_TUPLE &&
+        expr->GetValueType() == Type::INVALID) {
       auto val_expr = (expression::TupleValueExpression *)expr;
       auto col_id = schema->GetColumnID(val_expr->col_name_);
       // exception if we can't find the requested column by name
-      if (col_id == (oid_t)-1){
-        throw Exception("Column "+val_expr->col_name_ +" not found");
+      if (col_id == (oid_t)-1) {
+        throw Exception("Column " + val_expr->col_name_ + " not found");
       }
       auto column = schema->GetColumn(col_id);
       // make sure the column we need is returned from the scan
       // and we know where it is (for projection)
       size_t mapped_position;
-      if (find_columns){
-        if (column_mapping->count(col_id) == 0){
+      if (find_columns) {
+        if (column_mapping->count(col_id) == 0) {
           mapped_position = column_ids->size();
           column_ids->push_back(col_id);
           (*column_mapping)[col_id] = mapped_position;
-        }else{
+        } else {
           mapped_position = (*column_mapping)[col_id];
         }
-      }else{
+      } else {
         mapped_position = col_id;
       }
       auto type = column.GetType();
       // set the expression name to the alias if we have one
-      if (val_expr->alias.size() > 0){
+      if (val_expr->alias.size() > 0) {
         val_expr->expr_name_ = val_expr->alias;
-      }else{
+      } else {
         val_expr->expr_name_ = val_expr->col_name_;
       }
       // point to the correct column returned in the logical tuple underneath
@@ -269,21 +318,23 @@ class ExpressionUtil {
     }
     // if we have any expression besides column expressiona and star, we
     // need to add a projection node
-    else if (expr->GetExpressionType() != EXPRESSION_TYPE_STAR){
+    else if (expr->GetExpressionType() != EXPRESSION_TYPE_STAR) {
       needs_projection = true;
     }
     // if the expressio is a fucntion, do a lookup and make sure it exists
-    if (expr->GetExpressionType() == EXPRESSION_TYPE_FUNCTION){
-      auto func_expr = (expression::FunctionExpression*)expr;
-      auto  catalog = catalog::Catalog::GetInstance();
-      catalog::FunctionData func_data = catalog->GetFunction(func_expr->func_name_);
-      func_expr->SetFunctionExpressionParameters(func_data.func_ptr_, func_data.return_type_, func_data.num_arguments_);
+    if (expr->GetExpressionType() == EXPRESSION_TYPE_FUNCTION) {
+      auto func_expr = (expression::FunctionExpression *)expr;
+      auto catalog = catalog::Catalog::GetInstance();
+      catalog::FunctionData func_data =
+          catalog->GetFunction(func_expr->func_name_);
+      func_expr->SetFunctionExpressionParameters(func_data.func_ptr_,
+                                                 func_data.return_type_,
+                                                 func_data.num_arguments_);
     }
     // make sure the return types for expressions are set correctly
     // this is useful in operator expressions
     expr->DeduceExpressionType();
   }
-
 };
 }
 }

--- a/src/include/expression/expression_util.h
+++ b/src/include/expression/expression_util.h
@@ -241,40 +241,42 @@ private:
 
 public:
 
-  /**
-   * Return a list of all of the catalog::Column objects referenced
-   * in the given expression tree
-   */
-  static std::vector<catalog::Column> GetReferencedColumns(
-		  UNUSED_ATTRIBUTE catalog::Schema *schema,
-		  AbstractExpression *expr) {
-	  PL_ASSERT(expr != nullptr);
-	  PL_ASSERT(schema != nullptr);
-	  std::vector<catalog::Column> columns;
-
-	  return (columns);
-  }
-
-private:
-
-  static void GetReferencedColumns(
-		  UNUSED_ATTRIBUTE catalog::Schema *schema,
-		  AbstractExpression *expr,
-		  UNUSED_ATTRIBUTE std::vector<catalog::Column> &columns) {
-	  PL_ASSERT(schema != nullptr);
-	  PL_ASSERT(expr != nullptr);
-
-	  ExpressionType etype = expr->GetExpressionType();
-	  if (etype == EXPRESSION_TYPE_VALUE_TUPLE) {
-		  // TODO: Get the table + column name and grab the
-		  // the handle from schema object!
-
-	  }
-
-    }
-
-
-
+// TODO: Andy is commenting this out for now so that he can come back
+// 	 	 and fix it once we sort out our catalog information.
+//
+//  /**
+//   * Return a list of all of the catalog::Column objects referenced
+//   * in the given expression tree
+//   */
+//  static std::vector<catalog::Column> GetReferencedColumns(
+//		  catalog::Catalog *catalog,
+//		  AbstractExpression *expr) {
+//	  PL_ASSERT(catalog != nullptr);
+//	  PL_ASSERT(expr != nullptr);
+//	  std::vector<catalog::Column> columns;
+//
+//	  GetReferencedColumns(catalog, expr, columns);
+//
+//	  return (columns);
+//  }
+//
+//private:
+//
+//  static void GetReferencedColumns(
+//		  catalog::Catalog *catalog,
+//		  const AbstractExpression *expr,
+//		  std::vector<catalog::Column> &columns) {
+//
+//	  ExpressionType etype = expr->GetExpressionType();
+//	  if (etype == EXPRESSION_TYPE_VALUE_TUPLE) {
+//		  // TODO: Get the table + column name and grab the
+//		  // the handle from schema object!
+//		  const TupleValueExpression t_expr = dynamic_cast<const TupleValueExpression*>(expr);
+//		  // catalog->Get
+//
+//	  }
+//
+//    }
 
 public:
   /**

--- a/src/include/expression/expression_util.h
+++ b/src/include/expression/expression_util.h
@@ -240,6 +240,43 @@ private:
   }
 
 public:
+
+  /**
+   * Return a list of all of the catalog::Column objects referenced
+   * in the given expression tree
+   */
+  static std::vector<catalog::Column> GetReferencedColumns(
+		  UNUSED_ATTRIBUTE catalog::Schema *schema,
+		  AbstractExpression *expr) {
+	  PL_ASSERT(expr != nullptr);
+	  PL_ASSERT(schema != nullptr);
+	  std::vector<catalog::Column> columns;
+
+	  return (columns);
+  }
+
+private:
+
+  static void GetReferencedColumns(
+		  UNUSED_ATTRIBUTE catalog::Schema *schema,
+		  AbstractExpression *expr,
+		  UNUSED_ATTRIBUTE std::vector<catalog::Column> &columns) {
+	  PL_ASSERT(schema != nullptr);
+	  PL_ASSERT(expr != nullptr);
+
+	  ExpressionType etype = expr->GetExpressionType();
+	  if (etype == EXPRESSION_TYPE_VALUE_TUPLE) {
+		  // TODO: Get the table + column name and grab the
+		  // the handle from schema object!
+
+	  }
+
+    }
+
+
+
+
+public:
   /**
    * Walks an expression tree and fills in information about
    * columns and functions in their respective obejects
@@ -297,10 +334,10 @@ private:
     if (expr->GetExpressionType() == EXPRESSION_TYPE_VALUE_TUPLE &&
         expr->GetValueType() == Type::INVALID) {
       auto val_expr = (expression::TupleValueExpression *)expr;
-      auto col_id = schema->GetColumnID(val_expr->col_name_);
+      auto col_id = schema->GetColumnID(val_expr->GetColumnName());
       // exception if we can't find the requested column by name
       if (col_id == (oid_t)-1) {
-        throw Exception("Column " + val_expr->col_name_ + " not found");
+        throw Exception("Column " + val_expr->GetColumnName() + " not found");
       }
       auto column = schema->GetColumn(col_id);
       // make sure the column we need is returned from the scan
@@ -322,7 +359,7 @@ private:
       if (val_expr->alias.size() > 0) {
         val_expr->expr_name_ = val_expr->alias;
       } else {
-        val_expr->expr_name_ = val_expr->col_name_;
+        val_expr->expr_name_ = val_expr->GetColumnName();
       }
       // point to the correct column returned in the logical tuple underneath
       val_expr->SetTupleValueExpressionParams(type, mapped_position, 0);

--- a/src/include/expression/expression_util.h
+++ b/src/include/expression/expression_util.h
@@ -196,7 +196,7 @@ class ExpressionUtil {
 
   /**
    * Generate a pretty-printed string representation of the entire
-   * Expresssion tree
+   * Expresssion tree for the given root node
    */
   static std::string GetInfo(AbstractExpression *expr) {
     std::ostringstream os;
@@ -205,6 +205,41 @@ class ExpressionUtil {
     return os.str();
   }
 
+private:
+
+  /**
+   * Internal method for recursively traversing the expression tree
+   * and generating debug output
+   */
+  static void GetInfo(const AbstractExpression *expr, std::ostringstream &os,
+                      std::string spacer) {
+    ExpressionType etype = expr->GetExpressionType();
+    Type::TypeId vtype = expr->GetValueType();
+
+    // Basic Information
+    os << spacer << "+ " << ExpressionTypeToString(etype) << "::"
+       << "ValueType[" << TypeIdToString(vtype) << "]";
+
+    switch (etype) {
+    case EXPRESSION_TYPE_VALUE_CONSTANT: {
+    	const ConstantValueExpression *c_expr = dynamic_cast<const ConstantValueExpression*>(expr);
+    	os << " -> Value=" << c_expr->GetValue().ToString();
+    	break;
+    }
+    default: {
+    	break;
+    }
+    } // SWITCH
+
+    os << std::endl;
+    spacer += "   ";
+    for (int i = 0, cnt = expr->GetChildrenSize(); i < cnt; i++) {
+      GetInfo(expr->GetChild(i), os, spacer);
+    }
+    return;
+  }
+
+public:
   /**
    * Walks an expression tree and fills in information about
    * columns and functions in their respective obejects
@@ -232,31 +267,7 @@ class ExpressionUtil {
                         needs_projection, true);
   }
 
- private:
-  /**
-   *
-   */
-  static void GetInfo(const AbstractExpression *expr, std::ostringstream &os,
-                      std::string &spacer) {
-    std::string orig_spacer(spacer);
-    ExpressionType etype = expr->GetExpressionType();
-    Type::TypeId vtype = expr->GetValueType();
-
-    // spacer += "   ";
-    std::string info = ExpressionTypeToString(etype);
-
-    // Basic Information
-    os << spacer << "ValueType[" << TypeIdToString(vtype) << "]";
-    os << "[" << ExpressionTypeToString(etype) << "]";
-    os << "[NumChildren=" << expr->GetChildrenSize() << "]\n";
-
-    for (int i = 0, cnt = expr->GetChildrenSize(); i < cnt; i++) {
-      os << spacer << "[" << i << "]   ";
-      GetInfo(expr->GetChild(i), os, spacer);
-      os << "\n";
-    }
-    return;
-  }
+private:
 
   /**
    * this is a private function for transforming expressions as described

--- a/src/include/expression/tuple_value_expression.h
+++ b/src/include/expression/tuple_value_expression.h
@@ -28,8 +28,8 @@ class TupleValueExpression: public AbstractExpression {
 public:
 
   TupleValueExpression(std::string &&col_name) :
-      AbstractExpression(EXPRESSION_TYPE_VALUE_TUPLE, Type::INVALID), value_idx_(
-          -1), tuple_idx_(-1) {
+      AbstractExpression(EXPRESSION_TYPE_VALUE_TUPLE, Type::INVALID),
+	  value_idx_(-1), tuple_idx_(-1) {
     col_name_ = col_name;
   }
 
@@ -79,19 +79,25 @@ public:
 	  return tuple_idx_;
   }
 
-  // XXX: These should not be public!
-  std::string table_name_;
-  std::string col_name_;
+  std::string GetTableName() const {
+	  return table_name_;
+  }
 
+  std::string GetColumnName() const {
+	  return col_name_;
+  }
 
 protected:
   TupleValueExpression(const TupleValueExpression& other) :
-      AbstractExpression(other), table_name_(other.table_name_), col_name_(other.col_name_), value_idx_(other.value_idx_), tuple_idx_(
-          other.tuple_idx_) {
+      AbstractExpression(other),
+	  value_idx_(other.value_idx_), tuple_idx_(other.tuple_idx_),
+	  table_name_(other.table_name_), col_name_(other.col_name_)  {
   }
 
   int value_idx_;
   int tuple_idx_;
+  std::string table_name_;
+  std::string col_name_;
 
 };
 

--- a/src/include/expression/tuple_value_expression.h
+++ b/src/include/expression/tuple_value_expression.h
@@ -75,16 +75,23 @@ public:
     return value_idx_;
   }
 
+  int GetTupleId() const {
+	  return tuple_idx_;
+  }
+
+  // XXX: These should not be public!
   std::string table_name_;
   std::string col_name_;
-  int value_idx_;
-  int tuple_idx_;
+
 
 protected:
   TupleValueExpression(const TupleValueExpression& other) :
       AbstractExpression(other), table_name_(other.table_name_), col_name_(other.col_name_), value_idx_(other.value_idx_), tuple_idx_(
           other.tuple_idx_) {
   }
+
+  int value_idx_;
+  int tuple_idx_;
 
 };
 

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -126,7 +126,7 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
         LOG_TRACE("Found GROUP BY");
         for (auto elem : *group_by->columns) {
           auto tuple_elem = (expression::TupleValueExpression*) elem;
-          std::string col_name(tuple_elem->col_name_);
+          std::string col_name(tuple_elem->GetColumnName());
           auto column_id = target_table->GetSchema()->GetColumnID(col_name);
           group_by_columns.push_back(column_id);
         }
@@ -180,7 +180,7 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
           // just do a direct mapping
           if (expr->GetExpressionType() == EXPRESSION_TYPE_VALUE_TUPLE) {
             auto tup_expr = (expression::TupleValueExpression*) expr;
-            oid_t old_col_id = table_schema->GetColumnID(tup_expr->col_name_);
+            oid_t old_col_id = table_schema->GetColumnID(tup_expr->GetColumnName());
             columns.push_back(table_schema->GetColumn(old_col_id));
             dml.push_back(
                 DirectMap(i, std::make_pair(0, tup_expr->GetColumnId())));
@@ -225,11 +225,11 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
           }
           std::vector<oid_t> key;
 
-          std::string sort_col_name(((expression::TupleValueExpression*)select_stmt->order->expr)->col_name_);
+          std::string sort_col_name(((expression::TupleValueExpression*)select_stmt->order->expr)->GetColumnName());
           for (size_t column_ctr = 0;
                column_ctr < select_stmt->select_list->size(); column_ctr++) {
             std::string col_name(
-                ((expression::TupleValueExpression*)select_stmt->select_list->at(column_ctr))->col_name_);
+                ((expression::TupleValueExpression*)select_stmt->select_list->at(column_ctr))->GetColumnName());
             if (col_name == sort_col_name) key.push_back(column_ctr);
           }
           if (key.size() == 0) {
@@ -262,11 +262,11 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
             flags.push_back(true);
           }
           std::vector<oid_t> key;
-          std::string sort_col_name(((expression::TupleValueExpression*)select_stmt->order->expr)->col_name_);
+          std::string sort_col_name(((expression::TupleValueExpression*)select_stmt->order->expr)->GetColumnName());
           for (size_t column_ctr = 0;
                column_ctr < select_stmt->select_list->size(); column_ctr++) {
             std::string col_name(
-                ((expression::TupleValueExpression*)select_stmt->select_list->at(column_ctr))->col_name_);
+                ((expression::TupleValueExpression*)select_stmt->select_list->at(column_ctr))->GetColumnName());
             if (col_name == sort_col_name) key.push_back(column_ctr);
           }
           if (key.size() == 0) {
@@ -356,7 +356,7 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
               // Else it is the same as the column type
               else {
                 oid_t old_col_id = target_table->GetSchema()->GetColumnID(
-                    agg_over->col_name_);
+                    agg_over->GetColumnName());
                 auto table_column =
                     target_table->GetSchema()->GetColumn(old_col_id);
 
@@ -752,7 +752,7 @@ void SimpleOptimizer::GetPredicateColumns(
     if (right_type == EXPRESSION_TYPE_VALUE_CONSTANT ||
         right_type == EXPRESSION_TYPE_VALUE_PARAMETER) {
       auto expr = (expression::TupleValueExpression*)expression->GetChild(0);
-      std::string col_name(expr->col_name_);
+      std::string col_name(expr->GetColumnName());
       LOG_TRACE("Column name: %s", col_name.c_str());
       auto column_id = schema->GetColumnID(col_name);
       column_ids.push_back(column_id);
@@ -789,7 +789,7 @@ void SimpleOptimizer::GetPredicateColumns(
     if (left_type == EXPRESSION_TYPE_VALUE_CONSTANT ||
         left_type == EXPRESSION_TYPE_VALUE_PARAMETER) {
       auto expr = (expression::TupleValueExpression*)expression->GetChild(1);
-      std::string col_name(expr->col_name_);
+      std::string col_name(expr->GetColumnName());
       LOG_TRACE("Column name: %s", col_name.c_str());
       auto column_id = schema->GetColumnID(col_name);
       LOG_TRACE("Column id: %d", column_id);

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -183,7 +183,7 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
             oid_t old_col_id = table_schema->GetColumnID(tup_expr->col_name_);
             columns.push_back(table_schema->GetColumn(old_col_id));
             dml.push_back(
-                DirectMap(i, std::make_pair(0, tup_expr->value_idx_)));
+                DirectMap(i, std::make_pair(0, tup_expr->GetColumnId())));
           }
           // otherwise we need to evaluat the expression
           else {

--- a/src/planner/seq_scan_plan.cpp
+++ b/src/planner/seq_scan_plan.cpp
@@ -81,7 +81,7 @@ SeqScanPlan::SeqScanPlan(parser::SelectStatement *select_node) {
       for (auto col : *select_node->select_list) {
         LOG_TRACE("ExpressionType: %s",
                   ExpressionTypeToString(col->GetExpressionType()).c_str());
-        auto col_name = ((expression::TupleValueExpression*)col)->col_name_;
+        auto col_name = ((expression::TupleValueExpression*)col)->GetColumnName();
         oid_t col_id = SeqScanPlan::GetColumnID(std::string(col_name));
         SetColumnId(col_id);
       }

--- a/test/expression/expression_util_test.cpp
+++ b/test/expression/expression_util_test.cpp
@@ -32,6 +32,10 @@ namespace test {
 
 class ExpressionUtilTest : public PelotonTest {};
 
+std::string CONSTANT_VALUE_STRING1 = "ABC";
+std::string CONSTANT_VALUE_STRING2 = "XYZ";
+
+
 expression::AbstractExpression* createExpTree() {
   auto exp1 = expression::ExpressionUtil::ConstantValueFactory(
       common::ValueFactory::GetIntegerValue(1));
@@ -41,9 +45,9 @@ expression::AbstractExpression* createExpTree() {
       EXPRESSION_TYPE_COMPARE_EQUAL, exp1, exp2);
 
   auto exp4 = expression::ExpressionUtil::ConstantValueFactory(
-	  common::ValueFactory::GetVarcharValue("ABC"));
+	  common::ValueFactory::GetVarcharValue(CONSTANT_VALUE_STRING1));
   auto exp5 = expression::ExpressionUtil::ConstantValueFactory(
-  	  common::ValueFactory::GetVarcharValue("XYZ"));
+  	  common::ValueFactory::GetVarcharValue(CONSTANT_VALUE_STRING2));
   auto exp6 = expression::ExpressionUtil::ComparisonFactory(
       EXPRESSION_TYPE_COMPARE_NOTEQUAL, exp4, exp5);
 
@@ -55,12 +59,12 @@ expression::AbstractExpression* createExpTree() {
 // Make sure that we can traverse a tree
 TEST_F(ExpressionUtilTest, GetInfoTest) {
   auto root = createExpTree();
-
   std::string info = expression::ExpressionUtil::GetInfo(root);
 
-  printf("%s", info.c_str());
-
+  // Just make sure that it has our constant strings
   EXPECT_TRUE(info.size() > 0);
+  EXPECT_NE(std::string::npos, info.find(CONSTANT_VALUE_STRING1));
+  EXPECT_NE(std::string::npos, info.find(CONSTANT_VALUE_STRING2));
 
   delete root;
 }

--- a/test/expression/expression_util_test.cpp
+++ b/test/expression/expression_util_test.cpp
@@ -37,9 +37,18 @@ expression::AbstractExpression* createExpTree() {
       common::ValueFactory::GetIntegerValue(1));
   auto exp2 = expression::ExpressionUtil::ConstantValueFactory(
       common::ValueFactory::GetIntegerValue(1));
-  auto root = expression::ExpressionUtil::ComparisonFactory(
+  auto exp3 = expression::ExpressionUtil::ComparisonFactory(
       EXPRESSION_TYPE_COMPARE_EQUAL, exp1, exp2);
 
+  auto exp4 = expression::ExpressionUtil::ConstantValueFactory(
+	  common::ValueFactory::GetVarcharValue("ABC"));
+  auto exp5 = expression::ExpressionUtil::ConstantValueFactory(
+  	  common::ValueFactory::GetVarcharValue("XYZ"));
+  auto exp6 = expression::ExpressionUtil::ComparisonFactory(
+      EXPRESSION_TYPE_COMPARE_NOTEQUAL, exp4, exp5);
+
+  auto root = expression::ExpressionUtil::ConjunctionFactory(
+		  EXPRESSION_TYPE_CONJUNCTION_AND, exp3, exp6);
   return (root);
 }
 
@@ -49,7 +58,7 @@ TEST_F(ExpressionUtilTest, GetInfoTest) {
 
   std::string info = expression::ExpressionUtil::GetInfo(root);
 
-  LOG_INFO("%s", info.c_str());
+  printf("%s", info.c_str());
 
   EXPECT_TRUE(info.size() > 0);
 

--- a/test/expression/expression_util_test.cpp
+++ b/test/expression/expression_util_test.cpp
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// expression_test.cpp
+//
+// Identification: test/expression/expressionutil_test.cpp
+//
+// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "common/harness.h"
+#include "common/logger.h"
+
+#include "common/value.h"
+#include "common/value_factory.h"
+#include "expression/abstract_expression.h"
+#include "expression/expression_util.h"
+
+using ::testing::NotNull;
+using ::testing::Return;
+
+namespace peloton {
+
+namespace test {
+
+class ExpressionUtilTest : public PelotonTest {};
+
+expression::AbstractExpression* createExpTree() {
+  auto exp1 = expression::ExpressionUtil::ConstantValueFactory(
+      common::ValueFactory::GetIntegerValue(1));
+  auto exp2 = expression::ExpressionUtil::ConstantValueFactory(
+      common::ValueFactory::GetIntegerValue(1));
+  auto root = expression::ExpressionUtil::ComparisonFactory(
+      EXPRESSION_TYPE_COMPARE_EQUAL, exp1, exp2);
+
+  return (root);
+}
+
+// Make sure that we can traverse a tree
+TEST_F(ExpressionUtilTest, GetInfoTest) {
+  auto root = createExpTree();
+
+  std::string info = expression::ExpressionUtil::GetInfo(root);
+
+  LOG_INFO("%s", info.c_str());
+
+  EXPECT_TRUE(info.size() > 0);
+
+  delete root;
+}
+
+}  // namespace test
+}  // namespace peloton


### PR DESCRIPTION
I want to get this in now before I start making major changes. Otherwise my code will die on a branch when I get tied up with other professor duties and can't get back to this. Oh yeah this was for #356

* Added back the `TypeIdToString()` and `StringToTypeId()` utility functions to 'types.h'. Clang-format then cleaned up a bunch of other code.
* Added `ExpressionUtil::GetInfo(`) for creating a string representation of an entire `AbstractExpression` tree (with a testcase, you dank mofo)
* Refactored `TupleValueExpression` so that its internal data members are private.