### PR TITLE
Cleaning up types.h

### DIFF
--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -41,7 +41,7 @@ if [ "$DISTRO" = "UBUNTU" ]; then
 ## ------------------------------------------------
 ## FEDORA/REDHAT
 ## ------------------------------------------------
-elif [ "$DISTRO" = "FEDORA" ]; then
+elif [[ "$DISTRO" == *"FEDORA"* ]]; then
     dnf install -y git \
         gcc-c++ \
         cmake \

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -13,7 +13,7 @@
 #include "common/config.h"
 #include "common/types.h"
 
-DEFINE_uint64(port, 5432, "Peloton port (default: 5432)");
+DEFINE_uint64(port, 15721, "Peloton port (default: 15721)");
 
 DEFINE_uint64(max_connections, 64,
               "Maximum number of connections (default: 64)");

--- a/src/common/configuration.cpp
+++ b/src/common/configuration.cpp
@@ -10,20 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "common/types.h"
 
 // Layout mode
-int peloton_layout_mode = LAYOUT_TYPE_ROW;
+int peloton_layout_mode = peloton::LAYOUT_TYPE_ROW;
 
 // Logging mode
-LoggingType peloton_logging_mode = LOGGING_TYPE_INVALID;
+peloton::LoggingType peloton_logging_mode = peloton::LOGGING_TYPE_INVALID;
 
 // GC mode
-GarbageCollectionType peloton_gc_mode;
+peloton::GarbageCollectionType peloton_gc_mode;
 
 // Checkpoint mode
-CheckpointType peloton_checkpoint_mode;
+peloton::CheckpointType peloton_checkpoint_mode;
 
 // Directory for peloton logs
 char *peloton_log_directory;

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -797,7 +797,7 @@ IndexConstraintType StringToIndexConstraintType(const std::string& str) {
   } else if (str == "UNIQUE") {
     return INDEX_CONSTRAINT_TYPE_UNIQUE;
   } else {
-    throw ConversionException("No conversion from string :" + str);
+    throw ConversionException("No conversion from string '" + str + "'");
   }
   return INDEX_CONSTRAINT_TYPE_INVALID;
 }
@@ -808,94 +808,97 @@ IndexConstraintType StringToIndexConstraintType(const std::string& str) {
 std::string PlanNodeTypeToString(PlanNodeType type) {
   switch (type) {
     case PLAN_NODE_TYPE_INVALID: {
-      return "INVALID";
+      return ("INVALID");
     }
     case PLAN_NODE_TYPE_ABSTRACT_SCAN: {
-      return "ABSTRACT_SCAN";
+      return ("ABSTRACT_SCAN");
     }
     case PLAN_NODE_TYPE_SEQSCAN: {
-      return "SEQSCAN";
+      return ("SEQSCAN");
     }
     case PLAN_NODE_TYPE_INDEXSCAN: {
-      return "INDEXSCAN";
+      return ("INDEXSCAN");
     }
     case PLAN_NODE_TYPE_NESTLOOP: {
-      return "NESTLOOP";
+      return ("NESTLOOP");
     }
     case PLAN_NODE_TYPE_NESTLOOPINDEX: {
-      return "NESTLOOPINDEX";
+      return ("NESTLOOPINDEX");
     }
     case PLAN_NODE_TYPE_MERGEJOIN: {
-      return "MERGEJOIN";
+      return ("MERGEJOIN");
     }
     case PLAN_NODE_TYPE_HASHJOIN: {
-      return "HASHJOIN";
+      return ("HASHJOIN");
     }
     case PLAN_NODE_TYPE_UPDATE: {
-      return "UPDATE";
+      return ("UPDATE");
     }
     case PLAN_NODE_TYPE_INSERT: {
-      return "INSERT";
+      return ("INSERT");
     }
     case PLAN_NODE_TYPE_DELETE: {
-      return "DELETE";
-    }
-    case PLAN_NODE_TYPE_COPY: {
-      return "COPY";
-    }
-    case PLAN_NODE_TYPE_SEND: {
-      return "SEND";
-    }
-    case PLAN_NODE_TYPE_RECEIVE: {
-      return "RECEIVE";
-    }
-    case PLAN_NODE_TYPE_PRINT: {
-      return "PRINT";
-    }
-    case PLAN_NODE_TYPE_AGGREGATE: {
-      return "AGGREGATE";
-    }
-    case PLAN_NODE_TYPE_UNION: {
-      return "UNION";
-    }
-    case PLAN_NODE_TYPE_ORDERBY: {
-      return "RECEIVE";
-    }
-    case PLAN_NODE_TYPE_PROJECTION: {
-      return "PROJECTION";
-    }
-    case PLAN_NODE_TYPE_MATERIALIZE: {
-      return "MATERIALIZE";
-    }
-    case PLAN_NODE_TYPE_LIMIT: {
-      return "LIMIT";
-    }
-    case PLAN_NODE_TYPE_DISTINCT: {
-      return "DISTINCT";
-    }
-    case PLAN_NODE_TYPE_SETOP: {
-      return "SETOP";
-    }
-    case PLAN_NODE_TYPE_APPEND: {
-      return "APPEND";
-    }
-    case PLAN_NODE_TYPE_RESULT: {
-      return "RESULT";
-    }
-    case PLAN_NODE_TYPE_AGGREGATE_V2: {
-      return "AGGREGATE_V2";
-    }
-    case PLAN_NODE_TYPE_MOCK: {
-      return "MOCK";
-    }
-    case PLAN_NODE_TYPE_HASH: {
-      return "HASH";
+      return ("DELETE");
     }
     case PLAN_NODE_TYPE_DROP: {
-      return "DROP";
+      return ("DROP");
     }
     case PLAN_NODE_TYPE_CREATE: {
-      return "CREATE";
+      return ("CREATE");
+    }
+    case PLAN_NODE_TYPE_SEND: {
+      return ("SEND");
+    }
+    case PLAN_NODE_TYPE_RECEIVE: {
+      return ("RECEIVE");
+    }
+    case PLAN_NODE_TYPE_PRINT: {
+      return ("PRINT");
+    }
+    case PLAN_NODE_TYPE_AGGREGATE: {
+      return ("AGGREGATE");
+    }
+    case PLAN_NODE_TYPE_UNION: {
+      return ("UNION");
+    }
+    case PLAN_NODE_TYPE_ORDERBY: {
+      return ("ORDERBY");
+    }
+    case PLAN_NODE_TYPE_PROJECTION: {
+      return ("PROJECTION");
+    }
+    case PLAN_NODE_TYPE_MATERIALIZE: {
+      return ("MATERIALIZE");
+    }
+    case PLAN_NODE_TYPE_LIMIT: {
+      return ("LIMIT");
+    }
+    case PLAN_NODE_TYPE_DISTINCT: {
+      return ("DISTINCT");
+    }
+    case PLAN_NODE_TYPE_SETOP: {
+      return ("SETOP");
+    }
+    case PLAN_NODE_TYPE_APPEND: {
+      return ("APPEND");
+    }
+    case PLAN_NODE_TYPE_AGGREGATE_V2: {
+      return ("AGGREGATE_V2");
+    }
+    case PLAN_NODE_TYPE_HASH: {
+      return ("HASH");
+    }
+    case PLAN_NODE_TYPE_RESULT: {
+      return ("RESULT");
+    }
+    case PLAN_NODE_TYPE_COPY: {
+      return ("COPY");
+    }
+    case PLAN_NODE_TYPE_MOCK: {
+      return ("MOCK");
+    }
+    default: {
+      throw ConversionException("No conversion from PlanNodeType");  // FIXME
     }
   }
   return "INVALID";
@@ -914,12 +917,20 @@ PlanNodeType StringToPlanNodeType(const std::string& str) {
     return PLAN_NODE_TYPE_NESTLOOP;
   } else if (str == "NESTLOOPINDEX") {
     return PLAN_NODE_TYPE_NESTLOOPINDEX;
+  } else if (str == "MERGEJOIN") {
+    return PLAN_NODE_TYPE_MERGEJOIN;
+  } else if (str == "HASHJOIN") {
+    return PLAN_NODE_TYPE_HASHJOIN;
   } else if (str == "UPDATE") {
     return PLAN_NODE_TYPE_UPDATE;
   } else if (str == "INSERT") {
     return PLAN_NODE_TYPE_INSERT;
   } else if (str == "DELETE") {
     return PLAN_NODE_TYPE_DELETE;
+  } else if (str == "DROP") {
+    return PLAN_NODE_TYPE_DROP;
+  } else if (str == "CREATE") {
+    return PLAN_NODE_TYPE_CREATE;
   } else if (str == "SEND") {
     return PLAN_NODE_TYPE_SEND;
   } else if (str == "RECEIVE") {
@@ -940,8 +951,22 @@ PlanNodeType StringToPlanNodeType(const std::string& str) {
     return PLAN_NODE_TYPE_LIMIT;
   } else if (str == "DISTINCT") {
     return PLAN_NODE_TYPE_DISTINCT;
+  } else if (str == "SETOP") {
+    return PLAN_NODE_TYPE_SETOP;
+  } else if (str == "APPEND") {
+    return PLAN_NODE_TYPE_APPEND;
+  } else if (str == "AGGREGATE_V2") {
+    return PLAN_NODE_TYPE_AGGREGATE_V2;
+  } else if (str == "HASH") {
+    return PLAN_NODE_TYPE_HASH;
+  } else if (str == "RESULT") {
+    return PLAN_NODE_TYPE_RESULT;
+  } else if (str == "COPY") {
+    return PLAN_NODE_TYPE_COPY;
+  } else if (str == "MOCK") {
+    return PLAN_NODE_TYPE_MOCK;
   } else {
-    throw ConversionException("No conversion from string :" + str);
+    throw ConversionException("No conversion from string '" + str + "'");
   }
   return PLAN_NODE_TYPE_INVALID;
 }

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -783,6 +783,10 @@ std::string IndexConstraintTypeToString(IndexConstraintType type) {
     case INDEX_CONSTRAINT_TYPE_UNIQUE: {
       return "UNIQUE";
     }
+    default: {
+      throw ConversionException(
+          "No conversion from IndexConstraintType");  // FIXME
+    }
   }
   return "INVALID";
 }
@@ -1016,6 +1020,9 @@ std::string ParseNodeTypeToString(ParseNodeType type) {
     case PARSE_NODE_TYPE_MOCK: {
       return "MOCK";
     }
+    default: {
+      throw ConversionException("No conversion from ParseNodeType");  // FIXME
+    }
   }
   return "INVALID";
 }
@@ -1048,7 +1055,7 @@ ParseNodeType StringToParseNodeType(const std::string& str) {
   } else if (str == "MOCK") {
     return PARSE_NODE_TYPE_MOCK;
   } else {
-    throw ConversionException("No conversion from string :" + str);
+    throw ConversionException("No conversion from string '" + str + "'");
   }
   return PARSE_NODE_TYPE_INVALID;
 }
@@ -1060,31 +1067,34 @@ ParseNodeType StringToParseNodeType(const std::string& str) {
 std::string ConstraintTypeToString(ConstraintType type) {
   switch (type) {
     case CONSTRAINT_TYPE_INVALID: {
-      return "INVALID";
+      return ("INVALID");
     }
     case CONSTRAINT_TYPE_NULL: {
-      return "NULL";
+      return ("NULL");
     }
     case CONSTRAINT_TYPE_NOTNULL: {
-      return "NOTNULL";
+      return ("NOTNULL");
     }
     case CONSTRAINT_TYPE_DEFAULT: {
-      return "DEFAULT";
+      return ("DEFAULT");
     }
     case CONSTRAINT_TYPE_CHECK: {
-      return "CHECK";
+      return ("CHECK");
     }
     case CONSTRAINT_TYPE_PRIMARY: {
-      return "PRIMARY_KEY";
+      return ("PRIMARY");
     }
     case CONSTRAINT_TYPE_UNIQUE: {
-      return "UNIQUE";
+      return ("UNIQUE");
     }
     case CONSTRAINT_TYPE_FOREIGN: {
-      return "FOREIGN_KEY";
+      return ("FOREIGN");
     }
     case CONSTRAINT_TYPE_EXCLUSION: {
-      return "EXCLUSION";
+      return ("EXCLUSION");
+    }
+    default: {
+      throw ConversionException("No conversion from ConstraintType");  // FIXME
     }
   }
   return "INVALID";
@@ -1097,18 +1107,20 @@ ConstraintType StringToConstraintType(const std::string& str) {
     return CONSTRAINT_TYPE_NULL;
   } else if (str == "NOTNULL") {
     return CONSTRAINT_TYPE_NOTNULL;
-  } else if (str == "CHECK") {
-    return CONSTRAINT_TYPE_DEFAULT;
   } else if (str == "DEFAULT") {
-    return CONSTRAINT_TYPE_UNIQUE;
-  } else if (str == "PRIMARY_KEY") {
+    return CONSTRAINT_TYPE_DEFAULT;
+  } else if (str == "CHECK") {
     return CONSTRAINT_TYPE_CHECK;
-  } else if (str == "UNIQUE") {
+  } else if (str == "PRIMARY") {
     return CONSTRAINT_TYPE_PRIMARY;
-  } else if (str == "FOREIGN_KEY") {
+  } else if (str == "UNIQUE") {
+    return CONSTRAINT_TYPE_UNIQUE;
+  } else if (str == "FOREIGN") {
     return CONSTRAINT_TYPE_FOREIGN;
   } else if (str == "EXCLUSION") {
     return CONSTRAINT_TYPE_EXCLUSION;
+  } else {
+    throw ConversionException("No conversion from string '" + str + "'");
   }
   return CONSTRAINT_TYPE_INVALID;
 }

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -267,36 +267,6 @@ bool HexDecodeToBinary(unsigned char* bufferdst, const char* hexString) {
   return true;
 }
 
-BackendType GetBackendType(const LoggingType& logging_type) {
-  // Default backend type
-  BackendType backend_type = BACKEND_TYPE_MM;
-
-  switch (logging_type) {
-    case LOGGING_TYPE_NVM_WBL:
-      backend_type = BACKEND_TYPE_NVM;
-      break;
-
-    case LOGGING_TYPE_SSD_WBL:
-      backend_type = BACKEND_TYPE_SSD;
-      break;
-
-    case LOGGING_TYPE_HDD_WBL:
-      backend_type = BACKEND_TYPE_HDD;
-      break;
-
-    case LOGGING_TYPE_NVM_WAL:
-    case LOGGING_TYPE_SSD_WAL:
-    case LOGGING_TYPE_HDD_WAL:
-      backend_type = BACKEND_TYPE_MM;
-      break;
-
-    default:
-      break;
-  }
-
-  return backend_type;
-}
-
 bool AtomicUpdateItemPointer(ItemPointer* src_ptr, const ItemPointer& value) {
   PL_ASSERT(sizeof(ItemPointer) == sizeof(int64_t));
   int64_t* cast_src_ptr = reinterpret_cast<int64_t*>((void*)src_ptr);
@@ -355,6 +325,39 @@ std::string StatementTypeToString(StatementType type) {
     }
   }
   return "NOT A KNOWN TYPE - INVALID";
+}
+
+StatementType StringToStatementType(const std::string& str) {
+  if (str == "INVALID") {
+    return STATEMENT_TYPE_INVALID;
+  } else if (str == "SELECT") {
+    return STATEMENT_TYPE_SELECT;
+  } else if (str == "INSERT") {
+    return STATEMENT_TYPE_INSERT;
+  } else if (str == "UPDATE") {
+    return STATEMENT_TYPE_UPDATE;
+  } else if (str == "DELETE") {
+    return STATEMENT_TYPE_DELETE;
+  } else if (str == "CREATE") {
+    return STATEMENT_TYPE_CREATE;
+  } else if (str == "DROP") {
+    return STATEMENT_TYPE_DROP;
+  } else if (str == "PREPARE") {
+    return STATEMENT_TYPE_PREPARE;
+  } else if (str == "EXECUTE") {
+    return STATEMENT_TYPE_EXECUTE;
+  } else if (str == "RENAME") {
+    return STATEMENT_TYPE_RENAME;
+  } else if (str == "ALTER") {
+    return STATEMENT_TYPE_ALTER;
+  } else if (str == "TRANSACTION") {
+    return STATEMENT_TYPE_TRANSACTION;
+  } else if (str == "COPY") {
+    return STATEMENT_TYPE_COPY;
+  } else {
+    throw ConversionException("No conversion from string '" + str + "'");
+  }
+  return STATEMENT_TYPE_INVALID;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -192,12 +192,14 @@ std::string TypeIdToString(common::Type::TypeId type) {
       return "ARRAY";
     case common::Type::UDT:
       return "UDT";
-    default:
+    default: {
+      throw ConversionException("No string conversion for TypeId");  // FIXME
+    }
       return "INVALID";
   }
 }
 
-common::Type::TypeId StringToTypeId(std::string str) {
+common::Type::TypeId StringToTypeId(const std::string& str) {
   if (str == "INVALID") {
     return common::Type::INVALID;
   } else if (str == "PARAMETER_OFFSET") {
@@ -227,7 +229,7 @@ common::Type::TypeId StringToTypeId(std::string str) {
   } else if (str == "UDT") {
     return common::Type::UDT;
   } else {
-    throw ConversionException("No conversion from string :" + str);
+    throw ConversionException("No conversion from string '" + str + "'");
   }
   return common::Type::INVALID;
 }
@@ -263,42 +265,6 @@ bool HexDecodeToBinary(unsigned char* bufferdst, const char* hexString) {
     bufferdst[i] = static_cast<unsigned char>(result);
   }
   return true;
-}
-
-bool IsBasedOnWriteAheadLogging(const LoggingType& logging_type) {
-  bool status = false;
-
-  switch (logging_type) {
-    case LOGGING_TYPE_NVM_WAL:
-    case LOGGING_TYPE_SSD_WAL:
-    case LOGGING_TYPE_HDD_WAL:
-      status = true;
-      break;
-
-    default:
-      status = false;
-      break;
-  }
-
-  return status;
-}
-
-bool IsBasedOnWriteBehindLogging(const LoggingType& logging_type) {
-  bool status = true;
-
-  switch (logging_type) {
-    case LOGGING_TYPE_NVM_WBL:
-    case LOGGING_TYPE_SSD_WBL:
-    case LOGGING_TYPE_HDD_WBL:
-      status = true;
-      break;
-
-    default:
-      status = false;
-      break;
-  }
-
-  return status;
 }
 
 BackendType GetBackendType(const LoggingType& logging_type) {
@@ -384,6 +350,9 @@ std::string StatementTypeToString(StatementType type) {
     case STATEMENT_TYPE_UPDATE: {
       return "UPDATE";
     }
+    default: {
+      throw ConversionException("No conversion from StatementType");  // FIXME
+    }
   }
   return "NOT A KNOWN TYPE - INVALID";
 }
@@ -395,167 +364,206 @@ std::string StatementTypeToString(StatementType type) {
 std::string ExpressionTypeToString(ExpressionType type) {
   switch (type) {
     case EXPRESSION_TYPE_INVALID: {
-      return "INVALID";
+      return ("INVALID");
     }
     case EXPRESSION_TYPE_OPERATOR_PLUS: {
-      return "OPERATOR_PLUS";
+      return ("OPERATOR_PLUS");
     }
     case EXPRESSION_TYPE_OPERATOR_MINUS: {
-      return "OPERATOR_MINUS";
-    }
-    case EXPRESSION_TYPE_OPERATOR_UNARY_MINUS: {
-      return "OPERATOR_UNARY_MINUS";
-    }
-
-    case EXPRESSION_TYPE_OPERATOR_CASE_EXPR: {
-      return "OPERATOR_CASE_EXPR";
+      return ("OPERATOR_MINUS");
     }
     case EXPRESSION_TYPE_OPERATOR_MULTIPLY: {
-      return "OPERATOR_MULTIPLY";
+      return ("OPERATOR_MULTIPLY");
     }
     case EXPRESSION_TYPE_OPERATOR_DIVIDE: {
-      return "OPERATOR_DIVIDE";
+      return ("OPERATOR_DIVIDE");
     }
     case EXPRESSION_TYPE_OPERATOR_CONCAT: {
-      return "OPERATOR_CONCAT";
+      return ("OPERATOR_CONCAT");
     }
     case EXPRESSION_TYPE_OPERATOR_MOD: {
-      return "OPERATOR_MOD";
+      return ("OPERATOR_MOD");
     }
     case EXPRESSION_TYPE_OPERATOR_CAST: {
-      return "OPERATOR_CAST";
+      return ("OPERATOR_CAST");
     }
     case EXPRESSION_TYPE_OPERATOR_NOT: {
-      return "OPERATOR_NOT";
+      return ("OPERATOR_NOT");
     }
     case EXPRESSION_TYPE_OPERATOR_IS_NULL: {
-      return "OPERATOR_IS_NULL";
+      return ("OPERATOR_IS_NULL");
     }
     case EXPRESSION_TYPE_OPERATOR_EXISTS: {
-      return "OPERATOR_EXISTS";
+      return ("OPERATOR_EXISTS");
+    }
+    case EXPRESSION_TYPE_OPERATOR_UNARY_MINUS: {
+      return ("OPERATOR_UNARY_MINUS");
     }
     case EXPRESSION_TYPE_COMPARE_EQUAL: {
-      return "COMPARE_EQUAL";
+      return ("COMPARE_EQUAL");
     }
     case EXPRESSION_TYPE_COMPARE_NOTEQUAL: {
-      return "COMPARE_NOT_EQUAL";
+      return ("COMPARE_NOTEQUAL");
     }
     case EXPRESSION_TYPE_COMPARE_LESSTHAN: {
-      return "COMPARE_LESSTHAN";
+      return ("COMPARE_LESSTHAN");
     }
     case EXPRESSION_TYPE_COMPARE_GREATERTHAN: {
-      return "COMPARE_GREATERTHAN";
+      return ("COMPARE_GREATERTHAN");
     }
     case EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO: {
-      return "COMPARE_LESSTHANOREQUALTO";
+      return ("COMPARE_LESSTHANOREQUALTO");
     }
     case EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO: {
-      return "COMPARE_GREATERTHANOREQUALTO";
+      return ("COMPARE_GREATERTHANOREQUALTO");
+    }
+    case EXPRESSION_TYPE_COMPARE_LIKE: {
+      return ("COMPARE_LIKE");
+    }
+    case EXPRESSION_TYPE_COMPARE_NOTLIKE: {
+      return ("COMPARE_NOTLIKE");
+    }
+    case EXPRESSION_TYPE_COMPARE_IN: {
+      return ("COMPARE_IN");
     }
     case EXPRESSION_TYPE_CONJUNCTION_AND: {
-      return "CONJUNCTION_AND";
+      return ("CONJUNCTION_AND");
     }
     case EXPRESSION_TYPE_CONJUNCTION_OR: {
-      return "CONJUNCTION_OR";
+      return ("CONJUNCTION_OR");
     }
     case EXPRESSION_TYPE_VALUE_CONSTANT: {
-      return "VALUE_CONSTANT";
+      return ("VALUE_CONSTANT");
     }
     case EXPRESSION_TYPE_VALUE_PARAMETER: {
-      return "VALUE_PARAMETER";
+      return ("VALUE_PARAMETER");
     }
     case EXPRESSION_TYPE_VALUE_TUPLE: {
-      return "VALUE_TUPLE";
+      return ("VALUE_TUPLE");
+    }
+    case EXPRESSION_TYPE_VALUE_TUPLE_ADDRESS: {
+      return ("VALUE_TUPLE_ADDRESS");
+    }
+    case EXPRESSION_TYPE_VALUE_NULL: {
+      return ("VALUE_NULL");
+    }
+    case EXPRESSION_TYPE_VALUE_VECTOR: {
+      return ("VALUE_VECTOR");
+    }
+    case EXPRESSION_TYPE_VALUE_SCALAR: {
+      return ("VALUE_SCALAR");
     }
     case EXPRESSION_TYPE_AGGREGATE_COUNT: {
-      return "AGGREGATE_COUNT";
+      return ("AGGREGATE_COUNT");
     }
     case EXPRESSION_TYPE_AGGREGATE_COUNT_STAR: {
-      return "AGGREGATE_COUNT_STAR";
+      return ("AGGREGATE_COUNT_STAR");
     }
     case EXPRESSION_TYPE_AGGREGATE_SUM: {
-      return "AGGREGATE_SUM";
+      return ("AGGREGATE_SUM");
     }
     case EXPRESSION_TYPE_AGGREGATE_MIN: {
-      return "AGGREGATE_MIN";
+      return ("AGGREGATE_MIN");
     }
     case EXPRESSION_TYPE_AGGREGATE_MAX: {
-      return "AGGREGATE_MAX";
+      return ("AGGREGATE_MAX");
     }
     case EXPRESSION_TYPE_AGGREGATE_AVG: {
-      return "AGGREGATE_AVG";
+      return ("AGGREGATE_AVG");
     }
-    case EXPRESSION_TYPE_PLACEHOLDER: {
-      return "PLACEHOLDER";
+    case EXPRESSION_TYPE_FUNCTION: {
+      return ("FUNCTION");
     }
-    case EXPRESSION_TYPE_COLUMN_REF: {
-      return "COLUMN_REF";
+    case EXPRESSION_TYPE_HASH_RANGE: {
+      return ("HASH_RANGE");
     }
-    case EXPRESSION_TYPE_FUNCTION_REF: {
-      return "FUNCTION_REF";
+    case EXPRESSION_TYPE_OPERATOR_CASE_EXPR: {
+      return ("OPERATOR_CASE_EXPR");
     }
-    case EXPRESSION_TYPE_CAST: {
-      return "CAST";
+    case EXPRESSION_TYPE_OPERATOR_NULLIF: {
+      return ("OPERATOR_NULLIF");
     }
-    case EXPRESSION_TYPE_STAR: {
-      return "STAR";
+    case EXPRESSION_TYPE_OPERATOR_COALESCE: {
+      return ("OPERATOR_COALESCE");
+    }
+    case EXPRESSION_TYPE_ROW_SUBQUERY: {
+      return ("ROW_SUBQUERY");
+    }
+    case EXPRESSION_TYPE_SELECT_SUBQUERY: {
+      return ("SELECT_SUBQUERY");
     }
     case EXPRESSION_TYPE_SUBSTR: {
-      return "SUBSTRING";
+      return ("SUBSTR");
     }
     case EXPRESSION_TYPE_ASCII: {
-      return "ASCII";
+      return ("ASCII");
     }
     case EXPRESSION_TYPE_OCTET_LEN: {
-      return "OCTET_LENGTH";
+      return ("OCTET_LEN");
     }
     case EXPRESSION_TYPE_CHAR: {
-      return "CHAR";
+      return ("CHAR");
     }
     case EXPRESSION_TYPE_CHAR_LEN: {
-      return "CHAR_LEN";
+      return ("CHAR_LEN");
     }
     case EXPRESSION_TYPE_SPACE: {
-      return "SPACE";
+      return ("SPACE");
     }
     case EXPRESSION_TYPE_REPEAT: {
-      return "REPEAT";
+      return ("REPEAT");
     }
     case EXPRESSION_TYPE_POSITION: {
-      return "POSITION";
+      return ("POSITION");
     }
     case EXPRESSION_TYPE_LEFT: {
-      return "LEFT";
+      return ("LEFT");
     }
     case EXPRESSION_TYPE_RIGHT: {
-      return "RIGHT";
+      return ("RIGHT");
     }
     case EXPRESSION_TYPE_CONCAT: {
-      return "CONCAT";
+      return ("CONCAT");
     }
     case EXPRESSION_TYPE_LTRIM: {
-      return "L_TRIM";
+      return ("LTRIM");
     }
     case EXPRESSION_TYPE_RTRIM: {
-      return "R_TRIM";
+      return ("RTRIM");
     }
     case EXPRESSION_TYPE_BTRIM: {
-      return "B_TRIM";
+      return ("BTRIM");
     }
     case EXPRESSION_TYPE_REPLACE: {
-      return "REPLACE";
+      return ("REPLACE");
     }
     case EXPRESSION_TYPE_OVERLAY: {
-      return "OVERLAY";
+      return ("OVERLAY");
     }
     case EXPRESSION_TYPE_EXTRACT: {
-      return "EXTRACT";
+      return ("EXTRACT");
     }
     case EXPRESSION_TYPE_DATE_TO_TIMESTAMP: {
-      return "DATE_TO_TIMESTAMP";
+      return ("DATE_TO_TIMESTAMP");
     }
-    default:
-      break;
+    case EXPRESSION_TYPE_STAR: {
+      return ("STAR");
+    }
+    case EXPRESSION_TYPE_PLACEHOLDER: {
+      return ("PLACEHOLDER");
+    }
+    case EXPRESSION_TYPE_COLUMN_REF: {
+      return ("COLUMN_REF");
+    }
+    case EXPRESSION_TYPE_FUNCTION_REF: {
+      return ("FUNCTION_REF");
+    }
+    case EXPRESSION_TYPE_CAST: {
+      return ("CAST");
+    }
+    default: {
+      throw ConversionException("No conversion from ExpressionType");  // FIXME
+    } break;
   }
   return "INVALID";
 }
@@ -601,6 +609,8 @@ ExpressionType StringToExpressionType(const std::string& str) {
     return EXPRESSION_TYPE_OPERATOR_IS_NULL;
   } else if (str == "OPERATOR_EXISTS") {
     return EXPRESSION_TYPE_OPERATOR_EXISTS;
+  } else if (str == "OPERATOR_UNARY_MINUS") {
+    return EXPRESSION_TYPE_OPERATOR_UNARY_MINUS;
   } else if (str == "COMPARE_EQUAL") {
     return EXPRESSION_TYPE_COMPARE_EQUAL;
   } else if (str == "COMPARE_NOTEQUAL") {
@@ -613,6 +623,12 @@ ExpressionType StringToExpressionType(const std::string& str) {
     return EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO;
   } else if (str == "COMPARE_GREATERTHANOREQUALTO") {
     return EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO;
+  } else if (str == "COMPARE_LIKE") {
+    return EXPRESSION_TYPE_COMPARE_LIKE;
+  } else if (str == "COMPARE_NOTLIKE") {
+    return EXPRESSION_TYPE_COMPARE_NOTLIKE;
+  } else if (str == "COMPARE_IN") {
+    return EXPRESSION_TYPE_COMPARE_IN;
   } else if (str == "CONJUNCTION_AND") {
     return EXPRESSION_TYPE_CONJUNCTION_AND;
   } else if (str == "CONJUNCTION_OR") {
@@ -623,6 +639,88 @@ ExpressionType StringToExpressionType(const std::string& str) {
     return EXPRESSION_TYPE_VALUE_PARAMETER;
   } else if (str == "VALUE_TUPLE") {
     return EXPRESSION_TYPE_VALUE_TUPLE;
+  } else if (str == "VALUE_TUPLE_ADDRESS") {
+    return EXPRESSION_TYPE_VALUE_TUPLE_ADDRESS;
+  } else if (str == "VALUE_NULL") {
+    return EXPRESSION_TYPE_VALUE_NULL;
+  } else if (str == "VALUE_VECTOR") {
+    return EXPRESSION_TYPE_VALUE_VECTOR;
+  } else if (str == "VALUE_SCALAR") {
+    return EXPRESSION_TYPE_VALUE_SCALAR;
+  } else if (str == "AGGREGATE_COUNT") {
+    return EXPRESSION_TYPE_AGGREGATE_COUNT;
+  } else if (str == "AGGREGATE_COUNT_STAR") {
+    return EXPRESSION_TYPE_AGGREGATE_COUNT_STAR;
+  } else if (str == "AGGREGATE_SUM") {
+    return EXPRESSION_TYPE_AGGREGATE_SUM;
+  } else if (str == "AGGREGATE_MIN") {
+    return EXPRESSION_TYPE_AGGREGATE_MIN;
+  } else if (str == "AGGREGATE_MAX") {
+    return EXPRESSION_TYPE_AGGREGATE_MAX;
+  } else if (str == "AGGREGATE_AVG") {
+    return EXPRESSION_TYPE_AGGREGATE_AVG;
+  } else if (str == "FUNCTION") {
+    return EXPRESSION_TYPE_FUNCTION;
+  } else if (str == "HASH_RANGE") {
+    return EXPRESSION_TYPE_HASH_RANGE;
+  } else if (str == "OPERATOR_CASE_EXPR") {
+    return EXPRESSION_TYPE_OPERATOR_CASE_EXPR;
+  } else if (str == "OPERATOR_NULLIF") {
+    return EXPRESSION_TYPE_OPERATOR_NULLIF;
+  } else if (str == "OPERATOR_COALESCE") {
+    return EXPRESSION_TYPE_OPERATOR_COALESCE;
+  } else if (str == "ROW_SUBQUERY") {
+    return EXPRESSION_TYPE_ROW_SUBQUERY;
+  } else if (str == "SELECT_SUBQUERY") {
+    return EXPRESSION_TYPE_SELECT_SUBQUERY;
+  } else if (str == "SUBSTR") {
+    return EXPRESSION_TYPE_SUBSTR;
+  } else if (str == "ASCII") {
+    return EXPRESSION_TYPE_ASCII;
+  } else if (str == "OCTET_LEN") {
+    return EXPRESSION_TYPE_OCTET_LEN;
+  } else if (str == "CHAR") {
+    return EXPRESSION_TYPE_CHAR;
+  } else if (str == "CHAR_LEN") {
+    return EXPRESSION_TYPE_CHAR_LEN;
+  } else if (str == "SPACE") {
+    return EXPRESSION_TYPE_SPACE;
+  } else if (str == "REPEAT") {
+    return EXPRESSION_TYPE_REPEAT;
+  } else if (str == "POSITION") {
+    return EXPRESSION_TYPE_POSITION;
+  } else if (str == "LEFT") {
+    return EXPRESSION_TYPE_LEFT;
+  } else if (str == "RIGHT") {
+    return EXPRESSION_TYPE_RIGHT;
+  } else if (str == "CONCAT") {
+    return EXPRESSION_TYPE_CONCAT;
+  } else if (str == "LTRIM") {
+    return EXPRESSION_TYPE_LTRIM;
+  } else if (str == "RTRIM") {
+    return EXPRESSION_TYPE_RTRIM;
+  } else if (str == "BTRIM") {
+    return EXPRESSION_TYPE_BTRIM;
+  } else if (str == "REPLACE") {
+    return EXPRESSION_TYPE_REPLACE;
+  } else if (str == "OVERLAY") {
+    return EXPRESSION_TYPE_OVERLAY;
+  } else if (str == "EXTRACT") {
+    return EXPRESSION_TYPE_EXTRACT;
+  } else if (str == "DATE_TO_TIMESTAMP") {
+    return EXPRESSION_TYPE_DATE_TO_TIMESTAMP;
+  } else if (str == "STAR") {
+    return EXPRESSION_TYPE_STAR;
+  } else if (str == "PLACEHOLDER") {
+    return EXPRESSION_TYPE_PLACEHOLDER;
+  } else if (str == "COLUMN_REF") {
+    return EXPRESSION_TYPE_COLUMN_REF;
+  } else if (str == "FUNCTION_REF") {
+    return EXPRESSION_TYPE_FUNCTION_REF;
+  } else if (str == "CAST") {
+    return EXPRESSION_TYPE_CAST;
+  } else {
+    throw ConversionException("No conversion from string '" + str + "'");
   }
   return EXPRESSION_TYPE_INVALID;
 }
@@ -658,6 +756,8 @@ IndexType StringToIndexType(const std::string& str) {
     return INDEX_TYPE_BWTREE;
   } else if (str == "HASH") {
     return INDEX_TYPE_HASH;
+  } else {
+    throw ConversionException("No conversion from string '" + str + "'");
   }
   return INDEX_TYPE_INVALID;
 }
@@ -693,6 +793,8 @@ IndexConstraintType StringToIndexConstraintType(const std::string& str) {
     return INDEX_CONSTRAINT_TYPE_PRIMARY_KEY;
   } else if (str == "UNIQUE") {
     return INDEX_CONSTRAINT_TYPE_UNIQUE;
+  } else {
+    throw ConversionException("No conversion from string :" + str);
   }
   return INDEX_CONSTRAINT_TYPE_INVALID;
 }
@@ -835,6 +937,8 @@ PlanNodeType StringToPlanNodeType(const std::string& str) {
     return PLAN_NODE_TYPE_LIMIT;
   } else if (str == "DISTINCT") {
     return PLAN_NODE_TYPE_DISTINCT;
+  } else {
+    throw ConversionException("No conversion from string :" + str);
   }
   return PLAN_NODE_TYPE_INVALID;
 }
@@ -915,6 +1019,8 @@ ParseNodeType StringToParseNodeType(const std::string& str) {
     return PARSE_NODE_TYPE_TABLE;
   } else if (str == "MOCK") {
     return PARSE_NODE_TYPE_MOCK;
+  } else {
+    throw ConversionException("No conversion from string :" + str);
   }
   return PARSE_NODE_TYPE_INVALID;
 }

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -12,16 +12,17 @@
 
 #pragma once
 
-#include <iostream>
+#include <cxxabi.h>
+#include <errno.h>
+#include <execinfo.h>
+#include <signal.h>
 #include <cstdio>
 #include <cstdlib>
-#include <stdexcept>
-#include <execinfo.h>
-#include <errno.h>
-#include <cxxabi.h>
-#include <signal.h>
+#include <iostream>
 #include <memory>
+#include <stdexcept>
 
+#include "common/type.h"
 #include "common/types.h"
 
 namespace peloton {
@@ -86,7 +87,7 @@ class Exception : public std::runtime_error {
       case EXCEPTION_TYPE_MISMATCH_TYPE:
         return "Mismatch Type";
       case EXCEPTION_TYPE_DIVIDE_BY_ZERO:
-        return "Divede by Zero";
+        return "Divide by Zero";
       case EXCEPTION_TYPE_OBJECT_SIZE:
         return "Object Size";
       case EXCEPTION_TYPE_INCOMPATIBLE_TYPE:
@@ -204,33 +205,36 @@ class CastException : public Exception {
   CastException() = delete;
 
  public:
-  CastException(const ValueType origType, const ValueType newType)
+  CastException(const common::Type::TypeId origType,
+                const common::Type::TypeId newType)
       : Exception(EXCEPTION_TYPE_CONVERSION,
-                  "Type " + ValueTypeToString(origType) + " can't be cast as " +
-                      ValueTypeToString(newType)) {}
+                  "Type " + TypeIdToString(origType) + " can't be cast as " +
+                      TypeIdToString(newType)) {}
 };
 
 class ValueOutOfRangeException : public Exception {
   ValueOutOfRangeException() = delete;
 
  public:
-  ValueOutOfRangeException(const int64_t value, const ValueType origType,
-                           const ValueType newType)
+  ValueOutOfRangeException(const int64_t value,
+                           const common::Type::TypeId origType,
+                           const common::Type::TypeId newType)
       : Exception(EXCEPTION_TYPE_CONVERSION,
-                  "Type " + ValueTypeToString(origType) + " with value " +
+                  "Type " + TypeIdToString(origType) + " with value " +
                       std::to_string((intmax_t)value) +
                       " can't be cast as %s because the value is out of range "
                       "for the destination type " +
-                      ValueTypeToString(newType)) {}
+                      TypeIdToString(newType)) {}
 
-  ValueOutOfRangeException(const double value, const ValueType origType,
-                           const ValueType newType)
+  ValueOutOfRangeException(const double value,
+                           const common::Type::TypeId origType,
+                           const common::Type::TypeId newType)
       : Exception(EXCEPTION_TYPE_CONVERSION,
-                  "Type " + ValueTypeToString(origType) + " with value " +
+                  "Type " + TypeIdToString(origType) + " with value " +
                       std::to_string(value) +
                       " can't be cast as %s because the value is out of range "
                       "for the destination type " +
-                      ValueTypeToString(newType)) {}
+                      TypeIdToString(newType)) {}
 };
 
 class ConversionException : public Exception {
@@ -261,12 +265,11 @@ class TypeMismatchException : public Exception {
   TypeMismatchException() = delete;
 
  public:
-  TypeMismatchException(std::string msg, const ValueType type_1,
-                        const ValueType type_2)
+  TypeMismatchException(std::string msg, const common::Type::TypeId type_1,
+                        const common::Type::TypeId type_2)
       : Exception(EXCEPTION_TYPE_MISMATCH_TYPE,
-                  "Type " + ValueTypeToString(type_1) +
-                      " does not match with " + ValueTypeToString(type_2) +
-                      msg) {}
+                  "Type " + TypeIdToString(type_1) + " does not match with " +
+                      TypeIdToString(type_2) + msg) {}
 };
 
 class NumericValueOutOfRangeException : public Exception {
@@ -303,9 +306,10 @@ class IncompatibleTypeException : public Exception {
 
  public:
   IncompatibleTypeException(int type, std::string msg)
-      : Exception(
-            EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
-            "Incompatible type " + ValueTypeToString((ValueType)type) + msg) {}
+      : Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                  "Incompatible type " +
+                      TypeIdToString(static_cast<common::Type::TypeId>(type)) +
+                      msg) {}
 };
 
 class SerializationException : public Exception {

--- a/src/include/common/types.h
+++ b/src/include/common/types.h
@@ -24,6 +24,11 @@
 #include "common/config.h"
 #include "common/type.h"
 
+namespace peloton {
+
+// forward declare
+// class Value;
+
 //===--------------------------------------------------------------------===//
 // GUC Variables
 //===--------------------------------------------------------------------===//
@@ -79,57 +84,8 @@ enum GarbageCollectionType {
 };
 
 //===--------------------------------------------------------------------===//
-// Filesystem directories
-//===--------------------------------------------------------------------===//
-
-#define NVM_DIR "/mnt/pmfs/"
-#define HDD_DIR "/data/"
-#define SSD_DIR "/data1/"
-
-#define TMP_DIR "/tmp/"
-
-namespace peloton {
-
-// forward declare
-// class Value;
-
-//===--------------------------------------------------------------------===//
 // NULL-related Constants
 //===--------------------------------------------------------------------===//
-/*
-// We use these values for NULL to make it compact and fast
-// "-1" is a hack to shut up gcc warning
-
-/// NULL
-#define INT8_NULL INT8_MIN
-#define INT16_NULL INT16_MIN
-#define INT32_NULL INT32_MIN
-#define INT64_NULL INT64_MIN
-
-/// Minimum value user can represent that is not NULL
-#define PELOTON_INT8_MIN INT8_NULL + 1
-#define PELOTON_INT16_MIN INT16_NULL + 1
-#define PELOTON_INT32_MIN INT32_NULL + 1
-#define PELOTON_INT64_MIN INT64_NULL + 1
-
-#define DECIMAL_MIN -9999999
-#define DECIMAL_MAX 9999999
-
-#define PELOTON_INT8_MAX -(INT8_NULL + 1)
-#define PELOTON_INT16_MAX -(INT16_NULL + 1)
-#define PELOTON_INT32_MAX -(INT32_NULL + 1)
-#define PELOTON_INT64_MAX -(INT64_NULL + 1)
-
-/// Float/Double less than these values are NULL
-#define FLOAT_NULL -3.4e+38f
-#define DOUBLE_NULL -1.7E+308
-
-// Values to be substituted as NULL
-#define FLOAT_MIN -3.40282347e+38f
-#define DOUBLE_MIN -1.7976931348623157E+308
-*/
-// Objects (i.e., VARCHAR) with length prefix of -1 are NULL
-#define OBJECTLENGTH_NULL -1
 
 #define VALUE_COMPARE_LESSTHAN -1
 #define VALUE_COMPARE_EQUAL 0
@@ -208,53 +164,7 @@ enum ValueType {
 //===--------------------------------------------------------------------===//
 // Predicate Expression Operation Types
 //===--------------------------------------------------------------------===//
-/*
-enum ExpressionType {
-  EXPRESSION_TYPE_INVALID = 0,
 
-  // TODO: Add the expression types that you implemented
-
-
-  // -----------------------------
-  // String operators
-  // -----------------------------
-  EXPRESSION_TYPE_SUBSTR = 500,
-  EXPRESSION_TYPE_ASCII = 501,
-  EXPRESSION_TYPE_OCTET_LEN = 502,
-  EXPRESSION_TYPE_CHAR = 503,
-  EXPRESSION_TYPE_CHAR_LEN = 504,
-  EXPRESSION_TYPE_SPACE = 505,
-  EXPRESSION_TYPE_REPEAT = 506,
-  EXPRESSION_TYPE_POSITION = 507,
-  EXPRESSION_TYPE_LEFT = 508,
-  EXPRESSION_TYPE_RIGHT = 509,
-  EXPRESSION_TYPE_CONCAT = 510,
-  EXPRESSION_TYPE_LTRIM = 511,
-  EXPRESSION_TYPE_RTRIM = 512,
-  EXPRESSION_TYPE_BTRIM = 513,
-  EXPRESSION_TYPE_REPLACE = 514,
-  EXPRESSION_TYPE_OVERLAY = 515,
-
-  // -----------------------------
-  // Date operators
-  // -----------------------------
-  EXPRESSION_TYPE_EXTRACT = 600,
-  EXPRESSION_TYPE_DATE_TO_TIMESTAMP = 601,
-
-  // -----------------------------
-  // Parser
-  // -----------------------------
-  EXPRESSION_TYPE_STAR = 700,
-  EXPRESSION_TYPE_PLACEHOLDER = 701,
-  EXPRESSION_TYPE_COLUMN_REF = 702,
-  EXPRESSION_TYPE_FUNCTION_REF = 703,
-
-  // -----------------------------
-  // Misc
-  // -----------------------------
-  EXPRESSION_TYPE_CAST = 900
-};
-*/
 enum ExpressionType {
   EXPRESSION_TYPE_INVALID = 0,
 
@@ -330,9 +240,6 @@ enum ExpressionType {
   EXPRESSION_TYPE_AGGREGATE_MIN = 43,
   EXPRESSION_TYPE_AGGREGATE_MAX = 44,
   EXPRESSION_TYPE_AGGREGATE_AVG = 45,
-  EXPRESSION_TYPE_AGGREGATE_APPROX_COUNT_DISTINCT = 46,
-  EXPRESSION_TYPE_AGGREGATE_VALS_TO_HYPERLOGLOG = 47,
-  EXPRESSION_TYPE_AGGREGATE_HYPERLOGLOGS_TO_CARD = 48,
 
   // -----------------------------
   // Functions
@@ -1060,10 +967,6 @@ bool IsIntegralType(ValueType type);
 int64_t GetMaxTypeValue(ValueType type);
 
 bool HexDecodeToBinary(unsigned char *bufferdst, const char *hexString);
-
-bool IsBasedOnWriteAheadLogging(const LoggingType &logging_type);
-
-bool IsBasedOnWriteBehindLogging(const LoggingType &logging_type);
 
 BackendType GetBackendType(const LoggingType &logging_type);
 

--- a/src/include/common/types.h
+++ b/src/include/common/types.h
@@ -33,50 +33,6 @@ namespace peloton {
 // GUC Variables
 //===--------------------------------------------------------------------===//
 
-// Logging type
-// LOGGING_TYPE_AAA_BBB
-// Data stored in AAA
-// Log stored in BBB
-enum LoggingType {
-  LOGGING_TYPE_INVALID = 0,
-
-  // Based on write behind logging
-  LOGGING_TYPE_NVM_WBL = 1,
-  LOGGING_TYPE_SSD_WBL = 2,
-  LOGGING_TYPE_HDD_WBL = 3,
-
-  // Based on write ahead logging
-  LOGGING_TYPE_NVM_WAL = 4,
-  LOGGING_TYPE_SSD_WAL = 5,
-  LOGGING_TYPE_HDD_WAL = 6,
-};
-
-/* Possible values for peloton_tilegroup_layout GUC */
-typedef enum LayoutType {
-  LAYOUT_TYPE_INVALID = 0,
-  LAYOUT_TYPE_ROW = 1,    /* Pure row layout */
-  LAYOUT_TYPE_COLUMN = 2, /* Pure column layout */
-  LAYOUT_TYPE_HYBRID = 3  /* Hybrid layout */
-} LayoutType;
-
-enum LoggerMappingStrategyType {
-  LOGGER_MAPPING_TYPE_INVALID = 0,
-  LOGGER_MAPPING_TYPE_ROUND_ROBIN = 1,
-  LOGGER_MAPPING_TYPE_AFFINITY = 2,
-  LOGGER_MAPPING_TYPE_MANUAL = 3
-};
-
-enum CheckpointType {
-  CHECKPOINT_TYPE_INVALID = 0,
-  CHECKPOINT_TYPE_NORMAL = 1,
-};
-
-enum ReplicationType {
-  ASYNC_REPLICATION,
-  SYNC_REPLICATION,
-  SEMISYNC_REPLICATION
-};
-
 enum GarbageCollectionType {
   GARBAGE_COLLECTION_TYPE_INVALID = 0,
   GARBAGE_COLLECTION_TYPE_OFF = 1,  // turn off GC
@@ -689,8 +645,51 @@ enum SetOpType {
 };
 
 //===--------------------------------------------------------------------===//
-// Log Types
+// Logging + Recovery Types
 //===--------------------------------------------------------------------===//
+
+// LOGGING_TYPE_AAA_BBB
+// Data stored in AAA
+// Log stored in BBB
+enum LoggingType {
+  LOGGING_TYPE_INVALID = 0,
+
+  // Based on write behind logging
+  LOGGING_TYPE_NVM_WBL = 1,
+  LOGGING_TYPE_SSD_WBL = 2,
+  LOGGING_TYPE_HDD_WBL = 3,
+
+  // Based on write ahead logging
+  LOGGING_TYPE_NVM_WAL = 4,
+  LOGGING_TYPE_SSD_WAL = 5,
+  LOGGING_TYPE_HDD_WAL = 6,
+};
+
+/* Possible values for peloton_tilegroup_layout GUC */
+typedef enum LayoutType {
+  LAYOUT_TYPE_INVALID = 0,
+  LAYOUT_TYPE_ROW = 1,    /* Pure row layout */
+  LAYOUT_TYPE_COLUMN = 2, /* Pure column layout */
+  LAYOUT_TYPE_HYBRID = 3  /* Hybrid layout */
+} LayoutType;
+
+enum LoggerMappingStrategyType {
+  LOGGER_MAPPING_TYPE_INVALID = 0,
+  LOGGER_MAPPING_TYPE_ROUND_ROBIN = 1,
+  LOGGER_MAPPING_TYPE_AFFINITY = 2,
+  LOGGER_MAPPING_TYPE_MANUAL = 3
+};
+
+enum CheckpointType {
+  CHECKPOINT_TYPE_INVALID = 0,
+  CHECKPOINT_TYPE_NORMAL = 1,
+};
+
+enum ReplicationType {
+  ASYNC_REPLICATION,
+  SYNC_REPLICATION,
+  SEMISYNC_REPLICATION
+};
 
 enum LoggingStatus {
   LOGGING_STATUS_TYPE_INVALID = 0,
@@ -744,6 +743,10 @@ enum CheckpointStatus {
   CHECKPOINT_STATUS_DONE_RECOVERY = 3,
   CHECKPOINT_STATUS_CHECKPOINTING = 4,
 };
+
+//===--------------------------------------------------------------------===//
+// Statistics Types
+//===--------------------------------------------------------------------===//
 
 // Statistics Collection Type
 // Disable or enable
@@ -979,16 +982,12 @@ BackendType StringToBackendType(const std::string &str);
 
 std::string TypeIdToString(common::Type::TypeId type);
 common::Type::TypeId StringToTypeId(const std::string &str);
-std::string ValueTypeToString(ValueType type);
-ValueType StringToValueType(const std::string &str);
-ValueType PostgresStringToValueType(std::string str);
 
 std::string StatementTypeToString(StatementType type);
 StatementType StringToStatementType(const std::string &str);
 
 std::string ExpressionTypeToString(ExpressionType type);
 ExpressionType StringToExpressionType(const std::string &str);
-
 ExpressionType ParserExpressionNameToExpressionType(const std::string &str);
 
 std::string IndexTypeToString(IndexType type);
@@ -1005,6 +1004,7 @@ ConstraintType StringToConstraintType(const std::string &str);
 
 std::string LoggingTypeToString(LoggingType type);
 std::string LoggingStatusToString(LoggingStatus type);
+
 std::string LoggerTypeToString(LoggerType type);
 std::string LogRecordTypeToString(LogRecordType type);
 

--- a/src/include/common/types.h
+++ b/src/include/common/types.h
@@ -113,10 +113,6 @@ enum PostgresValueType {
   POSTGRES_VALUE_TYPE_DECIMAL = 1700
 };
 
-enum ValueType {
-  // TODO
-};
-
 //===--------------------------------------------------------------------===//
 // Predicate Expression Operation Types
 //===--------------------------------------------------------------------===//
@@ -957,17 +953,6 @@ extern FileHandle INVALID_FILE_HANDLE;
 //===--------------------------------------------------------------------===//
 // Utilities
 //===--------------------------------------------------------------------===//
-
-/// Works only for fixed-length types
-std::size_t GetTypeSize(ValueType type);
-
-bool IsNumeric(ValueType type);
-bool IsIntegralType(ValueType type);
-
-// for testing, obtain a random instance of the specified type
-// Value GetRandomValue(ValueType type);
-
-int64_t GetMaxTypeValue(ValueType type);
 
 bool HexDecodeToBinary(unsigned char *bufferdst, const char *hexString);
 

--- a/src/include/common/types.h
+++ b/src/include/common/types.h
@@ -968,8 +968,6 @@ int64_t GetMaxTypeValue(ValueType type);
 
 bool HexDecodeToBinary(unsigned char *bufferdst, const char *hexString);
 
-BackendType GetBackendType(const LoggingType &logging_type);
-
 bool AtomicUpdateItemPointer(ItemPointer *src_ptr, const ItemPointer &value);
 
 //===--------------------------------------------------------------------===//
@@ -986,6 +984,7 @@ ValueType StringToValueType(const std::string &str);
 ValueType PostgresStringToValueType(std::string str);
 
 std::string StatementTypeToString(StatementType type);
+StatementType StringToStatementType(const std::string &str);
 
 std::string ExpressionTypeToString(ExpressionType type);
 ExpressionType StringToExpressionType(const std::string &str);

--- a/src/include/common/value.h
+++ b/src/include/common/value.h
@@ -58,6 +58,9 @@ static const int8_t PELOTON_BOOLEAN_NULL = SCHAR_MIN;
 
 static const uint32_t PELOTON_VARCHAR_MAX_LEN = UINT_MAX;
 
+// Objects (i.e., VARCHAR) with length prefix of -1 are NULL
+#define OBJECTLENGTH_NULL -1
+
 // A value is an abstract class that represents a view over SQL data stored in
 // some materialized state. All values have a type and comparison functions, but
 // subclasses implement other type-specific functionality.

--- a/src/include/expression/expression_util.h
+++ b/src/include/expression/expression_util.h
@@ -166,9 +166,6 @@ class ExpressionUtil {
       case EXPRESSION_TYPE_AGGREGATE_MIN:
       case EXPRESSION_TYPE_AGGREGATE_MAX:
       case EXPRESSION_TYPE_AGGREGATE_AVG:
-      case EXPRESSION_TYPE_AGGREGATE_APPROX_COUNT_DISTINCT:
-      case EXPRESSION_TYPE_AGGREGATE_VALS_TO_HYPERLOGLOG:
-      case EXPRESSION_TYPE_AGGREGATE_HYPERLOGLOGS_TO_CARD:
         return true;
       default:
         return false;
@@ -269,7 +266,7 @@ class ExpressionUtil {
   //		  // TODO: Get the table + column name and grab the
   //		  // the handle from schema object!
   //		  const TupleValueExpression t_expr = dynamic_cast<const
-  //TupleValueExpression*>(expr);
+  // TupleValueExpression*>(expr);
   //		  // catalog->Get
   //
   //	  }

--- a/src/include/logging/checkpoint_manager.h
+++ b/src/include/logging/checkpoint_manager.h
@@ -10,17 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
-#include <vector>
-#include <memory>
 #include <condition_variable>
+#include <memory>
+#include <vector>
 
-#include "logging/checkpoint.h"
 #include "common/logger.h"
+#include "logging/checkpoint.h"
 
-extern CheckpointType peloton_checkpoint_mode;
+extern peloton::CheckpointType peloton_checkpoint_mode;
 
 namespace peloton {
 namespace logging {

--- a/src/include/logging/log_manager.h
+++ b/src/include/logging/log_manager.h
@@ -10,25 +10,24 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
-#include <mutex>
 #include <map>
+#include <mutex>
 #include <vector>
 
-#include "logging/logger.h"
 #include "backend_logger.h"
-#include "frontend_logger.h"
 #include "concurrency/transaction.h"
+#include "frontend_logger.h"
 #include "loggers/wal_frontend_logger.h"
+#include "logging/logger.h"
 
 #define DEFAULT_NUM_FRONTEND_LOGGERS 1
 
 //===--------------------------------------------------------------------===//
 // GUC Variables
 //===--------------------------------------------------------------------===//
-extern LoggingType peloton_logging_mode;
+extern peloton::LoggingType peloton_logging_mode;
 
 namespace peloton {
 namespace logging {
@@ -259,7 +258,8 @@ class LogManager {
   unsigned int num_frontend_loggers_ = DEFAULT_NUM_FRONTEND_LOGGERS;
 
   // set the strategy for mapping frontend loggers to worker threads
-  LoggerMappingStrategyType logger_mapping_strategy_ = LOGGER_MAPPING_TYPE_INVALID;
+  LoggerMappingStrategyType logger_mapping_strategy_ =
+      LOGGER_MAPPING_TYPE_INVALID;
 
   // default log file size
   size_t log_file_size_limit_ = LOG_FILE_LEN;

--- a/src/include/logging/logging_util.h
+++ b/src/include/logging/logging_util.h
@@ -27,6 +27,8 @@ namespace logging {
 
 class LoggingUtil {
  public:
+  static BackendType GetBackendType(const LoggingType &logging_type);
+
   static bool IsBasedOnWriteAheadLogging(const LoggingType &logging_type);
 
   static bool IsBasedOnWriteBehindLogging(const LoggingType &logging_type);

--- a/src/include/logging/logging_util.h
+++ b/src/include/logging/logging_util.h
@@ -10,11 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
-#include "common/types.h"
 #include "common/logger.h"
+#include "common/types.h"
 #include "logging/records/transaction_record.h"
 #include "logging/records/tuple_record.h"
 #include "storage/data_table.h"
@@ -28,6 +27,10 @@ namespace logging {
 
 class LoggingUtil {
  public:
+  static bool IsBasedOnWriteAheadLogging(const LoggingType &logging_type);
+
+  static bool IsBasedOnWriteBehindLogging(const LoggingType &logging_type);
+
   static void FFlushFsync(FileHandle &file_handle);
 
   static bool InitFileHandle(const char *name, FileHandle &file_handle,

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -12,23 +12,23 @@
 
 #pragma once
 
-#include <memory>
-#include <queue>
 #include <map>
+#include <memory>
 #include <mutex>
+#include <queue>
 #include <set>
 
 #include "common/platform.h"
-#include "storage/abstract_table.h"
 #include "container/lock_free_array.h"
 #include "index/index.h"
+#include "storage/abstract_table.h"
 #include "storage/indirection_array.h"
 
 //===--------------------------------------------------------------------===//
 // GUC Variables
 //===--------------------------------------------------------------------===//
 
-extern LayoutType peloton_layout_mode;
+extern peloton::LayoutType peloton_layout_mode;
 
 //===--------------------------------------------------------------------===//
 // Configuration Variables

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -10,16 +10,26 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include <mutex>
 
-#include "common/types.h"
 #include "common/platform.h"
+#include "common/types.h"
 
 namespace peloton {
 namespace storage {
+
+//===--------------------------------------------------------------------===//
+// Filesystem directories
+//===--------------------------------------------------------------------===//
+
+// TODO: These should be moved into a configuration file"
+#define NVM_DIR "/mnt/pmfs/"
+#define HDD_DIR "/data/"
+#define SSD_DIR "/data1/"
+
+#define TMP_DIR "/tmp/"
 
 //===--------------------------------------------------------------------===//
 // Storage Manager

--- a/src/logging/backend_logger.cpp
+++ b/src/logging/backend_logger.cpp
@@ -17,7 +17,6 @@
 #include "logging/loggers/wal_backend_logger.h"
 #include "logging/loggers/wbl_backend_logger.h"
 #include "logging/logging_util.h"
-#include "logging/logging_util.h"
 
 namespace peloton {
 namespace logging {

--- a/src/logging/backend_logger.cpp
+++ b/src/logging/backend_logger.cpp
@@ -10,13 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-#include "common/logger.h"
 #include "logging/backend_logger.h"
+#include "common/logger.h"
+#include "logging/log_manager.h"
+#include "logging/log_record.h"
 #include "logging/loggers/wal_backend_logger.h"
 #include "logging/loggers/wbl_backend_logger.h"
-#include "logging/log_record.h"
-#include "logging/log_manager.h"
+#include "logging/logging_util.h"
+#include "logging/logging_util.h"
 
 namespace peloton {
 namespace logging {
@@ -50,9 +51,9 @@ BackendLogger::~BackendLogger() {
 BackendLogger *BackendLogger::GetBackendLogger(LoggingType logging_type) {
   BackendLogger *backend_logger = nullptr;
 
-  if (IsBasedOnWriteAheadLogging(logging_type) == true) {
+  if (LoggingUtil::IsBasedOnWriteAheadLogging(logging_type) == true) {
     backend_logger = new WriteAheadBackendLogger();
-  } else if (IsBasedOnWriteBehindLogging(logging_type) == true) {
+  } else if (LoggingUtil::IsBasedOnWriteBehindLogging(logging_type) == true) {
     backend_logger = new WriteBehindBackendLogger();
   } else {
     LOG_ERROR("Unsupported logging type");

--- a/src/logging/frontend_logger.cpp
+++ b/src/logging/frontend_logger.cpp
@@ -10,16 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include <thread>
 
 #include "common/logger.h"
-#include "logging/log_manager.h"
+#include "logging/checkpoint.h"
 #include "logging/checkpoint_manager.h"
 #include "logging/frontend_logger.h"
-#include "logging/checkpoint.h"
+#include "logging/log_manager.h"
 #include "logging/loggers/wal_frontend_logger.h"
 #include "logging/loggers/wbl_frontend_logger.h"
+#include "logging/logging_util.h"
 
 // TODO peloton_wait_timeout is always 0
 // configuration for testing
@@ -29,7 +29,6 @@ namespace peloton {
 namespace logging {
 
 FrontendLogger::FrontendLogger() {
-
   logger_type = LOGGER_TYPE_FRONTEND;
 
   // Set wait timeout
@@ -54,9 +53,9 @@ FrontendLogger *FrontendLogger::GetFrontendLogger(LoggingType logging_type,
   FrontendLogger *frontend_logger = nullptr;
 
   LOG_TRACE("Logging_type is %d", (int)logging_type);
-  if (IsBasedOnWriteAheadLogging(logging_type) == true) {
+  if (LoggingUtil::IsBasedOnWriteAheadLogging(logging_type) == true) {
     frontend_logger = new WriteAheadFrontendLogger(test_mode);
-  } else if (IsBasedOnWriteBehindLogging(logging_type) == true) {
+  } else if (LoggingUtil::IsBasedOnWriteBehindLogging(logging_type) == true) {
     frontend_logger = new WriteBehindFrontendLogger();
   } else {
     LOG_ERROR("Unsupported logging type");

--- a/src/logging/logging_util.cpp
+++ b/src/logging/logging_util.cpp
@@ -10,11 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <sys/stat.h>
 #include <dirent.h>
+#include <sys/stat.h>
 #include <cstring>
 
 #include "catalog/catalog.h"
+#include "common/types.h"
 #include "logging/logging_util.h"
 #include "storage/database.h"
 
@@ -24,6 +25,44 @@ namespace logging {
 //===--------------------------------------------------------------------===//
 // LoggingUtil
 //===--------------------------------------------------------------------===//
+
+bool LoggingUtil::IsBasedOnWriteAheadLogging(
+    const peloton::LoggingType &logging_type) {
+  bool status = false;
+
+  switch (logging_type) {
+    case LOGGING_TYPE_NVM_WAL:
+    case LOGGING_TYPE_SSD_WAL:
+    case LOGGING_TYPE_HDD_WAL:
+      status = true;
+      break;
+
+    default:
+      status = false;
+      break;
+  }
+
+  return status;
+}
+
+bool LoggingUtil::IsBasedOnWriteBehindLogging(const LoggingType &logging_type) {
+  bool status = true;
+
+  switch (logging_type) {
+    case LOGGING_TYPE_NVM_WBL:
+    case LOGGING_TYPE_SSD_WBL:
+    case LOGGING_TYPE_HDD_WBL:
+      status = true;
+      break;
+
+    default:
+      status = false;
+      break;
+  }
+
+  return status;
+}
+
 void LoggingUtil::FFlushFsync(FileHandle &file_handle) {
   // First, flush
   PL_ASSERT(file_handle.fd != -1);

--- a/src/logging/logging_util.cpp
+++ b/src/logging/logging_util.cpp
@@ -26,6 +26,36 @@ namespace logging {
 // LoggingUtil
 //===--------------------------------------------------------------------===//
 
+BackendType LoggingUtil::GetBackendType(const LoggingType &logging_type) {
+  // Default backend type
+  BackendType backend_type = BACKEND_TYPE_MM;
+
+  switch (logging_type) {
+    case LOGGING_TYPE_NVM_WBL:
+      backend_type = BACKEND_TYPE_NVM;
+      break;
+
+    case LOGGING_TYPE_SSD_WBL:
+      backend_type = BACKEND_TYPE_SSD;
+      break;
+
+    case LOGGING_TYPE_HDD_WBL:
+      backend_type = BACKEND_TYPE_HDD;
+      break;
+
+    case LOGGING_TYPE_NVM_WAL:
+    case LOGGING_TYPE_SSD_WAL:
+    case LOGGING_TYPE_HDD_WAL:
+      backend_type = BACKEND_TYPE_MM;
+      break;
+
+    default:
+      break;
+  }
+
+  return backend_type;
+}
+
 bool LoggingUtil::IsBasedOnWriteAheadLogging(
     const peloton::LoggingType &logging_type) {
   bool status = false;

--- a/src/main/logger/logger.cpp
+++ b/src/main/logger/logger.cpp
@@ -10,16 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <thread>
 
-#include "common/logger.h"
 #include "benchmark/logger/logger_configuration.h"
 #include "benchmark/logger/logger_workload.h"
-#include "benchmark/ycsb/ycsb_configuration.h"
 #include "benchmark/tpcc/tpcc_configuration.h"
+#include "benchmark/ycsb/ycsb_configuration.h"
+#include "common/logger.h"
 
 // Logging mode
 extern LoggingType peloton_logging_mode;
@@ -66,7 +65,7 @@ void RunBenchmark() {
   //===--------------------------------------------------------------------===//
   // WAL
   //===--------------------------------------------------------------------===//
-  if (IsBasedOnWriteAheadLogging(peloton_logging_mode)) {
+  if (LoggingUtil::IsBasedOnWriteAheadLogging(peloton_logging_mode)) {
     // Prepare a simple log file
     PrepareLogFile();
 
@@ -76,7 +75,7 @@ void RunBenchmark() {
   //===--------------------------------------------------------------------===//
   // WBL
   //===--------------------------------------------------------------------===//
-  else if (IsBasedOnWriteBehindLogging(peloton_logging_mode)) {
+  else if (LoggingUtil::IsBasedOnWriteBehindLogging(peloton_logging_mode)) {
     LOG_ERROR("currently, we do not support write behind logging.");
     PL_ASSERT(false);
     // Test a simple log process

--- a/src/storage/tile_group_factory.cpp
+++ b/src/storage/tile_group_factory.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "storage/tile_group_factory.h"
+#include "logging/logging_util.h"
 #include "storage/tile_group_header.h"
 
 //===--------------------------------------------------------------------===//
@@ -28,7 +29,8 @@ TileGroup *TileGroupFactory::GetTileGroup(
     AbstractTable *table, const std::vector<catalog::Schema> &schemas,
     const column_map_type &column_map, int tuple_count) {
   // Allocate the data on appropriate backend
-  BackendType backend_type = GetBackendType(peloton_logging_mode);
+  BackendType backend_type =
+      logging::LoggingUtil::GetBackendType(peloton_logging_mode);
 
   TileGroupHeader *tile_header = new TileGroupHeader(backend_type, tuple_count);
   TileGroup *tile_group = new TileGroup(backend_type, tile_header, table,

--- a/src/storage/tile_group_factory.cpp
+++ b/src/storage/tile_group_factory.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "storage/tile_group_factory.h"
 #include "storage/tile_group_header.h"
 
@@ -19,7 +18,7 @@
 //===--------------------------------------------------------------------===//
 
 // Logging mode
-extern LoggingType peloton_logging_mode;
+extern peloton::LoggingType peloton_logging_mode;
 
 namespace peloton {
 namespace storage {

--- a/test/common/types_test.cpp
+++ b/test/common/types_test.cpp
@@ -43,7 +43,7 @@ TEST_F(TypesTests, TypeIdTest) {
   }
 
   // Then make sure that we can't cast garbage
-  std::string invalid("JoyArulrajIsDangerous");
+  std::string invalid("JoyIsDangerous");
   EXPECT_THROW(peloton::StringToTypeId(invalid), peloton::Exception);
 }
 
@@ -61,7 +61,7 @@ TEST_F(TypesTests, IndexTypeTest) {
   }
 
   // Then make sure that we can't cast garbage
-  std::string invalid("DanaVanAkenSlaysMofos");
+  std::string invalid("DanaSlaysMofos");
   EXPECT_THROW(peloton::StringToIndexType(invalid), peloton::Exception);
 }
 
@@ -85,7 +85,7 @@ TEST_F(TypesTests, StatementTypeTest) {
   }
 
   // Then make sure that we can't cast garbage
-  std::string invalid("PrashanthMenonTrillAsFuck");
+  std::string invalid("PrashanthTrillAsFuck");
   EXPECT_THROW(peloton::StringToStatementType(invalid), peloton::Exception);
 }
 
@@ -117,8 +117,54 @@ TEST_F(TypesTests, PlanNodeTypeTest) {
   }
 
   // Then make sure that we can't cast garbage
-  std::string invalid("AndyPavloSmellsBad");
+  std::string invalid("AndySmellsBad");
   EXPECT_THROW(peloton::StringToPlanNodeType(invalid), peloton::Exception);
+}
+
+TEST_F(TypesTests, ParseNodeTypeTest) {
+  std::vector<ParseNodeType> list = {
+      PARSE_NODE_TYPE_INVALID,   PARSE_NODE_TYPE_SCAN,
+      PARSE_NODE_TYPE_CREATE,    PARSE_NODE_TYPE_DROP,
+      PARSE_NODE_TYPE_UPDATE,    PARSE_NODE_TYPE_INSERT,
+      PARSE_NODE_TYPE_DELETE,    PARSE_NODE_TYPE_PREPARE,
+      PARSE_NODE_TYPE_EXECUTE,   PARSE_NODE_TYPE_SELECT,
+      PARSE_NODE_TYPE_JOIN_EXPR, PARSE_NODE_TYPE_TABLE,
+      PARSE_NODE_TYPE_MOCK};
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::ParseNodeTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToParseNodeType(str);
+    EXPECT_EQ(val, newVal);
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("TerrierHasFleas");
+  EXPECT_THROW(peloton::StringToParseNodeType(invalid), peloton::Exception);
+}
+
+TEST_F(TypesTests, ConstraintTypeTest) {
+  std::vector<ConstraintType> list = {
+      CONSTRAINT_TYPE_INVALID,  CONSTRAINT_TYPE_NULL,
+      CONSTRAINT_TYPE_NOTNULL,  CONSTRAINT_TYPE_DEFAULT,
+      CONSTRAINT_TYPE_CHECK,    CONSTRAINT_TYPE_PRIMARY,
+      CONSTRAINT_TYPE_UNIQUE,   CONSTRAINT_TYPE_FOREIGN,
+      CONSTRAINT_TYPE_EXCLUSION};
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::ConstraintTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToConstraintType(str);
+    EXPECT_EQ(val, newVal);
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("ZiqiGottTheFlu");
+  EXPECT_THROW(peloton::StringToConstraintType(invalid), peloton::Exception);
 }
 
 TEST_F(TypesTests, ExpressionTypeTest) {
@@ -200,7 +246,7 @@ TEST_F(TypesTests, ExpressionTypeTest) {
   }
 
   // Then make sure that we can't cast garbage
-  std::string invalid("LinMaLovesEverybody");
+  std::string invalid("LinLovesEverybody");
   EXPECT_THROW(peloton::StringToExpressionType(invalid), peloton::Exception);
 }
 

--- a/test/common/types_test.cpp
+++ b/test/common/types_test.cpp
@@ -47,6 +47,30 @@ TEST_F(TypesTests, TypeIdTest) {
   EXPECT_THROW(peloton::StringToTypeId(invalid), peloton::Exception);
 }
 
+TEST_F(TypesTests, StatementTypeTest) {
+  std::vector<StatementType> list = {
+      STATEMENT_TYPE_INVALID, STATEMENT_TYPE_SELECT,
+      STATEMENT_TYPE_INSERT,  STATEMENT_TYPE_UPDATE,
+      STATEMENT_TYPE_DELETE,  STATEMENT_TYPE_CREATE,
+      STATEMENT_TYPE_DROP,    STATEMENT_TYPE_PREPARE,
+      STATEMENT_TYPE_EXECUTE, STATEMENT_TYPE_RENAME,
+      STATEMENT_TYPE_ALTER,   STATEMENT_TYPE_TRANSACTION,
+      STATEMENT_TYPE_COPY};
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::StatementTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToStatementType(str);
+    EXPECT_EQ(val, newVal);
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("PrashanthMenonTrillAsFuck");
+  EXPECT_THROW(peloton::StringToStatementType(invalid), peloton::Exception);
+}
+
 TEST_F(TypesTests, ExpressionTypeTest) {
   std::vector<ExpressionType> list = {
       EXPRESSION_TYPE_INVALID,

--- a/test/common/types_test.cpp
+++ b/test/common/types_test.cpp
@@ -1,0 +1,137 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// types_test.cpp
+//
+// Identification: test/common/types_test.cpp
+//
+// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/types.h"
+#include "common/harness.h"
+#include "common/value_factory.h"
+
+namespace peloton {
+namespace test {
+
+//===--------------------------------------------------------------------===//
+// Types Test
+//===--------------------------------------------------------------------===//
+
+class TypesTests : public PelotonTest {};
+
+TEST_F(TypesTests, TypeIdTest) {
+  std::vector<common::Type::TypeId> list = {
+      common::Type::INVALID,   common::Type::PARAMETER_OFFSET,
+      common::Type::BOOLEAN,   common::Type::TINYINT,
+      common::Type::SMALLINT,  common::Type::INTEGER,
+      common::Type::BIGINT,    common::Type::DECIMAL,
+      common::Type::TIMESTAMP, common::Type::DATE,
+      common::Type::VARCHAR,   common::Type::VARBINARY,
+      common::Type::ARRAY,     common::Type::UDT};
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    const std::string str = TypeIdToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = StringToTypeId(str);
+    EXPECT_EQ(val, newVal);
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("JoyArulrajIsDangerous");
+  EXPECT_THROW(StringToTypeId(invalid), peloton::Exception);
+}
+
+TEST_F(TypesTests, ExpressionTypeTest) {
+  std::vector<ExpressionType> list = {
+      EXPRESSION_TYPE_INVALID,
+      EXPRESSION_TYPE_OPERATOR_PLUS,
+      EXPRESSION_TYPE_OPERATOR_MINUS,
+      EXPRESSION_TYPE_OPERATOR_MULTIPLY,
+      EXPRESSION_TYPE_OPERATOR_DIVIDE,
+      EXPRESSION_TYPE_OPERATOR_CONCAT,
+      EXPRESSION_TYPE_OPERATOR_MOD,
+      EXPRESSION_TYPE_OPERATOR_CAST,
+      EXPRESSION_TYPE_OPERATOR_NOT,
+      EXPRESSION_TYPE_OPERATOR_IS_NULL,
+      EXPRESSION_TYPE_OPERATOR_EXISTS,
+      EXPRESSION_TYPE_OPERATOR_UNARY_MINUS,
+      EXPRESSION_TYPE_COMPARE_EQUAL,
+      EXPRESSION_TYPE_COMPARE_NOTEQUAL,
+      EXPRESSION_TYPE_COMPARE_LESSTHAN,
+      EXPRESSION_TYPE_COMPARE_GREATERTHAN,
+      EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO,
+      EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO,
+      EXPRESSION_TYPE_COMPARE_LIKE,
+      EXPRESSION_TYPE_COMPARE_NOTLIKE,
+      EXPRESSION_TYPE_COMPARE_IN,
+      EXPRESSION_TYPE_CONJUNCTION_AND,
+      EXPRESSION_TYPE_CONJUNCTION_OR,
+      EXPRESSION_TYPE_VALUE_CONSTANT,
+      EXPRESSION_TYPE_VALUE_PARAMETER,
+      EXPRESSION_TYPE_VALUE_TUPLE,
+      EXPRESSION_TYPE_VALUE_TUPLE_ADDRESS,
+      EXPRESSION_TYPE_VALUE_NULL,
+      EXPRESSION_TYPE_VALUE_VECTOR,
+      EXPRESSION_TYPE_VALUE_SCALAR,
+      EXPRESSION_TYPE_AGGREGATE_COUNT,
+      EXPRESSION_TYPE_AGGREGATE_COUNT_STAR,
+      EXPRESSION_TYPE_AGGREGATE_SUM,
+      EXPRESSION_TYPE_AGGREGATE_MIN,
+      EXPRESSION_TYPE_AGGREGATE_MAX,
+      EXPRESSION_TYPE_AGGREGATE_AVG,
+      EXPRESSION_TYPE_AGGREGATE_APPROX_COUNT_DISTINCT,
+      EXPRESSION_TYPE_AGGREGATE_VALS_TO_HYPERLOGLOG,
+      EXPRESSION_TYPE_AGGREGATE_HYPERLOGLOGS_TO_CARD,
+      EXPRESSION_TYPE_FUNCTION,
+      EXPRESSION_TYPE_HASH_RANGE,
+      EXPRESSION_TYPE_OPERATOR_CASE_EXPR,
+      EXPRESSION_TYPE_OPERATOR_NULLIF,
+      EXPRESSION_TYPE_OPERATOR_COALESCE,
+      EXPRESSION_TYPE_ROW_SUBQUERY,
+      EXPRESSION_TYPE_SELECT_SUBQUERY,
+      EXPRESSION_TYPE_SUBSTR,
+      EXPRESSION_TYPE_ASCII,
+      EXPRESSION_TYPE_OCTET_LEN,
+      EXPRESSION_TYPE_CHAR,
+      EXPRESSION_TYPE_CHAR_LEN,
+      EXPRESSION_TYPE_SPACE,
+      EXPRESSION_TYPE_REPEAT,
+      EXPRESSION_TYPE_POSITION,
+      EXPRESSION_TYPE_LEFT,
+      EXPRESSION_TYPE_RIGHT,
+      EXPRESSION_TYPE_CONCAT,
+      EXPRESSION_TYPE_LTRIM,
+      EXPRESSION_TYPE_RTRIM,
+      EXPRESSION_TYPE_BTRIM,
+      EXPRESSION_TYPE_REPLACE,
+      EXPRESSION_TYPE_OVERLAY,
+      EXPRESSION_TYPE_EXTRACT,
+      EXPRESSION_TYPE_DATE_TO_TIMESTAMP,
+      EXPRESSION_TYPE_STAR,
+      EXPRESSION_TYPE_PLACEHOLDER,
+      EXPRESSION_TYPE_COLUMN_REF,
+      EXPRESSION_TYPE_FUNCTION_REF,
+      EXPRESSION_TYPE_CAST};
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    const std::string str = ExpressionTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = StringToExpressionType(str);
+    EXPECT_EQ(val, newVal);
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("LinMaLovesEverybody");
+  EXPECT_THROW(StringToTypeId(invalid), peloton::Exception);
+}
+
+}  // End test namespace
+}  // End peloton namespace

--- a/test/common/types_test.cpp
+++ b/test/common/types_test.cpp
@@ -35,16 +35,16 @@ TEST_F(TypesTests, TypeIdTest) {
 
   // Make sure that ToString and FromString work
   for (auto val : list) {
-    const std::string str = TypeIdToString(val);
+    std::string str = peloton::TypeIdToString(val);
     EXPECT_TRUE(str.size() > 0);
 
-    auto newVal = StringToTypeId(str);
+    auto newVal = peloton::StringToTypeId(str);
     EXPECT_EQ(val, newVal);
   }
 
   // Then make sure that we can't cast garbage
   std::string invalid("JoyArulrajIsDangerous");
-  EXPECT_THROW(StringToTypeId(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::StringToTypeId(invalid), peloton::Exception);
 }
 
 TEST_F(TypesTests, ExpressionTypeTest) {
@@ -85,9 +85,6 @@ TEST_F(TypesTests, ExpressionTypeTest) {
       EXPRESSION_TYPE_AGGREGATE_MIN,
       EXPRESSION_TYPE_AGGREGATE_MAX,
       EXPRESSION_TYPE_AGGREGATE_AVG,
-      EXPRESSION_TYPE_AGGREGATE_APPROX_COUNT_DISTINCT,
-      EXPRESSION_TYPE_AGGREGATE_VALS_TO_HYPERLOGLOG,
-      EXPRESSION_TYPE_AGGREGATE_HYPERLOGLOGS_TO_CARD,
       EXPRESSION_TYPE_FUNCTION,
       EXPRESSION_TYPE_HASH_RANGE,
       EXPRESSION_TYPE_OPERATOR_CASE_EXPR,
@@ -121,16 +118,16 @@ TEST_F(TypesTests, ExpressionTypeTest) {
 
   // Make sure that ToString and FromString work
   for (auto val : list) {
-    const std::string str = ExpressionTypeToString(val);
+    std::string str = peloton::ExpressionTypeToString(val);
     EXPECT_TRUE(str.size() > 0);
 
-    auto newVal = StringToExpressionType(str);
+    auto newVal = peloton::StringToExpressionType(str);
     EXPECT_EQ(val, newVal);
   }
 
   // Then make sure that we can't cast garbage
   std::string invalid("LinMaLovesEverybody");
-  EXPECT_THROW(StringToTypeId(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::StringToExpressionType(invalid), peloton::Exception);
 }
 
 }  // End test namespace

--- a/test/common/types_test.cpp
+++ b/test/common/types_test.cpp
@@ -47,6 +47,24 @@ TEST_F(TypesTests, TypeIdTest) {
   EXPECT_THROW(peloton::StringToTypeId(invalid), peloton::Exception);
 }
 
+TEST_F(TypesTests, IndexTypeTest) {
+  std::vector<IndexType> list = {INDEX_TYPE_INVALID, INDEX_TYPE_BTREE,
+                                 INDEX_TYPE_BWTREE, INDEX_TYPE_HASH};
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::IndexTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToIndexType(str);
+    EXPECT_EQ(val, newVal);
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("DanaVanAkenSlaysMofos");
+  EXPECT_THROW(peloton::StringToIndexType(invalid), peloton::Exception);
+}
+
 TEST_F(TypesTests, StatementTypeTest) {
   std::vector<StatementType> list = {
       STATEMENT_TYPE_INVALID, STATEMENT_TYPE_SELECT,
@@ -69,6 +87,38 @@ TEST_F(TypesTests, StatementTypeTest) {
   // Then make sure that we can't cast garbage
   std::string invalid("PrashanthMenonTrillAsFuck");
   EXPECT_THROW(peloton::StringToStatementType(invalid), peloton::Exception);
+}
+
+TEST_F(TypesTests, PlanNodeTypeTest) {
+  std::vector<PlanNodeType> list = {
+      PLAN_NODE_TYPE_INVALID,     PLAN_NODE_TYPE_ABSTRACT_SCAN,
+      PLAN_NODE_TYPE_SEQSCAN,     PLAN_NODE_TYPE_INDEXSCAN,
+      PLAN_NODE_TYPE_NESTLOOP,    PLAN_NODE_TYPE_NESTLOOPINDEX,
+      PLAN_NODE_TYPE_MERGEJOIN,   PLAN_NODE_TYPE_HASHJOIN,
+      PLAN_NODE_TYPE_UPDATE,      PLAN_NODE_TYPE_INSERT,
+      PLAN_NODE_TYPE_DELETE,      PLAN_NODE_TYPE_DROP,
+      PLAN_NODE_TYPE_CREATE,      PLAN_NODE_TYPE_SEND,
+      PLAN_NODE_TYPE_RECEIVE,     PLAN_NODE_TYPE_PRINT,
+      PLAN_NODE_TYPE_AGGREGATE,   PLAN_NODE_TYPE_UNION,
+      PLAN_NODE_TYPE_ORDERBY,     PLAN_NODE_TYPE_PROJECTION,
+      PLAN_NODE_TYPE_MATERIALIZE, PLAN_NODE_TYPE_LIMIT,
+      PLAN_NODE_TYPE_DISTINCT,    PLAN_NODE_TYPE_SETOP,
+      PLAN_NODE_TYPE_APPEND,      PLAN_NODE_TYPE_AGGREGATE_V2,
+      PLAN_NODE_TYPE_HASH,        PLAN_NODE_TYPE_RESULT,
+      PLAN_NODE_TYPE_COPY,        PLAN_NODE_TYPE_MOCK};
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::PlanNodeTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToPlanNodeType(str);
+    EXPECT_EQ(val, newVal);
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("AndyPavloSmellsBad");
+  EXPECT_THROW(peloton::StringToPlanNodeType(invalid), peloton::Exception);
 }
 
 TEST_F(TypesTests, ExpressionTypeTest) {

--- a/test/logging/logging_test.cpp
+++ b/test/logging/logging_test.cpp
@@ -10,27 +10,27 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "common/harness.h"
 #include "catalog/catalog.h"
+#include "common/harness.h"
 
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/logical_tile_factory.h"
-#include "storage/data_table.h"
-#include "storage/tile.h"
 #include "logging/loggers/wal_frontend_logger.h"
 #include "logging/logging_util.h"
-#include "storage/table_factory.h"
+#include "storage/data_table.h"
 #include "storage/database.h"
+#include "storage/table_factory.h"
+#include "storage/tile.h"
 
-#include "executor/mock_executor.h"
 #include "executor/executor_tests_util.h"
+#include "executor/mock_executor.h"
 #include "logging/logging_tests_util.h"
 
 using ::testing::NotNull;
 using ::testing::Return;
 using ::testing::InSequence;
 
-extern LoggingType peloton_logging_mode;
+extern peloton::LoggingType peloton_logging_mode;
 
 namespace peloton {
 namespace test {
@@ -322,11 +322,10 @@ TEST_F(LoggingTests, BasicLogManagerTest) {
   log_manager.DropFrontendLoggers();
   log_manager.SetLoggingStatus(LOGGING_STATUS_TYPE_INVALID);
   // just start, write a few records and exit
-  catalog::Schema *table_schema =
-      new catalog::Schema({ExecutorTestsUtil::GetColumnInfo(0),
-                           ExecutorTestsUtil::GetColumnInfo(1),
-                           ExecutorTestsUtil::GetColumnInfo(2),
-                           ExecutorTestsUtil::GetColumnInfo(3)});
+  catalog::Schema *table_schema = new catalog::Schema(
+      {ExecutorTestsUtil::GetColumnInfo(0), ExecutorTestsUtil::GetColumnInfo(1),
+       ExecutorTestsUtil::GetColumnInfo(2),
+       ExecutorTestsUtil::GetColumnInfo(3)});
   std::string table_name("TEST_TABLE");
 
   // Create table.


### PR DESCRIPTION
Our beloved 'types.h' file has become a dumping ground for whatever global value that people need. It's sad in some ways.

In this pull request, I moved stuff out that didn't belong there, fixed up some of the ToString/FromString functions, and made sure that everything falls under the 'peloton' namespace. 