### PR TITLE
Support reference count in varlen type

### DIFF
--- a/src/common/type.cpp
+++ b/src/common/type.cpp
@@ -351,6 +351,11 @@ const char* Type::GetData(const Value& val UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
+// Access the raw varlen data stored from the tuple storage
+char * Type::GetData(char *storage UNUSED_ATTRIBUTE) {
+  throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
+}
+
 // Get the length of the variable length data
 uint32_t Type::GetLength(const Value& val UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");

--- a/src/common/type.cpp
+++ b/src/common/type.cpp
@@ -327,6 +327,15 @@ Value Type::DeserializeFrom(SerializeInput& in UNUSED_ATTRIBUTE,
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
+// Perform a shallow copy from a serialized varlen value to another serialized varlen value
+// Only support VARCHAR/VARBINARY
+void Type::DoShallowCopy(char *dest UNUSED_ATTRIBUTE,
+                         char *src UNUSED_ATTRIBUTE,
+                         bool inlined UNUSED_ATTRIBUTE,
+                         VarlenPool *src_pool UNUSED_ATTRIBUTE) const {
+  throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
+}
+
 // Create a copy of this value
 Value Type::Copy(const Value& val UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");

--- a/src/common/value.cpp
+++ b/src/common/value.cpp
@@ -410,6 +410,19 @@ Value Value::CastAs(const Type::TypeId type_id) const {
 // Access the raw variable length data
 const char *Value::GetData() const { return type_->GetData(*this); }
 
+// Access the raw variable length data from a pointer pointed to a tuple storage
+char *Value::GetDataFromStorage(Type::TypeId type_id, char *storage) {
+  switch (type_id) {
+    case Type::VARCHAR:
+    case Type::VARBINARY: {
+      return Type::GetInstance(type_id)->GetData(storage);
+    }
+    default:
+      throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                      "Invalid Type for getting raw data pointer");
+  }
+}
+
 // Get the length of the variable length data
 uint32_t Value::GetLength() const { return type_->GetLength(*this); }
 

--- a/src/common/value.cpp
+++ b/src/common/value.cpp
@@ -394,6 +394,12 @@ void Value::SerializeTo(SerializeOutput &out) const {
   type_->SerializeTo(*this, out);
 }
 
+// Perform a shallow copy from a serialized varlen value to another serialized varlen value
+// Only support VARCHAR/VARBINARY
+void Value::ShallowCopyTo(char *dest, char *src, const Type::TypeId type_id, bool inlined, VarlenPool *src_pool) {
+  Type::GetInstance(type_id)->DoShallowCopy(dest, src, inlined, src_pool);
+}
+
 // Create a copy of this value
 Value Value::Copy() const { return type_->Copy(*this); }
 

--- a/src/common/varlen_pool.cpp
+++ b/src/common/varlen_pool.cpp
@@ -62,8 +62,27 @@ void VarlenPool::Init() {
 // Allocate a contiguous block of memory of the given size. If the allocation
 // is successful a non-null pointer is returned. If the allocation fails, a
 // null pointer will be returned.
+// Memory allocated block layout:
+//  +------------------+---------+
+//  | 8 byte ref count | payload |
+//  +------------------+---------+
+//                     ^
+//                     Returned pointer pointed to the payload
 // TODO: Provide good error codes for failure cases.
 void *VarlenPool::Allocate(size_t size) {
+  void *addr = AllocateHelper(size + sizeof(std::atomic<int64_t>));
+
+  if (addr == nullptr) {
+    return nullptr;
+  }
+
+  // Init the reference count
+  new (addr) std::atomic<int64_t>(1);
+  return ((char *) addr) + sizeof(std::atomic<int64_t>);
+}
+
+// Internal memory allocation
+void *VarlenPool::AllocateHelper(size_t size){
   // Allocate a large block.
   if (size > BUFFER_SIZE) {
     // Lock the corresponding list
@@ -132,8 +151,27 @@ void *VarlenPool::Allocate(size_t size) {
   return nullptr;
 }
 
+// Add one to the reference count of a block of memory allocated by the pool
+void VarlenPool::AddRefCount(void *ptr){
+  GetRefCntPtr(ptr)->fetch_add(1);
+}
+
+// Get the reference count of a block of memory allocated by the pool
+int64_t VarlenPool::GetRefCount(void *ptr) {
+  return GetRefCntPtr(ptr)->load();
+}
+
 // Returns the provided chunk of memory back into the pool
 void VarlenPool::Free(void *ptr) {
+  int64_t ref_cnt = GetRefCntPtr(ptr)->fetch_sub(1);
+  PL_ASSERT(ref_cnt > 0);
+  if (ref_cnt == 1) {
+    FreeHelper(((char *) ptr) - sizeof(std::atomic<int64_t>));
+  }
+}
+
+// Internal memory deallocation
+void VarlenPool::FreeHelper(void *ptr){
   bool freed = 0;
   // Find the buffer where the ptr is allocated
   for (size_t i = 0; i < MAX_LIST_NUM; i++) {
@@ -179,6 +217,16 @@ uint64_t VarlenPool::GetTotalAllocatedSpace() {
 
 // Get the maximum size of this pool.
 uint64_t VarlenPool::GetMaximumPoolSize() const { return MAX_POOL_SIZE; }
+
+// Get the empty buffer count for a given empty buffer list id
+int VarlenPool::GetEmptyCountByListId(size_t list_id) const {
+  PL_ASSERT(list_id <= LARGE_LIST_ID);
+  if (list_id > LARGE_LIST_ID) {
+    return -1;
+  }
+
+  return static_cast<int>(empty_cnt_[list_id]);
+}
 
 }  // namespace common
 }  // namespace peloton

--- a/src/common/varlen_pool.cpp
+++ b/src/common/varlen_pool.cpp
@@ -163,6 +163,10 @@ int64_t VarlenPool::GetRefCount(void *ptr) {
 
 // Returns the provided chunk of memory back into the pool
 void VarlenPool::Free(void *ptr) {
+  if (ptr == nullptr) {
+    return;
+  }
+
   int64_t ref_cnt = GetRefCntPtr(ptr)->fetch_sub(1);
   PL_ASSERT(ref_cnt > 0);
   if (ref_cnt == 1) {

--- a/src/common/varlen_type.cpp
+++ b/src/common/varlen_type.cpp
@@ -180,6 +180,19 @@ Value VarlenType::DeserializeFrom(SerializeInput &in UNUSED_ATTRIBUTE,
   return Value(type_id_, data, len);
 }
 
+// Perform a shallow copy from a serialized varlen value to another serialized varlen value
+void VarlenType::DoShallowCopy(char *dest, char *src, bool inlined UNUSED_ATTRIBUTE, VarlenPool *src_pool) const {
+  // Never do shallow copy for value that is not allocated in the pool
+  PL_ASSERT(inlined == false && src_pool != nullptr);
+  char *ptr = *reinterpret_cast<char **>(src);
+
+  // Construct a shallow copy of a varlen value
+  *reinterpret_cast<char **>(dest) = ptr;
+  if (ptr != nullptr) {
+    src_pool->AddRefCount(ptr);
+  }
+}
+
 Value VarlenType::Copy(const Value& val) const {
   uint32_t len = val.GetLength();
   return Value(val.GetTypeId(), val.GetData(), len);

--- a/src/common/varlen_type.cpp
+++ b/src/common/varlen_type.cpp
@@ -40,6 +40,12 @@ const char *VarlenType::GetData(const Value& val) const {
   return val.value_.varlen.data;
 }
 
+// Access the raw varlen data stored from the tuple storage
+char *VarlenType::GetData(char *storage) {
+  char *ptr = *reinterpret_cast<char **>(storage);
+  return ptr;
+}
+
 // Get the length of the variable length data
 uint32_t VarlenType::GetLength(const Value& val) const {
   return val.value_.varlen.len;

--- a/src/executor/update_executor.cpp
+++ b/src/executor/update_executor.cpp
@@ -196,8 +196,7 @@ bool UpdateExecutor::DExecute() {
         expression::ContainerTuple<storage::TileGroup> old_tuple(
             tile_group, physical_tuple_id);
         // Execute the projections
-        project_info_->Evaluate(&old_tuple, &old_tuple, nullptr,
-                                executor_context_);
+        project_info_->Evaluate(&old_tuple, &old_tuple, executor_context_, true);
 
         transaction_manager.PerformUpdate(current_txn, old_location);
       }
@@ -262,8 +261,7 @@ bool UpdateExecutor::DExecute() {
           // this triggers in-place update, and we do not need to allocate
           // another
           // version.
-          project_info_->Evaluate(&new_tuple, &old_tuple, nullptr,
-                                  executor_context_);
+          project_info_->Evaluate(&new_tuple, &old_tuple, executor_context_, false);
 
           // get indirection.
           ItemPointer *indirection =

--- a/src/gc/gc_manager.cpp
+++ b/src/gc/gc_manager.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// gc_manager.cpp
+//
+// Identification: src/gc/gc_manager.cpp
+//
+// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+#include "gc/gc_manager.h"
+
+#include "catalog/schema.h"
+#include "common/types.h"
+#include "common/value.h"
+#include "common/varlen_pool.h"
+#include "storage/tile.h"
+#include "storage/tile_group.h"
+
+namespace peloton {
+namespace gc {
+
+// Check a tuple and reclaim all varlen field
+void GCManager::CheckAndReclaimVarlenColumns(storage::TileGroup *tg, oid_t tuple_id) {
+  oid_t tile_count = tg->tile_count;
+  oid_t tile_col_count;
+  common::Type::TypeId type_id;
+  char *tuple_location;
+  char *field_location;
+  char *varlen_ptr;
+
+  for (oid_t tile_itr = 0; tile_itr < tile_count; tile_itr++) {
+    const catalog::Schema &schema = tg->tile_schemas[tile_itr];
+
+    tile_col_count = schema.GetColumnCount();
+
+    storage::Tile *tile = tg->GetTile(tile_itr);
+    PL_ASSERT(tile);
+    for (oid_t tile_col_itr = 0; tile_col_itr < tile_col_count; ++tile_col_itr) {
+      type_id = schema.GetType(tile_col_itr);
+
+      if ((type_id != common::Type::TypeId::VARCHAR && type_id != common::Type::TypeId::VARBINARY)
+          || (schema.IsInlined(tile_col_itr) == true)) {
+        // Not of varlen type, or is inlined, skip
+        continue;
+      }
+      // Get the raw varlen pointer
+      tuple_location = tile->GetTupleLocation(tuple_id);
+      field_location = tuple_location + schema.GetOffset(tile_col_itr);
+      varlen_ptr = common::Value::GetDataFromStorage(type_id, field_location);
+      // Call the corresponding varlen pool free
+      if (varlen_ptr != nullptr) {
+        tile->pool->Free(varlen_ptr);
+      }
+    }
+  }
+}
+
+}
+}

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -36,7 +36,7 @@ void TransactionLevelGCManager::StopGC(int thread_id) {
 
 bool TransactionLevelGCManager::ResetTuple(const ItemPointer &location) {
   auto &manager = catalog::Manager::GetInstance();
-  auto tile_group = manager.GetTileGroup(location.block);
+  auto tile_group = manager.GetTileGroup(location.block).get();
 
   auto tile_group_header = tile_group->GetHeader();
 
@@ -46,6 +46,10 @@ bool TransactionLevelGCManager::ResetTuple(const ItemPointer &location) {
   tile_group_header->SetEndCommitId(location.offset, MAX_CID);
   tile_group_header->SetPrevItemPointer(location.offset, INVALID_ITEMPOINTER);
   tile_group_header->SetNextItemPointer(location.offset, INVALID_ITEMPOINTER);
+
+  // Reclaim the varlen pool
+  CheckAndReclaimVarlenColumns(tile_group, location.offset);
+
   PL_MEMSET(
     tile_group_header->GetReservedFieldRef(location.offset), 0,
     storage::TileGroupHeader::GetReservedSize());

--- a/src/include/common/container_tuple.h
+++ b/src/include/common/container_tuple.h
@@ -115,6 +115,12 @@ class ContainerTuple : public AbstractTuple {
     return true;
   }
 
+  /** @brief Copy a column to a destination tuple
+   */
+  void CopyColumnTo(ContainerTuple<T> *dest, oid_t col_id) {
+    dest->SetValue(col_id, this->GetValue(col_id));
+  }
+
  private:
   /** @brief Underlying container behind this tuple interface. */
   T *container_;
@@ -252,6 +258,13 @@ class ContainerTuple<storage::TileGroup> : public AbstractTuple {
   void SetValue(oid_t column_id, const common::Value &value) {
     common::Value val = value.Copy();
     container_->SetValue(val, tuple_id_, column_id);
+  }
+
+  /** @brief Copy a column from this tuple to a destination tuple.
+   *  Note that we do shallow copy for varlen field here
+   */
+  void CopyColumnTo(ContainerTuple<storage::TileGroup> *dest, oid_t col_id) {
+    this->container_->CopyColumnValueTo(dest->container_, dest->tuple_id_, col_id, this->tuple_id_);
   }
 
   inline char *GetData() const override {

--- a/src/include/common/type.h
+++ b/src/include/common/type.h
@@ -131,6 +131,11 @@ class Type {
   virtual Value DeserializeFrom(SerializeInput &in,
                                 VarlenPool *pool = nullptr) const;
 
+  // Perform a shallow copy from a serialized varlen value to another serialized varlen value
+  // Only support VARCHAR/VARBINARY
+  virtual void DoShallowCopy(char *dest, char *src,
+                             bool inlined, VarlenPool *src_pool) const;
+
   // Create a copy of this value
   virtual Value Copy(const Value& val) const;
 

--- a/src/include/common/type.h
+++ b/src/include/common/type.h
@@ -144,6 +144,9 @@ class Type {
   // Access the raw variable length data
   virtual const char *GetData(const Value& val) const;
 
+  // Access the raw varlen data stored from the tuple storage
+  virtual char *GetData(char *storage);
+
   // Get the length of the variable length data
   virtual uint32_t GetLength(const Value& val) const;
 

--- a/src/include/common/value.h
+++ b/src/include/common/value.h
@@ -205,6 +205,9 @@ class Value : public Printable {
   // Access the raw variable length data
   const char *GetData() const;
 
+  // Access the raw variable length data from a pointer pointed to a tuple storage
+  static char *GetDataFromStorage(Type::TypeId type_id, char *storage);
+
   // Get the length of the variable length data
   uint32_t GetLength() const;
 

--- a/src/include/common/value.h
+++ b/src/include/common/value.h
@@ -198,6 +198,10 @@ class Value : public Printable {
   static Value DeserializeFrom(SerializeInput &in, const Type::TypeId type_id,
                                VarlenPool *pool = nullptr);
 
+  // Perform a shallow copy from a serialized varlen value to another serialized varlen value
+  // Only support VARCHAR/VARBINARY
+  static void ShallowCopyTo(char *dest, char *src, const Type::TypeId type_id, bool inlined, VarlenPool *src_pool);
+
   // Access the raw variable length data
   const char *GetData() const;
 

--- a/src/include/common/varlen_pool.h
+++ b/src/include/common/varlen_pool.h
@@ -50,7 +50,7 @@ class Buffer {
 
 // A memory pool that can quickly allocate chunks of memory to clients.
 class VarlenPool {
- public:
+public:
   // Create and return a new Varlen object of the given size. The caller may
   // optionally provide a pool from which memory can be requested to allocate
   // an object. If no pool is allocated, the implementation is free to acquire
@@ -71,10 +71,23 @@ class VarlenPool {
   // Allocate a contiguous block of memory of the given size. If the allocation
   // is successful a non-null pointer is returned. If the allocation fails, a
   // null pointer will be returned.
+  // Memory allocated block layout:
+  //  +------------------+---------+
+  //  | 8 byte ref count | payload |
+  //  +------------------+---------+
+  //                     ^
+  //                     Returned pointer pointed to the payload
   // TODO: Provide good error codes for failure cases.
   void *Allocate(size_t size);
 
-  // Returns the provided chunk of memory back into the pool
+  // Add one to the reference count of a block of memory allocated by the pool
+  void AddRefCount(void *ptr);
+
+  // Get the reference count of a block of memory allocated by the pool
+  int64_t GetRefCount(void *ptr);
+
+  // Minus one to the reference count of a block of memory allocated by the pool
+  // Returns the provided chunk of memory back into the pool if the reference count becomes 0
   void Free(void *ptr);
 
   // Get the total number of bytes that have been allocated by this pool.
@@ -83,10 +96,30 @@ class VarlenPool {
   // Get the maximum size of this pool.
   uint64_t GetMaximumPoolSize() const;
 
- public:
+  // Get the empty buffer count for a given empty buffer list id
+  // Return -1 if list_id is out of bound
+  int GetEmptyCountByListId(size_t list_id) const;
+
+  static size_t GetRefCountSize() {
+    return sizeof(std::atomic<int64_t>);
+  }
+
+private:
+  inline std::atomic<int64_t> *GetRefCntPtr(void *addr) {
+    char *ref_cnt_addr = ((char *) addr) - sizeof(std::atomic<int64_t>);
+    return reinterpret_cast<std::atomic<int64_t> *>(ref_cnt_addr);
+  }
+
+private:
   // All these fields are implementation specific.
   // This class must be thread-safe, very very fast and provide some form of
   // compaction or garbage-collection.
+
+  // Internal memory allocation
+  void *AllocateHelper(size_t size);
+
+  // Internal memory deallocation
+  void FreeHelper(void *ptr);
 
   // Buffer lists
   std::list<Buffer> buf_list_[MAX_LIST_NUM];

--- a/src/include/common/varlen_type.h
+++ b/src/include/common/varlen_type.h
@@ -61,6 +61,9 @@ class VarlenType : public Type {
   Value DeserializeFrom(SerializeInput &in,
                                 VarlenPool *pool = nullptr) const override;
 
+  // Perform a shallow copy from a serialized varlen value to another serialized varlen value
+  void DoShallowCopy(char *dest, char *src, bool inlined, VarlenPool *src_pool) const override;
+
   // Create a copy of this value
   Value Copy(const Value& val) const override;
 };

--- a/src/include/common/varlen_type.h
+++ b/src/include/common/varlen_type.h
@@ -27,6 +27,9 @@ class VarlenType : public Type {
   // Access the raw variable length data
   const char *GetData(const Value& val) const;
 
+  // Access the raw varlen data stored from the tuple storage
+  char *GetData(char *storage) override;
+
   // Get the length of the variable length data
   uint32_t GetLength(const Value& val) const;
 

--- a/src/include/gc/gc_manager.h
+++ b/src/include/gc/gc_manager.h
@@ -20,6 +20,11 @@
 #include "common/logger.h"
 
 namespace peloton {
+
+namespace storage {
+  class TileGroup;
+}
+
 namespace gc {
 
 //===--------------------------------------------------------------------===//
@@ -27,7 +32,7 @@ namespace gc {
 //===--------------------------------------------------------------------===//
 
 class GCManager {
- public:
+public:
   GCManager(const GCManager &) = delete;
   GCManager &operator=(const GCManager &) = delete;
   GCManager(GCManager &&) = delete;
@@ -59,7 +64,10 @@ class GCManager {
                                    const cid_t &timestamp UNUSED_ATTRIBUTE,
                                    const GCSetType gc_set_type UNUSED_ATTRIBUTE) {}
 
- private:
+protected:
+  void CheckAndReclaimVarlenColumns(storage::TileGroup *tg, oid_t tuple_id);
+
+private:
   bool is_running_;
 };
 

--- a/src/include/planner/project_info.h
+++ b/src/include/planner/project_info.h
@@ -20,6 +20,14 @@
 
 namespace peloton {
 
+namespace storage {
+  class TileGroup;
+}
+
+namespace expression {
+  template <class T> class ContainerTuple;
+}
+
 namespace planner {
 
 /**
@@ -62,9 +70,11 @@ class ProjectInfo {
                 const AbstractTuple *tuple2,
                 executor::ExecutorContext *econtext) const;
 
-  bool Evaluate(AbstractTuple *dest, const AbstractTuple *tuple1,
-                const AbstractTuple *tuple2,
-                executor::ExecutorContext *econtext) const;
+  // Used by the update executor
+  bool Evaluate(expression::ContainerTuple<storage::TileGroup> *dest,
+                expression::ContainerTuple<storage::TileGroup> *src,
+                executor::ExecutorContext *econtext,
+                bool inplace) const;
 
   std::string Debug() const;
 

--- a/src/include/storage/tile.h
+++ b/src/include/storage/tile.h
@@ -96,6 +96,11 @@ class Tile : public Printable {
   void SetValue(const common::Value &value, const oid_t tuple_offset,
                 const oid_t column_id);
 
+  // Copy a column from this tile to a destination tile.
+  // Note that we do shallow copy for varlen field
+  void CopyColumnValueTo(Tile *dest_tile, oid_t dest_tuple_offset, oid_t dest_col_id,
+                         oid_t src_tuple_offset, oid_t src_col_id);
+
   /*
    * Faster way to set value
    * By amortizing schema lookups

--- a/src/include/storage/tile.h
+++ b/src/include/storage/tile.h
@@ -23,6 +23,11 @@
 #include <mutex>
 
 namespace peloton {
+
+namespace gc {
+  class GCManager;
+}
+
 namespace storage {
 
 //===--------------------------------------------------------------------===//
@@ -45,6 +50,7 @@ class Tile : public Printable {
   friend class TileFactory;
   friend class TupleIterator;
   friend class TileGroupHeader;
+  friend class gc::GCManager;
 
   Tile() = delete;
   Tile(Tile const &) = delete;

--- a/src/include/storage/tile_group.h
+++ b/src/include/storage/tile_group.h
@@ -18,12 +18,12 @@
 #include <vector>
 #include <mutex>
 #include <memory>
-#include <planner/project_info.h>
 
 #include "common/types.h"
 #include "common/value.h"
 #include "common/printable.h"
 #include "common/varlen_pool.h"
+#include "planner/project_info.h"
 
 namespace peloton {
 
@@ -164,6 +164,11 @@ class TileGroup : public Printable {
   common::Value GetValue(oid_t tuple_id, oid_t column_id);
 
   void SetValue(common::Value &value, oid_t tuple_id, oid_t column_id);
+
+  // Copy a column from this tile group to a destination tile group.
+  // Note that we do shallow copy for varlen field
+  void CopyColumnValueTo(TileGroup *dest_tg, oid_t src_tuple_id,
+                         oid_t dest_tuple_id, oid_t col_id);
 
   double GetSchemaDifference(const storage::column_map_type &new_column_map);
 

--- a/src/include/storage/tile_group.h
+++ b/src/include/storage/tile_group.h
@@ -27,6 +27,10 @@
 
 namespace peloton {
 
+namespace gc {
+  class GCManager;
+}
+
 namespace catalog {
 class Manager;
 class Schema;
@@ -63,6 +67,7 @@ typedef std::map<oid_t, std::pair<oid_t, oid_t>> column_map_type;
 class TileGroup : public Printable {
   friend class Tile;
   friend class TileGroupFactory;
+  friend class gc::GCManager;
 
   TileGroup() = delete;
   TileGroup(TileGroup const &) = delete;

--- a/src/planner/project_info.cpp
+++ b/src/planner/project_info.cpp
@@ -95,7 +95,8 @@ bool ProjectInfo::Evaluate(expression::ContainerTuple<storage::TileGroup> *dest,
 
   // (B) Execute direct map
   if (inplace == false) {
-    // Only copy un-modified value if not in-place update
+    // For update that creates a new version, we copy all unmodified columns
+    // to the new version. Note that for varlen column, we perform shallow copy.
     for (auto dm : direct_map_list_) {
       // whether left tuple or right tuple ?
       auto tuple_index = dm.second.first;
@@ -108,6 +109,8 @@ bool ProjectInfo::Evaluate(expression::ContainerTuple<storage::TileGroup> *dest,
       }
     }
   }
+  // For inplace update, we don't need to do anything for unmodified columns
+  // because they are already there
 
   return true;
 }

--- a/src/planner/project_info.cpp
+++ b/src/planner/project_info.cpp
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "planner/project_info.h"
+
+#include "common/container_tuple.h"
 #include "executor/executor_context.h"
 #include "expression/constant_value_expression.h"
 #include "expression/expression_util.h"
@@ -80,30 +82,30 @@ bool ProjectInfo::Evaluate(storage::Tuple *dest, const AbstractTuple *tuple1,
   return true;
 }
 
-bool ProjectInfo::Evaluate(AbstractTuple *dest, const AbstractTuple *tuple1,
-                           const AbstractTuple *tuple2,
-                           executor::ExecutorContext *econtext) const {
+bool ProjectInfo::Evaluate(expression::ContainerTuple<storage::TileGroup> *dest,
+                           expression::ContainerTuple<storage::TileGroup> *src,
+                           executor::ExecutorContext *econtext, bool inplace) const {
   // (A) Execute target list
   for (auto target : target_list_) {
     auto col_id = target.first;
     auto expr = target.second;
-    auto value = expr->Evaluate(tuple1, tuple2, econtext);
+    auto value = expr->Evaluate(src, nullptr, econtext);
     dest->SetValue(col_id, value);
   }
 
   // (B) Execute direct map
-  for (auto dm : direct_map_list_) {
-    auto dest_col_id = dm.first;
-    // whether left tuple or right tuple ?
-    auto tuple_index = dm.second.first;
-    auto src_col_id = dm.second.second;
+  if (inplace == false) {
+    // Only copy un-modified value if not in-place update
+    for (auto dm : direct_map_list_) {
+      // whether left tuple or right tuple ?
+      auto tuple_index = dm.second.first;
+      auto src_col_id = dm.second.second;
 
-    if (tuple_index == 0) {
-      common::Value val1 = (tuple1->GetValue(src_col_id));
-      dest->SetValue(dest_col_id, val1);
-    } else {
-      common::Value val2 = (tuple2->GetValue(src_col_id));
-      dest->SetValue(dest_col_id, val2);
+      PL_ASSERT(dm.first == dm.second.second);
+      PL_ASSERT(tuple_index == 0);
+      if (tuple_index == 0) {
+        src->CopyColumnTo(dest, src_col_id);
+      }
     }
   }
 

--- a/src/storage/tile.cpp
+++ b/src/storage/tile.cpp
@@ -158,6 +158,45 @@ void Tile::SetValue(const common::Value &value, const oid_t tuple_offset,
   value.SerializeTo(field_location, is_inlined, pool);
 }
 
+// Copy a column from this tile to a destination tile.
+// Note that we do shallow copy for varlen field
+void Tile::CopyColumnValueTo(Tile *dest_tile, oid_t dest_tuple_offset, oid_t dest_col_id, oid_t src_tuple_offset,
+                             oid_t src_col_id) {
+  PL_ASSERT(src_tuple_offset < this->num_tuple_slots);
+  PL_ASSERT(dest_tuple_offset < this->num_tuple_slots);
+
+  common::Type::TypeId src_type_id = this->schema.GetType(src_col_id);
+
+  PL_ASSERT(src_type_id == this->schema.GetType(dest_col_id));
+  switch (src_type_id) {
+    case common::Type::VARCHAR:
+    case common::Type::VARBINARY: {
+      // Shallow copy
+      char *src_tuple_location = this->GetTupleLocation(src_tuple_offset);
+      char *src_filed_location = src_tuple_location + this->schema.GetOffset(src_col_id);
+      char *dest_tuple_location = dest_tile->GetTupleLocation(dest_tuple_offset);
+      char *dest_field_location = dest_tuple_location + dest_tile->schema.GetOffset(dest_col_id);
+      bool is_inlined = this->schema.IsInlined();
+      PL_ASSERT(dest_tile->schema.IsInlined() == is_inlined);
+      common::Value::ShallowCopyTo(dest_field_location, src_filed_location, src_type_id, is_inlined, this->pool);
+      break;
+    }
+    case common::Type::BOOLEAN:
+    case common::Type::TINYINT:
+    case common::Type::SMALLINT:
+    case common::Type::INTEGER:
+    case common::Type::BIGINT:
+    case common::Type::DECIMAL:
+    case common::Type::TIMESTAMP: {
+      common::Value val = this->GetValue(src_tuple_offset, src_col_id);
+      dest_tile->SetValue(val, dest_tuple_offset, dest_col_id);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
 /*
  * Faster way to set value
  * By amortizing schema lookups

--- a/src/storage/tile_group.cpp
+++ b/src/storage/tile_group.cpp
@@ -367,6 +367,19 @@ void TileGroup::SetValue(common::Value &value, oid_t tuple_id,
   GetTile(tile_offset)->SetValue(value, tuple_id, tile_column_id);
 }
 
+// Copy a column from this tile group to a destination tile group.
+// Note that we do shallow copy for varlen field
+void TileGroup::CopyColumnValueTo(TileGroup *dest_tg, oid_t dest_tuple_id, oid_t col_id, oid_t src_tuple_id) {
+  PL_ASSERT(src_tuple_id < this->GetNextTupleSlot() && dest_tuple_id < dest_tg->GetNextTupleSlot());
+  oid_t src_tile_col_id, src_tile_offset;
+  oid_t dest_tile_col_id, dest_tile_offset;
+  this->LocateTileAndColumn(col_id, src_tile_offset, src_tile_col_id);
+  dest_tg->LocateTileAndColumn(col_id, dest_tile_offset, dest_tile_col_id);
+
+  this->GetTile(src_tile_offset)->CopyColumnValueTo(
+    dest_tg->GetTile(dest_tile_offset), dest_tuple_id, dest_tile_col_id, src_tuple_id, src_tile_col_id);
+}
+
 Tile *TileGroup::GetTile(const oid_t tile_offset) const {
   PL_ASSERT(tile_offset < tile_count);
   Tile *tile = tiles[tile_offset].get();


### PR DESCRIPTION
In this PR, we implemented the following features:
- Support reference count in varlen pool. 
- Make the update executor aware of the reference count and perform a shallow copy on varlen column
- Make the GC manager aware of the reference count and reclaim memory in the varlen pool.

#396 