### PR TITLE
Handle NULL values with Frontend

### DIFF
--- a/src/executor/copy_executor.cpp
+++ b/src/executor/copy_executor.cpp
@@ -175,7 +175,7 @@ bool CopyExecutor::DExecute() {
     std::vector<std::vector<std::string>> answer_tuples;
     std::vector<int> result_format(col_count, 0);
     answer_tuples =
-        std::move(logical_tile->GetAllValuesAsStrings(result_format));
+        std::move(logical_tile->GetAllValuesAsStrings(result_format, true));
 
     // Loop over the returned results
     for (auto &tuple : answer_tuples) {

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -90,7 +90,7 @@ peloton_status PlanExecutor::ExecutePlan(
             logical_tile->GetPhysicalSchema());  // Physical schema of the tile
         std::vector<std::vector<std::string>> answer_tuples;
         answer_tuples =
-            std::move(logical_tile->GetAllValuesAsStrings(result_format));
+            std::move(logical_tile->GetAllValuesAsStrings(result_format, false));
 
         // Construct the returned results
         for (auto &tuple : answer_tuples) {

--- a/src/include/executor/logical_tile.h
+++ b/src/include/executor/logical_tile.h
@@ -107,7 +107,7 @@ class LogicalTile : public Printable {
   void SetPositionListsAndVisibility(PositionLists &&position_lists);
 
   std::vector<std::vector<std::string>> GetAllValuesAsStrings(
-      const std::vector<int> &result_format);
+      const std::vector<int> &result_format, bool use_to_string_null);
 
   // Get a string representation for debugging
   const std::string GetInfo() const;

--- a/src/include/wire/packet_manager.h
+++ b/src/include/wire/packet_manager.h
@@ -30,6 +30,9 @@
 #define TXN_BLOCK 'T'
 #define TXN_FAIL 'E'
 
+// Packet content macros
+#define NULL_CONTENT_SIZE -1
+
 namespace peloton {
 
 namespace wire {

--- a/src/networking/protocol.cpp
+++ b/src/networking/protocol.cpp
@@ -156,10 +156,17 @@ void PacketManager::SendDataRows(std::vector<ResultType> &results, int colcount,
     pkt->msg_type = DATA_ROW;
     PacketPutInt(pkt.get(), colcount, 2);
     for (int j = 0; j < colcount; j++) {
-      // length of the row attribute
-      PacketPutInt(pkt.get(), results[i * colcount + j].second.size(), 4);
-      // contents of the row attribute
-      PacketPutBytes(pkt.get(), results[i * colcount + j].second);
+      auto content = results[i * colcount + j].second;
+      if (content.size() == 0) {
+        // content is NULL
+        PacketPutInt(pkt.get(), NULL_CONTENT_SIZE, 4);
+        // no value bytes follow
+      } else {
+        // length of the row attribute
+        PacketPutInt(pkt.get(), content.size(), 4);
+        // contents of the row attribute
+        PacketPutBytes(pkt.get(), content);
+      }
     }
     responses.push_back(std::move(pkt));
   }

--- a/test/sql/aggregate_sql_test.cpp
+++ b/test/sql/aggregate_sql_test.cpp
@@ -43,8 +43,7 @@ TEST_F(AggregateSQLTests, EmptyTableTest) {
       type::Type::INTEGER, type::Type::INTEGER, type::Type::DECIMAL,
       type::Type::INTEGER};
   for (int i = 0; i < (int)nullAggregates.size(); i++) {
-    std::string expected =
-        type::ValueFactory::GetNullValueByType(expectedTypes[i]).ToString();
+    std::string expected;
 
     std::ostringstream os;
     os << "SELECT " << nullAggregates[i] << "(b) FROM xxx";


### PR DESCRIPTION
During result tuple materialization, this PR materializes NULL values as 0B strings instead of 'integer_null', 'timestamp_null', etc. Then, protocol.cpp checks if the size of the value string is 0B. If it is, it treats it as a NULL value and handles it according to the wire protocol specifications.

OrderStatus doesn't give unexpected errors any more.

Further details in #415 