### PR TITLE
Fix race condition in index metric initialization [#355]

### DIFF
--- a/src/include/statistics/backend_stats_context.h
+++ b/src/include/statistics/backend_stats_context.h
@@ -17,6 +17,7 @@
 #include <sstream>
 #include <unordered_map>
 
+#include "common/platform.h"
 #include "statistics/table_metric.h"
 #include "statistics/index_metric.h"
 #include "statistics/latency_metric.h"
@@ -151,6 +152,9 @@ class BackendStatsContext {
 
   // Index oids
   std::unordered_set<oid_t> index_ids_;
+
+  // Index oid spin lock
+  Spinlock index_id_lock;
 
   // Metrics for completed queries
   LockFreeQueue<std::shared_ptr<QueryMetric>> completed_query_metrics_{

--- a/src/statistics/backend_stats_context.cpp
+++ b/src/statistics/backend_stats_context.cpp
@@ -89,12 +89,17 @@ IndexMetric* BackendStatsContext::GetIndexMetric(oid_t database_id,
                                                  oid_t table_id,
                                                  oid_t index_id) {
   std::shared_ptr<IndexMetric> index_metric;
-  if (index_metrics_.Find(index_id, index_metric) == false) {
+  // Index metric doesn't exist yet
+  if (index_metrics_.Contains(index_id) == false) {
     index_metric.reset(
         new IndexMetric{INDEX_METRIC, database_id, table_id, index_id});
     index_metrics_.Insert(index_id, index_metric);
+    index_id_lock.Lock();
     index_ids_.insert(index_id);
+    index_id_lock.Unlock();
   }
+  // Get index metric from map
+  index_metrics_.Find(index_id, index_metric);
   return index_metric.get();
 }
 


### PR DESCRIPTION
There was a race condition when multiple threads initialize the metric for a new index. @malin1993ml 