### PR TITLE
Add pre-declared read only support

### DIFF
--- a/src/include/common/types.h
+++ b/src/include/common/types.h
@@ -924,7 +924,9 @@ static const txn_id_t INVALID_TXN_ID = 0;
 
 static const txn_id_t INITIAL_TXN_ID = 1;
 
-static const txn_id_t START_TXN_ID = 2;
+static const txn_id_t READONLY_TXN_ID = 2;
+
+static const txn_id_t START_TXN_ID = 3;
 
 static const txn_id_t MAX_TXN_ID = std::numeric_limits<txn_id_t>::max();
 
@@ -934,7 +936,9 @@ typedef uint64_t cid_t;
 
 static const cid_t INVALID_CID = 0;
 
-static const cid_t START_CID = 1;
+static const cid_t READ_ONLY_START_CID = 1;
+
+static const cid_t START_CID = 2;
 
 static const cid_t MAX_CID = std::numeric_limits<cid_t>::max();
 

--- a/src/include/concurrency/epoch_manager.h
+++ b/src/include/concurrency/epoch_manager.h
@@ -26,29 +26,47 @@ namespace peloton {
 namespace concurrency {
 
 struct Epoch {
-  std::atomic<int> txn_ref_count_;
+  std::atomic<int> ro_txn_ref_count_;
+  std::atomic<int> rw_txn_ref_count_;
   cid_t max_cid_;
 
-  Epoch() : txn_ref_count_(0), max_cid_(0) {}
+  Epoch()
+    :ro_txn_ref_count_(0), rw_txn_ref_count_(0),max_cid_(0) {}
 
   void Init() {
-    txn_ref_count_ = 0;
+    ro_txn_ref_count_ = 0;
+    rw_txn_ref_count_ = 0;
     max_cid_ = 0;
   }
 };
 
-class EpochManager {
- public:
-  EpochManager()
-      : epoch_queue_(epoch_queue_size_),
-        queue_tail_(0),
-        current_epoch_(0),
-        queue_tail_gc(true),
-        max_cid(0),
-        finish_(false) {
-  }
+/*
+Epoch queue layout:
+ current epoch               queue tail                reclaim tail
+/                           /                          /
++--------+--------+--------+--------+--------+--------+--------+-------
+| head   | safety |  ....  |readonly| safety |  ....  |gc usage|  ....
++--------+--------+--------+--------+--------+--------+--------+-------
+New                                                   Old
 
-  ~EpochManager() {}
+Note:
+1) Queue tail epoch and epochs which is older than it have 0 rw txn ref count
+2) Reclaim tail epoch and epochs which is older than it have 0 ro txn ref count
+3) Reclaim tail is at least 2 turns older than the queue tail epoch
+4) Queue tail is at least 2 turns older than the head epoch
+*/
+
+class EpochManager {
+  EpochManager(const EpochManager&) = delete;
+  static const int safety_interval_ = 2;
+
+public:
+  EpochManager()
+    : epoch_queue_(epoch_queue_size_),
+      queue_tail_(0), reclaim_tail_(0), current_epoch_(0),
+      queue_tail_token_(true), reclaim_tail_token_(true),
+      max_cid_ro_(READ_ONLY_START_CID), max_cid_gc_(0), finish_(false) {
+  }
 
   void StartEpoch() {
     finish_ = false;
@@ -59,15 +77,11 @@ class EpochManager {
     finish_ = true;
   }
 
-  void SetQueryThreadCount() {
-
-  }
-
-  size_t EnterEpoch(cid_t begin_cid) {
-    auto epoch = current_epoch_.load();
+  size_t EnterReadOnlyEpoch(cid_t begin_cid) {
+    auto epoch = queue_tail_.load();
 
     size_t epoch_idx = epoch % epoch_queue_size_;
-    epoch_queue_[epoch_idx].txn_ref_count_++;
+    epoch_queue_[epoch_idx].ro_txn_ref_count_++;
 
     // Set the max cid in the tuple
     auto max_cid_ptr = &(epoch_queue_[epoch_idx].max_cid_);
@@ -76,63 +90,61 @@ class EpochManager {
     return epoch;
   }
 
+  size_t EnterEpoch(cid_t begin_cid) {
+    auto epoch = current_epoch_.load();
+
+    size_t epoch_idx = epoch % epoch_queue_size_;
+    epoch_queue_[epoch_idx].rw_txn_ref_count_++;
+
+    // Set the max cid in the tuple
+    auto max_cid_ptr = &(epoch_queue_[epoch_idx].max_cid_);
+    AtomicMax(max_cid_ptr, begin_cid);
+
+    return epoch;
+  }
+
+  void ExitReadOnlyEpoch(size_t epoch) {
+    PL_ASSERT(epoch >= reclaim_tail_);
+    PL_ASSERT(epoch <= queue_tail_);
+
+    auto epoch_idx = epoch % epoch_queue_size_;
+    epoch_queue_[epoch_idx].ro_txn_ref_count_--;
+  }
+
   void ExitEpoch(size_t epoch) {
     PL_ASSERT(epoch >= queue_tail_);
     PL_ASSERT(epoch <= current_epoch_);
 
     auto epoch_idx = epoch % epoch_queue_size_;
-
-    epoch_queue_[epoch_idx].txn_ref_count_--;
+    epoch_queue_[epoch_idx].rw_txn_ref_count_--;
   }
+
   // assume we store epoch_store max_store previously
   cid_t GetMaxDeadTxnCid() {
-    // TODO:
-    // change to:
-    // increase tail
-    // return max
-    auto tail = queue_tail_.load();
-    auto head = current_epoch_.load();
-    if (head > 0) {
-      head--;
-    }
-    auto res = max_cid;
-
-    auto dead_num = 0;
-    while (tail < head) {
-      auto idx = tail % epoch_queue_size_;
-      // break when meeting running txn
-      if (epoch_queue_[idx].txn_ref_count_ > 0) {
-        break;
-      }
-
-      if (epoch_queue_[idx].max_cid_ > res) {
-        res = epoch_queue_[idx].max_cid_;
-      }
-      tail++;
-      dead_num++;
-    }
-    if (res > max_cid) {
-      AtomicMax(&max_cid, res);
-    }
-
-    if (dead_num > 32) {
-      IncreaseTail();
-    }
-    return max_cid;
+    IncreaseQueueTail();
+    IncreaseReclaimTail();
+    return max_cid_gc_;
   }
 
- private:
+  cid_t GetReadOnlyTxnCid() {
+    IncreaseQueueTail();
+    return max_cid_ro_;
+  }
+
+private:
   void Start() {
     while (!finish_) {
       // the epoch advances every EPOCH_LENGTH milliseconds.
       std::this_thread::sleep_for(std::chrono::milliseconds(EPOCH_LENGTH));
 
       auto next_idx = (current_epoch_.load() + 1) % epoch_queue_size_;
-      auto tail_idx = queue_tail_.load() % epoch_queue_size_;
-      if (next_idx == tail_idx) {
+      auto tail_idx = reclaim_tail_.load() % epoch_queue_size_;
+
+      if(next_idx == tail_idx) {
         // overflow
         // in this case, just increase tail
-        IncreaseTail();
+        IncreaseQueueTail();
+        IncreaseReclaimTail();
         continue;
       }
 
@@ -141,13 +153,51 @@ class EpochManager {
       epoch_queue_[next_idx].Init();
       current_epoch_++;
 
-      IncreaseTail();
+      IncreaseQueueTail();
+      IncreaseReclaimTail();
     }
   }
 
-  void IncreaseTail() {
+  void IncreaseReclaimTail() {
     bool expect = true, desired = false;
-    if (!queue_tail_gc.compare_exchange_weak(expect, desired)) {
+    if(!reclaim_tail_token_.compare_exchange_weak(expect, desired)){
+      // someone now is increasing tail
+      return;
+    }
+
+    auto current = queue_tail_.load();
+    auto tail = reclaim_tail_.load();
+
+    while(true) {
+      if(tail + safety_interval_ >= current) {
+        break;
+      }
+
+      auto idx = tail % epoch_queue_size_;
+
+      // inc tail until we find an epoch that has running txn
+      if(epoch_queue_[idx].ro_txn_ref_count_ > 0) {
+        break;
+      }
+
+      // save max cid
+      auto max = epoch_queue_[idx].max_cid_;
+      AtomicMax(&max_cid_gc_, max);
+      tail++;
+    }
+
+    reclaim_tail_ = tail;
+
+    expect = false;
+    desired = true;
+
+    reclaim_tail_token_.compare_exchange_weak(expect, desired);
+    return;
+  }
+
+  void IncreaseQueueTail() {
+    bool expect = true, desired = false;
+    if(!queue_tail_token_.compare_exchange_weak(expect, desired)){
       // someone now is increasing tail
       return;
     }
@@ -155,21 +205,21 @@ class EpochManager {
     auto current = current_epoch_.load();
     auto tail = queue_tail_.load();
 
-    while (true) {
-      if (tail + 1 == current) {
+    while(true) {
+      if(tail + safety_interval_ >= current) {
         break;
       }
 
       auto idx = tail % epoch_queue_size_;
 
       // inc tail until we find an epoch that has running txn
-      if (epoch_queue_[idx].txn_ref_count_ > 0) {
+      if(epoch_queue_[idx].rw_txn_ref_count_ > 0) {
         break;
       }
 
       // save max cid
       auto max = epoch_queue_[idx].max_cid_;
-      AtomicMax(&max_cid, max);
+      AtomicMax(&max_cid_ro_, max);
       tail++;
     }
 
@@ -178,33 +228,48 @@ class EpochManager {
     expect = false;
     desired = true;
 
-    queue_tail_gc.compare_exchange_weak(expect, desired);
+    queue_tail_token_.compare_exchange_weak(expect, desired);
     return;
   }
 
   void AtomicMax(cid_t* addr, cid_t max) {
-    while (true) {
+    while(true) {
       auto old = *addr;
-      if (old > max) {
+      if(old > max) {
         return;
-      } else if (__sync_bool_compare_and_swap(addr, old, max)) {
+      }else if ( __sync_bool_compare_and_swap(addr, old, max) ) {
         return;
       }
     }
   }
 
- private:
+  inline void InitEpochQueue() {
+    for (int i = 0; i < 5; ++i) {
+      epoch_queue_[i].Init();
+    }
+
+    current_epoch_ = 0;
+    queue_tail_ = 0;
+    reclaim_tail_ = 0;
+  }
+
+private:
   // queue size
-  static const size_t epoch_queue_size_ = 2048;
+  static const size_t epoch_queue_size_ = 4096;
 
   // Epoch vector
   std::vector<Epoch> epoch_queue_;
   std::atomic<size_t> queue_tail_;
+  std::atomic<size_t> reclaim_tail_;
   std::atomic<size_t> current_epoch_;
-  std::atomic<bool> queue_tail_gc;
-  cid_t max_cid;
+  std::atomic<bool> queue_tail_token_;
+  std::atomic<bool> reclaim_tail_token_;
+  cid_t max_cid_ro_;
+  cid_t max_cid_gc_;
   bool finish_;
 };
 
+
 }
 }
+

--- a/src/include/concurrency/timestamp_ordering_transaction_manager.h
+++ b/src/include/concurrency/timestamp_ordering_transaction_manager.h
@@ -103,9 +103,13 @@ class TimestampOrderingTransactionManager : public TransactionManager {
 
   virtual Transaction *BeginTransaction();
 
+  virtual Transaction *BeginReadonlyTransaction();
+
   virtual void EndTransaction(Transaction *current_txn);
 
- private:
+  virtual void EndReadonlyTransaction(Transaction *current_txn);
+
+private:
   static const int LOCK_OFFSET = 0;
   static const int LAST_READER_OFFSET = (LOCK_OFFSET + 8);
 

--- a/src/include/concurrency/transaction.h
+++ b/src/include/concurrency/transaction.h
@@ -48,6 +48,11 @@ class Transaction : public Printable {
     Init(txn_id, begin_cid);
   }
 
+  Transaction(const txn_id_t &txn_id, const cid_t &begin_cid, bool ro) {
+    Init(txn_id, begin_cid);
+    declared_readonly_ = ro;
+  }
+
   ~Transaction() {}
 
   void Init(const txn_id_t &txn_id, const cid_t &begin_cid) {
@@ -55,6 +60,7 @@ class Transaction : public Printable {
     begin_cid_ = begin_cid;
     end_cid_ = MAX_CID;
     is_written_ = false;
+    declared_readonly_ = false;
     insert_count_ = 0;
     gc_set_.reset(new ReadWriteSet());
   }
@@ -109,6 +115,10 @@ class Transaction : public Printable {
     return is_written_ == false && insert_count_ == 0;
   }
 
+  inline bool IsDeclaredReadOnly() const {
+    return declared_readonly_;
+  }
+
  private:
   //===--------------------------------------------------------------------===//
   // Data members
@@ -136,6 +146,8 @@ class Transaction : public Printable {
 
   bool is_written_;
   size_t insert_count_;
+
+  bool declared_readonly_;
 };
 
 }  // End concurrency namespace

--- a/src/include/concurrency/transaction_manager.h
+++ b/src/include/concurrency/transaction_manager.h
@@ -138,7 +138,11 @@ class TransactionManager {
 
   virtual Transaction *BeginTransaction() = 0;
 
+  virtual Transaction *BeginReadonlyTransaction() = 0;
+
   virtual void EndTransaction(Transaction *current_txn) = 0;
+
+  virtual void EndReadonlyTransaction(Transaction *current_txn) = 0;
 
   virtual Result CommitTransaction(Transaction *const current_txn) = 0;
 

--- a/test/include/concurrency/transaction_tests_util.h
+++ b/test/include/concurrency/transaction_tests_util.h
@@ -173,10 +173,12 @@ struct TransactionSchedule {
   std::vector<int> results;
   int stored_value;
   int schedule_id;
-  TransactionSchedule(int schedule_id_)
+  bool declared_ro;
+  TransactionSchedule(int schedule_id_, bool ro = false)
       : txn_result(RESULT_FAILURE),
         stored_value(0),
-        schedule_id(schedule_id_) {}
+        schedule_id(schedule_id_),
+        declared_ro(ro) {}
 };
 
 // A thread wrapper that runs a transaction
@@ -233,7 +235,14 @@ class TransactionThread {
     if (id == TXN_STORED_VALUE) id = schedule->stored_value;
     if (value == TXN_STORED_VALUE) value = schedule->stored_value;
 
-    if (cur_seq == 0) txn = txn_manager->BeginTransaction();
+    if (cur_seq == 0) {
+      if (schedule->declared_ro == true) {
+        txn = txn_manager->BeginReadonlyTransaction();
+      } else {
+        txn = txn_manager->BeginTransaction();
+      }
+    }
+
     if (schedule->txn_result == RESULT_ABORTED) {
       cur_seq++;
       return;
@@ -332,13 +341,18 @@ class TransactionThread {
 class TransactionScheduler {
  public:
   TransactionScheduler(size_t num_txn, storage::DataTable *datatable_,
-                       concurrency::TransactionManager *txn_manager_)
+                       concurrency::TransactionManager *txn_manager_,
+                       bool first_as_ro = false)
       : txn_manager(txn_manager_),
         table(datatable_),
         time(0),
         concurrent(false) {
     for (size_t i = 0; i < num_txn; i++) {
-      schedules.emplace_back(i);
+      if (first_as_ro && i == 0) {
+        schedules.emplace_back(i, true);
+      } else {
+        schedules.emplace_back(i, false);
+      }
     }
   }
 


### PR DESCRIPTION
Use the BeginReadOnlyTransaction() method to create a pre-declared read-only transaction.

Signed-off-by: Jiexi Lin <jxlin39@gmail.com>