### PR TITLE
#394: Added frontend txn handling bug fix

### DIFF
--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -44,7 +44,7 @@ void CleanExecutorTree(executor::AbstractExecutor *root);
  */
 peloton_status PlanExecutor::ExecutePlan(
     const planner::AbstractPlan *plan, concurrency::Transaction *txn,
-    const std::vector<common::Value> &params, std::vector<ResultType> &result,
+    const std::vector<type::Value> &params, std::vector<ResultType> &result,
     const std::vector<int> &result_format) {
   peloton_status p_status;
   if (plan == nullptr) return p_status;
@@ -69,7 +69,7 @@ peloton_status PlanExecutor::ExecutePlan(
     LOG_TRACE("Txn ID = %lu ", txn->GetTransactionId());
     LOG_TRACE("Building the executor tree");
 
-    // Use const std::vector<common::Value> &params to make it more elegant for
+    // Use const std::vector<type::Value> &params to make it more elegant for
     // network
     std::unique_ptr<executor::ExecutorContext> executor_context(
         BuildExecutorContext(params, txn));

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -47,7 +47,6 @@ peloton_status PlanExecutor::ExecutePlan(
     const std::vector<common::Value> &params, std::vector<ResultType> &result,
     const std::vector<int> &result_format) {
   peloton_status p_status;
-
   if (plan == nullptr) return p_status;
 
   LOG_TRACE("PlanExecutor Start ");
@@ -65,97 +64,105 @@ peloton_status PlanExecutor::ExecutePlan(
   }
   PL_ASSERT(txn);
 
-  LOG_TRACE("Txn ID = %lu ", txn->GetTransactionId());
-  LOG_TRACE("Building the executor tree");
+  // txn has already been aborted? don't execute this query
+  if (txn->GetResult() != Result::RESULT_ABORTED) {
+    LOG_TRACE("Txn ID = %lu ", txn->GetTransactionId());
+    LOG_TRACE("Building the executor tree");
 
-  // Use const std::vector<type::Value> &params to make it more elegant for
-  // network
-  std::unique_ptr<executor::ExecutorContext> executor_context(
-      BuildExecutorContext(params, txn));
+    // Use const std::vector<common::Value> &params to make it more elegant for
+    // network
+    std::unique_ptr<executor::ExecutorContext> executor_context(
+        BuildExecutorContext(params, txn));
 
-  // Build the executor tree
-  std::unique_ptr<executor::AbstractExecutor> executor_tree(
-      BuildExecutorTree(nullptr, plan, executor_context.get()));
+    // Build the executor tree
+    std::unique_ptr<executor::AbstractExecutor> executor_tree(
+        BuildExecutorTree(nullptr, plan, executor_context.get()));
 
-  LOG_TRACE("Initializing the executor tree");
+    LOG_TRACE("Initializing the executor tree");
 
-  // Initialize the executor tree
-  status = executor_tree->Init();
+    // Initialize the executor tree
+    status = executor_tree->Init();
 
-  // Abort and cleanup
-  if (status == false) {
-    init_failure = true;
-    txn->SetResult(Result::RESULT_FAILURE);
-    goto cleanup;
-  }
+    // Abort and cleanup
+    if (status == false) {
+      init_failure = true;
+      txn->SetResult(Result::RESULT_FAILURE);
+    } else {
+      LOG_TRACE("Running the executor tree");
+      result.clear();
 
-  LOG_TRACE("Running the executor tree");
-  result.clear();
+      // Execute the tree until we get result tiles from root node
+      while (status == true) {
+        status = executor_tree->Execute();
 
-  // Execute the tree until we get result tiles from root node
-  while (status == true) {
-    status = executor_tree->Execute();
+        std::unique_ptr<executor::LogicalTile> logical_tile(
+            executor_tree->GetOutput());
+        // Some executors don't return logical tiles (e.g., Update).
+        if (logical_tile.get() != nullptr) {
+          LOG_TRACE("Final Answer: %s",
+                    logical_tile->GetInfo().c_str());  // Printing the answers
+          std::unique_ptr<catalog::Schema> output_schema(
+              logical_tile->GetPhysicalSchema());  // Physical schema of the tile
+          std::vector<std::vector<std::string>> answer_tuples;
+          answer_tuples =
+              std::move(logical_tile->GetAllValuesAsStrings(result_format));
 
-    std::unique_ptr<executor::LogicalTile> logical_tile(
-        executor_tree->GetOutput());
-    // Some executors don't return logical tiles (e.g., Update).
-    if (logical_tile.get() != nullptr) {
-      LOG_TRACE("Final Answer: %s",
-                logical_tile->GetInfo().c_str());  // Printing the answers
-      std::unique_ptr<catalog::Schema> output_schema(
-          logical_tile->GetPhysicalSchema());  // Physical schema of the tile
-      std::vector<std::vector<std::string>> answer_tuples;
-      answer_tuples =
-          std::move(logical_tile->GetAllValuesAsStrings(result_format));
-
-      // Construct the returned results
-      for (auto &tuple : answer_tuples) {
-        unsigned int col_index = 0;
-        auto &schema_columns = output_schema->GetColumns();
-        for (auto &column : schema_columns) {
-          auto column_name = column.GetName();
-          auto res = ResultType();
-          PlanExecutor::copyFromTo(column_name, res.first);
-          LOG_TRACE("column name: %s", column_name.c_str());
-          PlanExecutor::copyFromTo(tuple[col_index++], res.second);
-          if (tuple[col_index - 1].c_str() != nullptr) {
-            LOG_TRACE("column content: %s", tuple[col_index - 1].c_str());
+          // Construct the returned results
+          for (auto &tuple : answer_tuples) {
+            unsigned int col_index = 0;
+            auto &schema_columns = output_schema->GetColumns();
+            for (auto &column : schema_columns) {
+              auto column_name = column.GetName();
+              auto res = ResultType();
+              PlanExecutor::copyFromTo(column_name, res.first);
+              LOG_TRACE("column name: %s", column_name.c_str());
+              PlanExecutor::copyFromTo(tuple[col_index++], res.second);
+              if (tuple[col_index - 1].c_str() != nullptr) {
+                LOG_TRACE("column content: %s", tuple[col_index - 1].c_str());
+              }
+              result.push_back(res);
+            }
           }
-          result.push_back(res);
         }
       }
     }
-  }
 
-  // Set the result
-  p_status.m_processed = executor_context->num_processed;
-  p_status.m_result_slots = nullptr;
+    // Set the result
+    p_status.m_processed = executor_context->num_processed;
+    p_status.m_result_slots = nullptr;
 
-// final cleanup
-cleanup:
+    auto txn_result = txn->GetResult();
 
-  // should we commit or abort ?
-  if (single_statement_txn == true || init_failure == true) {
-    LOG_TRACE("About to commit: single stmt: %d, init_failure: %d, status: %d",
-              single_statement_txn, init_failure, txn->GetResult());
-    auto status = txn->GetResult();
-    switch (status) {
-      case Result::RESULT_SUCCESS:
-        // Commit
-        LOG_TRACE("Commit Transaction");
-        p_status.m_result = txn_manager.CommitTransaction(txn);
-        break;
+    // should we commit or abort for single statement txns or
+    // abort entire txn block?
+    if (single_statement_txn == true || init_failure == true ||
+        txn_result == Result::RESULT_FAILURE) {
+      LOG_TRACE("About to commit: single stmt: %d, init_failure: %d, status: %d",
+                single_statement_txn, init_failure, txn_result);
+      switch (txn_result) {
+        case Result::RESULT_SUCCESS:
+          // Commit
+          LOG_TRACE("Commit Transaction");
+          p_status.m_result = txn_manager.CommitTransaction(txn);
+          break;
 
-      case Result::RESULT_FAILURE:
-      default:
-        // Abort
-        LOG_TRACE("Abort Transaction");
-        p_status.m_result = txn_manager.AbortTransaction(txn);
+        case Result::RESULT_FAILURE:
+        default:
+          // Abort
+          LOG_TRACE("Abort Transaction");
+          p_status.m_result = txn_manager.AbortTransaction(txn);
+      }
+    } else {
+      // Optimistic - assume the txn is successful so far
+      p_status.m_result = Result::RESULT_SUCCESS;
     }
-  }
 
-  // clean up executor tree
-  CleanExecutorTree(executor_tree.get());
+    // clean up executor tree
+    CleanExecutorTree(executor_tree.get());
+  } else {
+    // txn has already failed
+    p_status.m_result = Result::RESULT_ABORTED;
+  }
 
   return p_status;
 }

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -52,76 +52,60 @@ peloton_status PlanExecutor::ExecutePlan(
   LOG_TRACE("PlanExecutor Start ");
 
   bool status;
-  bool init_failure = false;
-  bool single_statement_txn = false;
 
-  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-
-  // This happens for single statement queries in PG
-  if (txn == nullptr) {
-    single_statement_txn = true;
-    txn = txn_manager.BeginTransaction();
-  }
   PL_ASSERT(txn);
 
-  // txn has already been aborted? don't execute this query
-  if (txn->GetResult() != Result::RESULT_ABORTED) {
-    LOG_TRACE("Txn ID = %lu ", txn->GetTransactionId());
-    LOG_TRACE("Building the executor tree");
+  LOG_TRACE("Txn ID = %lu ", txn->GetTransactionId());
+  LOG_TRACE("Building the executor tree");
 
-    // Use const std::vector<type::Value> &params to make it more elegant for
-    // network
-    std::unique_ptr<executor::ExecutorContext> executor_context(
-        BuildExecutorContext(params, txn));
+  // Use const std::vector<type::Value> &params to make it more elegant for
+  // network
+  std::unique_ptr<executor::ExecutorContext> executor_context(
+      BuildExecutorContext(params, txn));
 
-    // Build the executor tree
-    std::unique_ptr<executor::AbstractExecutor> executor_tree(
-        BuildExecutorTree(nullptr, plan, executor_context.get()));
+  // Build the executor tree
+  std::unique_ptr<executor::AbstractExecutor> executor_tree(
+      BuildExecutorTree(nullptr, plan, executor_context.get()));
 
-    LOG_TRACE("Initializing the executor tree");
+  LOG_TRACE("Initializing the executor tree");
 
-    // Initialize the executor tree
-    status = executor_tree->Init();
+  // Initialize the executor tree
+  status = executor_tree->Init();
 
-    // Abort and cleanup
-    if (status == false) {
-      init_failure = true;
-      txn->SetResult(Result::RESULT_FAILURE);
-    } else {
-      LOG_TRACE("Running the executor tree");
-      result.clear();
+  if (status == true) {
+    LOG_TRACE("Running the executor tree");
+    result.clear();
 
-      // Execute the tree until we get result tiles from root node
-      while (status == true) {
-        status = executor_tree->Execute();
+    // Execute the tree until we get result tiles from root node
+    while (status == true) {
+      status = executor_tree->Execute();
 
-        std::unique_ptr<executor::LogicalTile> logical_tile(
-            executor_tree->GetOutput());
-        // Some executors don't return logical tiles (e.g., Update).
-        if (logical_tile.get() != nullptr) {
-          LOG_TRACE("Final Answer: %s",
-                    logical_tile->GetInfo().c_str());  // Printing the answers
-          std::unique_ptr<catalog::Schema> output_schema(
-              logical_tile->GetPhysicalSchema());  // Physical schema of the tile
-          std::vector<std::vector<std::string>> answer_tuples;
-          answer_tuples =
-              std::move(logical_tile->GetAllValuesAsStrings(result_format));
+      std::unique_ptr<executor::LogicalTile> logical_tile(
+          executor_tree->GetOutput());
+      // Some executors don't return logical tiles (e.g., Update).
+      if (logical_tile.get() != nullptr) {
+        LOG_TRACE("Final Answer: %s",
+                  logical_tile->GetInfo().c_str());  // Printing the answers
+        std::unique_ptr<catalog::Schema> output_schema(
+            logical_tile->GetPhysicalSchema());  // Physical schema of the tile
+        std::vector<std::vector<std::string>> answer_tuples;
+        answer_tuples =
+            std::move(logical_tile->GetAllValuesAsStrings(result_format));
 
-          // Construct the returned results
-          for (auto &tuple : answer_tuples) {
-            unsigned int col_index = 0;
-            auto &schema_columns = output_schema->GetColumns();
-            for (auto &column : schema_columns) {
-              auto column_name = column.GetName();
-              auto res = ResultType();
-              PlanExecutor::copyFromTo(column_name, res.first);
-              LOG_TRACE("column name: %s", column_name.c_str());
-              PlanExecutor::copyFromTo(tuple[col_index++], res.second);
-              if (tuple[col_index - 1].c_str() != nullptr) {
-                LOG_TRACE("column content: %s", tuple[col_index - 1].c_str());
-              }
-              result.push_back(res);
+        // Construct the returned results
+        for (auto &tuple : answer_tuples) {
+          unsigned int col_index = 0;
+          auto &schema_columns = output_schema->GetColumns();
+          for (auto &column : schema_columns) {
+            auto column_name = column.GetName();
+            auto res = ResultType();
+            PlanExecutor::copyFromTo(column_name, res.first);
+            LOG_TRACE("column name: %s", column_name.c_str());
+            PlanExecutor::copyFromTo(tuple[col_index++], res.second);
+            if (tuple[col_index - 1].c_str() != nullptr) {
+              LOG_TRACE("column content: %s", tuple[col_index - 1].c_str());
             }
+            result.push_back(res);
           }
         }
       }
@@ -129,40 +113,16 @@ peloton_status PlanExecutor::ExecutePlan(
 
     // Set the result
     p_status.m_processed = executor_context->num_processed;
-    p_status.m_result_slots = nullptr;
-
-    auto txn_result = txn->GetResult();
-
-    // should we commit or abort for single statement txns or
-    // abort entire txn block?
-    if (single_statement_txn == true || init_failure == true ||
-        txn_result == Result::RESULT_FAILURE) {
-      LOG_TRACE("About to commit: single stmt: %d, init_failure: %d, status: %d",
-                single_statement_txn, init_failure, txn_result);
-      switch (txn_result) {
-        case Result::RESULT_SUCCESS:
-          // Commit
-          LOG_TRACE("Commit Transaction");
-          p_status.m_result = txn_manager.CommitTransaction(txn);
-          break;
-
-        case Result::RESULT_FAILURE:
-        default:
-          // Abort
-          LOG_TRACE("Abort Transaction");
-          p_status.m_result = txn_manager.AbortTransaction(txn);
-      }
-    } else {
-      // Optimistic - assume the txn is successful so far
-      p_status.m_result = Result::RESULT_SUCCESS;
-    }
-
-    // clean up executor tree
-    CleanExecutorTree(executor_tree.get());
+    // success so far
+    p_status.m_result = Result::RESULT_SUCCESS;
   } else {
-    // txn has already failed
-    p_status.m_result = Result::RESULT_ABORTED;
+    p_status.m_result = Result::RESULT_FAILURE;
   }
+
+  p_status.m_result_slots = nullptr;
+
+  // clean up executor tree
+  CleanExecutorTree(executor_tree.get());
 
   return p_status;
 }

--- a/src/include/executor/copy_executor.h
+++ b/src/include/executor/copy_executor.h
@@ -15,7 +15,7 @@
 #include "executor/abstract_executor.h"
 
 #include <vector>
-#include "wire/wire.h"
+#include "wire/packet_manager.h"
 
 #define COPY_BUFFER_SIZE 65536
 #define INVALID_COL_ID -1

--- a/src/include/executor/plan_executor.h
+++ b/src/include/executor/plan_executor.h
@@ -74,11 +74,9 @@ class PlanExecutor {
 
   /*
    * @brief Use std::vector<type::Value> as params to make it more elegant
-   * for
-   * networking
-   *        Before ExecutePlan, a node first receives value list, so we should
-   * pass
-   *        value list directly rather than passing Postgres's ParamListInfo
+   * for networking
+   * Before ExecutePlan, a node first receives value list, so we should
+   * pass value list directly rather than passing Postgres's ParamListInfo
    */
   static peloton_status ExecutePlan(const planner::AbstractPlan *plan,
                                     concurrency::Transaction* txn,

--- a/src/include/executor/plan_executor.h
+++ b/src/include/executor/plan_executor.h
@@ -15,6 +15,7 @@
 #include "common/statement.h"
 #include "executor/abstract_executor.h"
 #include "type/types.h"
+#include "concurrency/transaction_manager_factory.h"
 
 namespace peloton {
 namespace bridge {
@@ -80,7 +81,8 @@ class PlanExecutor {
    *        value list directly rather than passing Postgres's ParamListInfo
    */
   static peloton_status ExecutePlan(const planner::AbstractPlan *plan,
-                                    const std::vector<type::Value> &params,
+                                    concurrency::Transaction* txn,
+                                    const std::vector<common::Value> &params,
                                     std::vector<ResultType> &result,
                                     const std::vector<int> &result_format);
 

--- a/src/include/executor/plan_executor.h
+++ b/src/include/executor/plan_executor.h
@@ -82,7 +82,7 @@ class PlanExecutor {
    */
   static peloton_status ExecutePlan(const planner::AbstractPlan *plan,
                                     concurrency::Transaction* txn,
-                                    const std::vector<common::Value> &params,
+                                    const std::vector<type::Value> &params,
                                     std::vector<ResultType> &result,
                                     const std::vector<int> &result_format);
 

--- a/src/include/tcop/tcop.h
+++ b/src/include/tcop/tcop.h
@@ -79,17 +79,21 @@ class TrafficCop {
   // The optimizer used for this connection
   std::unique_ptr<optimizer::AbstractOptimizer> optimizer_;
 
-  // to support nested-txns use a stack
-  std::stack<concurrency::Transaction*> txn_ptrs;
+  // pair of txn ptr and the result so-far for that txn
+  // use a stack to support nested-txns
+  typedef std::pair<concurrency::Transaction*, Result> TcopTxnState;
+  std::stack<TcopTxnState> tcop_txn_state_;
 
  private:
-  concurrency::Transaction* GetCurrentTransaction();
+  static TcopTxnState& GetDefaultTxnState();
 
-  Result BeginTransactionHelper();
+  TcopTxnState& GetCurrentTxnState();
 
-  Result CommitTransactionHelper();
+  Result BeginQueryHelper();
 
-  Result AbortTransactionHelper();
+  Result CommitQueryHelper();
+
+  Result AbortQueryHelper();
 };
 
 }  // End tcop namespace

--- a/src/include/tcop/tcop.h
+++ b/src/include/tcop/tcop.h
@@ -20,12 +20,12 @@
 
 #include "common/portal.h"
 #include "common/statement.h"
-#include "type/type.h"
-#include "type/types.h"
+#include "concurrency/transaction.h"
+#include "executor/plan_executor.h"
 #include "optimizer/abstract_optimizer.h"
 #include "parser/sql_statement.h"
-
-#include "concurrency/transaction.h"
+#include "type/type.h"
+#include "type/types.h"
 
 namespace peloton {
 
@@ -40,6 +40,9 @@ class TrafficCop {
  public:
   TrafficCop();
   ~TrafficCop();
+
+  // static singleton method used by tests
+  static TrafficCop& GetInstance();
 
   // reset this object
   void Reset();
@@ -57,6 +60,11 @@ class TrafficCop {
       std::shared_ptr<stats::QueryMetric::QueryParams> param_stats,
       const std::vector<int> &result_format, std::vector<ResultType> &result,
       int &rows_change, std::string &error_message);
+
+  // ExecutePrepStmt - Helper to handle txn-specifics for the plan-tree of a statement
+  bridge::peloton_status ExecuteStatementPlan(
+      const planner::AbstractPlan *plan, const std::vector<type::Value> &params,
+      std::vector<ResultType> &result, const std::vector<int> &result_format);
 
   // InitBindPrepStmt - Prepare and bind a query from a query string
   std::shared_ptr<Statement> PrepareStatement(const std::string &statement_name,

--- a/src/include/tcop/tcop.h
+++ b/src/include/tcop/tcop.h
@@ -75,8 +75,6 @@ class TrafficCop {
   int BindParameters(std::vector<std::pair<int, std::string>> &parameters,
                      Statement **stmt, std::string &error_message);
 
-  void Reset();
-
  private:
   // The optimizer used for this connection
   std::unique_ptr<optimizer::AbstractOptimizer> optimizer_;

--- a/src/include/wire/libevent_server.h
+++ b/src/include/wire/libevent_server.h
@@ -2,9 +2,9 @@
 //
 //                         Peloton
 //
-// wire.h
+// libevent_server.h
 //
-// Identification: src/include/wire/libevent_thread.h
+// Identification: src/include/wire/libevent_server.h
 //
 // Copyright (c) 2015-16, Carnegie Mellon University Database Group
 //
@@ -35,7 +35,7 @@
 #include "configuration/configuration.h"
 #include "container/lock_free_queue.h"
 #include "wire/libevent_thread.h"
-#include "wire/wire.h"
+#include "wire/packet_manager.h"
 
 #define QUEUE_SIZE 100
 #define MASTER_THREAD_ID -1

--- a/src/include/wire/libevent_thread.h
+++ b/src/include/wire/libevent_thread.h
@@ -2,7 +2,7 @@
 //
 //                         Peloton
 //
-// wire.h
+// libevent_thread.h
 //
 // Identification: src/include/wire/libevent_thread.h
 //
@@ -35,7 +35,7 @@
 #include "configuration/configuration.h"
 #include "container/lock_free_queue.h"
 #include "wire/libevent_server.h"
-#include "wire/wire.h"
+#include "wire/packet_manager.h"
 
 namespace peloton {
 namespace wire {

--- a/src/include/wire/packet_manager.h
+++ b/src/include/wire/packet_manager.h
@@ -2,9 +2,9 @@
 //
 //                         Peloton
 //
-// wire.h
+// packet_manager.h
 //
-// Identification: src/include/wire/wire.h
+// Identification: src/include/wire/packet_manager.h
 //
 // Copyright (c) 2015-16, Carnegie Mellon University Database Group
 //

--- a/src/networking/protocol.cpp
+++ b/src/networking/protocol.cpp
@@ -26,7 +26,7 @@
 #include "planner/update_plan.h"
 #include "tcop/tcop.h"
 #include "wire/marshal.h"
-#include "wire/wire.h"
+#include "wire/packet_manager.h"
 
 #include <boost/algorithm/string.hpp>
 #include "wire/packet_manager.h"
@@ -819,7 +819,6 @@ void PacketManager::Reset() {
   skipped_stmt_ = false;
   skipped_query_string_.clear();
   skipped_query_type_.clear();
-  tcop_.Reset();
 
   statement_cache_.clear();
   portals_.clear();

--- a/src/networking/protocol.cpp
+++ b/src/networking/protocol.cpp
@@ -29,6 +29,7 @@
 #include "wire/wire.h"
 
 #include <boost/algorithm/string.hpp>
+#include "wire/packet_manager.h"
 
 #define PROTO_MAJOR_VERSION(x) x >> 16
 
@@ -818,6 +819,7 @@ void PacketManager::Reset() {
   skipped_stmt_ = false;
   skipped_query_string_.clear();
   skipped_query_type_.clear();
+  tcop_.Reset();
 
   statement_cache_.clear();
   portals_.clear();

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -173,12 +173,11 @@ Result TrafficCop::ExecuteStatement(
             planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
 
   try {
-    auto query_str = boost::to_upper_copy<std::string>(statement->GetQueryString());
-    if (query_str == "BEGIN")
+    if (statement->GetQueryType() == "BEGIN")
       return BeginQueryHelper();
-    else if (query_str == "COMMIT")
+    else if (statement->GetQueryType() == "COMMIT")
       return CommitQueryHelper();
-    else if (query_str == "ABORT")
+    else if (statement->GetQueryType() == "ROLLBACK")
       return AbortQueryHelper();
     else {
       auto status = ExecuteStatementPlan(statement->GetPlanTree().get(), params,

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -39,6 +39,7 @@ void TrafficCop::Reset() {
   std::stack<concurrency::Transaction*> new_txn_ptrs;
   // clear out the stack
   swap(txn_ptrs, new_txn_ptrs);
+  optimizer_->Reset();
 }
 
 TrafficCop::~TrafficCop() {
@@ -327,8 +328,5 @@ FieldInfoType TrafficCop::GetColumnFieldForAggregates(
 
   return std::make_tuple(name, POSTGRES_VALUE_TYPE_TEXT, 255);
 }
-
-void TrafficCop::Reset() { optimizer_->Reset(); }
-
 }  // End tcop namespace
 }  // End peloton namespace

--- a/test/executor/copy_test.cpp
+++ b/test/executor/copy_test.cpp
@@ -79,7 +79,8 @@ TEST_F(CopyTests, Copying) {
     std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
     std::vector<ResultType> result;
     bridge::peloton_status status = bridge::PlanExecutor::ExecutePlan(
-        statement->GetPlanTree().get(), params, result, result_format);
+        statement->GetPlanTree().get(), nullptr, params, result,
+        result_format);
     EXPECT_EQ(status.m_result, peloton::RESULT_SUCCESS);
     LOG_TRACE("Statement executed. Result: %d", status.m_result);
   }

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -81,7 +81,8 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   bridge::peloton_status status = bridge::PlanExecutor::ExecutePlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree().get(), nullptr, params, result,
+      result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Table Created");
   txn_manager.CommitTransaction(txn);
@@ -117,7 +118,8 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple inserted!");
   txn_manager.CommitTransaction(txn);
@@ -143,7 +145,8 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("INDEX CREATED!");
   txn_manager.CommitTransaction(txn);

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <cstdio>
+#include <include/tcop/tcop.h>
 
 #include "catalog/catalog.h"
 #include "common/harness.h"
@@ -28,6 +29,7 @@
 #include "planner/insert_plan.h"
 #include "planner/plan_util.h"
 #include "planner/update_plan.h"
+#include "tcop/tcop.h"
 
 #include "gtest/gtest.h"
 
@@ -46,6 +48,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   LOG_INFO("Bootstrapping completed!");
 
   optimizer::SimpleOptimizer optimizer;
+  auto &traffic_cop = tcop::TrafficCop::GetInstance();
 
   // Create a table first
   auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
@@ -80,9 +83,8 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   std::vector<int> result_format;
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  bridge::peloton_status status = bridge::PlanExecutor::ExecutePlan(
-      statement->GetPlanTree().get(), nullptr, params, result,
-      result_format);
+  bridge::peloton_status status = traffic_cop.ExecuteStatementPlan(
+      statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Table Created");
   txn_manager.CommitTransaction(txn);
@@ -117,9 +119,8 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   LOG_INFO("Executing plan...");
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple inserted!");
   txn_manager.CommitTransaction(txn);
@@ -144,9 +145,8 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   LOG_INFO("Executing plan...");
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("INDEX CREATED!");
   txn_manager.CommitTransaction(txn);

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -60,7 +60,8 @@ void ShowTable(std::string database_name, std::string table_name) {
       (parser::SelectStatement*)select_stmt->GetStatement(0));
   result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
 }
 
 TEST_F(DeleteTests, VariousOperations) {
@@ -124,7 +125,8 @@ TEST_F(DeleteTests, VariousOperations) {
   std::vector<int> result_format;
   result_format = std::move(std::vector<int>(0, 0));
   bridge::peloton_status status = bridge::PlanExecutor::ExecutePlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree().get(), nullptr, params, result,
+      result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple inserted!");
   ShowTable(DEFAULT_DB_NAME, "department_table");
@@ -147,7 +149,8 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple inserted!");
   ShowTable(DEFAULT_DB_NAME, "department_table");
@@ -170,7 +173,8 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple inserted!");
   ShowTable(DEFAULT_DB_NAME, "department_table");
@@ -195,7 +199,8 @@ TEST_F(DeleteTests, VariousOperations) {
       tcop::TrafficCop().GenerateTupleDescriptor(select_stmt->GetStatement(0));
   result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Counted Tuples!");
 
@@ -215,7 +220,8 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple deleted!");
   ShowTable(DEFAULT_DB_NAME, "department_table");
@@ -237,7 +243,8 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple deleted!");
   ShowTable(DEFAULT_DB_NAME, "department_table");

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -48,6 +48,7 @@ void ShowTable(std::string database_name, std::string table_name) {
   std::vector<type::Value> params;
   std::vector<ResultType> result;
   optimizer::SimpleOptimizer optimizer;
+  auto &traffic_cop = tcop::TrafficCop::GetInstance();
 
   statement.reset(new Statement("SELECT", "SELECT * FROM " + table->GetName()));
   auto select_stmt =
@@ -59,9 +60,8 @@ void ShowTable(std::string database_name, std::string table_name) {
   auto tuple_descriptor = tcop::TrafficCop().GenerateTupleDescriptor(
       (parser::SelectStatement*)select_stmt->GetStatement(0));
   result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                             params, result, result_format);
 }
 
 TEST_F(DeleteTests, VariousOperations) {
@@ -70,6 +70,7 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Bootstrapping completed!");
 
   optimizer::SimpleOptimizer optimizer;
+  auto &traffic_cop = tcop::TrafficCop::GetInstance();
 
   // Create a table first
   LOG_INFO("Creating a table...");
@@ -124,9 +125,8 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;
   result_format = std::move(std::vector<int>(0, 0));
-  bridge::peloton_status status = bridge::PlanExecutor::ExecutePlan(
-      statement->GetPlanTree().get(), nullptr, params, result,
-      result_format);
+  bridge::peloton_status status = traffic_cop.ExecuteStatementPlan(
+      statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple inserted!");
   ShowTable(DEFAULT_DB_NAME, "department_table");
@@ -148,9 +148,8 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple inserted!");
   ShowTable(DEFAULT_DB_NAME, "department_table");
@@ -172,9 +171,8 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple inserted!");
   ShowTable(DEFAULT_DB_NAME, "department_table");
@@ -198,9 +196,8 @@ TEST_F(DeleteTests, VariousOperations) {
   auto tuple_descriptor =
       tcop::TrafficCop().GenerateTupleDescriptor(select_stmt->GetStatement(0));
   result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Counted Tuples!");
 
@@ -219,9 +216,8 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple deleted!");
   ShowTable(DEFAULT_DB_NAME, "department_table");
@@ -242,9 +238,8 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple deleted!");
   ShowTable(DEFAULT_DB_NAME, "department_table");

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -213,7 +213,8 @@ TEST_F(UpdateTests, UpdatingOld) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   bridge::peloton_status status = bridge::PlanExecutor::ExecutePlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree().get(), nullptr, params, result,
+      result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple inserted!");
   txn_manager.CommitTransaction(txn);
@@ -240,7 +241,8 @@ TEST_F(UpdateTests, UpdatingOld) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple Updated!");
   txn_manager.CommitTransaction(txn);
@@ -268,7 +270,8 @@ TEST_F(UpdateTests, UpdatingOld) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple Updated!");
   txn_manager.CommitTransaction(txn);
@@ -292,7 +295,8 @@ TEST_F(UpdateTests, UpdatingOld) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple Updated!");
   txn_manager.CommitTransaction(txn);
@@ -317,7 +321,8 @@ TEST_F(UpdateTests, UpdatingOld) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple deleted!");
   txn_manager.CommitTransaction(txn);

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -150,6 +150,7 @@ TEST_F(UpdateTests, UpdatingOld) {
   LOG_INFO("Bootstrapping completed!");
 
   optimizer::SimpleOptimizer optimizer;
+  auto &traffic_cop = tcop::TrafficCop::GetInstance();
 
   // Create a table first
   LOG_INFO("Creating a table...");
@@ -212,9 +213,8 @@ TEST_F(UpdateTests, UpdatingOld) {
   std::vector<int> result_format;
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  bridge::peloton_status status = bridge::PlanExecutor::ExecutePlan(
-      statement->GetPlanTree().get(), nullptr, params, result,
-      result_format);
+  bridge::peloton_status status = traffic_cop.ExecuteStatementPlan(
+      statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple inserted!");
   txn_manager.CommitTransaction(txn);
@@ -240,9 +240,8 @@ TEST_F(UpdateTests, UpdatingOld) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple Updated!");
   txn_manager.CommitTransaction(txn);
@@ -269,9 +268,8 @@ TEST_F(UpdateTests, UpdatingOld) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple Updated!");
   txn_manager.CommitTransaction(txn);
@@ -294,9 +292,8 @@ TEST_F(UpdateTests, UpdatingOld) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple Updated!");
   txn_manager.CommitTransaction(txn);
@@ -320,9 +317,8 @@ TEST_F(UpdateTests, UpdatingOld) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple deleted!");
   txn_manager.CommitTransaction(txn);

--- a/test/optimizer/simple_optimizer_test.cpp
+++ b/test/optimizer/simple_optimizer_test.cpp
@@ -67,7 +67,8 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   bridge::peloton_status status = bridge::PlanExecutor::ExecutePlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree().get(), nullptr, params, result,
+      result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Table Created");
   txn_manager.CommitTransaction(txn);
@@ -97,7 +98,8 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple inserted!");
   txn_manager.CommitTransaction(txn);
@@ -117,7 +119,8 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("INDEX CREATED!");
   txn_manager.CommitTransaction(txn);

--- a/test/optimizer/simple_optimizer_test.cpp
+++ b/test/optimizer/simple_optimizer_test.cpp
@@ -16,6 +16,7 @@
 #include "planner/insert_plan.h"
 #include "planner/plan_util.h"
 #include "planner/update_plan.h"
+#include "tcop/tcop.h"
 
 namespace peloton {
 namespace test {
@@ -36,6 +37,7 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
   LOG_INFO("Bootstrapping completed!");
 
   optimizer::SimpleOptimizer optimizer;
+  auto &traffic_cop = tcop::TrafficCop::GetInstance();
 
   // Create a table first
   auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
@@ -66,9 +68,8 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
   std::vector<int> result_format;
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  bridge::peloton_status status = bridge::PlanExecutor::ExecutePlan(
-      statement->GetPlanTree().get(), nullptr, params, result,
-      result_format);
+  bridge::peloton_status status = traffic_cop.ExecuteStatementPlan(
+      statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Table Created");
   txn_manager.CommitTransaction(txn);
@@ -97,9 +98,8 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
 
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("Tuple inserted!");
   txn_manager.CommitTransaction(txn);
@@ -118,9 +118,8 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
 
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_INFO("Statement executed. Result: %d", status.m_result);
   LOG_INFO("INDEX CREATED!");
   txn_manager.CommitTransaction(txn);

--- a/test/sql/sql_tests_util.cpp
+++ b/test/sql/sql_tests_util.cpp
@@ -65,7 +65,8 @@ Result SQLTestsUtil::ExecuteSQLQueryWithOptimizer(
 
   try {
     LOG_DEBUG("%s", planner::PlanUtil::GetInfo(plan.get()).c_str());
-    auto status = bridge::PlanExecutor::ExecutePlan(plan.get(), params, result,
+    auto status = bridge::PlanExecutor::ExecutePlan(plan.get(), nullptr,
+                                                    params, result,
                                                     result_format);
     rows_changed = status.m_processed;
     LOG_INFO("Statement executed. Result: %d", status.m_result);

--- a/test/sql/sql_tests_util.cpp
+++ b/test/sql/sql_tests_util.cpp
@@ -65,9 +65,8 @@ Result SQLTestsUtil::ExecuteSQLQueryWithOptimizer(
 
   try {
     LOG_DEBUG("%s", planner::PlanUtil::GetInfo(plan.get()).c_str());
-    auto status = bridge::PlanExecutor::ExecutePlan(plan.get(), nullptr,
-                                                    params, result,
-                                                    result_format);
+    auto status = traffic_cop_.ExecuteStatementPlan(plan.get(), params,
+                                                    result, result_format);
     rows_changed = status.m_processed;
     LOG_INFO("Statement executed. Result: %d", status.m_result);
     return status.m_result;

--- a/test/statistics/stats_test.cpp
+++ b/test/statistics/stats_test.cpp
@@ -386,7 +386,8 @@ TEST_F(StatsTest, PerQueryStatsTest) {
   std::vector<ResultType> result;
   std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
   bridge::peloton_status status = bridge::PlanExecutor::ExecutePlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree().get(), nullptr, params, result,
+      result_format);
   LOG_TRACE("Statement executed. Result: %d", status.m_result);
   LOG_TRACE("Tuple inserted!");
 
@@ -401,7 +402,8 @@ TEST_F(StatsTest, PerQueryStatsTest) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_TRACE("Statement executed. Result: %d", status.m_result);
   LOG_TRACE("Tuple updated!");
 
@@ -416,7 +418,8 @@ TEST_F(StatsTest, PerQueryStatsTest) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             params, result, result_format);
+                                             nullptr, params, result,
+                                             result_format);
   LOG_TRACE("Statement executed. Result: %d", status.m_result);
   LOG_TRACE("Tuple deleted!");
 

--- a/test/statistics/stats_test.cpp
+++ b/test/statistics/stats_test.cpp
@@ -17,6 +17,7 @@
 
 #include <sys/resource.h>
 #include <time.h>
+#include <include/tcop/tcop.h>
 
 #include "executor/executor_context.h"
 #include "executor/executor_tests_util.h"
@@ -24,6 +25,7 @@
 #include "statistics/backend_stats_context.h"
 #include "statistics/stats_aggregator.h"
 #include "statistics/stats_tests_util.h"
+#include "tcop/tcop.h"
 
 #define NUM_ITERATION 50
 #define NUM_TABLE_INSERT 1
@@ -355,6 +357,7 @@ TEST_F(StatsTest, PerQueryStatsTest) {
   int64_t aggregate_interval = 1000;
   LaunchAggregator(aggregate_interval);
   auto &aggregator = stats::StatsAggregator::GetInstance();
+  auto &traffic_cop = tcop::TrafficCop::GetInstance();
 
   // Create a table first
   auto catalog = catalog::Catalog::GetInstance();
@@ -385,9 +388,8 @@ TEST_F(StatsTest, PerQueryStatsTest) {
   std::vector<type::Value> params;
   std::vector<ResultType> result;
   std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
-  bridge::peloton_status status = bridge::PlanExecutor::ExecutePlan(
-      statement->GetPlanTree().get(), nullptr, params, result,
-      result_format);
+  bridge::peloton_status status = traffic_cop.ExecuteStatementPlan(
+      statement->GetPlanTree().get(), params, result, result_format);
   LOG_TRACE("Statement executed. Result: %d", status.m_result);
   LOG_TRACE("Tuple inserted!");
 
@@ -401,9 +403,8 @@ TEST_F(StatsTest, PerQueryStatsTest) {
   result.clear();
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_TRACE("Statement executed. Result: %d", status.m_result);
   LOG_TRACE("Tuple updated!");
 
@@ -417,9 +418,8 @@ TEST_F(StatsTest, PerQueryStatsTest) {
   result.clear();
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
-                                             nullptr, params, result,
-                                             result_format);
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+                                            params, result, result_format);
   LOG_TRACE("Statement executed. Result: %d", status.m_result);
   LOG_TRACE("Tuple deleted!");
 

--- a/test/statistics/stats_tests_util.cpp
+++ b/test/statistics/stats_tests_util.cpp
@@ -24,6 +24,7 @@
 #include "planner/insert_plan.h"
 #include "planner/plan_util.h"
 #include "storage/tile.h"
+#include "tcop/tcop.h"
 
 namespace peloton {
 namespace test {
@@ -33,6 +34,8 @@ void StatsTestsUtil::ShowTable(std::string database_name,
   catalog::Catalog::GetInstance()->GetTableWithName(database_name, table_name);
   std::unique_ptr<Statement> statement;
   auto &peloton_parser = parser::Parser::GetInstance();
+  auto &traffic_cop = tcop::TrafficCop::GetInstance();
+
   std::vector<type::Value> params;
   std::vector<ResultType> result;
   std::string sql = "SELECT * FROM " + database_name + "." + table_name;
@@ -43,8 +46,8 @@ void StatsTestsUtil::ShowTable(std::string database_name,
   LOG_DEBUG("%s",
             planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
-  bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(), nullptr,
-                                    params, result, result_format);
+  traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(), params,
+                                   result, result_format);
 }
 
 storage::Tuple StatsTestsUtil::PopulateTuple(const catalog::Schema *schema,

--- a/test/statistics/stats_tests_util.cpp
+++ b/test/statistics/stats_tests_util.cpp
@@ -43,8 +43,8 @@ void StatsTestsUtil::ShowTable(std::string database_name,
   LOG_DEBUG("%s",
             planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
-  bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(), params,
-                                    result, result_format);
+  bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(), nullptr,
+                                    params, result, result_format);
 }
 
 storage::Tuple StatsTestsUtil::PopulateTuple(const catalog::Schema *schema,


### PR DESCRIPTION
Features introduced by this PR include:

- Instantiation of tcop per client
- Adding state in tcop to track active tansactions for a given connection
- Support nested transactions by maintaining tcop state as stack
- Reuse same transaction object for all queries within the same BEGIN-COMMIT block