### PR TITLE
Fixes for Boolean Value Type

### DIFF
--- a/src/common/array_type.cpp
+++ b/src/common/array_type.cpp
@@ -16,14 +16,14 @@
 #include "common/decimal_type.h"
 #include "common/numeric_type.h"
 #include "common/timestamp_type.h"
-#include "common/varlen_type.h"
 #include "common/type.h"
+#include "common/varlen_type.h"
 
 namespace peloton {
 namespace common {
 
 // Get the element at a given index in this array
-Value ArrayType::GetElementAt(const Value& val, uint64_t idx) const {
+Value ArrayType::GetElementAt(const Value &val, uint64_t idx) const {
   switch (val.GetElementType()) {
     case Type::BOOLEAN: {
       std::vector<bool> vec = *(std::vector<bool> *)(val.value_.array.data);
@@ -34,15 +34,18 @@ Value ArrayType::GetElementAt(const Value& val, uint64_t idx) const {
       return ValueFactory::GetTinyIntValue((int8_t)vec.at(idx));
     }
     case Type::SMALLINT: {
-      std::vector<int16_t> vec = *(std::vector<int16_t> *)(val.value_.array.data);
+      std::vector<int16_t> vec =
+          *(std::vector<int16_t> *)(val.value_.array.data);
       return ValueFactory::GetSmallIntValue((int16_t)vec.at(idx));
     }
     case Type::INTEGER: {
-      std::vector<int32_t> vec = *(std::vector<int32_t> *)(val.value_.array.data);
+      std::vector<int32_t> vec =
+          *(std::vector<int32_t> *)(val.value_.array.data);
       return ValueFactory::GetIntegerValue((int32_t)vec.at(idx));
     }
     case Type::BIGINT: {
-      std::vector<int64_t> vec = *(std::vector<int64_t> *)(val.value_.array.data);
+      std::vector<int64_t> vec =
+          *(std::vector<int64_t> *)(val.value_.array.data);
       return ValueFactory::GetBigIntValue((int64_t)vec.at(idx));
     }
     case Type::DECIMAL: {
@@ -50,11 +53,13 @@ Value ArrayType::GetElementAt(const Value& val, uint64_t idx) const {
       return ValueFactory::GetDoubleValue((double)vec.at(idx));
     }
     case Type::TIMESTAMP: {
-      std::vector<uint64_t> vec = *(std::vector<uint64_t> *)(val.value_.array.data);
+      std::vector<uint64_t> vec =
+          *(std::vector<uint64_t> *)(val.value_.array.data);
       return ValueFactory::GetTimestampValue((uint64_t)vec.at(idx));
     }
     case Type::VARCHAR: {
-      std::vector<std::string> vec = *(std::vector<std::string> *)(val.value_.array.data);
+      std::vector<std::string> vec =
+          *(std::vector<std::string> *)(val.value_.array.data);
       return ValueFactory::GetVarcharValue(vec.at(idx));
     }
     default:
@@ -64,99 +69,89 @@ Value ArrayType::GetElementAt(const Value& val, uint64_t idx) const {
 }
 
 // Does this value exist in this array?
-Value ArrayType::InList(const Value& list, const Value &object) const {
+Value ArrayType::InList(const Value &list, const Value &object) const {
   Value ele = (list.GetElementAt(0));
   ele.CheckComparable(object);
-  if (object.IsNull())
-    return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
+  if (object.IsNull()) return ValueFactory::GetNullValueByType(Type::BOOLEAN);
   switch (list.GetElementType()) {
     case Type::BOOLEAN: {
       std::vector<bool> vec = *(std::vector<bool> *)(list.value_.array.data);
       std::vector<bool>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetBooleanValue(*it).CompareEquals(object);
-        if (res.IsTrue())
-          return res;
-
+        if (res.IsTrue()) return res;
       }
-      return ValueFactory::GetBooleanValue(0);
+      return ValueFactory::GetBooleanValue(false);
     }
     case Type::TINYINT: {
-      std::vector<int8_t> vec = *(std::vector<int8_t> *)(list.value_.array.data);
+      std::vector<int8_t> vec =
+          *(std::vector<int8_t> *)(list.value_.array.data);
       std::vector<int8_t>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = Value(Type::TINYINT, *it).CompareEquals(object);
-        if (res.IsTrue())
-          return res;
-
+        if (res.IsTrue()) return res;
       }
-      return ValueFactory::GetBooleanValue(0);
+      return ValueFactory::GetBooleanValue(false);
     }
     case Type::SMALLINT: {
-      std::vector<int16_t> vec = *(std::vector<int16_t> *)(list.value_.array.data);
+      std::vector<int16_t> vec =
+          *(std::vector<int16_t> *)(list.value_.array.data);
       std::vector<int16_t>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = Value(Type::SMALLINT, *it).CompareEquals(object);
-        if (res.IsTrue())
-          return res;
-
+        if (res.IsTrue()) return res;
       }
-      return ValueFactory::GetBooleanValue(0);
+      return ValueFactory::GetBooleanValue(false);
     }
     case Type::INTEGER: {
-      std::vector<int32_t> vec = *(std::vector<int32_t> *)(list.value_.array.data);
+      std::vector<int32_t> vec =
+          *(std::vector<int32_t> *)(list.value_.array.data);
       std::vector<int32_t>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetIntegerValue(*it).CompareEquals(object);
-        if (res.IsTrue())
-          return res;
-
+        if (res.IsTrue()) return res;
       }
-      return ValueFactory::GetBooleanValue(0);
+      return ValueFactory::GetBooleanValue(false);
     }
     case Type::BIGINT: {
-      std::vector<int64_t> vec = *(std::vector<int64_t> *)(list.value_.array.data);
+      std::vector<int64_t> vec =
+          *(std::vector<int64_t> *)(list.value_.array.data);
       std::vector<int64_t>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetBigIntValue(*it).CompareEquals(object);
-        if (res.IsTrue())
-          return res;
-
+        if (res.IsTrue()) return res;
       }
-      return ValueFactory::GetBooleanValue(0);
+      return ValueFactory::GetBooleanValue(false);
     }
     case Type::DECIMAL: {
-      std::vector<double> vec = *(std::vector<double> *)(list.value_.array.data);
+      std::vector<double> vec =
+          *(std::vector<double> *)(list.value_.array.data);
       std::vector<double>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetDoubleValue(*it).CompareEquals(object);
-        if (res.IsTrue())
-          return res;
-
+        if (res.IsTrue()) return res;
       }
-      return ValueFactory::GetBooleanValue(0);
+      return ValueFactory::GetBooleanValue(false);
     }
     case Type::TIMESTAMP: {
-      std::vector<uint64_t> vec = *(std::vector<uint64_t> *)(list.value_.array.data);
+      std::vector<uint64_t> vec =
+          *(std::vector<uint64_t> *)(list.value_.array.data);
       std::vector<uint64_t>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetTimestampValue(*it).CompareEquals(object);
-        if (res.IsTrue())
-          return res;
-
+        if (res.IsTrue()) return res;
       }
-      return ValueFactory::GetBooleanValue(0);
+      return ValueFactory::GetBooleanValue(false);
     }
     case Type::VARCHAR: {
-      std::vector<std::string> vec = *(std::vector<std::string> *)(list.value_.array.data);
+      std::vector<std::string> vec =
+          *(std::vector<std::string> *)(list.value_.array.data);
       std::vector<std::string>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = Value(Type::VARCHAR, *it).CompareEquals(object);
-        if (res.IsTrue())
-          return res;
-
+        if (res.IsTrue()) return res;
       }
-      return ValueFactory::GetBooleanValue(0);
+      return ValueFactory::GetBooleanValue(false);
     }
     default:
       break;
@@ -164,13 +159,12 @@ Value ArrayType::InList(const Value& list, const Value &object) const {
   throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Element type is invalid.");
 }
 
-Value ArrayType::CompareEquals(const Value& left, const Value &right) const {
+Value ArrayType::CompareEquals(const Value &left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::ARRAY);
   left.CheckComparable(right);
   if (right.GetElementType() != left.GetElementType()) {
-    std::string msg = Type::GetInstance(
-                      right.GetElementType())->ToString()
-                      + " mismatch with " +
+    std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
+                      " mismatch with " +
                       Type::GetInstance(left.GetElementType())->ToString();
     throw Exception(EXCEPTION_TYPE_MISMATCH_TYPE, msg);
   }
@@ -181,38 +175,52 @@ Value ArrayType::CompareEquals(const Value& left, const Value &right) const {
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::TINYINT: {
-      std::vector<int8_t> vec1 = *(std::vector<int8_t> *)(left.value_.array.data);
-      std::vector<int8_t> vec2 = *(std::vector<int8_t> *)(right.GetAs<char *>());
+      std::vector<int8_t> vec1 =
+          *(std::vector<int8_t> *)(left.value_.array.data);
+      std::vector<int8_t> vec2 =
+          *(std::vector<int8_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::SMALLINT: {
-      std::vector<int16_t> vec1 = *(std::vector<int16_t> *)(left.value_.array.data);
-      std::vector<int16_t> vec2 = *(std::vector<int16_t> *)(right.GetAs<char *>());
+      std::vector<int16_t> vec1 =
+          *(std::vector<int16_t> *)(left.value_.array.data);
+      std::vector<int16_t> vec2 =
+          *(std::vector<int16_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::INTEGER: {
-      std::vector<int32_t> vec1 = *(std::vector<int32_t> *)(left.value_.array.data);
-      std::vector<int32_t> vec2 = *(std::vector<int32_t> *)(right.GetAs<char *>());
+      std::vector<int32_t> vec1 =
+          *(std::vector<int32_t> *)(left.value_.array.data);
+      std::vector<int32_t> vec2 =
+          *(std::vector<int32_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::BIGINT: {
-      std::vector<int64_t> vec1 = *(std::vector<int64_t> *)(left.value_.array.data);
-      std::vector<int64_t> vec2 = *(std::vector<int64_t> *)(right.GetAs<char *>());
+      std::vector<int64_t> vec1 =
+          *(std::vector<int64_t> *)(left.value_.array.data);
+      std::vector<int64_t> vec2 =
+          *(std::vector<int64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::DECIMAL: {
-      std::vector<double> vec1 = *(std::vector<double> *)(left.value_.array.data);
-      std::vector<double> vec2 = *(std::vector<double> *)(right.GetAs<char *>());
+      std::vector<double> vec1 =
+          *(std::vector<double> *)(left.value_.array.data);
+      std::vector<double> vec2 =
+          *(std::vector<double> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::TIMESTAMP: {
-      std::vector<uint64_t> vec1 = *(std::vector<uint64_t> *)(left.value_.array.data);
-      std::vector<uint64_t> vec2 = *(std::vector<uint64_t> *)(right.GetAs<char *>());
+      std::vector<uint64_t> vec1 =
+          *(std::vector<uint64_t> *)(left.value_.array.data);
+      std::vector<uint64_t> vec2 =
+          *(std::vector<uint64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::VARCHAR: {
-      std::vector<std::string> vec1 = *(std::vector<std::string> *)(left.value_.array.data);
-      std::vector<std::string> vec2 = *(std::vector<std::string> *)(right.GetAs<char *>());
+      std::vector<std::string> vec1 =
+          *(std::vector<std::string> *)(left.value_.array.data);
+      std::vector<std::string> vec2 =
+          *(std::vector<std::string> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     default:
@@ -221,13 +229,12 @@ Value ArrayType::CompareEquals(const Value& left, const Value &right) const {
   throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Element type is invalid.");
 }
 
-Value ArrayType::CompareNotEquals(const Value& left, const Value &right) const {
+Value ArrayType::CompareNotEquals(const Value &left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::ARRAY);
   left.CheckComparable(right);
   if (right.GetElementType() != left.GetElementType()) {
-    std::string msg = Type::GetInstance(
-                      right.GetElementType())->ToString()
-                      + " mismatch with " +
+    std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
+                      " mismatch with " +
                       Type::GetInstance(left.GetElementType())->ToString();
     throw Exception(EXCEPTION_TYPE_MISMATCH_TYPE, msg);
   }
@@ -238,38 +245,52 @@ Value ArrayType::CompareNotEquals(const Value& left, const Value &right) const {
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::TINYINT: {
-      std::vector<int8_t> vec1 = *(std::vector<int8_t> *)(left.value_.array.data);
-      std::vector<int8_t> vec2 = *(std::vector<int8_t> *)(right.GetAs<char *>());
+      std::vector<int8_t> vec1 =
+          *(std::vector<int8_t> *)(left.value_.array.data);
+      std::vector<int8_t> vec2 =
+          *(std::vector<int8_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::SMALLINT: {
-      std::vector<int16_t> vec1 = *(std::vector<int16_t> *)(left.value_.array.data);
-      std::vector<int16_t> vec2 = *(std::vector<int16_t> *)(right.GetAs<char *>());
+      std::vector<int16_t> vec1 =
+          *(std::vector<int16_t> *)(left.value_.array.data);
+      std::vector<int16_t> vec2 =
+          *(std::vector<int16_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::INTEGER: {
-      std::vector<int32_t> vec1 = *(std::vector<int32_t> *)(left.value_.array.data);
-      std::vector<int32_t> vec2 = *(std::vector<int32_t> *)(right.GetAs<char *>());
+      std::vector<int32_t> vec1 =
+          *(std::vector<int32_t> *)(left.value_.array.data);
+      std::vector<int32_t> vec2 =
+          *(std::vector<int32_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::BIGINT: {
-      std::vector<int64_t> vec1 = *(std::vector<int64_t> *)(left.value_.array.data);
-      std::vector<int64_t> vec2 = *(std::vector<int64_t> *)(right.GetAs<char *>());
+      std::vector<int64_t> vec1 =
+          *(std::vector<int64_t> *)(left.value_.array.data);
+      std::vector<int64_t> vec2 =
+          *(std::vector<int64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::DECIMAL: {
-      std::vector<double> vec1 = *(std::vector<double> *)(left.value_.array.data);
-      std::vector<double> vec2 = *(std::vector<double> *)(right.GetAs<char *>());
+      std::vector<double> vec1 =
+          *(std::vector<double> *)(left.value_.array.data);
+      std::vector<double> vec2 =
+          *(std::vector<double> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::TIMESTAMP: {
-      std::vector<uint64_t> vec1 = *(std::vector<uint64_t> *)(left.value_.array.data);
-      std::vector<uint64_t> vec2 = *(std::vector<uint64_t> *)(right.GetAs<char *>());
+      std::vector<uint64_t> vec1 =
+          *(std::vector<uint64_t> *)(left.value_.array.data);
+      std::vector<uint64_t> vec2 =
+          *(std::vector<uint64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::VARCHAR: {
-      std::vector<std::string> vec1 = *(std::vector<std::string> *)(left.value_.array.data);
-      std::vector<std::string> vec2 = *(std::vector<std::string> *)(right.GetAs<char *>());
+      std::vector<std::string> vec1 =
+          *(std::vector<std::string> *)(left.value_.array.data);
+      std::vector<std::string> vec2 =
+          *(std::vector<std::string> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     default:
@@ -278,13 +299,12 @@ Value ArrayType::CompareNotEquals(const Value& left, const Value &right) const {
   throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Element type is invalid.");
 }
 
-Value ArrayType::CompareLessThan(const Value& left, const Value &right) const {
+Value ArrayType::CompareLessThan(const Value &left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::ARRAY);
   left.CheckComparable(right);
   if (right.GetElementType() != left.GetElementType()) {
-    std::string msg = Type::GetInstance(
-                      right.GetElementType())->ToString()
-                      + " mismatch with " +
+    std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
+                      " mismatch with " +
                       Type::GetInstance(left.GetElementType())->ToString();
     throw Exception(EXCEPTION_TYPE_MISMATCH_TYPE, msg);
   }
@@ -295,38 +315,52 @@ Value ArrayType::CompareLessThan(const Value& left, const Value &right) const {
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::TINYINT: {
-      std::vector<int8_t> vec1 = *(std::vector<int8_t> *)(left.value_.array.data);
-      std::vector<int8_t> vec2 = *(std::vector<int8_t> *)(right.GetAs<char *>());
+      std::vector<int8_t> vec1 =
+          *(std::vector<int8_t> *)(left.value_.array.data);
+      std::vector<int8_t> vec2 =
+          *(std::vector<int8_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::SMALLINT: {
-      std::vector<int16_t> vec1 = *(std::vector<int16_t> *)(left.value_.array.data);
-      std::vector<int16_t> vec2 = *(std::vector<int16_t> *)(right.GetAs<char *>());
+      std::vector<int16_t> vec1 =
+          *(std::vector<int16_t> *)(left.value_.array.data);
+      std::vector<int16_t> vec2 =
+          *(std::vector<int16_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::INTEGER: {
-      std::vector<int32_t> vec1 = *(std::vector<int32_t> *)(left.value_.array.data);
-      std::vector<int32_t> vec2 = *(std::vector<int32_t> *)(right.GetAs<char *>());
+      std::vector<int32_t> vec1 =
+          *(std::vector<int32_t> *)(left.value_.array.data);
+      std::vector<int32_t> vec2 =
+          *(std::vector<int32_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::BIGINT: {
-      std::vector<int64_t> vec1 = *(std::vector<int64_t> *)(left.value_.array.data);
-      std::vector<int64_t> vec2 = *(std::vector<int64_t> *)(right.GetAs<char *>());
+      std::vector<int64_t> vec1 =
+          *(std::vector<int64_t> *)(left.value_.array.data);
+      std::vector<int64_t> vec2 =
+          *(std::vector<int64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::DECIMAL: {
-      std::vector<double> vec1 = *(std::vector<double> *)(left.value_.array.data);
-      std::vector<double> vec2 = *(std::vector<double> *)(right.GetAs<char *>());
+      std::vector<double> vec1 =
+          *(std::vector<double> *)(left.value_.array.data);
+      std::vector<double> vec2 =
+          *(std::vector<double> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::TIMESTAMP: {
-      std::vector<uint64_t> vec1 = *(std::vector<uint64_t> *)(left.value_.array.data);
-      std::vector<uint64_t> vec2 = *(std::vector<uint64_t> *)(right.GetAs<char *>());
+      std::vector<uint64_t> vec1 =
+          *(std::vector<uint64_t> *)(left.value_.array.data);
+      std::vector<uint64_t> vec2 =
+          *(std::vector<uint64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::VARCHAR: {
-      std::vector<std::string> *vec1 = (std::vector<std::string> *)(left.value_.array.data);
-      std::vector<std::string> *vec2 = (std::vector<std::string> *)(right.GetAs<char *>());
+      std::vector<std::string> *vec1 =
+          (std::vector<std::string> *)(left.value_.array.data);
+      std::vector<std::string> *vec2 =
+          (std::vector<std::string> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     default:
@@ -335,13 +369,13 @@ Value ArrayType::CompareLessThan(const Value& left, const Value &right) const {
   throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Element type is invalid.");
 }
 
-Value ArrayType::CompareLessThanEquals(const Value& left, const Value &right) const {
+Value ArrayType::CompareLessThanEquals(const Value &left,
+                                       const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::ARRAY);
   left.CheckComparable(right);
   if (right.GetElementType() != left.GetElementType()) {
-    std::string msg = Type::GetInstance(
-                      right.GetElementType())->ToString()
-                      + " mismatch with " +
+    std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
+                      " mismatch with " +
                       Type::GetInstance(left.GetElementType())->ToString();
     throw Exception(EXCEPTION_TYPE_MISMATCH_TYPE, msg);
   }
@@ -352,38 +386,52 @@ Value ArrayType::CompareLessThanEquals(const Value& left, const Value &right) co
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::TINYINT: {
-      std::vector<int8_t> vec1 = *(std::vector<int8_t> *)(left.value_.array.data);
-      std::vector<int8_t> vec2 = *(std::vector<int8_t> *)(right.GetAs<char *>());
+      std::vector<int8_t> vec1 =
+          *(std::vector<int8_t> *)(left.value_.array.data);
+      std::vector<int8_t> vec2 =
+          *(std::vector<int8_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::SMALLINT: {
-      std::vector<int16_t> vec1 = *(std::vector<int16_t> *)(left.value_.array.data);
-      std::vector<int16_t> vec2 = *(std::vector<int16_t> *)(right.GetAs<char *>());
+      std::vector<int16_t> vec1 =
+          *(std::vector<int16_t> *)(left.value_.array.data);
+      std::vector<int16_t> vec2 =
+          *(std::vector<int16_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::INTEGER: {
-      std::vector<int32_t> vec1 = *(std::vector<int32_t> *)(left.value_.array.data);
-      std::vector<int32_t> vec2 = *(std::vector<int32_t> *)(right.GetAs<char *>());
+      std::vector<int32_t> vec1 =
+          *(std::vector<int32_t> *)(left.value_.array.data);
+      std::vector<int32_t> vec2 =
+          *(std::vector<int32_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::BIGINT: {
-      std::vector<int64_t> vec1 = *(std::vector<int64_t> *)(left.value_.array.data);
-      std::vector<int64_t> vec2 = *(std::vector<int64_t> *)(right.GetAs<char *>());
+      std::vector<int64_t> vec1 =
+          *(std::vector<int64_t> *)(left.value_.array.data);
+      std::vector<int64_t> vec2 =
+          *(std::vector<int64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::DECIMAL: {
-      std::vector<double> vec1 = *(std::vector<double> *)(left.value_.array.data);
-      std::vector<double> vec2 = *(std::vector<double> *)(right.GetAs<char *>());
+      std::vector<double> vec1 =
+          *(std::vector<double> *)(left.value_.array.data);
+      std::vector<double> vec2 =
+          *(std::vector<double> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::TIMESTAMP: {
-      std::vector<uint64_t> vec1 = *(std::vector<uint64_t> *)(left.value_.array.data);
-      std::vector<uint64_t> vec2 = *(std::vector<uint64_t> *)(right.GetAs<char *>());
+      std::vector<uint64_t> vec1 =
+          *(std::vector<uint64_t> *)(left.value_.array.data);
+      std::vector<uint64_t> vec2 =
+          *(std::vector<uint64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::VARCHAR: {
-      std::vector<std::string> vec1 = *(std::vector<std::string> *)(left.value_.array.data);
-      std::vector<std::string> vec2 = *(std::vector<std::string> *)(right.GetAs<char *>());
+      std::vector<std::string> vec1 =
+          *(std::vector<std::string> *)(left.value_.array.data);
+      std::vector<std::string> vec2 =
+          *(std::vector<std::string> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     default:
@@ -392,13 +440,13 @@ Value ArrayType::CompareLessThanEquals(const Value& left, const Value &right) co
   throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Element type is invalid.");
 }
 
-Value ArrayType::CompareGreaterThan(const Value& left, const Value &right) const {
+Value ArrayType::CompareGreaterThan(const Value &left,
+                                    const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::ARRAY);
   left.CheckComparable(right);
   if (right.GetElementType() != left.GetElementType()) {
-    std::string msg = Type::GetInstance(
-                      right.GetElementType())->ToString()
-                      + " mismatch with " +
+    std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
+                      " mismatch with " +
                       Type::GetInstance(left.GetElementType())->ToString();
     throw Exception(EXCEPTION_TYPE_MISMATCH_TYPE, msg);
   }
@@ -409,38 +457,52 @@ Value ArrayType::CompareGreaterThan(const Value& left, const Value &right) const
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::TINYINT: {
-      std::vector<int8_t> vec1 = *(std::vector<int8_t> *)(left.value_.array.data);
-      std::vector<int8_t> vec2 = *(std::vector<int8_t> *)(right.GetAs<char *>());
+      std::vector<int8_t> vec1 =
+          *(std::vector<int8_t> *)(left.value_.array.data);
+      std::vector<int8_t> vec2 =
+          *(std::vector<int8_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::SMALLINT: {
-      std::vector<int16_t> vec1 = *(std::vector<int16_t> *)(left.value_.array.data);
-      std::vector<int16_t> vec2 = *(std::vector<int16_t> *)(right.GetAs<char *>());
+      std::vector<int16_t> vec1 =
+          *(std::vector<int16_t> *)(left.value_.array.data);
+      std::vector<int16_t> vec2 =
+          *(std::vector<int16_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::INTEGER: {
-      std::vector<int32_t> vec1 = *(std::vector<int32_t> *)(left.value_.array.data);
-      std::vector<int32_t> vec2 = *(std::vector<int32_t> *)(right.GetAs<char *>());
+      std::vector<int32_t> vec1 =
+          *(std::vector<int32_t> *)(left.value_.array.data);
+      std::vector<int32_t> vec2 =
+          *(std::vector<int32_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::BIGINT: {
-      std::vector<int64_t> vec1 = *(std::vector<int64_t> *)(left.value_.array.data);
-      std::vector<int64_t> vec2 = *(std::vector<int64_t> *)(right.GetAs<char *>());
+      std::vector<int64_t> vec1 =
+          *(std::vector<int64_t> *)(left.value_.array.data);
+      std::vector<int64_t> vec2 =
+          *(std::vector<int64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::DECIMAL: {
-      std::vector<double> vec1 = *(std::vector<double> *)(left.value_.array.data);
-      std::vector<double> vec2 = *(std::vector<double> *)(right.GetAs<char *>());
+      std::vector<double> vec1 =
+          *(std::vector<double> *)(left.value_.array.data);
+      std::vector<double> vec2 =
+          *(std::vector<double> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::TIMESTAMP: {
-      std::vector<uint64_t> vec1 = *(std::vector<uint64_t> *)(left.value_.array.data);
-      std::vector<uint64_t> vec2 = *(std::vector<uint64_t> *)(right.GetAs<char *>());
+      std::vector<uint64_t> vec1 =
+          *(std::vector<uint64_t> *)(left.value_.array.data);
+      std::vector<uint64_t> vec2 =
+          *(std::vector<uint64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::VARCHAR: {
-      std::vector<std::string> vec1 = *(std::vector<std::string> *)(left.value_.array.data);
-      std::vector<std::string> vec2 = *(std::vector<std::string> *)(right.GetAs<char *>());
+      std::vector<std::string> vec1 =
+          *(std::vector<std::string> *)(left.value_.array.data);
+      std::vector<std::string> vec2 =
+          *(std::vector<std::string> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     default:
@@ -449,13 +511,13 @@ Value ArrayType::CompareGreaterThan(const Value& left, const Value &right) const
   throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Element type is invalid.");
 }
 
-Value ArrayType::CompareGreaterThanEquals(const Value& left, const Value &right) const {
+Value ArrayType::CompareGreaterThanEquals(const Value &left,
+                                          const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::ARRAY);
   left.CheckComparable(right);
   if (right.GetElementType() != left.GetElementType()) {
-    std::string msg = Type::GetInstance(
-                      right.GetElementType())->ToString()
-                      + " mismatch with " +
+    std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
+                      " mismatch with " +
                       Type::GetInstance(left.GetElementType())->ToString();
     throw Exception(EXCEPTION_TYPE_MISMATCH_TYPE, msg);
   }
@@ -466,38 +528,52 @@ Value ArrayType::CompareGreaterThanEquals(const Value& left, const Value &right)
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::TINYINT: {
-      std::vector<int8_t> vec1 = *(std::vector<int8_t> *)(left.value_.array.data);
-      std::vector<int8_t> vec2 = *(std::vector<int8_t> *)(right.GetAs<char *>());
+      std::vector<int8_t> vec1 =
+          *(std::vector<int8_t> *)(left.value_.array.data);
+      std::vector<int8_t> vec2 =
+          *(std::vector<int8_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::SMALLINT: {
-      std::vector<int16_t> vec1 = *(std::vector<int16_t> *)(left.value_.array.data);
-      std::vector<int16_t> vec2 = *(std::vector<int16_t> *)(right.GetAs<char *>());
+      std::vector<int16_t> vec1 =
+          *(std::vector<int16_t> *)(left.value_.array.data);
+      std::vector<int16_t> vec2 =
+          *(std::vector<int16_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::INTEGER: {
-      std::vector<int32_t> vec1 = *(std::vector<int32_t> *)(left.value_.array.data);
-      std::vector<int32_t> vec2 = *(std::vector<int32_t> *)(right.GetAs<char *>());
+      std::vector<int32_t> vec1 =
+          *(std::vector<int32_t> *)(left.value_.array.data);
+      std::vector<int32_t> vec2 =
+          *(std::vector<int32_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::BIGINT: {
-      std::vector<int64_t> vec1 = *(std::vector<int64_t> *)(left.value_.array.data);
-      std::vector<int64_t> vec2 = *(std::vector<int64_t> *)(right.GetAs<char *>());
+      std::vector<int64_t> vec1 =
+          *(std::vector<int64_t> *)(left.value_.array.data);
+      std::vector<int64_t> vec2 =
+          *(std::vector<int64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::DECIMAL: {
-      std::vector<double> vec1 = *(std::vector<double> *)(left.value_.array.data);
-      std::vector<double> vec2 = *(std::vector<double> *)(right.GetAs<char *>());
+      std::vector<double> vec1 =
+          *(std::vector<double> *)(left.value_.array.data);
+      std::vector<double> vec2 =
+          *(std::vector<double> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::TIMESTAMP: {
-      std::vector<uint64_t> vec1 = *(std::vector<uint64_t> *)(left.value_.array.data);
-      std::vector<uint64_t> vec2 = *(std::vector<uint64_t> *)(right.GetAs<char *>());
+      std::vector<uint64_t> vec1 =
+          *(std::vector<uint64_t> *)(left.value_.array.data);
+      std::vector<uint64_t> vec2 =
+          *(std::vector<uint64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::VARCHAR: {
-      std::vector<std::string> vec1 = *(std::vector<std::string> *)(left.value_.array.data);
-      std::vector<std::string> vec2 = *(std::vector<std::string> *)(right.GetAs<char *>());
+      std::vector<std::string> vec1 =
+          *(std::vector<std::string> *)(left.value_.array.data);
+      std::vector<std::string> vec2 =
+          *(std::vector<std::string> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     default:
@@ -506,12 +582,15 @@ Value ArrayType::CompareGreaterThanEquals(const Value& left, const Value &right)
   throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Element type is invalid.");
 }
 
-Value ArrayType::CastAs(const Value& val UNUSED_ATTRIBUTE, UNUSED_ATTRIBUTE const Type::TypeId type_id) const {
+Value ArrayType::CastAs(const Value &val UNUSED_ATTRIBUTE,
+                        UNUSED_ATTRIBUTE const Type::TypeId type_id) const {
   PL_ASSERT(false);
-  throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE, "Cannot cast array values.");
+  throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                  "Cannot cast array values.");
 }
 
-Type::TypeId ArrayType::GetElementType(const Value& val UNUSED_ATTRIBUTE) const {
+Type::TypeId ArrayType::GetElementType(
+    const Value &val UNUSED_ATTRIBUTE) const {
   return val.value_.array.array_type;
 }
 

--- a/src/common/boolean_type.cpp
+++ b/src/common/boolean_type.cpp
@@ -13,69 +13,76 @@
 #include "common/boolean_type.h"
 
 #include <iostream>
-#include "common/varlen_type.h"
 #include "common/value_factory.h"
+#include "common/varlen_type.h"
 
 namespace peloton {
 namespace common {
 
-BooleanType::BooleanType()
-  : Type(Type::BOOLEAN) {
-}
+BooleanType::BooleanType() : Type(Type::BOOLEAN) {}
 
-Value BooleanType::CompareEquals(const Value& left, const Value &right) const {
+Value BooleanType::CompareEquals(const Value& left, const Value& right) const {
   PL_ASSERT(GetTypeId() == Type::BOOLEAN);
   left.CheckComparable(right);
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
-  return ValueFactory::GetBooleanValue(left.value_.boolean == right.GetAs<int8_t>());
+  return ValueFactory::GetBooleanValue(left.value_.boolean ==
+                                       right.GetAs<int8_t>());
 }
 
-Value BooleanType::CompareNotEquals(const Value& left, const Value &right) const {
+Value BooleanType::CompareNotEquals(const Value& left,
+                                    const Value& right) const {
   PL_ASSERT(GetTypeId() == Type::BOOLEAN);
   left.CheckComparable(right);
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
-  return ValueFactory::GetBooleanValue(left.value_.boolean != right.GetAs<int8_t>());
+  return ValueFactory::GetBooleanValue(left.value_.boolean !=
+                                       right.GetAs<int8_t>());
 }
 
-Value BooleanType::CompareLessThan(const Value& left, const Value &right) const {
+Value BooleanType::CompareLessThan(const Value& left,
+                                   const Value& right) const {
   PL_ASSERT(GetTypeId() == Type::BOOLEAN);
   left.CheckComparable(right);
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
-  return ValueFactory::GetBooleanValue(left.value_.boolean < right.GetAs<int8_t>());
+  return ValueFactory::GetBooleanValue(left.value_.boolean <
+                                       right.GetAs<int8_t>());
 }
 
-Value BooleanType::CompareLessThanEquals(const Value& left, const Value &right) const {
+Value BooleanType::CompareLessThanEquals(const Value& left,
+                                         const Value& right) const {
   PL_ASSERT(GetTypeId() == Type::BOOLEAN);
   left.CheckComparable(right);
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
-  return ValueFactory::GetBooleanValue(left.value_.boolean <= right.GetAs<int8_t>());
+  return ValueFactory::GetBooleanValue(left.value_.boolean <=
+                                       right.GetAs<int8_t>());
 }
 
-Value BooleanType::CompareGreaterThan(const Value& left, const Value &right) const {
+Value BooleanType::CompareGreaterThan(const Value& left,
+                                      const Value& right) const {
   PL_ASSERT(GetTypeId() == Type::BOOLEAN);
   left.CheckComparable(right);
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
-  return ValueFactory::GetBooleanValue(left.value_.boolean > right.GetAs<int8_t>());
+  return ValueFactory::GetBooleanValue(left.value_.boolean >
+                                       right.GetAs<int8_t>());
 }
 
-Value BooleanType::CompareGreaterThanEquals(const Value& left, const Value &right) const {
+Value BooleanType::CompareGreaterThanEquals(const Value& left,
+                                            const Value& right) const {
   PL_ASSERT(GetTypeId() == Type::BOOLEAN);
   left.CheckComparable(right);
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
-  return ValueFactory::GetBooleanValue(left.value_.boolean >= right.GetAs<int8_t>());
+  return ValueFactory::GetBooleanValue(left.value_.boolean >=
+                                       right.GetAs<int8_t>());
 }
 
 std::string BooleanType::ToString(const Value& val) const {
-  if (val.IsTrue())
-    return "true";
-  if (val.IsFalse())
-    return "false";
+  if (val.IsTrue()) return "true";
+  if (val.IsFalse()) return "false";
   return "boolean_null";
 }
 
@@ -83,7 +90,7 @@ size_t BooleanType::Hash(const Value& val) const {
   return std::hash<int8_t>{}(val.value_.boolean);
 }
 
-void BooleanType::HashCombine(const Value& val, size_t &seed) const {
+void BooleanType::HashCombine(const Value& val, size_t& seed) const {
   val.hash_combine<int8_t>(seed, val.value_.boolean);
 }
 
@@ -96,14 +103,13 @@ Value BooleanType::CastAs(const Value& val, const Type::TypeId type_id) const {
     case Type::BOOLEAN:
       return val.Copy();
     case Type::VARCHAR:
-      if (val.IsNull())
-        return ValueFactory::GetVarcharValue(nullptr, 0);
+      if (val.IsNull()) return ValueFactory::GetVarcharValue(nullptr, 0);
       return ValueFactory::GetVarcharValue(val.ToString());
     default:
       break;
   }
-  throw Exception("BOOLEAN is not coercable to "
-      + Type::GetInstance(type_id)->ToString());
+  throw Exception("BOOLEAN is not coercable to " +
+                  Type::GetInstance(type_id)->ToString());
 }
 
 }  // namespace peloton

--- a/src/common/type.cpp
+++ b/src/common/type.cpp
@@ -13,41 +13,41 @@
 #include "common/type.h"
 
 #include "common/array_type.h"
+#include "common/bigint_type.h"
 #include "common/boolean_type.h"
 #include "common/decimal_type.h"
-#include "common/numeric_type.h"
-#include "common/timestamp_type.h"
-#include "common/varlen_type.h"
-#include "common/value.h"
 #include "common/exception.h"
-#include "common/varlen_pool.h"
-#include "common/tinyint_type.h"
-#include "common/smallint_type.h"
 #include "common/integer_type.h"
-#include "common/bigint_type.h"
+#include "common/numeric_type.h"
+#include "common/smallint_type.h"
+#include "common/timestamp_type.h"
+#include "common/tinyint_type.h"
+#include "common/value.h"
+#include "common/varlen_pool.h"
+#include "common/varlen_type.h"
 
 namespace peloton {
 namespace common {
 
 Type* Type::kTypes[] = {
-  new Type(Type::INVALID),
-  new IntegerType(Type::PARAMETER_OFFSET),
-  new BooleanType(),
-  new TinyintType(),
-  new SmallintType(),
-  new IntegerType(Type::INTEGER),
-  new BigintType(),
-  new DecimalType(),
-  new TimestampType(),
-  new Type(Type::DATE), // not yet implemented
-  new VarlenType(Type::VARCHAR),
-  new VarlenType(Type::VARBINARY),
-  new ArrayType(),
-  new Type(Type::UDT), // not yet implemented
+    new Type(Type::INVALID),
+    new IntegerType(Type::PARAMETER_OFFSET),
+    new BooleanType(),
+    new TinyintType(),
+    new SmallintType(),
+    new IntegerType(Type::INTEGER),
+    new BigintType(),
+    new DecimalType(),
+    new TimestampType(),
+    new Type(Type::DATE),  // not yet implemented
+    new VarlenType(Type::VARCHAR),
+    new VarlenType(Type::VARBINARY),
+    new ArrayType(),
+    new Type(Type::UDT),  // not yet implemented
 };
 
 //// Is this type equivalent to the other
-//bool Type::Equals(const Type &other) const {
+// bool Type::Equals(const Type &other) const {
 //  return (type_id_ == other.type_id_);
 //}
 
@@ -82,7 +82,9 @@ uint64_t Type::GetTypeSize(const TypeId type_id) {
 bool Type::IsCoercableFrom(const TypeId type_id) const {
   switch (type_id_) {
     case INVALID:
-      return 0;
+      return false;
+    case BOOLEAN:
+      return true;
     case TINYINT:
     case SMALLINT:
     case INTEGER:
@@ -95,9 +97,9 @@ bool Type::IsCoercableFrom(const TypeId type_id) const {
         case BIGINT:
         case DECIMAL:
         case VARCHAR:
-          return 1;
+          return true;
         default:
-          return 0;
+          return false;
       }
       break;
     case TIMESTAMP:
@@ -112,9 +114,9 @@ bool Type::IsCoercableFrom(const TypeId type_id) const {
         case DECIMAL:
         case TIMESTAMP:
         case VARCHAR:
-          return 1;
+          return true;
         default:
-          return 0;
+          return false;
       }
       break;
     default:
@@ -161,13 +163,13 @@ Value Type::GetMinValue(TypeId type_id) {
     case BOOLEAN:
       return Value(type_id, 0);
     case TINYINT:
-      return Value(type_id, (int8_t) PELOTON_INT8_MIN);
+      return Value(type_id, (int8_t)PELOTON_INT8_MIN);
     case SMALLINT:
-      return Value(type_id, (int16_t) PELOTON_INT16_MIN);
+      return Value(type_id, (int16_t)PELOTON_INT16_MIN);
     case INTEGER:
-      return Value(type_id, (int32_t) PELOTON_INT32_MIN);
+      return Value(type_id, (int32_t)PELOTON_INT32_MIN);
     case BIGINT:
-      return Value(type_id, (int64_t) PELOTON_INT64_MIN);
+      return Value(type_id, (int64_t)PELOTON_INT64_MIN);
     case DECIMAL:
       return Value(type_id, PELOTON_DECIMAL_MIN);
     case TIMESTAMP:
@@ -187,17 +189,17 @@ Value Type::GetMaxValue(TypeId type_id) {
     case BOOLEAN:
       return Value(type_id, 1);
     case TINYINT:
-      return Value(type_id, (int8_t) PELOTON_INT8_MAX);
+      return Value(type_id, (int8_t)PELOTON_INT8_MAX);
     case SMALLINT:
-      return Value(type_id, (int16_t) PELOTON_INT16_MAX);
+      return Value(type_id, (int16_t)PELOTON_INT16_MAX);
     case INTEGER:
-      return Value(type_id, (int32_t) PELOTON_INT32_MAX);
+      return Value(type_id, (int32_t)PELOTON_INT32_MAX);
     case BIGINT:
-      return Value(type_id, (int64_t) PELOTON_INT64_MAX);
+      return Value(type_id, (int64_t)PELOTON_INT64_MAX);
     case DECIMAL:
-      return Value(type_id,PELOTON_DECIMAL_MAX);
+      return Value(type_id, PELOTON_DECIMAL_MAX);
     case TIMESTAMP:
-      return Value(type_id,PELOTON_TIMESTAMP_MAX);
+      return Value(type_id, PELOTON_TIMESTAMP_MAX);
     case VARCHAR:
       return Value(type_id, nullptr, 0);
     case VARBINARY:
@@ -208,81 +210,93 @@ Value Type::GetMaxValue(TypeId type_id) {
   throw Exception(EXCEPTION_TYPE_MISMATCH_TYPE, "Cannot get maximal value.");
 }
 
-Type *Type::GetInstance(TypeId type_id) {
-  return kTypes[type_id];
-}
+Type* Type::GetInstance(TypeId type_id) { return kTypes[type_id]; }
 
-Type::TypeId Type::GetTypeId() const {
-  return type_id_;
-}
+Type::TypeId Type::GetTypeId() const { return type_id_; }
 
-Value Type::CompareEquals(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::CompareEquals(const Value& left UNUSED_ATTRIBUTE,
+                          const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::CompareNotEquals(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::CompareNotEquals(const Value& left UNUSED_ATTRIBUTE,
+                             const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::CompareLessThan(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::CompareLessThan(const Value& left UNUSED_ATTRIBUTE,
+                            const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::CompareLessThanEquals(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::CompareLessThanEquals(const Value& left UNUSED_ATTRIBUTE,
+                                  const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::CompareGreaterThan(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::CompareGreaterThan(const Value& left UNUSED_ATTRIBUTE,
+                               const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::CompareGreaterThanEquals(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::CompareGreaterThanEquals(const Value& left UNUSED_ATTRIBUTE,
+                                     const Value& right
+                                         UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
 // Other mathematical functions
-Value Type::Add(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::Add(const Value& left UNUSED_ATTRIBUTE,
+                const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::Subtract(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::Subtract(const Value& left UNUSED_ATTRIBUTE,
+                     const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::Multiply(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::Multiply(const Value& left UNUSED_ATTRIBUTE,
+                     const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::Divide(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::Divide(const Value& left UNUSED_ATTRIBUTE,
+                   const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::Modulo(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::Modulo(const Value& left UNUSED_ATTRIBUTE,
+                   const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::Min(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::Min(const Value& left UNUSED_ATTRIBUTE,
+                const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::Max(const Value& left UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::Max(const Value& left UNUSED_ATTRIBUTE,
+                const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::Sqrt(const Value& val UNUSED_ATTRIBUTE) const{
+Value Type::Sqrt(const Value& val UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::OperateNull(const Value& val UNUSED_ATTRIBUTE, const Value& right UNUSED_ATTRIBUTE) const{
+Value Type::OperateNull(const Value& val UNUSED_ATTRIBUTE,
+                        const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-bool Type::IsZero(const Value& val UNUSED_ATTRIBUTE) const{
+bool Type::IsZero(const Value& val UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
 // Is the data inlined into this classes storage space, or must it be accessed
 // through an indirection/pointer?
-bool Type::IsInlined(const Value& val UNUSED_ATTRIBUTE) const{
+bool Type::IsInlined(const Value& val UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
 // Return a stringified version of this value
-std::string Type::ToString(const Value& val UNUSED_ATTRIBUTE) const{
+std::string Type::ToString(const Value& val UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
 // Compute a hash value
-size_t Type::Hash(const Value& val UNUSED_ATTRIBUTE) const{
+size_t Type::Hash(const Value& val UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-void Type::HashCombine(const Value& val UNUSED_ATTRIBUTE, size_t &seed UNUSED_ATTRIBUTE) const{
+void Type::HashCombine(const Value& val UNUSED_ATTRIBUTE,
+                       size_t& seed UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
@@ -291,54 +305,61 @@ void Type::HashCombine(const Value& val UNUSED_ATTRIBUTE, size_t &seed UNUSED_AT
 // space, or whether we must store only a reference to this value. If inlined
 // is false, we may use the provided data pool to allocate space for this
 // value, storing a reference into the allocated pool space in the storage.
-void Type::SerializeTo(const Value& val UNUSED_ATTRIBUTE, char *storage UNUSED_ATTRIBUTE, bool inlined UNUSED_ATTRIBUTE,
-                         VarlenPool *pool UNUSED_ATTRIBUTE) const{
+void Type::SerializeTo(const Value& val UNUSED_ATTRIBUTE,
+                       char* storage UNUSED_ATTRIBUTE,
+                       bool inlined UNUSED_ATTRIBUTE,
+                       VarlenPool* pool UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-void Type::SerializeTo(const Value& val UNUSED_ATTRIBUTE, SerializeOutput &out UNUSED_ATTRIBUTE) const{
+void Type::SerializeTo(const Value& val UNUSED_ATTRIBUTE,
+                       SerializeOutput& out UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
 // Deserialize a value of the given type from the given storage space.
-Value Type::DeserializeFrom(const char *storage UNUSED_ATTRIBUTE,
-                              const bool inlined UNUSED_ATTRIBUTE, VarlenPool *pool UNUSED_ATTRIBUTE) const{
+Value Type::DeserializeFrom(const char* storage UNUSED_ATTRIBUTE,
+                            const bool inlined UNUSED_ATTRIBUTE,
+                            VarlenPool* pool UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
-Value Type::DeserializeFrom(SerializeInput &in UNUSED_ATTRIBUTE,
-                              VarlenPool *pool UNUSED_ATTRIBUTE) const{
+Value Type::DeserializeFrom(SerializeInput& in UNUSED_ATTRIBUTE,
+                            VarlenPool* pool UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
 // Create a copy of this value
-Value Type::Copy(const Value& val UNUSED_ATTRIBUTE) const{
+Value Type::Copy(const Value& val UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
-Value Type::CastAs(const Value& val UNUSED_ATTRIBUTE, const Type::TypeId type_id UNUSED_ATTRIBUTE) const{
+Value Type::CastAs(const Value& val UNUSED_ATTRIBUTE,
+                   const Type::TypeId type_id UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
 // Access the raw variable length data
-const char *Type::GetData(const Value& val UNUSED_ATTRIBUTE) const{
+const char* Type::GetData(const Value& val UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
 // Get the length of the variable length data
-uint32_t Type::GetLength(const Value& val UNUSED_ATTRIBUTE) const{
+uint32_t Type::GetLength(const Value& val UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
 // Get the element at a given index in this array
-Value Type::GetElementAt(const Value& val UNUSED_ATTRIBUTE, uint64_t idx UNUSED_ATTRIBUTE) const{
+Value Type::GetElementAt(const Value& val UNUSED_ATTRIBUTE,
+                         uint64_t idx UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
-Type::TypeId Type::GetElementType(const Value& val UNUSED_ATTRIBUTE) const{
+Type::TypeId Type::GetElementType(const Value& val UNUSED_ATTRIBUTE) const {
   return type_id_;
 }
 
-  // Does this value exist in this array?
-Value Type::InList(const Value& list UNUSED_ATTRIBUTE, const Value &object UNUSED_ATTRIBUTE) const{
+// Does this value exist in this array?
+Value Type::InList(const Value& list UNUSED_ATTRIBUTE,
+                   const Value& object UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 

--- a/src/common/value.cpp
+++ b/src/common/value.cpp
@@ -21,25 +21,24 @@
 namespace peloton {
 namespace common {
 
-Value::Value(const Value& other){
+Value::Value(const Value &other) {
   type_ = other.type_;
-  switch(type_->GetTypeId()){
-  case Type::VARCHAR:
-  case Type::VARBINARY:
-    value_.varlen.len = other.value_.varlen.len;
-    value_.varlen.data = new char[value_.varlen.len];
-    PL_MEMCPY(value_.varlen.data, other.value_.varlen.data, value_.varlen.len);
-    break;
-  default:
-    value_ = other.value_;
+  switch (type_->GetTypeId()) {
+    case Type::VARCHAR:
+    case Type::VARBINARY:
+      value_.varlen.len = other.value_.varlen.len;
+      value_.varlen.data = new char[value_.varlen.len];
+      PL_MEMCPY(value_.varlen.data, other.value_.varlen.data,
+                value_.varlen.len);
+      break;
+    default:
+      value_ = other.value_;
   }
 }
 
-Value::Value(Value&& other) : Value(){
-  swap(*this, other);
-}
+Value::Value(Value &&other) : Value() { swap(*this, other); }
 
-Value& Value::operator=(Value other){
+Value &Value::operator=(Value other) {
   swap(*this, other);
   return *this;
 }
@@ -47,307 +46,289 @@ Value& Value::operator=(Value other){
 // ARRAY is implemented in the header to ease template creation
 
 // BOOLEAN and TINYINT
-Value::Value(Type::TypeId type, int8_t i) :
-    Value(type) {
+Value::Value(Type::TypeId type, int8_t i) : Value(type) {
   switch (type) {
-  case Type::BOOLEAN:
+    case Type::BOOLEAN:
       value_.boolean = i;
       break;
-  case Type::TINYINT:
-    value_.tinyint = i;
-    break;
-  case Type::SMALLINT:
-    value_.smallint = i;
-    break;
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    value_.integer = i;
-    break;
-  case Type::BIGINT:
-    value_.bigint = i;
-    break;
-  default:
-    throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
-        "Invalid Type for constructor");
+    case Type::TINYINT:
+      value_.tinyint = i;
+      break;
+    case Type::SMALLINT:
+      value_.smallint = i;
+      break;
+    case Type::INTEGER:
+    case Type::PARAMETER_OFFSET:
+      value_.integer = i;
+      break;
+    case Type::BIGINT:
+      value_.bigint = i;
+      break;
+    default:
+      throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                      "Invalid Type for constructor");
   }
 }
 
-//SMALLINT
-Value::Value(Type::TypeId type, int16_t i) :
-    Value(type) {
+// SMALLINT
+Value::Value(Type::TypeId type, int16_t i) : Value(type) {
   switch (type) {
-  case Type::BOOLEAN:
+    case Type::BOOLEAN:
       value_.boolean = i;
       break;
-  case Type::TINYINT:
-    value_.tinyint = i;
-    break;
-  case Type::SMALLINT:
-    value_.smallint = i;
-    break;
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    value_.integer = i;
-    break;
-  case Type::BIGINT:
-    value_.bigint = i;
-    break;
-  default:
-    throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
-        "Invalid Type for constructor");
+    case Type::TINYINT:
+      value_.tinyint = i;
+      break;
+    case Type::SMALLINT:
+      value_.smallint = i;
+      break;
+    case Type::INTEGER:
+    case Type::PARAMETER_OFFSET:
+      value_.integer = i;
+      break;
+    case Type::BIGINT:
+      value_.bigint = i;
+      break;
+    default:
+      throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                      "Invalid Type for constructor");
   }
 }
 
-//INTEGER and PARAMETER_OFFSET
-Value::Value(Type::TypeId type, int32_t i) :
-    Value(type) {
+// INTEGER and PARAMETER_OFFSET
+Value::Value(Type::TypeId type, int32_t i) : Value(type) {
   switch (type) {
-  case Type::BOOLEAN:
-    value_.boolean = i;
-    break;
-  case Type::TINYINT:
-    value_.tinyint = i;
-    break;
-  case Type::SMALLINT:
-    value_.smallint = i;
-    break;
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    value_.integer = i;
-    break;
-  case Type::BIGINT:
-    value_.bigint = i;
-    break;
-  default:
-    throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
-        "Invalid Type for constructor");
+    case Type::BOOLEAN:
+      value_.boolean = i;
+      break;
+    case Type::TINYINT:
+      value_.tinyint = i;
+      break;
+    case Type::SMALLINT:
+      value_.smallint = i;
+      break;
+    case Type::INTEGER:
+    case Type::PARAMETER_OFFSET:
+      value_.integer = i;
+      break;
+    case Type::BIGINT:
+      value_.bigint = i;
+      break;
+    default:
+      throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                      "Invalid Type for constructor");
   }
 }
 
-//BIGINT and TIMESTAMP
-Value::Value(Type::TypeId type, int64_t i) :
-    Value(type) {
+// BIGINT and TIMESTAMP
+Value::Value(Type::TypeId type, int64_t i) : Value(type) {
   switch (type) {
-  case Type::BOOLEAN:
-    value_.boolean = i;
-    break;
-  case Type::TINYINT:
-    value_.tinyint = i;
-    break;
-  case Type::SMALLINT:
-    value_.smallint = i;
-    break;
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    value_.integer = i;
-    break;
-  case Type::BIGINT:
-    value_.bigint = i;
-    break;
-  case Type::TIMESTAMP:
-    value_.timestamp = i;
-    break;
-  default:
-    throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
-        "Invalid Type for constructor");
+    case Type::BOOLEAN:
+      value_.boolean = i;
+      break;
+    case Type::TINYINT:
+      value_.tinyint = i;
+      break;
+    case Type::SMALLINT:
+      value_.smallint = i;
+      break;
+    case Type::INTEGER:
+    case Type::PARAMETER_OFFSET:
+      value_.integer = i;
+      break;
+    case Type::BIGINT:
+      value_.bigint = i;
+      break;
+    case Type::TIMESTAMP:
+      value_.timestamp = i;
+      break;
+    default:
+      throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                      "Invalid Type for constructor");
   }
 }
 
-//BIGINT
-Value::Value(Type::TypeId type, uint64_t i) :
-    Value(type) {
+// BIGINT
+Value::Value(Type::TypeId type, uint64_t i) : Value(type) {
   switch (type) {
-  case Type::BOOLEAN:
-    value_.boolean = i;
-    break;
-  case Type::TIMESTAMP:
-    value_.timestamp = i;
-    break;
-  default:
-    throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
-        "Invalid Type for constructor");
+    case Type::BOOLEAN:
+      value_.boolean = i;
+      break;
+    case Type::TIMESTAMP:
+      value_.timestamp = i;
+      break;
+    default:
+      throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                      "Invalid Type for constructor");
   }
 }
 
-//DECIMAL
-Value::Value(Type::TypeId type, double d) :
-    Value(type) {
+// DECIMAL
+Value::Value(Type::TypeId type, double d) : Value(type) {
   switch (type) {
-  case Type::DECIMAL:
-    value_.decimal = d;
-    break;
-  default:
-    throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
-        "Invalid Type for constructor");
+    case Type::DECIMAL:
+      value_.decimal = d;
+      break;
+    default:
+      throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                      "Invalid Type for constructor");
   }
 }
 
-Value::Value(Type::TypeId type, float f) :
-    Value(type) {
+Value::Value(Type::TypeId type, float f) : Value(type) {
   switch (type) {
-  case Type::DECIMAL:
-    value_.decimal = f;
-    break;
-  default:
-    throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
-        "Invalid Type for constructor");
+    case Type::DECIMAL:
+      value_.decimal = f;
+      break;
+    default:
+      throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                      "Invalid Type for constructor");
   }
 }
 
-//VARCHAR and VARBINARY
-Value::Value(Type::TypeId type, const char *data, uint32_t len) :
-    Value(type) {
+// VARCHAR and VARBINARY
+Value::Value(Type::TypeId type, const char *data, uint32_t len) : Value(type) {
   switch (type) {
-  case Type::VARCHAR:
-  case Type::VARBINARY:
-    PL_ASSERT(len < PELOTON_VARCHAR_MAX_LEN);
-    value_.varlen.data = new char[len];
-    PL_ASSERT(value_.varlen.data != nullptr);
-    value_.varlen.len = len;
-    PL_MEMCPY(value_.varlen.data, data, len);
-    break;
-  default:
-    throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
-        "Invalid Type for constructor");
+    case Type::VARCHAR:
+    case Type::VARBINARY:
+      PL_ASSERT(len < PELOTON_VARCHAR_MAX_LEN);
+      value_.varlen.data = new char[len];
+      PL_ASSERT(value_.varlen.data != nullptr);
+      value_.varlen.len = len;
+      PL_MEMCPY(value_.varlen.data, data, len);
+      break;
+    default:
+      throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                      "Invalid Type for constructor");
   }
 }
 
-Value::Value(Type::TypeId type, const std::string &data) :
-    Value(type) {
+Value::Value(Type::TypeId type, const std::string &data) : Value(type) {
   switch (type) {
-  case Type::VARCHAR:
-  case Type::VARBINARY: {
-    uint32_t len = data.length() + (type == Type::VARCHAR);
-    value_.varlen.data = new char[len];
-    PL_ASSERT(value_.varlen.data != nullptr);
-    value_.varlen.len = len;
-    PL_MEMCPY(value_.varlen.data, data.c_str(), len);
-    break;
-  }
-  default:
-    throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
-        "Invalid Type for constructor");
+    case Type::VARCHAR:
+    case Type::VARBINARY: {
+      uint32_t len = data.length() + (type == Type::VARCHAR);
+      value_.varlen.data = new char[len];
+      PL_ASSERT(value_.varlen.data != nullptr);
+      value_.varlen.len = len;
+      PL_MEMCPY(value_.varlen.data, data.c_str(), len);
+      break;
+    }
+    default:
+      throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                      "Invalid Type for constructor");
   }
 }
 
-Value::Value() :
-    Value(Type::INVALID) {
-}
+Value::Value() : Value(Type::INVALID) {}
 
 Value::~Value() {
   switch (type_->GetTypeId()) {
-  case Type::VARBINARY:
-  case Type::VARCHAR:
-    delete[] value_.varlen.data;
-    break;
-  default:
-    break;
+    case Type::VARBINARY:
+    case Type::VARCHAR:
+      delete[] value_.varlen.data;
+      break;
+    default:
+      break;
   }
 }
 
 const std::string Value::GetInfo() const {
   std::ostringstream os;
-
-  os << "Value :: " << " type = "
-      << Type::GetInstance(GetTypeId())->ToString() << "," << " value = "
-      << ToString();
-
+  os << "Value::" << Type::GetInstance(GetTypeId())->ToString() << "["
+     << ToString() << "]";
   return os.str();
 }
 
 bool Value::IsNull() const {
   switch (GetTypeId()) {
-  case Type::BOOLEAN:
-    return (value_.boolean == PELOTON_BOOLEAN_NULL);
-  case Type::TINYINT:
-    return (value_.tinyint == PELOTON_INT8_NULL);
-  case Type::SMALLINT:
-    return (value_.smallint == PELOTON_INT16_NULL);
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return (value_.integer == PELOTON_INT32_NULL);
-  case Type::BIGINT:
-    return (value_.bigint == PELOTON_INT64_NULL);
-  case Type::DECIMAL:
-    return (value_.decimal == PELOTON_DECIMAL_NULL);
-  case Type::TIMESTAMP:
-    return (value_.timestamp == PELOTON_TIMESTAMP_NULL);
-  case Type::VARCHAR:
-  case Type::VARBINARY:
-    return value_.varlen.len == 0;
-  default:
-    break;
+    case Type::BOOLEAN:
+      return (value_.boolean == PELOTON_BOOLEAN_NULL);
+    case Type::TINYINT:
+      return (value_.tinyint == PELOTON_INT8_NULL);
+    case Type::SMALLINT:
+      return (value_.smallint == PELOTON_INT16_NULL);
+    case Type::INTEGER:
+    case Type::PARAMETER_OFFSET:
+      return (value_.integer == PELOTON_INT32_NULL);
+    case Type::BIGINT:
+      return (value_.bigint == PELOTON_INT64_NULL);
+    case Type::DECIMAL:
+      return (value_.decimal == PELOTON_DECIMAL_NULL);
+    case Type::TIMESTAMP:
+      return (value_.timestamp == PELOTON_TIMESTAMP_NULL);
+    case Type::VARCHAR:
+    case Type::VARBINARY:
+      return value_.varlen.len == 0;
+    default:
+      break;
   }
   throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Unknown type.");
 }
 
 void Value::CheckComparable(const Value &o) const {
   switch (GetTypeId()) {
-  case Type::BOOLEAN:
-    if (o.GetTypeId() == Type::BOOLEAN)
-      return;
-    break;
-  case Type::TINYINT:
-  case Type::SMALLINT:
-  case Type::INTEGER:
-  case Type::BIGINT:
-  case Type::DECIMAL:
-    switch (o.GetTypeId()) {
+    case Type::BOOLEAN:
+      if (o.GetTypeId() == Type::BOOLEAN) return;
+      break;
     case Type::TINYINT:
     case Type::SMALLINT:
     case Type::INTEGER:
     case Type::BIGINT:
     case Type::DECIMAL:
-      return;
+      switch (o.GetTypeId()) {
+        case Type::TINYINT:
+        case Type::SMALLINT:
+        case Type::INTEGER:
+        case Type::BIGINT:
+        case Type::DECIMAL:
+          return;
+        default:
+          break;
+      }
+      break;
+    case Type::VARCHAR:
+      if (o.GetTypeId() == Type::VARCHAR) return;
+      break;
+    case Type::VARBINARY:
+      if (o.GetTypeId() == Type::VARBINARY) return;
+      break;
+    case Type::TIMESTAMP:
+      if (o.GetTypeId() == Type::TIMESTAMP) return;
+      break;
     default:
       break;
-    }
-    break;
-  case Type::VARCHAR:
-    if (o.GetTypeId() == Type::VARCHAR)
-      return;
-    break;
-  case Type::VARBINARY:
-    if (o.GetTypeId() == Type::VARBINARY)
-      return;
-    break;
-  case Type::TIMESTAMP:
-    if (o.GetTypeId() == Type::TIMESTAMP)
-      return;
-    break;
-  default:
-    break;
   }
-  std::string msg = "Operation between "
-      + Type::GetInstance(GetTypeId())->ToString() + " and "
-      + Type::GetInstance(o.GetTypeId())->ToString() + " is invalid.";
+  std::string msg =
+      "Operation between " + Type::GetInstance(GetTypeId())->ToString() +
+      " and " + Type::GetInstance(o.GetTypeId())->ToString() + " is invalid.";
   throw Exception(EXCEPTION_TYPE_MISMATCH_TYPE, msg);
 }
 
 void Value::CheckInteger() const {
   switch (GetTypeId()) {
-  case Type::TINYINT:
-  case Type::SMALLINT:
-  case Type::INTEGER:
-  case Type::BIGINT:
-  case Type::PARAMETER_OFFSET:
-    return;
-  default:
-    break;
+    case Type::TINYINT:
+    case Type::SMALLINT:
+    case Type::INTEGER:
+    case Type::BIGINT:
+    case Type::PARAMETER_OFFSET:
+      return;
+    default:
+      break;
   }
-  std::string msg = "Type " + Type::GetInstance(GetTypeId())->ToString()
-      + " is not an integer type.";
+  std::string msg = "Type " + Type::GetInstance(GetTypeId())->ToString() +
+                    " is not an integer type.";
   throw Exception(EXCEPTION_TYPE_MISMATCH_TYPE, msg);
 }
 
 Value Value::DeserializeFrom(const char *storage, const Type::TypeId type_id,
-UNUSED_ATTRIBUTE const bool inlined,
-UNUSED_ATTRIBUTE VarlenPool *pool) {
+                             UNUSED_ATTRIBUTE const bool inlined,
+                             UNUSED_ATTRIBUTE VarlenPool *pool) {
   return Type::GetInstance(type_id)->DeserializeFrom(storage, inlined, pool);
 }
 
 Value Value::DeserializeFrom(SerializeInput &in, const Type::TypeId type_id,
-    VarlenPool *pool UNUSED_ATTRIBUTE) {
+                             VarlenPool *pool UNUSED_ATTRIBUTE) {
   return Type::GetInstance(type_id)->DeserializeFrom(in, pool);
 }
 
@@ -371,52 +352,32 @@ Value Value::CompareGreaterThanEquals(const Value &o) const {
 }
 
 // Other mathematical functions
-Value Value::Add(const Value &o) const {
-  return type_->Add(*this, o);
-}
+Value Value::Add(const Value &o) const { return type_->Add(*this, o); }
 Value Value::Subtract(const Value &o) const {
   return type_->Subtract(*this, o);
 }
 Value Value::Multiply(const Value &o) const {
   return type_->Multiply(*this, o);
 }
-Value Value::Divide(const Value &o) const {
-  return type_->Divide(*this, o);
-}
-Value Value::Modulo(const Value &o) const {
-  return type_->Modulo(*this, o);
-}
-Value Value::Min(const Value &o) const {
-  return type_->Min(*this, o);
-}
-Value Value::Max(const Value &o) const {
-  return type_->Max(*this, o);
-}
-Value Value::Sqrt() const {
-  return type_->Sqrt(*this);
-}
+Value Value::Divide(const Value &o) const { return type_->Divide(*this, o); }
+Value Value::Modulo(const Value &o) const { return type_->Modulo(*this, o); }
+Value Value::Min(const Value &o) const { return type_->Min(*this, o); }
+Value Value::Max(const Value &o) const { return type_->Max(*this, o); }
+Value Value::Sqrt() const { return type_->Sqrt(*this); }
 Value Value::OperateNull(const Value &o) const {
   return type_->OperateNull(*this, o);
 }
-bool Value::IsZero() const {
-  return type_->IsZero(*this);
-}
+bool Value::IsZero() const { return type_->IsZero(*this); }
 
 // Is the data inlined into this classes storage space, or must it be accessed
 // through an indirection/pointer?
-bool Value::IsInlined() const {
-  return type_->IsInlined(*this);
-}
+bool Value::IsInlined() const { return type_->IsInlined(*this); }
 
 // Return a stringified version of this value
-std::string Value::ToString() const {
-  return type_->ToString(*this);
-}
+std::string Value::ToString() const { return type_->ToString(*this); }
 
 // Compute a hash value
-size_t Value::Hash() const {
-  return type_->Hash(*this);
-}
+size_t Value::Hash() const { return type_->Hash(*this); }
 void Value::HashCombine(size_t &seed) const {
   return type_->HashCombine(*this, seed);
 }
@@ -434,23 +395,17 @@ void Value::SerializeTo(SerializeOutput &out) const {
 }
 
 // Create a copy of this value
-Value Value::Copy() const {
-  return type_->Copy(*this);
-}
+Value Value::Copy() const { return type_->Copy(*this); }
 
 Value Value::CastAs(const Type::TypeId type_id) const {
   return type_->CastAs(*this, type_id);
 }
 
 // Access the raw variable length data
-const char *Value::GetData() const {
-  return type_->GetData(*this);
-}
+const char *Value::GetData() const { return type_->GetData(*this); }
 
 // Get the length of the variable length data
-uint32_t Value::GetLength() const {
-  return type_->GetLength(*this);
-}
+uint32_t Value::GetLength() const { return type_->GetLength(*this); }
 
 // Get the element at a given index in this array
 Value Value::GetElementAt(uint64_t idx) const {

--- a/src/include/common/value.h
+++ b/src/include/common/value.h
@@ -12,16 +12,16 @@
 
 #pragma once
 
-#include "common/type.h"
-#include "common/varlen_pool.h"
-#include "serializeio.h"
-#include "printable.h"
-#include <climits>
 #include <cfloat>
+#include <climits>
 #include <cstdint>
 #include <vector>
-#include "common/macros.h"
 #include "common/exception.h"
+#include "common/macros.h"
+#include "common/type.h"
+#include "common/varlen_pool.h"
+#include "printable.h"
+#include "serializeio.h"
 
 namespace peloton {
 namespace common {
@@ -63,57 +63,57 @@ static const uint32_t PELOTON_VARCHAR_MAX_LEN = UINT_MAX;
 // subclasses implement other type-specific functionality.
 class Value : public Printable {
 #ifdef VALUE_TESTS
-public:
+ public:
 #else
  private:
 #endif
 
   Value(const Type::TypeId type) : type_(Type::GetInstance(type)) {}
 
-  //ARRAY values
-  template<class T>
-  Value(Type::TypeId type, const std::vector<T> &vals, Type::TypeId element_type);
+  // ARRAY values
+  template <class T>
+  Value(Type::TypeId type, const std::vector<T> &vals,
+        Type::TypeId element_type);
 
-  //BOOLEAN and TINYINT
+  // BOOLEAN and TINYINT
   Value(Type::TypeId type, int8_t val);
 
-  //DECIMAL
+  // DECIMAL
   Value(Type::TypeId type, double d);
   Value(Type::TypeId type, float f);
 
-  //SMALLINT
+  // SMALLINT
   Value(Type::TypeId type, int16_t i);
-  //INTEGER and PARAMETER_OFFSET
+  // INTEGER and PARAMETER_OFFSET
   Value(Type::TypeId type, int32_t i);
-  //BIGINT
+  // BIGINT
   Value(Type::TypeId type, int64_t i);
 
-  //TIMESTAMP
+  // TIMESTAMP
   Value(Type::TypeId type, uint64_t i);
 
-  //VARCHAR and VARBINARY
+  // VARCHAR and VARBINARY
   Value(Type::TypeId type, const char *data, uint32_t len);
   Value(Type::TypeId type, const std::string &data);
 
  public:
-
   Value();
-  Value(Value&& other);
-  Value(const Value& other);
+  Value(Value &&other);
+  Value(const Value &other);
   ~Value();
 
-  friend void swap(Value& first, Value& second) // nothrow
+  friend void swap(Value &first, Value &second)  // nothrow
   {
-      std::swap(first.type_, second.type_);
-      std::swap(first.value_, second.value_);
+    std::swap(first.type_, second.type_);
+    std::swap(first.value_, second.value_);
   }
 
-  Value& operator=(Value other);
+  Value &operator=(Value other);
 
   // Get the type of this value
   Type::TypeId GetTypeId() const { return type_->GetTypeId(); }
   const std::string GetInfo() const override;
-  
+
   // Comparison functions
   //
   // NOTE:
@@ -186,15 +186,14 @@ public:
   // space, or whether we must store only a reference to this value. If inlined
   // is false, we may use the provided data pool to allocate space for this
   // value, storing a reference into the allocated pool space in the storage.
-  void SerializeTo(char *storage, bool inlined,
-                           VarlenPool *pool) const;
+  void SerializeTo(char *storage, bool inlined, VarlenPool *pool) const;
   void SerializeTo(SerializeOutput &out) const;
 
   // Deserialize a value of the given type from the given storage space.
   static Value DeserializeFrom(const char *storage, const Type::TypeId type_id,
-                                const bool inlined, VarlenPool *pool = nullptr);
+                               const bool inlined, VarlenPool *pool = nullptr);
   static Value DeserializeFrom(SerializeInput &in, const Type::TypeId type_id,
-                                VarlenPool *pool = nullptr);
+                               VarlenPool *pool = nullptr);
 
   // Access the raw variable length data
   const char *GetData() const;
@@ -203,7 +202,9 @@ public:
   uint32_t GetLength() const;
 
   template <class T>
-  T GetAs() const { return *reinterpret_cast<const T*>(&value_); }
+  T GetAs() const {
+    return *reinterpret_cast<const T *>(&value_);
+  }
 
   // Create a copy of this value
   Value Copy() const;
@@ -220,7 +221,7 @@ public:
 
   // For unordered_map
   struct equal_to {
-    bool operator()(const Value& x, const Value& y) const {
+    bool operator()(const Value &x, const Value &y) const {
       Value cmp(x.type_->CompareEquals(x, y));
       return cmp.IsTrue();
     }
@@ -233,17 +234,14 @@ public:
   }
 
   struct hash {
-    size_t operator()(const Value& x) const {
-      return x.type_->Hash(x);
-    }
+    size_t operator()(const Value &x) const { return x.type_->Hash(x); }
   };
-
 
   friend struct equal_to;
   friend struct hash_combine;
   friend struct hash;
 
-  //Type classes
+  // Type classes
   friend class Type;
   friend class ArrayType;
   friend class BooleanType;
@@ -259,7 +257,6 @@ public:
 
   friend class ValueFactory;
 
-
  protected:
   // The data type
   Type *type_;
@@ -273,33 +270,33 @@ public:
     int64_t bigint;
     double decimal;
     uint64_t timestamp;
-//    char *ptr;
-    struct{
+    //    char *ptr;
+    struct {
       uint32_t len;
       char *data;
-    }varlen;
-    struct{
+    } varlen;
+    struct {
       Type::TypeId array_type;
       char *data;
     } array;
   } value_;
 };
 
-//ARRAY here to ease creation of templates
-template<class T>
-Value::Value(Type::TypeId type, const std::vector<T> &vals, Type::TypeId element_type)
-                            : Value(Type::ARRAY){
+// ARRAY here to ease creation of templates
+template <class T>
+Value::Value(Type::TypeId type, const std::vector<T> &vals,
+             Type::TypeId element_type)
+    : Value(Type::ARRAY) {
   switch (type) {
     case Type::ARRAY:
-      value_.array.data = (char *) &vals;
+      value_.array.data = (char *)&vals;
       value_.array.array_type = element_type;
       break;
     default:
       throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
-          "Invalid Type for constructor");
-    }
-
+                      "Invalid Type for constructor");
   }
+}
 
 }  // namespace common
 }  // namespace peloton

--- a/src/include/common/value_factory.h
+++ b/src/include/common/value_factory.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <algorithm>
 #include <stdexcept>
 
 #include "common/boolean_type.h"
-#include "common/macros.h"
-#include "common/serializer.h"
 #include "common/decimal_type.h"
+#include "common/macros.h"
 #include "common/numeric_type.h"
+#include "common/serializer.h"
 #include "common/timestamp_type.h"
 #include "common/varlen_type.h"
 
@@ -20,7 +21,7 @@ namespace common {
 class ValueFactory {
  public:
   static inline Value Clone(const Value &src,
-                             UNUSED_ATTRIBUTE VarlenPool *dataPool = nullptr) {
+                            UNUSED_ATTRIBUTE VarlenPool *dataPool = nullptr) {
     return src.Copy();
   }
 
@@ -56,9 +57,14 @@ class ValueFactory {
     return Value(Type::BOOLEAN, value);
   }
 
+  static inline Value GetBooleanValue(int8_t value) {
+    return Value(Type::BOOLEAN, value);
+  }
+
   static inline Value GetVarcharValue(
       const char *value, UNUSED_ATTRIBUTE VarlenPool *pool = nullptr) {
-    return Value(Type::VARCHAR, value, value == nullptr ? 0 : strlen(value) + 1);
+    return Value(Type::VARCHAR, value,
+                 value == nullptr ? 0 : strlen(value) + 1);
   }
 
   static inline Value GetVarcharValue(
@@ -80,7 +86,7 @@ class ValueFactory {
   static inline Value GetNullValueByType(Type::TypeId type_id) {
     switch (type_id) {
       case Type::BOOLEAN:
-        return Value(Type::BOOLEAN, PELOTON_BOOLEAN_NULL);
+        return GetBooleanValue(PELOTON_BOOLEAN_NULL);
       case Type::TINYINT:
         return GetTinyIntValue(PELOTON_INT8_NULL);
       case Type::SMALLINT:
@@ -108,7 +114,7 @@ class ValueFactory {
 
     switch (type_id) {
       case Type::BOOLEAN:
-        return GetBooleanValue(0);
+        return GetBooleanValue(false);
       case Type::TINYINT:
         return GetTinyIntValue(0);
       case Type::SMALLINT:
@@ -133,7 +139,8 @@ class ValueFactory {
 
   static inline Value CastAsBigInt(const Value &value) {
     if (Type::GetInstance(Type::BIGINT)->IsCoercableFrom(value.GetTypeId())) {
-      if (value.IsNull()) return ValueFactory::GetBigIntValue((int64_t)PELOTON_INT64_NULL);
+      if (value.IsNull())
+        return ValueFactory::GetBigIntValue((int64_t)PELOTON_INT64_NULL);
       switch (value.GetTypeId()) {
         case Type::TINYINT:
           return ValueFactory::GetBigIntValue((int64_t)value.GetAs<int8_t>());
@@ -174,7 +181,8 @@ class ValueFactory {
 
   static inline Value CastAsInteger(const Value &value) {
     if (Type::GetInstance(Type::INTEGER)->IsCoercableFrom(value.GetTypeId())) {
-      if (value.IsNull()) return ValueFactory::GetIntegerValue((int32_t)PELOTON_INT32_NULL);
+      if (value.IsNull())
+        return ValueFactory::GetIntegerValue((int32_t)PELOTON_INT32_NULL);
       switch (value.GetTypeId()) {
         case Type::TINYINT:
           return ValueFactory::GetIntegerValue((int32_t)value.GetAs<int8_t>());
@@ -220,7 +228,8 @@ class ValueFactory {
 
   static inline Value CastAsSmallInt(const Value &value) {
     if (Type::GetInstance(Type::SMALLINT)->IsCoercableFrom(value.GetTypeId())) {
-      if (value.IsNull()) return ValueFactory::GetSmallIntValue((int16_t)PELOTON_INT16_NULL);
+      if (value.IsNull())
+        return ValueFactory::GetSmallIntValue((int16_t)PELOTON_INT16_NULL);
       switch (value.GetTypeId()) {
         case Type::TINYINT:
           return ValueFactory::GetSmallIntValue((int16_t)value.GetAs<int8_t>());
@@ -231,14 +240,16 @@ class ValueFactory {
               value.GetAs<int32_t>() < (int32_t)PELOTON_INT16_MIN)
             throw Exception(EXCEPTION_TYPE_OUT_OF_RANGE,
                             "Numeric value out of range.");
-          return ValueFactory::GetSmallIntValue((int16_t)value.GetAs<int32_t>());
+          return ValueFactory::GetSmallIntValue(
+              (int16_t)value.GetAs<int32_t>());
         }
         case Type::BIGINT: {
           if (value.GetAs<int64_t>() > (int64_t)PELOTON_INT16_MAX ||
               value.GetAs<int64_t>() < (int64_t)PELOTON_INT16_MIN)
             throw Exception(EXCEPTION_TYPE_OUT_OF_RANGE,
                             "Numeric value out of range.");
-          return ValueFactory::GetSmallIntValue((int16_t)value.GetAs<int64_t>());
+          return ValueFactory::GetSmallIntValue(
+              (int16_t)value.GetAs<int64_t>());
         }
         case Type::DECIMAL: {
           if (value.GetAs<double>() > (double)PELOTON_INT16_MAX ||
@@ -271,7 +282,8 @@ class ValueFactory {
 
   static inline Value CastAsTinyInt(const Value &value) {
     if (Type::GetInstance(Type::TINYINT)->IsCoercableFrom(value.GetTypeId())) {
-      if (value.IsNull()) return ValueFactory::GetTinyIntValue(PELOTON_INT8_NULL);
+      if (value.IsNull())
+        return ValueFactory::GetTinyIntValue(PELOTON_INT8_NULL);
       switch (value.GetTypeId()) {
         case Type::TINYINT:
           return ValueFactory::GetTinyIntValue(value.GetAs<int8_t>());
@@ -327,7 +339,8 @@ class ValueFactory {
 
   static inline Value CastAsDecimal(const Value &value) {
     if (Type::GetInstance(Type::DECIMAL)->IsCoercableFrom(value.GetTypeId())) {
-      if (value.IsNull()) return ValueFactory::GetDoubleValue((double)PELOTON_DECIMAL_NULL);
+      if (value.IsNull())
+        return ValueFactory::GetDoubleValue((double)PELOTON_DECIMAL_NULL);
       switch (value.GetTypeId()) {
         case Type::TINYINT:
           return ValueFactory::GetDoubleValue((double)value.GetAs<int8_t>());
@@ -383,8 +396,10 @@ class ValueFactory {
   }
 
   static inline Value CastAsTimestamp(const Value &value) {
-    if (Type::GetInstance(Type::TIMESTAMP)->IsCoercableFrom(value.GetTypeId())) {
-      if (value.IsNull()) return ValueFactory::GetTimestampValue(PELOTON_TIMESTAMP_NULL);
+    if (Type::GetInstance(Type::TIMESTAMP)
+            ->IsCoercableFrom(value.GetTypeId())) {
+      if (value.IsNull())
+        return ValueFactory::GetTimestampValue(PELOTON_TIMESTAMP_NULL);
       switch (value.GetTypeId()) {
         case Type::TIMESTAMP:
           return ValueFactory::GetTimestampValue(value.GetAs<uint64_t>());
@@ -456,16 +471,18 @@ class ValueFactory {
 
   static inline Value CastAsBoolean(const Value &value) {
     if (Type::GetInstance(Type::BOOLEAN)->IsCoercableFrom(value.GetTypeId())) {
-      if (value.IsNull()) return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
+      if (value.IsNull())
+        return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
       switch (value.GetTypeId()) {
         case Type::BOOLEAN:
           return ValueFactory::GetBooleanValue(value.GetAs<int8_t>());
         case Type::VARCHAR: {
           std::string str = value.ToString();
-          if (str == "true" || str == "TURE" || str == "1")
-            return ValueFactory::GetBooleanValue(1);
-          else if (str == "flase" || str == "FALSE" || str == "0")
-            return ValueFactory::GetBooleanValue(0);
+          std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+          if (str == "true" || str == "1")
+            return ValueFactory::GetBooleanValue(true);
+          else if (str == "false" || str == "0")
+            return ValueFactory::GetBooleanValue(false);
           else
             throw Exception("Boolean value format error.");
         }

--- a/src/include/expression/conjunction_expression.h
+++ b/src/include/expression/conjunction_expression.h
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include "expression/abstract_expression.h"
@@ -26,15 +25,14 @@ using namespace peloton::common;
 
 class ConjunctionExpression : public AbstractExpression {
  public:
-  ConjunctionExpression(ExpressionType type)
-    : AbstractExpression(type) {}
+  ConjunctionExpression(ExpressionType type) : AbstractExpression(type) {}
 
-  ConjunctionExpression(ExpressionType type,
-                        AbstractExpression *left,
+  ConjunctionExpression(ExpressionType type, AbstractExpression *left,
                         AbstractExpression *right)
-    : AbstractExpression(type, Type::BOOLEAN, left, right) {}
+      : AbstractExpression(type, Type::BOOLEAN, left, right) {}
 
-  Value Evaluate(UNUSED_ATTRIBUTE const AbstractTuple *tuple1,
+  Value Evaluate(
+      UNUSED_ATTRIBUTE const AbstractTuple *tuple1,
       UNUSED_ATTRIBUTE const AbstractTuple *tuple2,
       UNUSED_ATTRIBUTE executor::ExecutorContext *context) const override {
     PL_ASSERT(children_.size() == 2);
@@ -43,19 +41,17 @@ class ConjunctionExpression : public AbstractExpression {
     switch (exp_type_) {
       case (EXPRESSION_TYPE_CONJUNCTION_AND): {
         if (vl.IsTrue() && vr.IsTrue())
-          return ValueFactory::GetBooleanValue(1);
+          return ValueFactory::GetBooleanValue(true);
         if (vl.IsFalse() || vr.IsFalse())
-          return ValueFactory::GetBooleanValue(0);
-        return ValueFactory::GetBooleanValue(
-            PELOTON_BOOLEAN_NULL);
+          return ValueFactory::GetBooleanValue(false);
+        return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
       }
       case (EXPRESSION_TYPE_CONJUNCTION_OR): {
         if (vl.IsFalse() && vr.IsFalse())
-          return ValueFactory::GetBooleanValue(0);
+          return ValueFactory::GetBooleanValue(false);
         if (vl.IsTrue() || vr.IsTrue())
-          return ValueFactory::GetBooleanValue(1);
-        return ValueFactory::GetBooleanValue(
-            PELOTON_BOOLEAN_NULL);
+          return ValueFactory::GetBooleanValue(true);
+        return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
       }
       default:
         throw Exception("Invalid conjunction expression type.");
@@ -67,7 +63,7 @@ class ConjunctionExpression : public AbstractExpression {
   }
 
  protected:
-  ConjunctionExpression(const ConjunctionExpression& other)
+  ConjunctionExpression(const ConjunctionExpression &other)
       : AbstractExpression(other) {}
 };
 

--- a/src/include/expression/expression_util.h
+++ b/src/include/expression/expression_util.h
@@ -148,7 +148,7 @@ class ExpressionUtil {
       const std::list<expression::AbstractExpression *> &child_exprs) {
     if (child_exprs.empty())
       return new ConstantValueExpression(
-          common::ValueFactory::GetBooleanValue(1));
+          common::ValueFactory::GetBooleanValue(true));
     AbstractExpression *left = nullptr;
     AbstractExpression *right = nullptr;
     for (auto expr : child_exprs) {
@@ -205,8 +205,7 @@ class ExpressionUtil {
     return os.str();
   }
 
-private:
-
+ private:
   /**
    * Internal method for recursively traversing the expression tree
    * and generating debug output
@@ -221,15 +220,14 @@ private:
        << "ValueType[" << TypeIdToString(vtype) << "]";
 
     switch (etype) {
-    case EXPRESSION_TYPE_VALUE_CONSTANT: {
-    	const ConstantValueExpression *c_expr = dynamic_cast<const ConstantValueExpression*>(expr);
-    	os << " -> Value=" << c_expr->GetValue().ToString();
-    	break;
-    }
-    default: {
-    	break;
-    }
-    } // SWITCH
+      case EXPRESSION_TYPE_VALUE_CONSTANT: {
+        const ConstantValueExpression *c_expr =
+            dynamic_cast<const ConstantValueExpression *>(expr);
+        os << " -> Value=" << c_expr->GetValue().ToString();
+        break;
+      }
+      default: { break; }
+    }  // SWITCH
 
     os << std::endl;
     spacer += "   ";
@@ -239,46 +237,46 @@ private:
     return;
   }
 
-public:
+ public:
+  // TODO: Andy is commenting this out for now so that he can come back
+  // 	 	 and fix it once we sort out our catalog information.
+  //
+  //  /**
+  //   * Return a list of all of the catalog::Column objects referenced
+  //   * in the given expression tree
+  //   */
+  //  static std::vector<catalog::Column> GetReferencedColumns(
+  //		  catalog::Catalog *catalog,
+  //		  AbstractExpression *expr) {
+  //	  PL_ASSERT(catalog != nullptr);
+  //	  PL_ASSERT(expr != nullptr);
+  //	  std::vector<catalog::Column> columns;
+  //
+  //	  GetReferencedColumns(catalog, expr, columns);
+  //
+  //	  return (columns);
+  //  }
+  //
+  // private:
+  //
+  //  static void GetReferencedColumns(
+  //		  catalog::Catalog *catalog,
+  //		  const AbstractExpression *expr,
+  //		  std::vector<catalog::Column> &columns) {
+  //
+  //	  ExpressionType etype = expr->GetExpressionType();
+  //	  if (etype == EXPRESSION_TYPE_VALUE_TUPLE) {
+  //		  // TODO: Get the table + column name and grab the
+  //		  // the handle from schema object!
+  //		  const TupleValueExpression t_expr = dynamic_cast<const
+  //TupleValueExpression*>(expr);
+  //		  // catalog->Get
+  //
+  //	  }
+  //
+  //    }
 
-// TODO: Andy is commenting this out for now so that he can come back
-// 	 	 and fix it once we sort out our catalog information.
-//
-//  /**
-//   * Return a list of all of the catalog::Column objects referenced
-//   * in the given expression tree
-//   */
-//  static std::vector<catalog::Column> GetReferencedColumns(
-//		  catalog::Catalog *catalog,
-//		  AbstractExpression *expr) {
-//	  PL_ASSERT(catalog != nullptr);
-//	  PL_ASSERT(expr != nullptr);
-//	  std::vector<catalog::Column> columns;
-//
-//	  GetReferencedColumns(catalog, expr, columns);
-//
-//	  return (columns);
-//  }
-//
-//private:
-//
-//  static void GetReferencedColumns(
-//		  catalog::Catalog *catalog,
-//		  const AbstractExpression *expr,
-//		  std::vector<catalog::Column> &columns) {
-//
-//	  ExpressionType etype = expr->GetExpressionType();
-//	  if (etype == EXPRESSION_TYPE_VALUE_TUPLE) {
-//		  // TODO: Get the table + column name and grab the
-//		  // the handle from schema object!
-//		  const TupleValueExpression t_expr = dynamic_cast<const TupleValueExpression*>(expr);
-//		  // catalog->Get
-//
-//	  }
-//
-//    }
-
-public:
+ public:
   /**
    * Walks an expression tree and fills in information about
    * columns and functions in their respective obejects
@@ -306,8 +304,7 @@ public:
                         needs_projection, true);
   }
 
-private:
-
+ private:
   /**
    * this is a private function for transforming expressions as described
    * above

--- a/src/include/expression/operator_expression.h
+++ b/src/include/expression/operator_expression.h
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include "expression/abstract_expression.h"
@@ -27,24 +26,23 @@ using namespace peloton::common;
 class OperatorExpression : public AbstractExpression {
  public:
   OperatorExpression(ExpressionType type, Type::TypeId type_id)
-    : AbstractExpression(type, type_id) {}
+      : AbstractExpression(type, type_id) {}
 
-  OperatorExpression(ExpressionType type,
-                     Type::TypeId type_id,
-                     AbstractExpression *left,
-                     AbstractExpression *right)
-    : AbstractExpression(type, type_id, left, right) {}
+  OperatorExpression(ExpressionType type, Type::TypeId type_id,
+                     AbstractExpression *left, AbstractExpression *right)
+      : AbstractExpression(type, type_id, left, right) {}
 
-  Value Evaluate(UNUSED_ATTRIBUTE const AbstractTuple *tuple1,
+  Value Evaluate(
+      UNUSED_ATTRIBUTE const AbstractTuple *tuple1,
       UNUSED_ATTRIBUTE const AbstractTuple *tuple2,
       UNUSED_ATTRIBUTE executor::ExecutorContext *context) const override {
     if (exp_type_ == EXPRESSION_TYPE_OPERATOR_NOT) {
       PL_ASSERT(children_.size() == 1);
       Value vl = children_[0]->Evaluate(tuple1, tuple2, context);
       if (vl.IsTrue())
-        return (ValueFactory::GetBooleanValue(0));
+        return (ValueFactory::GetBooleanValue(false));
       else if (vl.IsFalse())
-        return (ValueFactory::GetBooleanValue(1));
+        return (ValueFactory::GetBooleanValue(true));
       else
         return (ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL));
     }
@@ -68,10 +66,12 @@ class OperatorExpression : public AbstractExpression {
     }
   }
 
-  void DeduceExpressionType(){
-    // if we are a decimal or int we should take the highest type id of both children
+  void DeduceExpressionType() {
+    // if we are a decimal or int we should take the highest type id of both
+    // children
     // This relies on a particular order in types.h
-    auto type = std::max(children_[0]->GetValueType(), children_[1]->GetValueType());
+    auto type =
+        std::max(children_[0]->GetValueType(), children_[1]->GetValueType());
     PL_ASSERT(type <= Type::DECIMAL);
     return_value_type_ = type;
   }
@@ -81,7 +81,8 @@ class OperatorExpression : public AbstractExpression {
   }
 
  protected:
-  OperatorExpression(const OperatorExpression& other) :AbstractExpression(other){}
+  OperatorExpression(const OperatorExpression &other)
+      : AbstractExpression(other) {}
 };
 
 class OperatorUnaryMinusExpression : public AbstractExpression {
@@ -90,8 +91,7 @@ class OperatorUnaryMinusExpression : public AbstractExpression {
       : AbstractExpression(EXPRESSION_TYPE_OPERATOR_UNARY_MINUS,
                            left->GetValueType(), left, nullptr) {}
 
-  Value Evaluate(const AbstractTuple *tuple1,
-                                  const AbstractTuple *tuple2,
+  Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
                  executor::ExecutorContext *context) const override {
     PL_ASSERT(children_.size() == 1);
     auto vl = children_[0]->Evaluate(tuple1, tuple2, context);
@@ -105,7 +105,7 @@ class OperatorUnaryMinusExpression : public AbstractExpression {
 
  protected:
   OperatorUnaryMinusExpression(const OperatorUnaryMinusExpression &other)
-        : AbstractExpression(other) {}
+      : AbstractExpression(other) {}
 };
 
 }  // End expression namespace

--- a/test/common/array_value_test.cpp
+++ b/test/common/array_value_test.cpp
@@ -13,17 +13,17 @@
 #define VALUE_TESTS
 
 #include <limits.h>
-#include <iostream>
-#include <cstdint>
 #include <cmath>
+#include <cstdint>
+#include <iostream>
 
 #include "common/array_type.h"
 #include "common/boolean_type.h"
 #include "common/decimal_type.h"
-#include "common/numeric_type.h"
-#include "common/varlen_type.h"
 #include "common/harness.h"
+#include "common/numeric_type.h"
 #include "common/value_factory.h"
+#include "common/varlen_type.h"
 
 namespace peloton {
 namespace test {
@@ -178,7 +178,7 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
-  EXPECT_THROW(array_tinyint.InList(ValueFactory::GetBooleanValue(0)),
+  EXPECT_THROW(array_tinyint.InList(ValueFactory::GetBooleanValue(false)),
                peloton::Exception);
   EXPECT_THROW(array_tinyint.InList(ValueFactory::GetVarcharValue(nullptr, 0)),
                peloton::Exception);
@@ -204,7 +204,7 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
-  EXPECT_THROW(array_smallint.InList(ValueFactory::GetBooleanValue(0)),
+  EXPECT_THROW(array_smallint.InList(ValueFactory::GetBooleanValue(false)),
                peloton::Exception);
   EXPECT_THROW(array_smallint.InList(ValueFactory::GetVarcharValue(nullptr, 0)),
                peloton::Exception);
@@ -229,7 +229,7 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
-  EXPECT_THROW(array_integer.InList(ValueFactory::GetBooleanValue(0)),
+  EXPECT_THROW(array_integer.InList(ValueFactory::GetBooleanValue(false)),
                peloton::Exception);
   EXPECT_THROW(array_integer.InList(ValueFactory::GetVarcharValue(nullptr, 0)),
                peloton::Exception);
@@ -254,7 +254,7 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
-  EXPECT_THROW(array_bigint.InList(ValueFactory::GetBooleanValue(0)),
+  EXPECT_THROW(array_bigint.InList(ValueFactory::GetBooleanValue(false)),
                peloton::Exception);
   EXPECT_THROW(array_bigint.InList(ValueFactory::GetVarcharValue(nullptr, 0)),
                peloton::Exception);
@@ -279,7 +279,7 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
-  EXPECT_THROW(array_decimal.InList(ValueFactory::GetBooleanValue(0)),
+  EXPECT_THROW(array_decimal.InList(ValueFactory::GetBooleanValue(false)),
                peloton::Exception);
   EXPECT_THROW(array_decimal.InList(ValueFactory::GetVarcharValue(nullptr, 0)),
                peloton::Exception);
@@ -304,7 +304,7 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
-  EXPECT_THROW(array_varchar.InList(ValueFactory::GetBooleanValue(0)),
+  EXPECT_THROW(array_varchar.InList(ValueFactory::GetBooleanValue(false)),
                peloton::Exception);
   EXPECT_THROW(array_varchar.InList(ValueFactory::GetIntegerValue(0)),
                peloton::Exception);
@@ -380,7 +380,7 @@ TEST_F(ArrayValueTests, CompareTest) {
 
   // Test type mismatch
   Value v = ValueFactory::GetVarcharValue("");
-  EXPECT_THROW(v.CompareEquals(ValueFactory::GetBooleanValue(0)),
+  EXPECT_THROW(v.CompareEquals(ValueFactory::GetBooleanValue(false)),
                peloton::Exception);
   EXPECT_THROW(v.CompareEquals(ValueFactory::GetIntegerValue(0)),
                peloton::Exception);

--- a/test/common/boolean_value_test.cpp
+++ b/test/common/boolean_value_test.cpp
@@ -2,9 +2,9 @@
 //
 //                         Peloton
 //
-// sample_test.cpp
+// boolean_value_test.cpp
 //
-// Identification: test/common/sample_test.cpp
+// Identification: test/common/boolean_value_test.cpp
 //
 // Copyright (c) 2015-16, Carnegie Mellon University Database Group
 //
@@ -115,12 +115,20 @@ TEST_F(BooleanValueTests, NullTest) {
 TEST_F(BooleanValueTests, CastTest) {
   common::Value result;
 
-  auto valTrue = common::ValueFactory::GetVarcharValue("TrUe");
-  result = common::ValueFactory::CastAsBoolean(valTrue);
+  auto valTrue0 = common::ValueFactory::GetVarcharValue("TrUe");
+  result = common::ValueFactory::CastAsBoolean(valTrue0);
   EXPECT_TRUE(result.IsTrue());
 
-  auto valFalse = common::ValueFactory::GetVarcharValue("FaLsE");
-  result = common::ValueFactory::CastAsBoolean(valFalse);
+  auto valTrue1 = common::ValueFactory::GetVarcharValue("1");
+  result = common::ValueFactory::CastAsBoolean(valTrue1);
+  EXPECT_TRUE(result.IsTrue());
+
+  auto valFalse0 = common::ValueFactory::GetVarcharValue("FaLsE");
+  result = common::ValueFactory::CastAsBoolean(valFalse0);
+  EXPECT_TRUE(result.IsFalse());
+
+  auto valFalse1 = common::ValueFactory::GetVarcharValue("0");
+  result = common::ValueFactory::CastAsBoolean(valFalse1);
   EXPECT_TRUE(result.IsFalse());
 
   auto valBustedLike = common::ValueFactory::GetVarcharValue("YourMom");

--- a/test/common/boolean_value_test.cpp
+++ b/test/common/boolean_value_test.cpp
@@ -1,0 +1,132 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// sample_test.cpp
+//
+// Identification: test/common/sample_test.cpp
+//
+// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/boolean_type.h"
+#include "common/harness.h"
+#include "common/value_factory.h"
+
+namespace peloton {
+namespace test {
+
+//===--------------------------------------------------------------------===//
+// Boolean Value Test
+//===--------------------------------------------------------------------===//
+
+class BooleanValueTests : public PelotonTest {};
+
+TEST_F(BooleanValueTests, BasicTest) {
+  auto valTrue = common::ValueFactory::GetBooleanValue(true);
+  auto valFalse = common::ValueFactory::GetBooleanValue(false);
+  auto valNull =
+      common::ValueFactory::GetNullValueByType(common::Type::BOOLEAN);
+
+  EXPECT_TRUE(valTrue.IsTrue());
+  EXPECT_FALSE(valTrue.IsFalse());
+  EXPECT_FALSE(valTrue.IsNull());
+
+  EXPECT_FALSE(valFalse.IsTrue());
+  EXPECT_TRUE(valFalse.IsFalse());
+  EXPECT_FALSE(valFalse.IsNull());
+
+  EXPECT_FALSE(valNull.IsTrue());
+  EXPECT_FALSE(valNull.IsFalse());
+  EXPECT_TRUE(valNull.IsNull());
+}
+
+TEST_F(BooleanValueTests, ComparisonTest) {
+  auto valTrue = common::ValueFactory::GetBooleanValue(true);
+  auto valFalse = common::ValueFactory::GetBooleanValue(false);
+
+  common::Value result;
+
+  // TRUE == TRUE
+  result = valTrue.CompareEquals(valTrue);
+  EXPECT_TRUE(result.IsTrue());
+  EXPECT_FALSE(result.IsFalse());
+  EXPECT_FALSE(result.IsNull());
+
+  // TRUE == FALSE
+  result = valTrue.CompareEquals(valFalse);
+  EXPECT_FALSE(result.IsTrue());
+  EXPECT_TRUE(result.IsFalse());
+  EXPECT_FALSE(result.IsNull());
+
+  // TRUE != TRUE
+  result = valTrue.CompareNotEquals(valTrue);
+  EXPECT_FALSE(result.IsTrue());
+  EXPECT_TRUE(result.IsFalse());
+  EXPECT_FALSE(result.IsNull());
+
+  // TRUE != FALSE
+  result = valTrue.CompareNotEquals(valFalse);
+  EXPECT_TRUE(result.IsTrue());
+  EXPECT_FALSE(result.IsFalse());
+  EXPECT_FALSE(result.IsNull());
+}
+
+TEST_F(BooleanValueTests, NullTest) {
+  auto valTrue = common::ValueFactory::GetBooleanValue(true);
+  auto valFalse = common::ValueFactory::GetBooleanValue(false);
+  auto valNull =
+      common::ValueFactory::GetNullValueByType(common::Type::BOOLEAN);
+
+  common::Value result;
+
+  // TRUE == NULL
+  result = valTrue.CompareEquals(valNull);
+  EXPECT_FALSE(result.IsTrue());
+  EXPECT_FALSE(result.IsFalse());
+  EXPECT_TRUE(result.IsNull());
+
+  // FALSE == NULL
+  result = valTrue.CompareEquals(valNull);
+  EXPECT_FALSE(result.IsTrue());
+  EXPECT_FALSE(result.IsFalse());
+  EXPECT_TRUE(result.IsNull());
+
+  // FALSE == NULL
+  result = valTrue.CompareEquals(valNull);
+  EXPECT_FALSE(result.IsTrue());
+  EXPECT_FALSE(result.IsFalse());
+  EXPECT_TRUE(result.IsNull());
+
+  // TRUE != NULL
+  result = valTrue.CompareNotEquals(valNull);
+  EXPECT_FALSE(result.IsTrue());
+  EXPECT_FALSE(result.IsFalse());
+  EXPECT_TRUE(result.IsNull());
+
+  // FALSE != NULL
+  result = valTrue.CompareNotEquals(valNull);
+  EXPECT_FALSE(result.IsTrue());
+  EXPECT_FALSE(result.IsFalse());
+  EXPECT_TRUE(result.IsNull());
+}
+
+TEST_F(BooleanValueTests, CastTest) {
+  common::Value result;
+
+  auto valTrue = common::ValueFactory::GetVarcharValue("TrUe");
+  result = common::ValueFactory::CastAsBoolean(valTrue);
+  EXPECT_TRUE(result.IsTrue());
+
+  auto valFalse = common::ValueFactory::GetVarcharValue("FaLsE");
+  result = common::ValueFactory::CastAsBoolean(valFalse);
+  EXPECT_TRUE(result.IsFalse());
+
+  auto valBustedLike = common::ValueFactory::GetVarcharValue("YourMom");
+  EXPECT_THROW(common::ValueFactory::CastAsBoolean(valBustedLike),
+               peloton::Exception);
+}
+
+}  // End test namespace
+}  // End peloton namespace

--- a/test/common/boolean_value_test.cpp
+++ b/test/common/boolean_value_test.cpp
@@ -43,34 +43,62 @@ TEST_F(BooleanValueTests, BasicTest) {
 }
 
 TEST_F(BooleanValueTests, ComparisonTest) {
-  auto valTrue = common::ValueFactory::GetBooleanValue(true);
-  auto valFalse = common::ValueFactory::GetBooleanValue(false);
+  std::vector<ExpressionType> compares = {
+      EXPRESSION_TYPE_COMPARE_EQUAL,
+      EXPRESSION_TYPE_COMPARE_NOTEQUAL,
+      EXPRESSION_TYPE_COMPARE_LESSTHAN,
+      EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO,
+      EXPRESSION_TYPE_COMPARE_GREATERTHAN,
+      EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO};
 
-  common::Value result;
+  bool values[] = {true, false};
 
-  // TRUE == TRUE
-  result = valTrue.CompareEquals(valTrue);
-  EXPECT_TRUE(result.IsTrue());
-  EXPECT_FALSE(result.IsFalse());
-  EXPECT_FALSE(result.IsNull());
+  for (int i = 0; i < 2; i++) {
+    for (int j = 0; j < 2; j++) {
+      for (auto etype : compares) {
+        bool expected;
+        common::Value result;
+        auto val0 = common::ValueFactory::GetBooleanValue(values[i]);
+        auto val1 = common::ValueFactory::GetBooleanValue(values[j]);
 
-  // TRUE == FALSE
-  result = valTrue.CompareEquals(valFalse);
-  EXPECT_FALSE(result.IsTrue());
-  EXPECT_TRUE(result.IsFalse());
-  EXPECT_FALSE(result.IsNull());
+        switch (etype) {
+          case EXPRESSION_TYPE_COMPARE_EQUAL:
+            expected = values[i] == values[j];
+            result = val0.CompareEquals(val1);
+            break;
+          case EXPRESSION_TYPE_COMPARE_NOTEQUAL:
+            expected = values[i] != values[j];
+            result = val0.CompareNotEquals(val1);
+            break;
+          case EXPRESSION_TYPE_COMPARE_LESSTHAN:
+            expected = values[i] < values[j];
+            result = val0.CompareLessThan(val1);
+            break;
+          case EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO:
+            expected = values[i] <= values[j];
+            result = val0.CompareLessThanEquals(val1);
+            break;
+          case EXPRESSION_TYPE_COMPARE_GREATERTHAN:
+            expected = values[i] > values[j];
+            result = val0.CompareGreaterThan(val1);
+            break;
+          case EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO:
+            expected = values[i] >= values[j];
+            result = val0.CompareGreaterThanEquals(val1);
+            break;
+          default:
+            throw Exception("Unexpected comparison");
+        }  // SWITCH
+           //        printf("%s %s %s => %d | %d\n", val0.ToString().c_str(),
+           //               ExpressionTypeToString(etype).c_str(),
+           //               val1.ToString().c_str(),
+           //               expected, result.IsTrue());
 
-  // TRUE != TRUE
-  result = valTrue.CompareNotEquals(valTrue);
-  EXPECT_FALSE(result.IsTrue());
-  EXPECT_TRUE(result.IsFalse());
-  EXPECT_FALSE(result.IsNull());
-
-  // TRUE != FALSE
-  result = valTrue.CompareNotEquals(valFalse);
-  EXPECT_TRUE(result.IsTrue());
-  EXPECT_FALSE(result.IsFalse());
-  EXPECT_FALSE(result.IsNull());
+        EXPECT_EQ(expected, result.IsTrue());
+        EXPECT_FALSE(result.IsNull());
+      }
+    }
+  }
 }
 
 TEST_F(BooleanValueTests, NullTest) {

--- a/test/common/boolean_value_test.cpp
+++ b/test/common/boolean_value_test.cpp
@@ -89,10 +89,9 @@ TEST_F(BooleanValueTests, ComparisonTest) {
           default:
             throw Exception("Unexpected comparison");
         }  // SWITCH
-           //        printf("%s %s %s => %d | %d\n", val0.ToString().c_str(),
-           //               ExpressionTypeToString(etype).c_str(),
-           //               val1.ToString().c_str(),
-           //               expected, result.IsTrue());
+        LOG_TRACE("%s %s %s => %d | %d\n", val0.ToString().c_str(),
+                  ExpressionTypeToString(etype).c_str(),
+                  val1.ToString().c_str(), expected, result.IsTrue());
 
         EXPECT_EQ(expected, result.IsTrue());
         EXPECT_FALSE(result.IsNull());

--- a/test/executor/seq_scan_test.cpp
+++ b/test/executor/seq_scan_test.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include <memory>
 #include <set>
 #include <string>
@@ -24,8 +23,8 @@
 #include "common/value_factory.h"
 #include "concurrency/transaction.h"
 #include "concurrency/transaction_manager_factory.h"
-#include "executor/executor_context.h"
 #include "executor/abstract_executor.h"
+#include "executor/executor_context.h"
 #include "executor/logical_tile.h"
 #include "executor/logical_tile_factory.h"
 #include "executor/seq_scan_executor.h"
@@ -35,9 +34,9 @@
 #include "storage/data_table.h"
 #include "storage/tile_group_factory.h"
 
+#include "common/harness.h"
 #include "executor/executor_tests_util.h"
 #include "executor/mock_executor.h"
-#include "common/harness.h"
 
 using ::testing::NotNull;
 using ::testing::Return;
@@ -130,7 +129,8 @@ expression::AbstractExpression *CreatePredicate(
   PL_ASSERT(tuple_ids.size() >= 1);
 
   expression::AbstractExpression *predicate =
-      expression::ExpressionUtil::ConstantValueFactory(common::ValueFactory::GetBooleanValue(0));
+      expression::ExpressionUtil::ConstantValueFactory(
+          common::ValueFactory::GetBooleanValue(false));
 
   bool even = false;
   for (oid_t tuple_id : tuple_ids) {
@@ -150,14 +150,13 @@ expression::AbstractExpression *CreatePredicate(
     if (even) {
       auto constant_value = common::ValueFactory::GetIntegerValue(
           ExecutorTestsUtil::PopulatedValue(tuple_id, 0));
-      constant_value_expr = expression::ExpressionUtil::ConstantValueFactory(
-          constant_value);
-    }
-    else {
+      constant_value_expr =
+          expression::ExpressionUtil::ConstantValueFactory(constant_value);
+    } else {
       auto constant_value = common::ValueFactory::GetVarcharValue(
-        std::to_string(ExecutorTestsUtil::PopulatedValue(tuple_id, 3)));
-      constant_value_expr = expression::ExpressionUtil::ConstantValueFactory(
-          constant_value);
+          std::to_string(ExecutorTestsUtil::PopulatedValue(tuple_id, 3)));
+      constant_value_expr =
+          expression::ExpressionUtil::ConstantValueFactory(constant_value);
     }
 
     // Finally, link them together using an equality expression.
@@ -220,15 +219,13 @@ void RunTest(executor::SeqScanExecutor &executor, int expected_num_tiles,
       // We divide by 10 because we know how PopulatedValue() computes.
       // Bad style. Being a bit lazy here...
 
-      common::Value value1 = (
-          result_tiles[i]->GetValue(new_tuple_id, 0));
+      common::Value value1 = (result_tiles[i]->GetValue(new_tuple_id, 0));
       int old_tuple_id = value1.GetAs<int32_t>() / 10;
 
       EXPECT_EQ(1, expected_tuples_left.erase(old_tuple_id));
 
       int val1 = ExecutorTestsUtil::PopulatedValue(old_tuple_id, 1);
-      common::Value value2 = (
-          result_tiles[i]->GetValue(new_tuple_id, 1));
+      common::Value value2 = (result_tiles[i]->GetValue(new_tuple_id, 1));
       EXPECT_EQ(val1, value2.GetAs<int32_t>());
       int val2 = ExecutorTestsUtil::PopulatedValue(old_tuple_id, 3);
 
@@ -237,9 +234,10 @@ void RunTest(executor::SeqScanExecutor &executor, int expected_num_tiles,
       // For the tile group test case, it'll be 2 (one column is removed
       // during the scan as part of the test case).
       // For the logical tile test case, it'll be 3.
-      common::Value string_value = (common::ValueFactory::GetVarcharValue(std::to_string(val2)));
-      common::Value val = (
-          result_tiles[i]->GetValue(new_tuple_id, expected_num_cols - 1));
+      common::Value string_value =
+          (common::ValueFactory::GetVarcharValue(std::to_string(val2)));
+      common::Value val =
+          (result_tiles[i]->GetValue(new_tuple_id, expected_num_cols - 1));
       common::Value cmp = (val.CompareEquals(string_value));
       EXPECT_TRUE(cmp.IsTrue());
     }

--- a/test/optimizer/rule_test.cpp
+++ b/test/optimizer/rule_test.cpp
@@ -10,16 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "common/harness.h"
 
 #define private public
 
+#include "optimizer/op_expression.h"
+#include "optimizer/operators.h"
 #include "optimizer/optimizer.h"
 #include "optimizer/rule.h"
 #include "optimizer/rule_impls.h"
-#include "optimizer/op_expression.h"
-#include "optimizer/operators.h"
 
 #include "catalog/catalog.h"
 #include "common/logger.h"
@@ -51,9 +50,8 @@ TEST_F(RuleTests, SimpleRuleApplyTest) {
   // Build op plan node to match rule
   auto left_get = std::make_shared<OpExpression>(LogicalGet::make(0, {}));
   auto right_get = std::make_shared<OpExpression>(LogicalGet::make(0, {}));
-  auto val = common::ValueFactory::GetBooleanValue(1);
-  auto pred =
-    std::make_shared<OpExpression>(ExprConstant::make(val));
+  auto val = common::ValueFactory::GetBooleanValue(true);
+  auto pred = std::make_shared<OpExpression>(ExprConstant::make(val));
   auto join = std::make_shared<OpExpression>(LogicalInnerJoin::make());
   join->PushChild(left_get);
   join->PushChild(right_get);


### PR DESCRIPTION
This commit fixes a lot of the problems with the Boolean type:

1. We were not able to convert VARCHARs to BOOLEANs.
2. And then even if we could, we had mispelled 'true' and 'false' so it wouldn't have worked anyway.
3. `BooleanType::CompareEquals` would always return true if you compared a NULL value...
4. This was because it would call `ValueFactory::GetBooleanValue` which only supported bool inputs. That means `PELOTON_BOOLEAN_NULL` was always converted to true
5. And then because I was disappointed that our code coverage has not moved up in a few months, I busted out new boolean test cases to make sure that all of this is working properly.

Note that **clang-format** reformatted some of the the source code files when I edited them so that's why there are a bunch of changes...