### PR TITLE
Remove PlanExecutor::Print() and replace it with PlanUtil::GetInfo()

### DIFF
--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -9,6 +9,7 @@
 // Copyright (c) 2015-16, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
+#include "executor/plan_executor.h"
 
 #include <vector>
 
@@ -16,7 +17,6 @@
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/executor_context.h"
 #include "executor/executors.h"
-#include "executor/plan_executor.h"
 #include "optimizer/util.h"
 #include "storage/tuple_iterator.h"
 
@@ -262,32 +262,6 @@ cleanup:
     }
   }
   return executor_context->num_processed;
-}
-
-/**
- * @brief Pretty print the plan tree.
- * @param The plan tree
- * @return none.
- */
-void PlanExecutor::PrintPlan(const planner::AbstractPlan *plan,
-                             std::string prefix) {
-  if (plan == nullptr) {
-    LOG_TRACE("Plan is null");
-    return;
-  }
-
-  prefix += "  ";
-  LOG_TRACE("Plan Type: %s",
-            PlanNodeTypeToString(plan->GetPlanNodeType()).c_str());
-  LOG_TRACE("%s->Plan Info :: %s ", prefix.c_str(), plan->GetInfo().c_str());
-
-  auto &children = plan->GetChildren();
-
-  LOG_TRACE("Number of children in plan: %d ", (int)children.size());
-
-  for (auto &child : children) {
-    PrintPlan(child.get(), prefix);
-  }
 }
 
 /**

--- a/src/include/executor/plan_executor.h
+++ b/src/include/executor/plan_executor.h
@@ -13,8 +13,8 @@
 #pragma once
 
 #include "common/statement.h"
-#include "type/types.h"
 #include "executor/abstract_executor.h"
+#include "type/types.h"
 
 namespace peloton {
 namespace bridge {
@@ -53,9 +53,6 @@ class PlanExecutor {
 
   PlanExecutor(){};
 
-  static void PrintPlan(const planner::AbstractPlan *plan,
-                        std::string prefix = "");
-
   // Copy From
   static inline void copyFromTo(const std::string &src,
                                 std::vector<unsigned char> &dst) {
@@ -93,8 +90,7 @@ class PlanExecutor {
    * @return the number of tuple it executes and logical_tile_list
    */
   static int ExecutePlan(
-      const planner::AbstractPlan *plan,
-      const std::vector<type::Value> &params,
+      const planner::AbstractPlan *plan, const std::vector<type::Value> &params,
       std::vector<std::unique_ptr<executor::LogicalTile>> &logical_tile_list);
 };
 

--- a/src/include/expression/expression_util.h
+++ b/src/include/expression/expression_util.h
@@ -20,13 +20,11 @@
 #include "expression/comparison_expression.h"
 #include "expression/conjunction_expression.h"
 #include "expression/constant_value_expression.h"
-#include "expression/constant_value_expression.h"
 #include "expression/function_expression.h"
 #include "expression/operator_expression.h"
 #include "expression/parameter_value_expression.h"
+#include "expression/string_functions.h"
 #include "expression/tuple_value_expression.h"
-#include "expression/tuple_value_expression.h"
-#include "string_functions.h"
 
 namespace peloton {
 namespace expression {
@@ -58,8 +56,8 @@ class ExpressionUtil {
    * a value from the value vector
    */
   static void ConvertParameterExpressions(
-      expression::AbstractExpression *expression, std::vector<type::Value> *values,
-      catalog::Schema *schema) {
+      expression::AbstractExpression *expression,
+      std::vector<type::Value> *values, catalog::Schema *schema) {
     LOG_TRACE("expression: %s", expression->GetInfo().c_str());
 
     if (expression->GetChild(0)) {

--- a/src/include/planner/plan_util.h
+++ b/src/include/planner/plan_util.h
@@ -1,0 +1,60 @@
+
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// plan_util.h
+//
+// Identification: /peloton/src/include/planner/plan_util.h
+//
+// Copyright (c) 2015, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <string>
+
+#include "planner/abstract_plan.h"
+#include "util/string_util.h"
+
+namespace peloton {
+namespace planner {
+
+class PlanUtil {
+ public:
+  /**
+   * @brief Pretty print the plan tree.
+   * @param The plan tree
+   * @return The string with the pretty-print plan
+   */
+  static std::string GetInfo(const planner::AbstractPlan *plan) {
+    std::ostringstream os;
+    std::string spacer("");
+
+    if (plan == nullptr) {
+      os << "<NULL>";
+    } else {
+      PlanUtil::GetInfo(plan, os, spacer);
+    }
+    return (os.str());
+  }
+
+ private:
+  static void GetInfo(const planner::AbstractPlan *plan, std::ostringstream &os,
+                      std::string prefix) {
+    prefix += "  ";
+    os << "Plan Type: " << PlanNodeTypeToString(plan->GetPlanNodeType())
+       << std::endl;
+    os << prefix << plan->GetInfo() << std::endl;
+
+    auto &children = plan->GetChildren();
+    os << "NumChildren: " << children.size();
+
+    for (auto &child : children) {
+      GetInfo(child.get(), os, prefix);
+    }
+  }
+};
+}
+}

--- a/src/planner/abstract_plan.cpp
+++ b/src/planner/abstract_plan.cpp
@@ -18,8 +18,8 @@
 #include <utility>
 
 #include "common/logger.h"
-#include "type/types.h"
 #include "expression/expression_util.h"
+#include "type/types.h"
 
 namespace peloton {
 namespace planner {
@@ -48,17 +48,8 @@ std::ostream &operator<<(std::ostream &os, const AbstractPlan &plan) {
 
 const std::string AbstractPlan::GetInfo() const {
   std::ostringstream os;
-
-  os << GetInfo();
-
-  // Traverse the tree
-  std::string child_spacer = "  ";
-  for (int ctr = 0, cnt = static_cast<int>(children_.size()); ctr < cnt;
-       ctr++) {
-    os << child_spacer << children_[ctr].get()->GetPlanNodeType() << "\n";
-    os << children_[ctr].get()->GetInfo();
-  }
-
+  os << PlanNodeTypeToString(GetPlanNodeType())
+     << " [NumChildren=" << children_.size() << "]";
   return os.str();
 }
 

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -86,7 +86,7 @@ Result TrafficCop::ExecuteStatement(
             statement->GetStatementName().c_str());
   LOG_TRACE("Execute Statement of query: %s",
             statement->GetStatementName().c_str());
-  LOG_DEBUG("Execute Statement Plan:\n%s",
+  LOG_TRACE("Execute Statement Plan:\n%s",
             planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
 
   try {
@@ -125,9 +125,9 @@ std::shared_ptr<Statement> TrafficCop::PrepareStatement(
       }
       break;
     }
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
     if (statement->GetPlanTree().get() != nullptr) {
-      LOG_DEBUG("Statement Prepared\n%s",
+      LOG_TRACE("Statement Prepared\n%s",
                 statement->GetPlanTree().get()->GetInfo().c_str());
     }
 #endif

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -26,6 +26,7 @@
 #include "planner/create_plan.h"
 #include "planner/delete_plan.h"
 #include "planner/insert_plan.h"
+#include "planner/plan_util.h"
 #include "planner/update_plan.h"
 
 #include "gtest/gtest.h"
@@ -74,8 +75,8 @@ TEST_F(CreateIndexTests, CreatingIndex) {
 
   std::vector<type::Value> params;
   std::vector<ResultType> result;
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
-  LOG_INFO("Executing plan...");
+  LOG_INFO("Executing plan...\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
@@ -109,8 +110,8 @@ TEST_F(CreateIndexTests, CreatingIndex) {
 
   LOG_INFO("Building plan tree...");
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(insert_stmt));
-  LOG_INFO("Building plan tree completed!");
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
+  LOG_INFO("Building plan tree completed!\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
 
   LOG_INFO("Executing plan...");
   result_format =
@@ -135,8 +136,8 @@ TEST_F(CreateIndexTests, CreatingIndex) {
 
   LOG_INFO("Building plan tree...");
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(update_stmt));
-  LOG_INFO("Building plan tree completed!");
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
+  LOG_INFO("Building plan tree completed!\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
 
   LOG_INFO("Executing plan...");
   result_format =

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -25,6 +25,7 @@
 #include "planner/create_plan.h"
 #include "planner/delete_plan.h"
 #include "planner/insert_plan.h"
+#include "planner/plan_util.h"
 #include "tcop/tcop.h"
 
 #include "gtest/gtest.h"
@@ -52,7 +53,8 @@ void ShowTable(std::string database_name, std::string table_name) {
   auto select_stmt =
       peloton_parser.BuildParseTree("SELECT * FROM " + table->GetName());
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(select_stmt));
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
+  LOG_TRACE("Query Plan\n%s",
+            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;
   auto tuple_descriptor = tcop::TrafficCop().GenerateTupleDescriptor(
       (parser::SelectStatement*)select_stmt->GetStatement(0));
@@ -70,9 +72,9 @@ TEST_F(DeleteTests, VariousOperations) {
 
   // Create a table first
   LOG_INFO("Creating a table...");
-  auto id_column = catalog::Column(
-      type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
-      "dept_id", true);
+  auto id_column = catalog::Column(type::Type::INTEGER,
+                                   type::Type::GetTypeSize(type::Type::INTEGER),
+                                   "dept_id", true);
   auto name_column =
       catalog::Column(type::Type::VARCHAR, 32, "dept_name", false);
 
@@ -117,8 +119,8 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Building plan tree completed!");
   std::vector<type::Value> params;
   std::vector<ResultType> result;
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
-  LOG_INFO("Executing plan...");
+  LOG_INFO("Executing plan...\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;
   result_format = std::move(std::vector<int>(0, 0));
   bridge::peloton_status status = bridge::PlanExecutor::ExecutePlan(
@@ -140,8 +142,8 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Building parse tree completed!");
   LOG_INFO("Building plan tree...");
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(insert_stmt));
-  LOG_INFO("Building plan tree completed!");
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
+  LOG_INFO("Building plan tree completed!\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
@@ -163,8 +165,8 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Building parse tree completed!");
   LOG_INFO("Building plan tree...");
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(insert_stmt));
-  LOG_INFO("Building plan tree completed!");
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
+  LOG_INFO("Building plan tree completed!\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
@@ -186,8 +188,8 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Building parse tree completed!");
   LOG_INFO("Building plan tree...");
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(select_stmt));
-  LOG_INFO("Building plan tree completed!");
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
+  LOG_INFO("Building plan tree completed!\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   auto tuple_descriptor =
       tcop::TrafficCop().GenerateTupleDescriptor(select_stmt->GetStatement(0));
@@ -208,8 +210,8 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Building parse tree completed!");
   LOG_INFO("Building plan tree...");
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(delete_stmt_2));
-  LOG_INFO("Building plan tree completed!");
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
+  LOG_INFO("Building plan tree completed!\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
@@ -230,8 +232,8 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Building parse tree completed!");
   LOG_INFO("Building plan tree...");
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(delete_stmt));
-  LOG_INFO("Building plan tree completed!");
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
+  LOG_INFO("Building plan tree completed!\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),

--- a/test/executor/drop_test.cpp
+++ b/test/executor/drop_test.cpp
@@ -14,11 +14,12 @@
 
 #include "gtest/gtest.h"
 
-#include "../../src/include/executor/drop_executor.h"
+#include "catalog/catalog.h"
 #include "common/harness.h"
 #include "common/logger.h"
-#include "catalog/catalog.h"
+#include "executor/drop_executor.h"
 #include "planner/drop_plan.h"
+#include "planner/plan_util.h"
 
 namespace peloton {
 namespace test {
@@ -30,14 +31,14 @@ namespace test {
 class DropTests : public PelotonTest {};
 
 TEST_F(DropTests, DroppingTable) {
-
   auto catalog = catalog::Catalog::GetInstance();
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   // Insert a table first
-  auto id_column = catalog::Column(
-      type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER), "dept_id", true);
+  auto id_column = catalog::Column(type::Type::INTEGER,
+                                   type::Type::GetTypeSize(type::Type::INTEGER),
+                                   "dept_id", true);
   auto name_column =
       catalog::Column(type::Type::VARCHAR, 32, "dept_name", false);
 

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -18,9 +18,6 @@
 #include "catalog/schema.h"
 #include "common/logger.h"
 #include "common/statement.h"
-#include "type/types.h"
-#include "type/value.h"
-#include "type/value_factory.h"
 #include "concurrency/transaction.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/abstract_executor.h"
@@ -40,11 +37,15 @@
 #include "planner/create_plan.h"
 #include "planner/delete_plan.h"
 #include "planner/insert_plan.h"
+#include "planner/plan_util.h"
 #include "planner/seq_scan_plan.h"
 #include "planner/update_plan.h"
 #include "storage/data_table.h"
 #include "storage/tile_group_factory.h"
 #include "tcop/tcop.h"
+#include "type/types.h"
+#include "type/value.h"
+#include "type/value_factory.h"
 
 #include "common/harness.h"
 #include "executor/executor_tests_util.h"
@@ -152,9 +153,9 @@ TEST_F(UpdateTests, UpdatingOld) {
 
   // Create a table first
   LOG_INFO("Creating a table...");
-  auto id_column = catalog::Column(
-      type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
-      "dept_id", true);
+  auto id_column = catalog::Column(type::Type::INTEGER,
+                                   type::Type::GetTypeSize(type::Type::INTEGER),
+                                   "dept_id", true);
   catalog::Constraint constraint(CONSTRAINT_TYPE_PRIMARY, "con_primary");
   id_column.AddConstraint(constraint);
   auto manager_id_column = catalog::Column(
@@ -205,8 +206,9 @@ TEST_F(UpdateTests, UpdatingOld) {
   LOG_INFO("Building plan tree completed!");
   std::vector<type::Value> params;
   std::vector<ResultType> result;
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
-  LOG_INFO("Executing plan...");
+  LOG_INFO("Executing plan...\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
+
   std::vector<int> result_format;
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
@@ -233,8 +235,8 @@ TEST_F(UpdateTests, UpdatingOld) {
   LOG_INFO("Building plan tree...");
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(update_stmt));
   LOG_INFO("Building plan tree completed!");
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
-  LOG_INFO("Executing plan...");
+  LOG_INFO("Executing plan...\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
@@ -261,8 +263,8 @@ TEST_F(UpdateTests, UpdatingOld) {
   LOG_INFO("Building plan tree...");
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(update_stmt));
   LOG_INFO("Building plan tree completed!");
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
-  LOG_INFO("Executing plan...");
+  LOG_INFO("Executing plan...\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
@@ -285,8 +287,8 @@ TEST_F(UpdateTests, UpdatingOld) {
   LOG_INFO("Building plan tree...");
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(update_stmt));
   LOG_INFO("Building plan tree completed!");
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
-  LOG_INFO("Executing plan...");
+  LOG_INFO("Executing plan...\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
@@ -310,8 +312,8 @@ TEST_F(UpdateTests, UpdatingOld) {
   LOG_INFO("Building plan tree...");
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(delete_stmt));
   LOG_INFO("Building plan tree completed!");
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
-  LOG_INFO("Executing plan...");
+  LOG_INFO("Executing plan...\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   status = bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),

--- a/test/optimizer/simple_optimizer_test.cpp
+++ b/test/optimizer/simple_optimizer_test.cpp
@@ -14,6 +14,7 @@
 #include "planner/create_plan.h"
 #include "planner/delete_plan.h"
 #include "planner/insert_plan.h"
+#include "planner/plan_util.h"
 #include "planner/update_plan.h"
 
 namespace peloton {
@@ -25,11 +26,11 @@ namespace test {
 
 using namespace optimizer;
 
-class OptimizerTests : public PelotonTest {};
+class SimpleOptimizerTests : public PelotonTest {};
 
 // Test whether update stament will use index scan plan
 // TODO: Split the tests into separate test cases.
-TEST_F(OptimizerTests, UpdateDelWithIndexScanTest) {
+TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
   LOG_INFO("Bootstrapping...");
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, nullptr);
   LOG_INFO("Bootstrapping completed!");
@@ -60,7 +61,8 @@ TEST_F(OptimizerTests, UpdateDelWithIndexScanTest) {
 
   std::vector<type::Value> params;
   std::vector<ResultType> result;
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
+  LOG_INFO("Query Plan:\n%s",
+           planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));

--- a/test/sql/sql_tests_util.cpp
+++ b/test/sql/sql_tests_util.cpp
@@ -9,6 +9,7 @@
 // Copyright (c) 2015-16, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
+#include "sql/sql_tests_util.h"
 
 #include "catalog/catalog.h"
 #include "common/logger.h"
@@ -16,9 +17,8 @@
 #include "optimizer/rule.h"
 #include "optimizer/simple_optimizer.h"
 #include "parser/parser.h"
+#include "planner/plan_util.h"
 #include "tcop/tcop.h"
-
-#include "sql/sql_tests_util.h"
 
 namespace peloton {
 
@@ -64,7 +64,7 @@ Result SQLTestsUtil::ExecuteSQLQueryWithOptimizer(
   auto result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
 
   try {
-    bridge::PlanExecutor::PrintPlan(plan.get(), "Plan");
+    LOG_DEBUG("%s", planner::PlanUtil::GetInfo(plan.get()).c_str());
     auto status = bridge::PlanExecutor::ExecutePlan(plan.get(), params, result,
                                                     result_format);
     rows_changed = status.m_processed;

--- a/test/statistics/stats_tests_util.cpp
+++ b/test/statistics/stats_tests_util.cpp
@@ -22,6 +22,7 @@
 #include "expression/expression_util.h"
 #include "planner/delete_plan.h"
 #include "planner/insert_plan.h"
+#include "planner/plan_util.h"
 #include "storage/tile.h"
 
 namespace peloton {
@@ -39,7 +40,8 @@ void StatsTestsUtil::ShowTable(std::string database_name,
   auto select_stmt = peloton_parser.BuildParseTree(sql);
   statement->SetPlanTree(
       optimizer::SimpleOptimizer().BuildPelotonPlanTree(select_stmt));
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
+  LOG_DEBUG("%s",
+            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
   bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(), params,
                                     result, result_format);
@@ -97,9 +99,9 @@ std::shared_ptr<stats::QueryMetric::QueryParams> StatsTestsUtil::GetQueryParams(
 void StatsTestsUtil::CreateTable(bool has_primary_key) {
   LOG_INFO("Creating a table...");
 
-  auto id_column = catalog::Column(
-      type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
-      "dept_id", true);
+  auto id_column = catalog::Column(type::Type::INTEGER,
+                                   type::Type::GetTypeSize(type::Type::INTEGER),
+                                   "dept_id", true);
   if (has_primary_key) {
     catalog::Constraint constraint(CONSTRAINT_TYPE_PRIMARY, "con_primary");
     id_column.AddConstraint(constraint);
@@ -160,7 +162,7 @@ void StatsTestsUtil::ParseAndPlan(Statement *statement, std::string sql) {
   statement->SetPlanTree(
       optimizer::SimpleOptimizer().BuildPelotonPlanTree(update_stmt));
   LOG_TRACE("Building plan tree completed!");
-  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
+  LOG_TRACE("%s", statement->GetPlanTree().get()->GetInfo().c_str());
 }
 
 }  // namespace test


### PR DESCRIPTION
This PR makes it so that we don't call the pretty-print function on the query plan *every* time we execute a query.

We never saw this because `PlanExecutor::Print()` was using `LOG_TRACE`. This is not a huge win but it does remove wasted cycles.