### PR TITLE
Fix value/type system issues

### DIFF
--- a/src/catalog/catalog_util.cpp
+++ b/src/catalog/catalog_util.cpp
@@ -213,11 +213,11 @@ std::unique_ptr<storage::Tuple> GetQueryMetricsCatalogTuple(
 
   if (num_params != 0) {
     param_type =
-        type::ValueFactory::GetVarbinaryValue(type_buf.buf, type_buf.len);
+        type::ValueFactory::GetVarbinaryValue(type_buf.buf, type_buf.len, false);
     param_format =
-        type::ValueFactory::GetVarbinaryValue(format_buf.buf, format_buf.len);
+        type::ValueFactory::GetVarbinaryValue(format_buf.buf, format_buf.len, false);
     param_value =
-        type::ValueFactory::GetVarbinaryValue(val_buf.buf, val_buf.len);
+        type::ValueFactory::GetVarbinaryValue(val_buf.buf, val_buf.len, false);
   }
 
   auto val7 = type::ValueFactory::GetIntegerValue(reads);

--- a/src/include/type/type.h
+++ b/src/include/type/type.h
@@ -65,8 +65,13 @@ class Type {
   static Value GetMinValue(TypeId type_id);
   static Value GetMaxValue(TypeId type_id);
 
-  static Type * GetInstance(TypeId type_id);
-  TypeId GetTypeId() const;
+  inline static Type * GetInstance(TypeId type_id) {
+    return kTypes[type_id];
+  }
+
+  inline TypeId GetTypeId() const {
+    return type_id_;
+  }
 
   // Comparison functions
   //

--- a/src/include/type/type.h
+++ b/src/include/type/type.h
@@ -27,7 +27,7 @@ class ValueFactory;
 class Type {
  public:
   enum TypeId {
-    INVALID,
+    INVALID = 0,
     PARAMETER_OFFSET,
     BOOLEAN,
     TINYINT,

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -164,10 +164,10 @@ class Value : public Printable {
   bool IsNull() const;
 
   // Examine the type of this object.
-  void CheckInteger() const;
+  bool CheckInteger() const;
 
   // Can two types of value be compared?
-  void CheckComparable(const Value &o) const;
+  bool CheckComparable(const Value &o) const;
 
   bool IsTrue() const {
     PL_ASSERT(GetTypeId() == Type::BOOLEAN);

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -74,7 +74,7 @@ class Value : public Printable {
  private:
 #endif
 
-  Value(const Type::TypeId type) : type_(Type::GetInstance(type)) {}
+  Value(const Type::TypeId type) : type_(Type::GetInstance(type)), manage_data_(false) {}
 
   // ARRAY values
   template <class T>
@@ -99,7 +99,7 @@ class Value : public Printable {
   Value(Type::TypeId type, uint64_t i);
 
   // VARCHAR and VARBINARY
-  Value(Type::TypeId type, const char *data, uint32_t len);
+  Value(Type::TypeId type, const char *data, uint32_t len, bool manage_data);
   Value(Type::TypeId type, const std::string &data);
 
  public:
@@ -113,6 +113,7 @@ class Value : public Printable {
     std::swap(first.type_, second.type_);
     std::swap(first.value_, second.value_);
     std::swap(first.size_, second.size_);
+    std::swap(first.manage_data_, second.manage_data_);
   }
 
   Value &operator=(Value other);
@@ -364,6 +365,7 @@ class Value : public Printable {
     double decimal;
     uint64_t timestamp;
     char * varlen;
+    const char * const_varlen;
     char * array;
   } value_;
 
@@ -372,7 +374,7 @@ class Value : public Printable {
    Type::TypeId elem_type_id;
   } size_;
 
-  bool allocated_;
+  bool manage_data_;
 };
 
 // ARRAY here to ease creation of templates

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -85,29 +85,40 @@ class ValueFactory {
   }
 
   static inline Value GetNullValueByType(Type::TypeId type_id) {
+    Value ret_value;
     switch (type_id) {
       case Type::BOOLEAN:
-        return GetBooleanValue(PELOTON_BOOLEAN_NULL);
-      case Type::TINYINT:
-        return GetTinyIntValue(PELOTON_INT8_NULL);
-      case Type::SMALLINT:
-        return GetSmallIntValue(PELOTON_INT16_NULL);
-      case Type::INTEGER:
-        return GetIntegerValue(PELOTON_INT32_NULL);
-      case Type::BIGINT:
-        return GetBigIntValue(PELOTON_INT64_NULL);
-      case Type::DECIMAL:
-        return GetDoubleValue(PELOTON_DECIMAL_NULL);
-      case Type::TIMESTAMP:
-        return GetTimestampValue(PELOTON_TIMESTAMP_NULL);
-      case Type::VARCHAR:
-        return GetVarcharValue(nullptr, 0);
-      case Type::VARBINARY:
-        return GetVarbinaryValue(nullptr, 0);
-      default:
+        ret_value = GetBooleanValue(PELOTON_BOOLEAN_NULL);
         break;
+      case Type::TINYINT:
+        ret_value = GetTinyIntValue(PELOTON_INT8_NULL);
+        break;
+      case Type::SMALLINT:
+        ret_value = GetSmallIntValue(PELOTON_INT16_NULL);
+        break;
+      case Type::INTEGER:
+        ret_value = GetIntegerValue(PELOTON_INT32_NULL);
+        break;
+      case Type::BIGINT:
+        ret_value = GetBigIntValue(PELOTON_INT64_NULL);
+        break;
+      case Type::DECIMAL:
+        ret_value = GetDoubleValue(PELOTON_DECIMAL_NULL);
+        break;
+      case Type::TIMESTAMP:
+        ret_value = GetTimestampValue(PELOTON_TIMESTAMP_NULL);
+        break;
+      case Type::VARCHAR:
+        ret_value = GetVarcharValue(nullptr, 0);
+        break;
+      case Type::VARBINARY:
+        ret_value = GetVarbinaryValue(nullptr, 0);
+        break;
+      default:
+        throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Unknown type.");
     }
-    throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Unknown type.");
+    ret_value.size_.len = PELOTON_VALUE_NULL;
+    return ret_value;
   }
 
   static inline Value GetZeroValueByType(Type::TypeId type_id) {

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -63,9 +63,9 @@ class ValueFactory {
   }
 
   static inline Value GetVarcharValue(
-      const char *value, UNUSED_ATTRIBUTE VarlenPool *pool = nullptr) {
+      const char *value, bool manage_data, UNUSED_ATTRIBUTE VarlenPool *pool = nullptr) {
     return Value(Type::VARCHAR, value,
-                 value == nullptr ? 0 : strlen(value) + 1);
+                 value == nullptr ? 0 : strlen(value) + 1 , manage_data);
   }
 
   static inline Value GetVarcharValue(
@@ -79,9 +79,9 @@ class ValueFactory {
   }
 
   static inline Value GetVarbinaryValue(
-      const unsigned char *rawBuf, int32_t rawLength,
+      const unsigned char *rawBuf, int32_t rawLength, bool manage_data,
       UNUSED_ATTRIBUTE VarlenPool *pool = nullptr) {
-    return Value(Type::VARBINARY, (const char *)rawBuf, rawLength);
+    return Value(Type::VARBINARY, (const char *)rawBuf, rawLength, manage_data);
   }
 
   static inline Value GetNullValueByType(Type::TypeId type_id) {
@@ -109,10 +109,10 @@ class ValueFactory {
         ret_value = GetTimestampValue(PELOTON_TIMESTAMP_NULL);
         break;
       case Type::VARCHAR:
-        ret_value = GetVarcharValue(nullptr, 0);
+        ret_value = GetVarcharValue(nullptr, false, nullptr);
         break;
       case Type::VARBINARY:
-        ret_value = GetVarbinaryValue(nullptr, 0);
+        ret_value = GetVarbinaryValue(nullptr, 0, false, nullptr);
         break;
       default:
         throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Unknown type.");

--- a/src/networking/protocol.cpp
+++ b/src/networking/protocol.cpp
@@ -607,8 +607,8 @@ size_t PacketManager::ReadParamValue(
                 type::Type::VARBINARY,
                 std::string(reinterpret_cast<char *>(&param[0]), param_len));
             param_values[param_idx] =
-                type::ValueFactory::GetVarbinaryValue(&param[0], param_len)
-                    .Copy();
+                type::ValueFactory::GetVarbinaryValue(&param[0], param_len, true);
+
           } break;
           default: {
             LOG_ERROR("Do not support data type: %d", param_types[param_idx]);

--- a/src/type/array_type.cpp
+++ b/src/type/array_type.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <include/type/value.h>
 #include "type/array_type.h"
 
 #include "type/boolean_type.h"
@@ -26,40 +27,40 @@ namespace type {
 Value ArrayType::GetElementAt(const Value &val, uint64_t idx) const {
   switch (val.GetElementType()) {
     case Type::BOOLEAN: {
-      std::vector<bool> vec = *(std::vector<bool> *)(val.value_.array.data);
+      std::vector<bool> vec = *(std::vector<bool> *)(val.value_.array);
       return ValueFactory::GetBooleanValue(vec.at(idx));
     }
     case Type::TINYINT: {
-      std::vector<int8_t> vec = *(std::vector<int8_t> *)(val.value_.array.data);
+      std::vector<int8_t> vec = *(std::vector<int8_t> *)(val.value_.array);
       return ValueFactory::GetTinyIntValue((int8_t)vec.at(idx));
     }
     case Type::SMALLINT: {
       std::vector<int16_t> vec =
-          *(std::vector<int16_t> *)(val.value_.array.data);
+          *(std::vector<int16_t> *)(val.value_.array);
       return ValueFactory::GetSmallIntValue((int16_t)vec.at(idx));
     }
     case Type::INTEGER: {
       std::vector<int32_t> vec =
-          *(std::vector<int32_t> *)(val.value_.array.data);
+          *(std::vector<int32_t> *)(val.value_.array);
       return ValueFactory::GetIntegerValue((int32_t)vec.at(idx));
     }
     case Type::BIGINT: {
       std::vector<int64_t> vec =
-          *(std::vector<int64_t> *)(val.value_.array.data);
+          *(std::vector<int64_t> *)(val.value_.array);
       return ValueFactory::GetBigIntValue((int64_t)vec.at(idx));
     }
     case Type::DECIMAL: {
-      std::vector<double> vec = *(std::vector<double> *)(val.value_.array.data);
+      std::vector<double> vec = *(std::vector<double> *)(val.value_.array);
       return ValueFactory::GetDoubleValue((double)vec.at(idx));
     }
     case Type::TIMESTAMP: {
       std::vector<uint64_t> vec =
-          *(std::vector<uint64_t> *)(val.value_.array.data);
+          *(std::vector<uint64_t> *)(val.value_.array);
       return ValueFactory::GetTimestampValue((uint64_t)vec.at(idx));
     }
     case Type::VARCHAR: {
       std::vector<std::string> vec =
-          *(std::vector<std::string> *)(val.value_.array.data);
+          *(std::vector<std::string> *)(val.value_.array);
       return ValueFactory::GetVarcharValue(vec.at(idx));
     }
     default:
@@ -75,7 +76,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
   if (object.IsNull()) return ValueFactory::GetNullValueByType(Type::BOOLEAN);
   switch (list.GetElementType()) {
     case Type::BOOLEAN: {
-      std::vector<bool> vec = *(std::vector<bool> *)(list.value_.array.data);
+      std::vector<bool> vec = *(std::vector<bool> *)(list.value_.array);
       std::vector<bool>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetBooleanValue(*it).CompareEquals(object);
@@ -85,7 +86,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
     }
     case Type::TINYINT: {
       std::vector<int8_t> vec =
-          *(std::vector<int8_t> *)(list.value_.array.data);
+          *(std::vector<int8_t> *)(list.value_.array);
       std::vector<int8_t>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = Value(Type::TINYINT, *it).CompareEquals(object);
@@ -95,7 +96,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
     }
     case Type::SMALLINT: {
       std::vector<int16_t> vec =
-          *(std::vector<int16_t> *)(list.value_.array.data);
+          *(std::vector<int16_t> *)(list.value_.array);
       std::vector<int16_t>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = Value(Type::SMALLINT, *it).CompareEquals(object);
@@ -105,7 +106,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
     }
     case Type::INTEGER: {
       std::vector<int32_t> vec =
-          *(std::vector<int32_t> *)(list.value_.array.data);
+          *(std::vector<int32_t> *)(list.value_.array);
       std::vector<int32_t>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetIntegerValue(*it).CompareEquals(object);
@@ -115,7 +116,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
     }
     case Type::BIGINT: {
       std::vector<int64_t> vec =
-          *(std::vector<int64_t> *)(list.value_.array.data);
+          *(std::vector<int64_t> *)(list.value_.array);
       std::vector<int64_t>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetBigIntValue(*it).CompareEquals(object);
@@ -125,7 +126,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
     }
     case Type::DECIMAL: {
       std::vector<double> vec =
-          *(std::vector<double> *)(list.value_.array.data);
+          *(std::vector<double> *)(list.value_.array);
       std::vector<double>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetDoubleValue(*it).CompareEquals(object);
@@ -135,7 +136,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
     }
     case Type::TIMESTAMP: {
       std::vector<uint64_t> vec =
-          *(std::vector<uint64_t> *)(list.value_.array.data);
+          *(std::vector<uint64_t> *)(list.value_.array);
       std::vector<uint64_t>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetTimestampValue(*it).CompareEquals(object);
@@ -145,7 +146,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
     }
     case Type::VARCHAR: {
       std::vector<std::string> vec =
-          *(std::vector<std::string> *)(list.value_.array.data);
+          *(std::vector<std::string> *)(list.value_.array);
       std::vector<std::string>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = Value(Type::VARCHAR, *it).CompareEquals(object);
@@ -170,55 +171,55 @@ Value ArrayType::CompareEquals(const Value &left, const Value &right) const {
   }
   switch (left.GetElementType()) {
     case Type::BOOLEAN: {
-      std::vector<bool> vec1 = *(std::vector<bool> *)(left.value_.array.data);
+      std::vector<bool> vec1 = *(std::vector<bool> *)(left.value_.array);
       std::vector<bool> vec2 = *(std::vector<bool> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::TINYINT: {
       std::vector<int8_t> vec1 =
-          *(std::vector<int8_t> *)(left.value_.array.data);
+          *(std::vector<int8_t> *)(left.value_.array);
       std::vector<int8_t> vec2 =
           *(std::vector<int8_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::SMALLINT: {
       std::vector<int16_t> vec1 =
-          *(std::vector<int16_t> *)(left.value_.array.data);
+          *(std::vector<int16_t> *)(left.value_.array);
       std::vector<int16_t> vec2 =
           *(std::vector<int16_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::INTEGER: {
       std::vector<int32_t> vec1 =
-          *(std::vector<int32_t> *)(left.value_.array.data);
+          *(std::vector<int32_t> *)(left.value_.array);
       std::vector<int32_t> vec2 =
           *(std::vector<int32_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::BIGINT: {
       std::vector<int64_t> vec1 =
-          *(std::vector<int64_t> *)(left.value_.array.data);
+          *(std::vector<int64_t> *)(left.value_.array);
       std::vector<int64_t> vec2 =
           *(std::vector<int64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::DECIMAL: {
       std::vector<double> vec1 =
-          *(std::vector<double> *)(left.value_.array.data);
+          *(std::vector<double> *)(left.value_.array);
       std::vector<double> vec2 =
           *(std::vector<double> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::TIMESTAMP: {
       std::vector<uint64_t> vec1 =
-          *(std::vector<uint64_t> *)(left.value_.array.data);
+          *(std::vector<uint64_t> *)(left.value_.array);
       std::vector<uint64_t> vec2 =
           *(std::vector<uint64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
     }
     case Type::VARCHAR: {
       std::vector<std::string> vec1 =
-          *(std::vector<std::string> *)(left.value_.array.data);
+          *(std::vector<std::string> *)(left.value_.array);
       std::vector<std::string> vec2 =
           *(std::vector<std::string> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 == vec2);
@@ -240,55 +241,55 @@ Value ArrayType::CompareNotEquals(const Value &left, const Value &right) const {
   }
   switch (left.GetElementType()) {
     case Type::BOOLEAN: {
-      std::vector<bool> vec1 = *(std::vector<bool> *)(left.value_.array.data);
+      std::vector<bool> vec1 = *(std::vector<bool> *)(left.value_.array);
       std::vector<bool> vec2 = *(std::vector<bool> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::TINYINT: {
       std::vector<int8_t> vec1 =
-          *(std::vector<int8_t> *)(left.value_.array.data);
+          *(std::vector<int8_t> *)(left.value_.array);
       std::vector<int8_t> vec2 =
           *(std::vector<int8_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::SMALLINT: {
       std::vector<int16_t> vec1 =
-          *(std::vector<int16_t> *)(left.value_.array.data);
+          *(std::vector<int16_t> *)(left.value_.array);
       std::vector<int16_t> vec2 =
           *(std::vector<int16_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::INTEGER: {
       std::vector<int32_t> vec1 =
-          *(std::vector<int32_t> *)(left.value_.array.data);
+          *(std::vector<int32_t> *)(left.value_.array);
       std::vector<int32_t> vec2 =
           *(std::vector<int32_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::BIGINT: {
       std::vector<int64_t> vec1 =
-          *(std::vector<int64_t> *)(left.value_.array.data);
+          *(std::vector<int64_t> *)(left.value_.array);
       std::vector<int64_t> vec2 =
           *(std::vector<int64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::DECIMAL: {
       std::vector<double> vec1 =
-          *(std::vector<double> *)(left.value_.array.data);
+          *(std::vector<double> *)(left.value_.array);
       std::vector<double> vec2 =
           *(std::vector<double> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::TIMESTAMP: {
       std::vector<uint64_t> vec1 =
-          *(std::vector<uint64_t> *)(left.value_.array.data);
+          *(std::vector<uint64_t> *)(left.value_.array);
       std::vector<uint64_t> vec2 =
           *(std::vector<uint64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
     }
     case Type::VARCHAR: {
       std::vector<std::string> vec1 =
-          *(std::vector<std::string> *)(left.value_.array.data);
+          *(std::vector<std::string> *)(left.value_.array);
       std::vector<std::string> vec2 =
           *(std::vector<std::string> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 != vec2);
@@ -310,55 +311,55 @@ Value ArrayType::CompareLessThan(const Value &left, const Value &right) const {
   }
   switch (left.GetElementType()) {
     case Type::BOOLEAN: {
-      std::vector<bool> vec1 = *(std::vector<bool> *)(left.value_.array.data);
+      std::vector<bool> vec1 = *(std::vector<bool> *)(left.value_.array);
       std::vector<bool> vec2 = *(std::vector<bool> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::TINYINT: {
       std::vector<int8_t> vec1 =
-          *(std::vector<int8_t> *)(left.value_.array.data);
+          *(std::vector<int8_t> *)(left.value_.array);
       std::vector<int8_t> vec2 =
           *(std::vector<int8_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::SMALLINT: {
       std::vector<int16_t> vec1 =
-          *(std::vector<int16_t> *)(left.value_.array.data);
+          *(std::vector<int16_t> *)(left.value_.array);
       std::vector<int16_t> vec2 =
           *(std::vector<int16_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::INTEGER: {
       std::vector<int32_t> vec1 =
-          *(std::vector<int32_t> *)(left.value_.array.data);
+          *(std::vector<int32_t> *)(left.value_.array);
       std::vector<int32_t> vec2 =
           *(std::vector<int32_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::BIGINT: {
       std::vector<int64_t> vec1 =
-          *(std::vector<int64_t> *)(left.value_.array.data);
+          *(std::vector<int64_t> *)(left.value_.array);
       std::vector<int64_t> vec2 =
           *(std::vector<int64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::DECIMAL: {
       std::vector<double> vec1 =
-          *(std::vector<double> *)(left.value_.array.data);
+          *(std::vector<double> *)(left.value_.array);
       std::vector<double> vec2 =
           *(std::vector<double> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::TIMESTAMP: {
       std::vector<uint64_t> vec1 =
-          *(std::vector<uint64_t> *)(left.value_.array.data);
+          *(std::vector<uint64_t> *)(left.value_.array);
       std::vector<uint64_t> vec2 =
           *(std::vector<uint64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
     }
     case Type::VARCHAR: {
       std::vector<std::string> *vec1 =
-          (std::vector<std::string> *)(left.value_.array.data);
+          (std::vector<std::string> *)(left.value_.array);
       std::vector<std::string> *vec2 =
           (std::vector<std::string> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 < vec2);
@@ -381,55 +382,55 @@ Value ArrayType::CompareLessThanEquals(const Value &left,
   }
   switch (left.GetElementType()) {
     case Type::BOOLEAN: {
-      std::vector<bool> vec1 = *(std::vector<bool> *)(left.value_.array.data);
+      std::vector<bool> vec1 = *(std::vector<bool> *)(left.value_.array);
       std::vector<bool> vec2 = *(std::vector<bool> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::TINYINT: {
       std::vector<int8_t> vec1 =
-          *(std::vector<int8_t> *)(left.value_.array.data);
+          *(std::vector<int8_t> *)(left.value_.array);
       std::vector<int8_t> vec2 =
           *(std::vector<int8_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::SMALLINT: {
       std::vector<int16_t> vec1 =
-          *(std::vector<int16_t> *)(left.value_.array.data);
+          *(std::vector<int16_t> *)(left.value_.array);
       std::vector<int16_t> vec2 =
           *(std::vector<int16_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::INTEGER: {
       std::vector<int32_t> vec1 =
-          *(std::vector<int32_t> *)(left.value_.array.data);
+          *(std::vector<int32_t> *)(left.value_.array);
       std::vector<int32_t> vec2 =
           *(std::vector<int32_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::BIGINT: {
       std::vector<int64_t> vec1 =
-          *(std::vector<int64_t> *)(left.value_.array.data);
+          *(std::vector<int64_t> *)(left.value_.array);
       std::vector<int64_t> vec2 =
           *(std::vector<int64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::DECIMAL: {
       std::vector<double> vec1 =
-          *(std::vector<double> *)(left.value_.array.data);
+          *(std::vector<double> *)(left.value_.array);
       std::vector<double> vec2 =
           *(std::vector<double> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::TIMESTAMP: {
       std::vector<uint64_t> vec1 =
-          *(std::vector<uint64_t> *)(left.value_.array.data);
+          *(std::vector<uint64_t> *)(left.value_.array);
       std::vector<uint64_t> vec2 =
           *(std::vector<uint64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
     }
     case Type::VARCHAR: {
       std::vector<std::string> vec1 =
-          *(std::vector<std::string> *)(left.value_.array.data);
+          *(std::vector<std::string> *)(left.value_.array);
       std::vector<std::string> vec2 =
           *(std::vector<std::string> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 <= vec2);
@@ -452,55 +453,55 @@ Value ArrayType::CompareGreaterThan(const Value &left,
   }
   switch (left.GetElementType()) {
     case Type::BOOLEAN: {
-      std::vector<bool> vec1 = *(std::vector<bool> *)(left.value_.array.data);
+      std::vector<bool> vec1 = *(std::vector<bool> *)(left.value_.array);
       std::vector<bool> vec2 = *(std::vector<bool> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::TINYINT: {
       std::vector<int8_t> vec1 =
-          *(std::vector<int8_t> *)(left.value_.array.data);
+          *(std::vector<int8_t> *)(left.value_.array);
       std::vector<int8_t> vec2 =
           *(std::vector<int8_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::SMALLINT: {
       std::vector<int16_t> vec1 =
-          *(std::vector<int16_t> *)(left.value_.array.data);
+          *(std::vector<int16_t> *)(left.value_.array);
       std::vector<int16_t> vec2 =
           *(std::vector<int16_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::INTEGER: {
       std::vector<int32_t> vec1 =
-          *(std::vector<int32_t> *)(left.value_.array.data);
+          *(std::vector<int32_t> *)(left.value_.array);
       std::vector<int32_t> vec2 =
           *(std::vector<int32_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::BIGINT: {
       std::vector<int64_t> vec1 =
-          *(std::vector<int64_t> *)(left.value_.array.data);
+          *(std::vector<int64_t> *)(left.value_.array);
       std::vector<int64_t> vec2 =
           *(std::vector<int64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::DECIMAL: {
       std::vector<double> vec1 =
-          *(std::vector<double> *)(left.value_.array.data);
+          *(std::vector<double> *)(left.value_.array);
       std::vector<double> vec2 =
           *(std::vector<double> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::TIMESTAMP: {
       std::vector<uint64_t> vec1 =
-          *(std::vector<uint64_t> *)(left.value_.array.data);
+          *(std::vector<uint64_t> *)(left.value_.array);
       std::vector<uint64_t> vec2 =
           *(std::vector<uint64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
     }
     case Type::VARCHAR: {
       std::vector<std::string> vec1 =
-          *(std::vector<std::string> *)(left.value_.array.data);
+          *(std::vector<std::string> *)(left.value_.array);
       std::vector<std::string> vec2 =
           *(std::vector<std::string> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 > vec2);
@@ -523,55 +524,55 @@ Value ArrayType::CompareGreaterThanEquals(const Value &left,
   }
   switch (left.GetElementType()) {
     case Type::BOOLEAN: {
-      std::vector<bool> vec1 = *(std::vector<bool> *)(left.value_.array.data);
+      std::vector<bool> vec1 = *(std::vector<bool> *)(left.value_.array);
       std::vector<bool> vec2 = *(std::vector<bool> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::TINYINT: {
       std::vector<int8_t> vec1 =
-          *(std::vector<int8_t> *)(left.value_.array.data);
+          *(std::vector<int8_t> *)(left.value_.array);
       std::vector<int8_t> vec2 =
           *(std::vector<int8_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::SMALLINT: {
       std::vector<int16_t> vec1 =
-          *(std::vector<int16_t> *)(left.value_.array.data);
+          *(std::vector<int16_t> *)(left.value_.array);
       std::vector<int16_t> vec2 =
           *(std::vector<int16_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::INTEGER: {
       std::vector<int32_t> vec1 =
-          *(std::vector<int32_t> *)(left.value_.array.data);
+          *(std::vector<int32_t> *)(left.value_.array);
       std::vector<int32_t> vec2 =
           *(std::vector<int32_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::BIGINT: {
       std::vector<int64_t> vec1 =
-          *(std::vector<int64_t> *)(left.value_.array.data);
+          *(std::vector<int64_t> *)(left.value_.array);
       std::vector<int64_t> vec2 =
           *(std::vector<int64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::DECIMAL: {
       std::vector<double> vec1 =
-          *(std::vector<double> *)(left.value_.array.data);
+          *(std::vector<double> *)(left.value_.array);
       std::vector<double> vec2 =
           *(std::vector<double> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::TIMESTAMP: {
       std::vector<uint64_t> vec1 =
-          *(std::vector<uint64_t> *)(left.value_.array.data);
+          *(std::vector<uint64_t> *)(left.value_.array);
       std::vector<uint64_t> vec2 =
           *(std::vector<uint64_t> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
     }
     case Type::VARCHAR: {
       std::vector<std::string> vec1 =
-          *(std::vector<std::string> *)(left.value_.array.data);
+          *(std::vector<std::string> *)(left.value_.array);
       std::vector<std::string> vec2 =
           *(std::vector<std::string> *)(right.GetAs<char *>());
       return ValueFactory::GetBooleanValue(vec1 >= vec2);
@@ -591,7 +592,7 @@ Value ArrayType::CastAs(const Value &val UNUSED_ATTRIBUTE,
 
 Type::TypeId ArrayType::GetElementType(
     const Value &val UNUSED_ATTRIBUTE) const {
-  return val.value_.array.array_type;
+  return val.size_.elem_type_id;
 }
 
 }  // namespace type

--- a/src/type/array_type.cpp
+++ b/src/type/array_type.cpp
@@ -71,7 +71,7 @@ Value ArrayType::GetElementAt(const Value &val, uint64_t idx) const {
 // Does this value exist in this array?
 Value ArrayType::InList(const Value &list, const Value &object) const {
   Value ele = (list.GetElementAt(0));
-  ele.CheckComparable(object);
+  PL_ASSERT(ele.CheckComparable(object));
   if (object.IsNull()) return ValueFactory::GetNullValueByType(Type::BOOLEAN);
   switch (list.GetElementType()) {
     case Type::BOOLEAN: {
@@ -161,7 +161,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
 
 Value ArrayType::CompareEquals(const Value &left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::ARRAY);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
                       " mismatch with " +
@@ -231,7 +231,7 @@ Value ArrayType::CompareEquals(const Value &left, const Value &right) const {
 
 Value ArrayType::CompareNotEquals(const Value &left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::ARRAY);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
                       " mismatch with " +
@@ -301,7 +301,7 @@ Value ArrayType::CompareNotEquals(const Value &left, const Value &right) const {
 
 Value ArrayType::CompareLessThan(const Value &left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::ARRAY);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
                       " mismatch with " +
@@ -372,7 +372,7 @@ Value ArrayType::CompareLessThan(const Value &left, const Value &right) const {
 Value ArrayType::CompareLessThanEquals(const Value &left,
                                        const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::ARRAY);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
                       " mismatch with " +
@@ -443,7 +443,7 @@ Value ArrayType::CompareLessThanEquals(const Value &left,
 Value ArrayType::CompareGreaterThan(const Value &left,
                                     const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::ARRAY);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
                       " mismatch with " +
@@ -514,7 +514,7 @@ Value ArrayType::CompareGreaterThan(const Value &left,
 Value ArrayType::CompareGreaterThanEquals(const Value &left,
                                           const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::ARRAY);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
                       " mismatch with " +

--- a/src/type/bigint_type.cpp
+++ b/src/type/bigint_type.cpp
@@ -31,8 +31,8 @@ bool BigintType::IsZero(const Value& val) const {
 }
 
 Value BigintType::Add(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -55,8 +55,8 @@ Value BigintType::Add(const Value& left, const Value &right) const {
 }
 
 Value BigintType::Subtract(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -79,8 +79,8 @@ Value BigintType::Subtract(const Value& left, const Value &right) const {
 }
 
 Value BigintType::Multiply(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -104,8 +104,8 @@ Value BigintType::Multiply(const Value& left, const Value &right) const {
 }
 
 Value BigintType::Divide(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -132,8 +132,8 @@ Value BigintType::Divide(const Value& left, const Value &right) const {
 }
 
 Value BigintType::Modulo(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -161,7 +161,7 @@ Value BigintType::Modulo(const Value& left, const Value &right) const {
 }
 
 Value BigintType::Sqrt(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
   if (val.IsNull())
     return ValueFactory::GetDoubleValue(PELOTON_DECIMAL_NULL);
 
@@ -191,8 +191,8 @@ Value BigintType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value &r
 }
 
 Value BigintType::CompareEquals(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
@@ -220,8 +220,8 @@ Value BigintType::CompareEquals(const Value& left, const Value &right) const {
 
 Value BigintType::CompareNotEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -248,8 +248,8 @@ Value BigintType::CompareNotEquals(const Value& left,
 
 Value BigintType::CompareLessThan(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -273,8 +273,8 @@ Value BigintType::CompareLessThan(const Value& left,
 
 Value BigintType::CompareLessThanEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -301,8 +301,8 @@ Value BigintType::CompareLessThanEquals(const Value& left,
 
 Value BigintType::CompareGreaterThan(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -327,8 +327,8 @@ Value BigintType::CompareGreaterThan(const Value& left,
 
 Value BigintType::CompareGreaterThanEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -355,7 +355,7 @@ Value BigintType::CompareGreaterThanEquals(const Value& left,
 }
 
 std::string BigintType::ToString(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
 
   if (val.IsNull())
     return "bigint_null";
@@ -364,7 +364,7 @@ std::string BigintType::ToString(const Value& val) const {
 }
 
 size_t BigintType::Hash(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
 
   return std::hash<int64_t> { }(val.value_.bigint);
 

--- a/src/type/boolean_type.cpp
+++ b/src/type/boolean_type.cpp
@@ -23,7 +23,7 @@ BooleanType::BooleanType() : Type(Type::BOOLEAN) {}
 
 Value BooleanType::CompareEquals(const Value& left, const Value& right) const {
   PL_ASSERT(GetTypeId() == Type::BOOLEAN);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
   return ValueFactory::GetBooleanValue(left.value_.boolean ==
@@ -33,7 +33,7 @@ Value BooleanType::CompareEquals(const Value& left, const Value& right) const {
 Value BooleanType::CompareNotEquals(const Value& left,
                                     const Value& right) const {
   PL_ASSERT(GetTypeId() == Type::BOOLEAN);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
   return ValueFactory::GetBooleanValue(left.value_.boolean !=
@@ -43,7 +43,7 @@ Value BooleanType::CompareNotEquals(const Value& left,
 Value BooleanType::CompareLessThan(const Value& left,
                                    const Value& right) const {
   PL_ASSERT(GetTypeId() == Type::BOOLEAN);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
   return ValueFactory::GetBooleanValue(left.value_.boolean <
@@ -53,7 +53,7 @@ Value BooleanType::CompareLessThan(const Value& left,
 Value BooleanType::CompareLessThanEquals(const Value& left,
                                          const Value& right) const {
   PL_ASSERT(GetTypeId() == Type::BOOLEAN);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
   return ValueFactory::GetBooleanValue(left.value_.boolean <=
@@ -63,7 +63,7 @@ Value BooleanType::CompareLessThanEquals(const Value& left,
 Value BooleanType::CompareGreaterThan(const Value& left,
                                       const Value& right) const {
   PL_ASSERT(GetTypeId() == Type::BOOLEAN);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
   return ValueFactory::GetBooleanValue(left.value_.boolean >
@@ -73,7 +73,7 @@ Value BooleanType::CompareGreaterThan(const Value& left,
 Value BooleanType::CompareGreaterThanEquals(const Value& left,
                                             const Value& right) const {
   PL_ASSERT(GetTypeId() == Type::BOOLEAN);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
   return ValueFactory::GetBooleanValue(left.value_.boolean >=

--- a/src/type/decimal_type.cpp
+++ b/src/type/decimal_type.cpp
@@ -36,7 +36,7 @@ bool DecimalType::IsZero(const Value& val) const {
 
 Value DecimalType::Add(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -58,7 +58,7 @@ Value DecimalType::Add(const Value& left, const Value &right) const {
 
 Value DecimalType::Subtract(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
   
@@ -80,7 +80,7 @@ Value DecimalType::Subtract(const Value& left, const Value &right) const {
 
 Value DecimalType::Multiply(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -102,7 +102,7 @@ Value DecimalType::Multiply(const Value& left, const Value &right) const {
 
 Value DecimalType::Divide(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -128,7 +128,7 @@ Value DecimalType::Divide(const Value& left, const Value &right) const {
 
 Value DecimalType::Modulo(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
   
@@ -154,7 +154,7 @@ Value DecimalType::Modulo(const Value& left, const Value &right) const {
 
 Value DecimalType::Min(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -166,7 +166,7 @@ Value DecimalType::Min(const Value& left, const Value &right) const {
 
 Value DecimalType::Max(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -193,7 +193,7 @@ Value DecimalType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value &
 
 Value DecimalType::CompareEquals(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
     
@@ -215,7 +215,7 @@ Value DecimalType::CompareEquals(const Value& left, const Value &right) const {
 
 Value DecimalType::CompareNotEquals(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -237,7 +237,7 @@ Value DecimalType::CompareNotEquals(const Value& left, const Value &right) const
 
 Value DecimalType::CompareLessThan(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -259,7 +259,7 @@ Value DecimalType::CompareLessThan(const Value& left, const Value &right) const 
 
 Value DecimalType::CompareLessThanEquals(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -281,7 +281,7 @@ Value DecimalType::CompareLessThanEquals(const Value& left, const Value &right) 
 
 Value DecimalType::CompareGreaterThan(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -303,7 +303,7 @@ Value DecimalType::CompareGreaterThan(const Value& left, const Value &right) con
 
 Value DecimalType::CompareGreaterThanEquals(const Value& left, const Value &right) const {
   PL_ASSERT(GetTypeId() == Type::DECIMAL);
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
     

--- a/src/type/integer_parent_type.cpp
+++ b/src/type/integer_parent_type.cpp
@@ -24,8 +24,8 @@ namespace type {
 IntegerParentType::IntegerParentType(TypeId type) : NumericType(type) {}
 
 Value IntegerParentType::Min(const Value& left, const Value& right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
 
   Value cmp = (left.CompareLessThan(right));
@@ -34,8 +34,8 @@ Value IntegerParentType::Min(const Value& left, const Value& right) const {
 }
 
 Value IntegerParentType::Max(const Value& left, const Value& right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
 
   Value cmp = (left.CompareGreaterThanEquals(right));

--- a/src/type/integer_type.cpp
+++ b/src/type/integer_type.cpp
@@ -32,8 +32,8 @@ bool IntegerType::IsZero(const Value& val) const {
 }
 
 Value IntegerType::Add(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -57,8 +57,8 @@ Value IntegerType::Add(const Value& left, const Value &right) const {
 }
 
 Value IntegerType::Subtract(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -82,8 +82,8 @@ Value IntegerType::Subtract(const Value& left, const Value &right) const {
 }
 
 Value IntegerType::Multiply(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -107,8 +107,8 @@ Value IntegerType::Multiply(const Value& left, const Value &right) const {
 }
 
 Value IntegerType::Divide(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -136,8 +136,8 @@ Value IntegerType::Divide(const Value& left, const Value &right) const {
 }
 
 Value IntegerType::Modulo(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -166,7 +166,7 @@ Value IntegerType::Modulo(const Value& left, const Value &right) const {
 }
 
 Value IntegerType::Sqrt(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
   if (val.IsNull())
     return ValueFactory::GetDoubleValue(PELOTON_DECIMAL_NULL);
 
@@ -198,8 +198,8 @@ Value IntegerType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value &
 }
 
 Value IntegerType::CompareEquals(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
     return ValueFactory::GetNullValueByType(Type::BOOLEAN);
@@ -230,8 +230,8 @@ Value IntegerType::CompareEquals(const Value& left, const Value &right) const {
 
 Value IntegerType::CompareNotEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -261,8 +261,8 @@ Value IntegerType::CompareNotEquals(const Value& left,
 
 Value IntegerType::CompareLessThan(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -290,8 +290,8 @@ Value IntegerType::CompareLessThan(const Value& left,
 
 Value IntegerType::CompareLessThanEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -321,8 +321,8 @@ Value IntegerType::CompareLessThanEquals(const Value& left,
 
 Value IntegerType::CompareGreaterThan(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -350,8 +350,8 @@ Value IntegerType::CompareGreaterThan(const Value& left,
 
 Value IntegerType::CompareGreaterThanEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -379,7 +379,7 @@ Value IntegerType::CompareGreaterThanEquals(const Value& left,
 }
 
 std::string IntegerType::ToString(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
 
   if (val.IsNull())
     return "integer_null";
@@ -388,7 +388,7 @@ std::string IntegerType::ToString(const Value& val) const {
 }
 
 size_t IntegerType::Hash(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
 
   return std::hash<int32_t> { }(val.value_.integer);
 
@@ -426,7 +426,7 @@ Value IntegerType::DeserializeFrom(SerializeInput &in UNUSED_ATTRIBUTE,
 }
 
 Value IntegerType::Copy(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
   return Value(val.GetTypeId(), val.value_.integer);
 }
 

--- a/src/type/smallint_type.cpp
+++ b/src/type/smallint_type.cpp
@@ -31,8 +31,8 @@ bool SmallintType::IsZero(const Value& val) const {
 }
 
 Value SmallintType::Add(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -57,8 +57,8 @@ Value SmallintType::Add(const Value& left, const Value &right) const {
 }
 
 Value SmallintType::Subtract(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -83,8 +83,8 @@ Value SmallintType::Subtract(const Value& left, const Value &right) const {
 }
 
 Value SmallintType::Multiply(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -109,8 +109,8 @@ Value SmallintType::Multiply(const Value& left, const Value &right) const {
 }
 
 Value SmallintType::Divide(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -139,8 +139,8 @@ Value SmallintType::Divide(const Value& left, const Value &right) const {
 }
 
 Value SmallintType::Modulo(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -169,7 +169,7 @@ Value SmallintType::Modulo(const Value& left, const Value &right) const {
 }
 
 Value SmallintType::Sqrt(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
   if (val.IsNull())
     return ValueFactory::GetDoubleValue(PELOTON_DECIMAL_NULL);
 
@@ -205,8 +205,8 @@ Value SmallintType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value 
 
 Value SmallintType::CompareEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
@@ -237,8 +237,8 @@ Value SmallintType::CompareEquals(const Value& left,
 
 Value SmallintType::CompareNotEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -268,8 +268,8 @@ Value SmallintType::CompareNotEquals(const Value& left,
 
 Value SmallintType::CompareLessThan(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -299,8 +299,8 @@ Value SmallintType::CompareLessThan(const Value& left,
 
 Value SmallintType::CompareLessThanEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -329,8 +329,8 @@ Value SmallintType::CompareLessThanEquals(const Value& left,
 
 Value SmallintType::CompareGreaterThan(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -360,8 +360,8 @@ Value SmallintType::CompareGreaterThan(const Value& left,
 
 Value SmallintType::CompareGreaterThanEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -390,7 +390,7 @@ Value SmallintType::CompareGreaterThanEquals(const Value& left,
 }
 
 std::string SmallintType::ToString(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
   switch (val.GetTypeId()) {
   case Type::TINYINT:
     if (val.IsNull())
@@ -416,7 +416,7 @@ std::string SmallintType::ToString(const Value& val) const {
 }
 
 size_t SmallintType::Hash(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
 
   return std::hash<int16_t> { }(val.value_.smallint);
 
@@ -455,7 +455,7 @@ Value SmallintType::DeserializeFrom(SerializeInput &in UNUSED_ATTRIBUTE,
 }
 
 Value SmallintType::Copy(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
 
   return ValueFactory::GetSmallIntValue(val.value_.smallint);
 

--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -134,13 +134,13 @@ Value TimestampType::DeserializeFrom(SerializeInput &in UNUSED_ATTRIBUTE,
 
 // Create a copy of this value
 Value TimestampType::Copy(const Value& val) const {
-  return ValueFactory::GetTimestampValue(val.value_.timestamp);
+  return Value(val);
 }
 
 Value TimestampType::CastAs(const Value& val, const Type::TypeId type_id) const {
   switch (type_id) {
     case Type::TIMESTAMP:
-      return val.Copy();
+      return Copy(val);
     case Type::VARCHAR:
       if (val.IsNull())
         return ValueFactory::GetVarcharValue(nullptr, 0);

--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -24,42 +24,42 @@ TimestampType::TimestampType()
 }
 
 Value TimestampType::CompareEquals(const Value& left, const Value &right) const {
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
   return ValueFactory::GetBooleanValue(left.GetAs<uint64_t>() == right.GetAs<uint64_t>());
 }
 
 Value TimestampType::CompareNotEquals(const Value& left, const Value &right) const {
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
   return ValueFactory::GetBooleanValue(left.GetAs<uint64_t>() != right.GetAs<uint64_t>());
 }
 
 Value TimestampType::CompareLessThan(const Value& left, const Value &right) const {
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
   return ValueFactory::GetBooleanValue(left.GetAs<uint64_t>() < right.GetAs<uint64_t>());
 }
 
 Value TimestampType::CompareLessThanEquals(const Value& left, const Value &right) const {
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
   return ValueFactory::GetBooleanValue(left.GetAs<uint64_t>() <= right.GetAs<uint64_t>());
 }
 
 Value TimestampType::CompareGreaterThan(const Value& left, const Value &right) const {
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
   return ValueFactory::GetBooleanValue(left.GetAs<int64_t>() > right.GetAs<int64_t>());
 }
 
 Value TimestampType::CompareGreaterThanEquals(const Value& left, const Value &right) const {
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
   return ValueFactory::GetBooleanValue(left.GetAs<uint64_t>() >= right.GetAs<uint64_t>());

--- a/src/type/tinyint_type.cpp
+++ b/src/type/tinyint_type.cpp
@@ -30,8 +30,8 @@ bool TinyintType::IsZero(const Value& val) const {
 }
 
 Value TinyintType::Add(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -54,8 +54,8 @@ Value TinyintType::Add(const Value& left, const Value &right) const {
 }
 
 Value TinyintType::Subtract(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -79,8 +79,8 @@ Value TinyintType::Subtract(const Value& left, const Value &right) const {
 }
 
 Value TinyintType::Multiply(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
   switch (right.GetTypeId()) {
@@ -103,8 +103,8 @@ Value TinyintType::Multiply(const Value& left, const Value &right) const {
 }
 
 Value TinyintType::Divide(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -131,8 +131,8 @@ Value TinyintType::Divide(const Value& left, const Value &right) const {
 }
 
 Value TinyintType::Modulo(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -161,7 +161,7 @@ Value TinyintType::Modulo(const Value& left, const Value &right) const {
 }
 
 Value TinyintType::Sqrt(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
   if (val.IsNull())
     return ValueFactory::GetDoubleValue(PELOTON_DECIMAL_NULL);
 
@@ -194,8 +194,8 @@ Value TinyintType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value &
 }
 
 Value TinyintType::CompareEquals(const Value& left, const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
@@ -225,8 +225,8 @@ Value TinyintType::CompareEquals(const Value& left, const Value &right) const {
 
 Value TinyintType::CompareNotEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -256,8 +256,8 @@ Value TinyintType::CompareNotEquals(const Value& left,
 
 Value TinyintType::CompareLessThan(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -285,8 +285,8 @@ Value TinyintType::CompareLessThan(const Value& left,
 
 Value TinyintType::CompareLessThanEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -316,8 +316,8 @@ Value TinyintType::CompareLessThanEquals(const Value& left,
 
 Value TinyintType::CompareGreaterThan(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -344,8 +344,8 @@ Value TinyintType::CompareGreaterThan(const Value& left,
 
 Value TinyintType::CompareGreaterThanEquals(const Value& left,
     const Value &right) const {
-  left.CheckInteger();
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckInteger());
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
 
@@ -374,7 +374,7 @@ Value TinyintType::CompareGreaterThanEquals(const Value& left,
 }
 
 std::string TinyintType::ToString(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
   if (val.IsNull())
     return "tinyint_null";
   return std::to_string(val.value_.tinyint);
@@ -382,7 +382,7 @@ std::string TinyintType::ToString(const Value& val) const {
 }
 
 size_t TinyintType::Hash(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
   return std::hash<int8_t> { }(val.value_.tinyint);
 }
 
@@ -415,7 +415,7 @@ Value TinyintType::DeserializeFrom(SerializeInput &in UNUSED_ATTRIBUTE,
 }
 
 Value TinyintType::Copy(const Value& val) const {
-  val.CheckInteger();
+  PL_ASSERT(val.CheckInteger());
   return ValueFactory::GetTinyIntValue(val.value_.tinyint);
 }
 

--- a/src/type/type.cpp
+++ b/src/type/type.cpp
@@ -175,9 +175,9 @@ Value Type::GetMinValue(TypeId type_id) {
     case TIMESTAMP:
       return Value(type_id, 0);
     case VARCHAR:
-      return Value(type_id, "", false);
+      return Value(type_id, "");
     case VARBINARY:
-      return Value(type_id, "", true);
+      return Value(type_id, "");
     default:
       break;
   }
@@ -201,9 +201,9 @@ Value Type::GetMaxValue(TypeId type_id) {
     case TIMESTAMP:
       return Value(type_id, PELOTON_TIMESTAMP_MAX);
     case VARCHAR:
-      return Value(type_id, nullptr, 0);
+      return Value(type_id, nullptr, 0, false);
     case VARBINARY:
-      return Value(type_id, nullptr, 0);
+      return Value(type_id, nullptr, 0, false);
     default:
       break;
   }

--- a/src/type/type.cpp
+++ b/src/type/type.cpp
@@ -210,10 +210,6 @@ Value Type::GetMaxValue(TypeId type_id) {
   throw Exception(EXCEPTION_TYPE_MISMATCH_TYPE, "Cannot get maximal value.");
 }
 
-Type* Type::GetInstance(TypeId type_id) { return kTypes[type_id]; }
-
-Type::TypeId Type::GetTypeId() const { return type_id_; }
-
 Value Type::CompareEquals(const Value& left UNUSED_ATTRIBUTE,
                           const Value& right UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -276,10 +276,6 @@ const std::string Value::GetInfo() const {
   return os.str();
 }
 
-bool Value::IsNull() const {
-  return size_.len == PELOTON_VALUE_NULL;
-}
-
 bool Value::CheckComparable(const Value &o) const {
   switch (GetTypeId()) {
     case Type::BOOLEAN:
@@ -331,124 +327,9 @@ bool Value::CheckInteger() const {
   return false;
 }
 
-Value Value::DeserializeFrom(const char *storage, const Type::TypeId type_id,
-                             UNUSED_ATTRIBUTE const bool inlined,
-                             UNUSED_ATTRIBUTE VarlenPool *pool) {
-  return Type::GetInstance(type_id)->DeserializeFrom(storage, inlined, pool);
-}
-
-Value Value::DeserializeFrom(SerializeInput &in, const Type::TypeId type_id,
-                             VarlenPool *pool UNUSED_ATTRIBUTE) {
-  return Type::GetInstance(type_id)->DeserializeFrom(in, pool);
-}
-
-Value Value::CompareEquals(const Value &o) const {
-  return type_->CompareEquals(*this, o);
-}
-Value Value::CompareNotEquals(const Value &o) const {
-  return type_->CompareNotEquals(*this, o);
-}
-Value Value::Value::CompareLessThan(const Value &o) const {
-  return type_->CompareLessThan(*this, o);
-}
-Value Value::CompareLessThanEquals(const Value &o) const {
-  return type_->CompareLessThanEquals(*this, o);
-}
-Value Value::CompareGreaterThan(const Value &o) const {
-  return type_->CompareGreaterThan(*this, o);
-}
-Value Value::CompareGreaterThanEquals(const Value &o) const {
-  return type_->CompareGreaterThanEquals(*this, o);
-}
-
-// Other mathematical functions
-Value Value::Add(const Value &o) const { return type_->Add(*this, o); }
-Value Value::Subtract(const Value &o) const {
-  return type_->Subtract(*this, o);
-}
-Value Value::Multiply(const Value &o) const {
-  return type_->Multiply(*this, o);
-}
-Value Value::Divide(const Value &o) const { return type_->Divide(*this, o); }
-Value Value::Modulo(const Value &o) const { return type_->Modulo(*this, o); }
-Value Value::Min(const Value &o) const { return type_->Min(*this, o); }
-Value Value::Max(const Value &o) const { return type_->Max(*this, o); }
-Value Value::Sqrt() const { return type_->Sqrt(*this); }
-Value Value::OperateNull(const Value &o) const {
-  return type_->OperateNull(*this, o);
-}
-bool Value::IsZero() const { return type_->IsZero(*this); }
-
 // Is the data inlined into this classes storage space, or must it be accessed
 // through an indirection/pointer?
 bool Value::IsInlined() const { return type_->IsInlined(*this); }
-
-// Return a stringified version of this value
-std::string Value::ToString() const { return type_->ToString(*this); }
-
-// Compute a hash value
-size_t Value::Hash() const { return type_->Hash(*this); }
-void Value::HashCombine(size_t &seed) const {
-  return type_->HashCombine(*this, seed);
-}
-
-// Serialize this value into the given storage space. The inlined parameter
-// indicates whether we are allowed to inline this value into the storage
-// space, or whether we must store only a reference to this value. If inlined
-// is false, we may use the provided data pool to allocate space for this
-// value, storing a reference into the allocated pool space in the storage.
-void Value::SerializeTo(char *storage, bool inlined, VarlenPool *pool) const {
-  type_->SerializeTo(*this, storage, inlined, pool);
-}
-void Value::SerializeTo(SerializeOutput &out) const {
-  type_->SerializeTo(*this, out);
-}
-
-// Perform a shallow copy from a serialized varlen value to another serialized varlen value
-// Only support VARCHAR/VARBINARY
-void Value::ShallowCopyTo(char *dest, char *src, const Type::TypeId type_id, bool inlined, VarlenPool *src_pool) {
-  Type::GetInstance(type_id)->DoShallowCopy(dest, src, inlined, src_pool);
-}
-
-// Create a copy of this value
-Value Value::Copy() const { return type_->Copy(*this); }
-
-Value Value::CastAs(const Type::TypeId type_id) const {
-  return type_->CastAs(*this, type_id);
-}
-
-// Access the raw variable length data
-const char *Value::GetData() const { return type_->GetData(*this); }
-
-// Access the raw variable length data from a pointer pointed to a tuple storage
-char *Value::GetDataFromStorage(Type::TypeId type_id, char *storage) {
-  switch (type_id) {
-    case Type::VARCHAR:
-    case Type::VARBINARY: {
-      return Type::GetInstance(type_id)->GetData(storage);
-    }
-    default:
-      throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
-                      "Invalid Type for getting raw data pointer");
-  }
-}
-
-// Get the length of the variable length data
-uint32_t Value::GetLength() const { return type_->GetLength(*this); }
-
-// Get the element at a given index in this array
-Value Value::GetElementAt(uint64_t idx) const {
-  return type_->GetElementAt(*this, idx);
-}
-
-Type::TypeId Value::GetElementType() const {
-  return type_->GetElementType(*this);
-}
-
-// Does this value exist in this array?
-Value Value::InList(const Value &object) const {
-  return type_->InList(*this, object);
-}
 
 }  // namespace peloton
 }  // namespace type

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -23,10 +23,10 @@ namespace peloton {
 namespace type {
 
 Value::Value(const Value &other) {
-  type_ = other.type_;
+  type_id_ = other.type_id_;
   size_ = other.size_;
   manage_data_ = other.manage_data_;
-  switch (type_->GetTypeId()) {
+  switch (type_id_) {
     case Type::VARCHAR:
     case Type::VARBINARY:
       if (size_.len == PELOTON_VALUE_NULL) {
@@ -273,7 +273,7 @@ Value::Value(Type::TypeId type, const std::string &data) : Value(type) {
 Value::Value() : Value(Type::INVALID) {}
 
 Value::~Value() {
-  switch (type_->GetTypeId()) {
+  switch (type_id_) {
     case Type::VARBINARY:
     case Type::VARCHAR:
       if (manage_data_){
@@ -342,10 +342,6 @@ bool Value::CheckInteger() const {
 
   return false;
 }
-
-// Is the data inlined into this classes storage space, or must it be accessed
-// through an indirection/pointer?
-bool Value::IsInlined() const { return type_->IsInlined(*this); }
 
 }  // namespace peloton
 }  // namespace type

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <include/type/value.h>
 #include "type/value.h"
 
 #include "type/boolean_type.h"
@@ -23,13 +24,17 @@ namespace type {
 
 Value::Value(const Value &other) {
   type_ = other.type_;
+  size_ = other.size_;
   switch (type_->GetTypeId()) {
     case Type::VARCHAR:
     case Type::VARBINARY:
-      value_.varlen.len = other.value_.varlen.len;
-      value_.varlen.data = new char[value_.varlen.len];
-      PL_MEMCPY(value_.varlen.data, other.value_.varlen.data,
-                value_.varlen.len);
+      if (size_.len == PELOTON_VALUE_NULL) {
+        value_.varlen = nullptr;
+      } else {
+        value_.varlen = new char[size_.len];
+        PL_MEMCPY(value_.varlen, other.value_.varlen,
+                  size_.len);
+      }
       break;
     default:
       value_ = other.value_;
@@ -50,19 +55,24 @@ Value::Value(Type::TypeId type, int8_t i) : Value(type) {
   switch (type) {
     case Type::BOOLEAN:
       value_.boolean = i;
+      size_.len = (value_.boolean == PELOTON_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::TINYINT:
       value_.tinyint = i;
+      size_.len = (value_.tinyint == PELOTON_INT8_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::SMALLINT:
       value_.smallint = i;
+      size_.len = (value_.smallint == PELOTON_INT16_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::INTEGER:
     case Type::PARAMETER_OFFSET:
       value_.integer = i;
+      size_.len = (value_.integer == PELOTON_INT32_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::BIGINT:
       value_.bigint = i;
+      size_.len = (value_.bigint == PELOTON_INT64_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default:
       throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
@@ -75,19 +85,24 @@ Value::Value(Type::TypeId type, int16_t i) : Value(type) {
   switch (type) {
     case Type::BOOLEAN:
       value_.boolean = i;
+      size_.len = (value_.boolean == PELOTON_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::TINYINT:
       value_.tinyint = i;
+      size_.len = (value_.tinyint == PELOTON_INT8_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::SMALLINT:
       value_.smallint = i;
+      size_.len = (value_.smallint == PELOTON_INT16_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::INTEGER:
     case Type::PARAMETER_OFFSET:
       value_.integer = i;
+      size_.len = (value_.integer == PELOTON_INT32_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::BIGINT:
       value_.bigint = i;
+      size_.len = (value_.bigint == PELOTON_INT64_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default:
       throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
@@ -100,19 +115,24 @@ Value::Value(Type::TypeId type, int32_t i) : Value(type) {
   switch (type) {
     case Type::BOOLEAN:
       value_.boolean = i;
+      size_.len = (value_.boolean == PELOTON_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::TINYINT:
       value_.tinyint = i;
+      size_.len = (value_.tinyint == PELOTON_INT8_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::SMALLINT:
       value_.smallint = i;
+      size_.len = (value_.smallint == PELOTON_INT16_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::INTEGER:
     case Type::PARAMETER_OFFSET:
       value_.integer = i;
+      size_.len = (value_.integer == PELOTON_INT32_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::BIGINT:
       value_.bigint = i;
+      size_.len = (value_.bigint == PELOTON_INT64_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default:
       throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
@@ -125,22 +145,28 @@ Value::Value(Type::TypeId type, int64_t i) : Value(type) {
   switch (type) {
     case Type::BOOLEAN:
       value_.boolean = i;
+      size_.len = (value_.boolean == PELOTON_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::TINYINT:
       value_.tinyint = i;
+      size_.len = (value_.tinyint == PELOTON_INT8_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::SMALLINT:
       value_.smallint = i;
+      size_.len = (value_.smallint == PELOTON_INT16_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::INTEGER:
     case Type::PARAMETER_OFFSET:
       value_.integer = i;
+      size_.len = (value_.integer == PELOTON_INT32_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::BIGINT:
       value_.bigint = i;
+      size_.len = (value_.bigint == PELOTON_INT64_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::TIMESTAMP:
       value_.timestamp = i;
+      size_.len = (value_.timestamp == PELOTON_TIMESTAMP_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default:
       throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
@@ -153,9 +179,11 @@ Value::Value(Type::TypeId type, uint64_t i) : Value(type) {
   switch (type) {
     case Type::BOOLEAN:
       value_.boolean = i;
+      size_.len = (value_.boolean == PELOTON_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case Type::TIMESTAMP:
       value_.timestamp = i;
+      size_.len = (value_.timestamp == PELOTON_TIMESTAMP_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default:
       throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
@@ -168,6 +196,7 @@ Value::Value(Type::TypeId type, double d) : Value(type) {
   switch (type) {
     case Type::DECIMAL:
       value_.decimal = d;
+      size_.len = (value_.decimal == PELOTON_DECIMAL_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default:
       throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
@@ -179,6 +208,7 @@ Value::Value(Type::TypeId type, float f) : Value(type) {
   switch (type) {
     case Type::DECIMAL:
       value_.decimal = f;
+      size_.len = (value_.decimal == PELOTON_DECIMAL_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default:
       throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
@@ -191,11 +221,16 @@ Value::Value(Type::TypeId type, const char *data, uint32_t len) : Value(type) {
   switch (type) {
     case Type::VARCHAR:
     case Type::VARBINARY:
-      PL_ASSERT(len < PELOTON_VARCHAR_MAX_LEN);
-      value_.varlen.data = new char[len];
-      PL_ASSERT(value_.varlen.data != nullptr);
-      value_.varlen.len = len;
-      PL_MEMCPY(value_.varlen.data, data, len);
+      if (data == nullptr) {
+        value_.varlen = nullptr;
+        size_.len = PELOTON_VALUE_NULL;
+      } else {
+        PL_ASSERT(len < PELOTON_VARCHAR_MAX_LEN);
+        value_.varlen = new char[len];
+        PL_ASSERT(value_.varlen != nullptr);
+        size_.len = len;
+        PL_MEMCPY(value_.varlen, data, len);
+      }
       break;
     default:
       throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
@@ -207,11 +242,12 @@ Value::Value(Type::TypeId type, const std::string &data) : Value(type) {
   switch (type) {
     case Type::VARCHAR:
     case Type::VARBINARY: {
+      // TODO: How to represent a null string here?
       uint32_t len = data.length() + (type == Type::VARCHAR);
-      value_.varlen.data = new char[len];
-      PL_ASSERT(value_.varlen.data != nullptr);
-      value_.varlen.len = len;
-      PL_MEMCPY(value_.varlen.data, data.c_str(), len);
+      value_.varlen = new char[len];
+      PL_ASSERT(value_.varlen != nullptr);
+      size_.len = len;
+      PL_MEMCPY(value_.varlen, data.c_str(), len);
       break;
     }
     default:
@@ -226,7 +262,7 @@ Value::~Value() {
   switch (type_->GetTypeId()) {
     case Type::VARBINARY:
     case Type::VARCHAR:
-      delete[] value_.varlen.data;
+      delete[] value_.varlen;
       break;
     default:
       break;
@@ -241,29 +277,7 @@ const std::string Value::GetInfo() const {
 }
 
 bool Value::IsNull() const {
-  switch (GetTypeId()) {
-    case Type::BOOLEAN:
-      return (value_.boolean == PELOTON_BOOLEAN_NULL);
-    case Type::TINYINT:
-      return (value_.tinyint == PELOTON_INT8_NULL);
-    case Type::SMALLINT:
-      return (value_.smallint == PELOTON_INT16_NULL);
-    case Type::INTEGER:
-    case Type::PARAMETER_OFFSET:
-      return (value_.integer == PELOTON_INT32_NULL);
-    case Type::BIGINT:
-      return (value_.bigint == PELOTON_INT64_NULL);
-    case Type::DECIMAL:
-      return (value_.decimal == PELOTON_DECIMAL_NULL);
-    case Type::TIMESTAMP:
-      return (value_.timestamp == PELOTON_TIMESTAMP_NULL);
-    case Type::VARCHAR:
-    case Type::VARBINARY:
-      return value_.varlen.len == 0;
-    default:
-      break;
-  }
-  throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Unknown type.");
+  return size_.len == PELOTON_VALUE_NULL;
 }
 
 bool Value::CheckComparable(const Value &o) const {

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -266,10 +266,10 @@ bool Value::IsNull() const {
   throw Exception(EXCEPTION_TYPE_UNKNOWN_TYPE, "Unknown type.");
 }
 
-void Value::CheckComparable(const Value &o) const {
+bool Value::CheckComparable(const Value &o) const {
   switch (GetTypeId()) {
     case Type::BOOLEAN:
-      if (o.GetTypeId() == Type::BOOLEAN) return;
+      if (o.GetTypeId() == Type::BOOLEAN) return true;
       break;
     case Type::TINYINT:
     case Type::SMALLINT:
@@ -282,43 +282,39 @@ void Value::CheckComparable(const Value &o) const {
         case Type::INTEGER:
         case Type::BIGINT:
         case Type::DECIMAL:
-          return;
+          return true;
         default:
           break;
       }
       break;
     case Type::VARCHAR:
-      if (o.GetTypeId() == Type::VARCHAR) return;
+      if (o.GetTypeId() == Type::VARCHAR) return true;
       break;
     case Type::VARBINARY:
-      if (o.GetTypeId() == Type::VARBINARY) return;
+      if (o.GetTypeId() == Type::VARBINARY) return true;
       break;
     case Type::TIMESTAMP:
-      if (o.GetTypeId() == Type::TIMESTAMP) return;
+      if (o.GetTypeId() == Type::TIMESTAMP) return true;
       break;
     default:
       break;
   }
-  std::string msg =
-      "Operation between " + Type::GetInstance(GetTypeId())->ToString() +
-      " and " + Type::GetInstance(o.GetTypeId())->ToString() + " is invalid.";
-  throw Exception(EXCEPTION_TYPE_MISMATCH_TYPE, msg);
+  return false;
 }
 
-void Value::CheckInteger() const {
+bool Value::CheckInteger() const {
   switch (GetTypeId()) {
     case Type::TINYINT:
     case Type::SMALLINT:
     case Type::INTEGER:
     case Type::BIGINT:
     case Type::PARAMETER_OFFSET:
-      return;
+      return true;
     default:
       break;
   }
-  std::string msg = "Type " + Type::GetInstance(GetTypeId())->ToString() +
-                    " is not an integer type.";
-  throw Exception(EXCEPTION_TYPE_MISMATCH_TYPE, msg);
+
+  return false;
 }
 
 Value Value::DeserializeFrom(const char *storage, const Type::TypeId type_id,

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -187,19 +187,19 @@ Value VarlenType::DeserializeFrom(const char *storage ,
                               const bool inlined UNUSED_ATTRIBUTE, VarlenPool *pool UNUSED_ATTRIBUTE) const{
   const char *ptr = *reinterpret_cast<const char * const *>(storage);
   if (ptr == nullptr) {
-    return Value(type_id_, nullptr, 0);
+    return Value(type_id_, nullptr, 0, false);
   }
   uint32_t len = *reinterpret_cast<const uint32_t *>(ptr);
-  return Value(type_id_, ptr + sizeof(uint32_t), len);
+  return Value(type_id_, ptr + sizeof(uint32_t), len, false);
 }
 Value VarlenType::DeserializeFrom(SerializeInput &in UNUSED_ATTRIBUTE,
                               VarlenPool *pool UNUSED_ATTRIBUTE) const{
   uint32_t len = in.ReadInt();
   if (len == PELOTON_VALUE_NULL) {
-    return Value(type_id_, nullptr, 0);
+    return Value(type_id_, nullptr, 0, false);
   } else {
     const char *data = (char *) in.getRawPointer(len);
-    return Value(type_id_, data, len);
+    return Value(type_id_, data, len, false);
   }
 }
 
@@ -217,8 +217,7 @@ void VarlenType::DoShallowCopy(char *dest, char *src, bool inlined UNUSED_ATTRIB
 }
 
 Value VarlenType::Copy(const Value& val) const {
-  uint32_t len = GetLength(val);
-  return Value(val.GetTypeId(), val.GetData(), len);
+  return Value(val);
 }
 
 Value VarlenType::CastAs(const Value& val, const Type::TypeId type_id) const {

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -52,7 +52,7 @@ uint32_t VarlenType::GetLength(const Value& val) const {
 }
 
 Value VarlenType::CompareEquals(const Value& left, const Value &right) const {
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
   if (left.GetLength() == PELOTON_VARCHAR_MAX_LEN
@@ -66,7 +66,7 @@ Value VarlenType::CompareEquals(const Value& left, const Value &right) const {
 }
 
 Value VarlenType::CompareNotEquals(const Value& left, const Value &right) const {
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
   if (left.GetLength() == PELOTON_VARCHAR_MAX_LEN
@@ -80,7 +80,7 @@ Value VarlenType::CompareNotEquals(const Value& left, const Value &right) const 
 }
 
 Value VarlenType::CompareLessThan(const Value& left, const Value &right) const {
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
   if (left.GetLength() == PELOTON_VARCHAR_MAX_LEN
@@ -94,7 +94,7 @@ Value VarlenType::CompareLessThan(const Value& left, const Value &right) const {
 }
 
 Value VarlenType::CompareLessThanEquals(const Value& left, const Value &right) const {
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
   if (left.GetLength() == PELOTON_VARCHAR_MAX_LEN
@@ -108,7 +108,7 @@ Value VarlenType::CompareLessThanEquals(const Value& left, const Value &right) c
 }
 
 Value VarlenType::CompareGreaterThan(const Value& left, const Value &right) const {
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
   if (left.GetLength() == PELOTON_VARCHAR_MAX_LEN
@@ -122,7 +122,7 @@ Value VarlenType::CompareGreaterThan(const Value& left, const Value &right) cons
 }
 
 Value VarlenType::CompareGreaterThanEquals(const Value& left, const Value &right) const {
-  left.CheckComparable(right);
+  PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
   if (left.GetLength() == PELOTON_VARCHAR_MAX_LEN

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -37,7 +37,7 @@ inline static int CompareStrings(const char *str1, int len1, const char *str2, i
 
 // Access the raw variable length data
 const char *VarlenType::GetData(const Value& val) const {
-  return val.value_.varlen.data;
+  return val.value_.varlen;
 }
 
 // Access the raw varlen data stored from the tuple storage
@@ -48,101 +48,106 @@ char *VarlenType::GetData(char *storage) {
 
 // Get the length of the variable length data
 uint32_t VarlenType::GetLength(const Value& val) const {
-  return val.value_.varlen.len;
+  return val.size_.len;
 }
 
 Value VarlenType::CompareEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
-  if (left.GetLength() == PELOTON_VARCHAR_MAX_LEN
-      || right.GetLength() == PELOTON_VARCHAR_MAX_LEN) {
-    return ValueFactory::GetBooleanValue(left.GetLength() == right.GetLength());
+  if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN
+      || GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
+    return ValueFactory::GetBooleanValue(GetLength(left) == GetLength(right));
   }
   const char *str1 = left.GetData();
   const char *str2 = right.GetData();
   // TODO strcmp does not work on binary values
-  return ValueFactory::GetBooleanValue(CompareStrings(str1, left.GetLength(), str2, right.GetLength()) == 0);
+  return ValueFactory::GetBooleanValue(CompareStrings(str1, GetLength(left), str2, GetLength(right)) == 0);
 }
 
 Value VarlenType::CompareNotEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
-  if (left.GetLength() == PELOTON_VARCHAR_MAX_LEN
-      || right.GetLength() == PELOTON_VARCHAR_MAX_LEN) {
-    return ValueFactory::GetBooleanValue(left.GetLength() != right.GetLength());
+  if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN
+      || GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
+    return ValueFactory::GetBooleanValue(GetLength(left) != GetLength(right));
   }
   const char *str1 = left.GetData();
   const char *str2 = right.GetData();
   // TODO strcmp does not work on binary values
-  return ValueFactory::GetBooleanValue(CompareStrings(str1, left.GetLength(), str2, right.GetLength()) != 0);
+  return ValueFactory::GetBooleanValue(CompareStrings(str1, GetLength(left), str2, GetLength(right)) != 0);
 }
 
 Value VarlenType::CompareLessThan(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
-  if (left.GetLength() == PELOTON_VARCHAR_MAX_LEN
-      || right.GetLength() == PELOTON_VARCHAR_MAX_LEN) {
-    return ValueFactory::GetBooleanValue(left.GetLength() < right.GetLength());
+  if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN
+      || GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
+    return ValueFactory::GetBooleanValue(GetLength(left) < GetLength(right));
   }
   const char *str1 = left.GetData();
   const char *str2 = right.GetData();
   // TODO strcmp does not work on binary values
-  return ValueFactory::GetBooleanValue(CompareStrings(str1, left.GetLength(), str2, right.GetLength()) < 0);
+  return ValueFactory::GetBooleanValue(CompareStrings(str1, GetLength(left), str2, GetLength(right)) < 0);
 }
 
 Value VarlenType::CompareLessThanEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
-  if (left.GetLength() == PELOTON_VARCHAR_MAX_LEN
-      || right.GetLength() == PELOTON_VARCHAR_MAX_LEN) {
-    return ValueFactory::GetBooleanValue(left.GetLength() <= right.GetLength());
+  if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN
+      || GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
+    return ValueFactory::GetBooleanValue(GetLength(left) <= GetLength(right));
   }
   const char *str1 = left.GetData();
   const char *str2 = right.GetData();
   // TODO strcmp does not work on binary values
-  return ValueFactory::GetBooleanValue(CompareStrings(str1, left.GetLength(), str2, right.GetLength()) <= 0);
+  return ValueFactory::GetBooleanValue(CompareStrings(str1, GetLength(left), str2, GetLength(right)) <= 0);
 }
 
 Value VarlenType::CompareGreaterThan(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
-  if (left.GetLength() == PELOTON_VARCHAR_MAX_LEN
-      || right.GetLength() == PELOTON_VARCHAR_MAX_LEN) {
-    return ValueFactory::GetBooleanValue(left.GetLength() > right.GetLength());
+  if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN
+      || GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
+    return ValueFactory::GetBooleanValue(GetLength(left) > GetLength(right));
   }
   const char *str1 = left.GetData();
   const char *str2 = right.GetData();
   // TODO strcmp does not work on binary values
-  return ValueFactory::GetBooleanValue(CompareStrings(str1, left.GetLength(), str2, right.GetLength()) > 0);
+  return ValueFactory::GetBooleanValue(CompareStrings(str1, GetLength(left), str2, GetLength(right)) > 0);
 }
 
 Value VarlenType::CompareGreaterThanEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return  ValueFactory::GetNullValueByType(Type::BOOLEAN);
-  if (left.GetLength() == PELOTON_VARCHAR_MAX_LEN
-      || right.GetLength() == PELOTON_VARCHAR_MAX_LEN) {
-    return ValueFactory::GetBooleanValue(left.GetLength() >= right.GetLength());
+  if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN
+      || GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
+    return ValueFactory::GetBooleanValue(GetLength(left) >= GetLength(right));
   }
   const char *str1 = left.GetData();
   const char *str2 = right.GetData();
   // TODO strcmp does not work on binary values
-  return ValueFactory::GetBooleanValue(CompareStrings(str1, left.GetLength(), str2, right.GetLength()) >= 0);
+  return ValueFactory::GetBooleanValue(CompareStrings(str1, GetLength(left), str2, GetLength(right)) >= 0);
 }
 
 std::string VarlenType::ToString(const Value& val) const {
+  uint32_t len = GetLength(val);
+
   if (val.IsNull())
     return "varlen_null";
-  if (val.GetLength() == PELOTON_VARCHAR_MAX_LEN)
+  if (len == PELOTON_VARCHAR_MAX_LEN)
     return "varlen_max";
+  if (len == 0) {
+    return "";
+  }
   if (GetTypeId() == Type::VARBINARY)
-    return std::string(val.GetData(), val.GetLength());
-  return std::string(val.GetData(), val.GetLength() - 1);
+    return std::string(GetData(val), len);
+  return std::string(GetData(val), len - 1);
 }
 
 size_t VarlenType::Hash(const Value& val) const {
@@ -155,35 +160,47 @@ void VarlenType::HashCombine(const Value& val, size_t &seed) const {
 }
 
 void VarlenType::SerializeTo(const Value& val, SerializeOutput &out) const {
-  out.WriteInt(val.GetLength());
-  if (val.GetLength() > 0) {
-    out.WriteBytes(val.GetData(), val.GetLength());
+  uint32_t len = GetLength(val);
+  out.WriteInt(len);
+  if (len > 0 && len < PELOTON_VALUE_NULL) {
+    out.WriteBytes(val.GetData(), len);
   }
 }
 
 void VarlenType::SerializeTo(const Value& val, char *storage, bool inlined UNUSED_ATTRIBUTE,
     VarlenPool *pool) const {
-  uint32_t size = val.GetLength() + sizeof(uint32_t);
-  char *data = (pool == nullptr ) ? new char[size] : (char *) pool->Allocate(size);
+  uint32_t len = GetLength(val);
+  char *data;
+  if (len == PELOTON_VALUE_NULL) {
+    data = nullptr;
+  } else {
+    uint32_t size = len + sizeof(uint32_t);
+    data = (pool == nullptr) ? new char[size] :(char *) pool->Allocate(size);
+    PL_MEMCPY(data, &len, sizeof(uint32_t));
+    PL_MEMCPY(data + sizeof(uint32_t), val.value_.varlen, size-sizeof(uint32_t));
+  }
   *reinterpret_cast<const char **>(storage) = data;
-  PL_MEMCPY(data, &val.value_.varlen.len, sizeof(uint32_t));
-  PL_MEMCPY(data + sizeof(uint32_t), val.value_.varlen.data, size-sizeof(uint32_t));
 }
 
 // Deserialize a value of the given type from the given storage space.
 Value VarlenType::DeserializeFrom(const char *storage ,
                               const bool inlined UNUSED_ATTRIBUTE, VarlenPool *pool UNUSED_ATTRIBUTE) const{
   const char *ptr = *reinterpret_cast<const char * const *>(storage);
-  if (ptr == nullptr)
-  return Value(type_id_, nullptr, 0);
+  if (ptr == nullptr) {
+    return Value(type_id_, nullptr, 0);
+  }
   uint32_t len = *reinterpret_cast<const uint32_t *>(ptr);
   return Value(type_id_, ptr + sizeof(uint32_t), len);
 }
 Value VarlenType::DeserializeFrom(SerializeInput &in UNUSED_ATTRIBUTE,
                               VarlenPool *pool UNUSED_ATTRIBUTE) const{
   uint32_t len = in.ReadInt();
-  const char *data = (char *) in.getRawPointer(len);
-  return Value(type_id_, data, len);
+  if (len == PELOTON_VALUE_NULL) {
+    return Value(type_id_, nullptr, 0);
+  } else {
+    const char *data = (char *) in.getRawPointer(len);
+    return Value(type_id_, data, len);
+  }
 }
 
 // Perform a shallow copy from a serialized varlen value to another serialized varlen value
@@ -200,7 +217,7 @@ void VarlenType::DoShallowCopy(char *dest, char *src, bool inlined UNUSED_ATTRIB
 }
 
 Value VarlenType::Copy(const Value& val) const {
-  uint32_t len = val.GetLength();
+  uint32_t len = GetLength(val);
   return Value(val.GetTypeId(), val.GetData(), len);
 }
 

--- a/test/common/array_value_test.cpp
+++ b/test/common/array_value_test.cpp
@@ -151,13 +151,6 @@ TEST_F(ArrayValueTests, InListTest) {
         array_bool.InList(type::ValueFactory::GetBooleanValue(vec_bool[i]));
     EXPECT_TRUE((in_list).IsTrue());
   }
-  EXPECT_THROW(array_bool.InList(type::ValueFactory::GetIntegerValue(0)),
-               peloton::Exception);
-  EXPECT_THROW(array_bool.InList(type::ValueFactory::GetDoubleValue(0.0)),
-               peloton::Exception);
-  EXPECT_THROW(array_bool.InList(type::ValueFactory::GetVarcharValue(nullptr, 0)),
-               peloton::Exception);
-  EXPECT_THROW(array_bool.InList(array_bool), peloton::Exception);
 
   std::vector<int8_t> vec_tinyint;
   for (size_t i = 0; i < n; i++) {
@@ -178,11 +171,6 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
-  EXPECT_THROW(array_tinyint.InList(type::ValueFactory::GetBooleanValue(false)),
-               peloton::Exception);
-  EXPECT_THROW(array_tinyint.InList(type::ValueFactory::GetVarcharValue(nullptr, 0)),
-               peloton::Exception);
-  EXPECT_THROW(array_tinyint.InList(array_tinyint), peloton::Exception);
 
   std::vector<int16_t> vec_smallint;
   for (size_t i = 0; i < n; i++) {
@@ -204,11 +192,6 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
-  EXPECT_THROW(array_smallint.InList(type::ValueFactory::GetBooleanValue(false)),
-               peloton::Exception);
-  EXPECT_THROW(array_smallint.InList(type::ValueFactory::GetVarcharValue(nullptr, 0)),
-               peloton::Exception);
-  EXPECT_THROW(array_smallint.InList(array_smallint), peloton::Exception);
 
   std::vector<int32_t> vec_integer;
   for (size_t i = 0; i < n; i++) {
@@ -229,11 +212,6 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
-  EXPECT_THROW(array_integer.InList(type::ValueFactory::GetBooleanValue(false)),
-               peloton::Exception);
-  EXPECT_THROW(array_integer.InList(type::ValueFactory::GetVarcharValue(nullptr, 0)),
-               peloton::Exception);
-  EXPECT_THROW(array_integer.InList(array_integer), peloton::Exception);
 
   std::vector<int64_t> vec_bigint;
   for (size_t i = 0; i < n; i++) {
@@ -254,11 +232,6 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
-  EXPECT_THROW(array_bigint.InList(type::ValueFactory::GetBooleanValue(false)),
-               peloton::Exception);
-  EXPECT_THROW(array_bigint.InList(type::ValueFactory::GetVarcharValue(nullptr, 0)),
-               peloton::Exception);
-  EXPECT_THROW(array_bigint.InList(array_bigint), peloton::Exception);
 
   std::vector<double> vec_decimal;
   for (size_t i = 0; i < n; i++) {
@@ -279,11 +252,6 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
-  EXPECT_THROW(array_decimal.InList(type::ValueFactory::GetBooleanValue(false)),
-               peloton::Exception);
-  EXPECT_THROW(array_decimal.InList(type::ValueFactory::GetVarcharValue(nullptr, 0)),
-               peloton::Exception);
-  EXPECT_THROW(array_decimal.InList(array_decimal), peloton::Exception);
 
   std::vector<std::string> vec_varchar;
   for (size_t i = 0; i < n; i++) {
@@ -304,13 +272,6 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
-  EXPECT_THROW(array_varchar.InList(type::ValueFactory::GetBooleanValue(false)),
-               peloton::Exception);
-  EXPECT_THROW(array_varchar.InList(type::ValueFactory::GetIntegerValue(0)),
-               peloton::Exception);
-  EXPECT_THROW(array_varchar.InList(type::ValueFactory::GetDoubleValue(0.0)),
-               peloton::Exception);
-  EXPECT_THROW(array_varchar.InList(array_varchar), peloton::Exception);
 }
 
 void CheckEqual(type::Value v1, type::Value v2) {
@@ -380,12 +341,6 @@ TEST_F(ArrayValueTests, CompareTest) {
 
   // Test type mismatch
   type::Value v = type::ValueFactory::GetVarcharValue("");
-  EXPECT_THROW(v.CompareEquals(type::ValueFactory::GetBooleanValue(false)),
-               peloton::Exception);
-  EXPECT_THROW(v.CompareEquals(type::ValueFactory::GetIntegerValue(0)),
-               peloton::Exception);
-  EXPECT_THROW(v.CompareEquals(type::ValueFactory::GetDoubleValue(0.0)),
-               peloton::Exception);
 
   // Test null varchar
   type::Value cmp = (v.CompareEquals(type::ValueFactory::GetVarcharValue(nullptr, 0)));

--- a/test/planner/planner_test.cpp
+++ b/test/planner/planner_test.cpp
@@ -225,8 +225,7 @@ TEST_F(PlannerTests, InsertPlanTestParameter) {
   auto values = new std::vector<type::Value>();
   values->push_back(type::ValueFactory::GetIntegerValue(1).Copy());
   values->push_back(type::ValueFactory::GetVarcharValue(
-                        "CS", TestingHarness::GetInstance().GetTestingPool())
-                        .Copy());
+      (std::string)"CS", TestingHarness::GetInstance().GetTestingPool()).Copy());
   LOG_INFO("Value 1: %s", values->at(0).GetInfo().c_str());
   LOG_INFO("Value 2: %s", values->at(1).GetInfo().c_str());
   // bind values to parameters in plan

--- a/test/storage/tuple_test.cpp
+++ b/test/storage/tuple_test.cpp
@@ -99,7 +99,7 @@ TEST_F(TupleTests, VarcharTest) {
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(45), pool);
   tuple->SetValue(2, type::ValueFactory::GetTinyIntValue(1), pool);
 
-  type::Value val = type::ValueFactory::GetVarcharValue("hello hello world", pool);
+  type::Value val = type::ValueFactory::GetVarcharValue((std::string)"hello hello world", pool);
   tuple->SetValue(3, val, pool);
   type::Value value3 = (tuple->GetValue(3));
   type::Value cmp = (value3.CompareEquals(val));
@@ -107,7 +107,7 @@ TEST_F(TupleTests, VarcharTest) {
 
   LOG_INFO("%s", tuple->GetInfo().c_str());
 
-  auto val2 = type::ValueFactory::GetVarcharValue("hi joy !", pool);
+  auto val2 = type::ValueFactory::GetVarcharValue((std::string)"hi joy !", pool);
   tuple->SetValue(3, val2, pool);
   value3 = (tuple->GetValue(3));
   cmp = (value3.CompareNotEquals(val));

--- a/test/storage/value_copy_test.cpp
+++ b/test/storage/value_copy_test.cpp
@@ -41,9 +41,9 @@ TEST_F(ValueCopyTests, VarcharTest) {
   auto pool = TestingHarness::GetInstance().GetTestingPool();
 
   type::Value val1 = (
-      type::ValueFactory::GetVarcharValue("hello hello world", nullptr).Copy());
+      type::ValueFactory::GetVarcharValue(std::string("hello hello world"), nullptr).Copy());
   type::Value val2 = (
-      type::ValueFactory::GetVarcharValue("hello hello world", nullptr).Copy());
+      type::ValueFactory::GetVarcharValue(std::string("hello hello world"), nullptr).Copy());
 
   tuple->SetValue(0, val1, pool);
   tuple->SetValue(1, val2, pool);


### PR DESCRIPTION
In this PR, we:
- Replace all `CheckComparable()` and `CheckInteger()` with asserts
- Add a null flag to value type and simplify the `IsNull()`'s check
- Inline simple functions in type/value
- Support shallow copy in varlen type

#419 