### PR TITLE
Index IntsKey Fixes

### DIFF
--- a/script/oltpbenchmark/testbed/.gitignore
+++ b/script/oltpbenchmark/testbed/.gitignore
@@ -1,0 +1,3 @@
+outputfile*
+oltpbench
+*_config.xml

--- a/script/oltpbenchmark/testbed/measure-performance-tpcc.py
+++ b/script/oltpbenchmark/testbed/measure-performance-tpcc.py
@@ -5,14 +5,15 @@ import sys
 import time
 import subprocess
 import re
+import argparse
 from subprocess import call
 
 
 cwd = os.getcwd()
 OLTP_HOME = "%s/oltpbench" % (cwd)
 
-db_host = 'dev1.db.pdl.cmu.local'
-db_port = '15721'
+db_host = None
+db_port = None
 
 thread_num = 1
 new_order_ratio = 100
@@ -72,6 +73,17 @@ def collect_data(result_dir_name):
     os.system("mv %s.* %s/" % (get_result_path(), result_dir_name))
 
 if __name__ == "__main__":
+    aparser = argparse.ArgumentParser(description='Timeseries')
+    aparser.add_argument('db_host', help='DB Hostname')
+    aparser.add_argument('db_port', help='DB Port')
+    args = vars(aparser.parse_args())
+    
+    
+    
+    db_host = str(args['db_host'])
+    db_port = str(args['db_port'])
+    
+    
     # 45:43:4:4:4
     # thread_num = 20
     new_order_ratio = 45

--- a/script/oltpbenchmark/testbed/measure-performance-tpcc.py
+++ b/script/oltpbenchmark/testbed/measure-performance-tpcc.py
@@ -7,7 +7,7 @@ import subprocess
 import re
 import argparse
 from subprocess import call
-
+from pprint import pprint
 
 cwd = os.getcwd()
 OLTP_HOME = "%s/oltpbench" % (cwd)
@@ -22,8 +22,8 @@ order_status_ratio = 0
 delivery_ratio = 0
 stock_level_ratio = 0
 scale_factor = 1
-test_time = 60
-# test_time = 60
+TEST_TIME = 20
+# TEST_TIME = 60
 
 # Requires that peloton-testbed is in the home directory
 config_filename = "tpcc_config.xml"
@@ -43,7 +43,7 @@ def prepare_parameters():
     parameters["$SCALE_FACTOR"] = str(scale_factor)
     parameters["$IP"] = db_host
     parameters["$PORT"] = db_port
-    parameters["$TIME"] = str(test_time)
+    parameters["$TIME"] = str(TEST_TIME)
 
     template = ""
     with open("tpcc_template.xml") as in_file:
@@ -54,18 +54,25 @@ def prepare_parameters():
         out_file.write(template)
 
 def get_result_path():
-  global cwd
-  base_dir = "%s/results/" % cwd
-  if not os.path.exists(base_dir):
-      os.mkdir(base_dir)
-  return base_dir + "outputfile_%d_%d_%d_%d_%d_%d" % (new_order_ratio, payment_ratio, order_status_ratio, delivery_ratio, stock_level_ratio, scale_factor)
+    global cwd
+    #base_dir = "%s/results/" % cwd
+    #if not os.path.exists(base_dir):
+        #os.mkdir(base_dir)
+    #return base_dir +
+    return "outputfile_%d_%d_%d_%d_%d_%d" % (new_order_ratio, payment_ratio, order_status_ratio, delivery_ratio, stock_level_ratio, scale_factor)
 
 def start_bench():
+    global cwd
     # go to oltpbench directory
     os.chdir(os.path.expanduser(OLTP_HOME))
     # call("git pull origin master", shell=True)
+    
+    resultsDir = "results"
+    if not os.path.exists(resultsDir):
+        os.mkdir(resultsDir)
+    
     call("ant", shell=True)
-    cmd = start_benchmark_script + get_result_path() + " 2>&1 | tee %s.log" % (get_result_path())
+    cmd = start_benchmark_script + get_result_path() + " 2>&1 | tee results/%s.log" % (get_result_path())
     print cmd
     call(cmd, shell=True)
 
@@ -74,17 +81,37 @@ def collect_data(result_dir_name):
     os.system("rm -rf " + result_dir_name)
     os.system("mkdir " + result_dir_name)
     os.system("mv callgrind.out.* " + result_dir_name)
-    call("cat %s.log" % (get_result_path()), shell=True)
-    os.system("mv %s.* %s/" % (get_result_path(), result_dir_name))
+    call("cat %s/results/%s.log" % (OLTP_HOME, get_result_path()), shell=True)
+    os.system("mv %s/results/%s.* %s/" % (OLTP_HOME, get_result_path(), result_dir_name))
 
 if __name__ == "__main__":
     aparser = argparse.ArgumentParser(description='Timeseries')
-    aparser.add_argument('db_host', help='DB Hostname')
-    aparser.add_argument('db_port', help='DB Port')
+    aparser.add_argument('db-host', help='DB Hostname')
+    aparser.add_argument('db-port', type=int, help='DB Port')
+    aparser.add_argument('--client-threads', type=int, metavar='N', \
+                         help='Number of client threads to use')
+    aparser.add_argument('--client-time', type=int, metavar='T', \
+                         help='How long to execute each benchmark trial')
     args = vars(aparser.parse_args())
     
-    db_host = str(args['db_host'])
-    db_port = str(args['db_port'])
+    ## ----------------------------------------------
+    ## ARGUMENT PROCESSING 
+    ## ----------------------------------------------
+    
+    db_host = str(args['db-host'])
+    db_port = str(args['db-port'])
+    
+    # If we are given a specific client thread count, then we will just test that
+    thread_counts = None
+    if "client_threads" in args and args["client_threads"]:
+        thread_counts = [ int(args["client_threads"]) ]
+    # Otherwise we will sweep across these numbers
+    else:
+        thread_counts = [1, 2, 4, 6, 8, 10, 16, 20, 24, 28, 32, 40, 48, 56, 64]
+    
+    if "client_time" in args and args["client_time"]:
+        TEST_TIME = int(args["client_time"])
+    
     
     # 45:43:4:4:4
     # thread_num = 20
@@ -94,12 +121,13 @@ if __name__ == "__main__":
     delivery_ratio = 4
     stock_level_ratio = 4
 
-    # test_time = 1800
-    test_time = 60
-    for thread_num in [1, 2, 4, 6, 8, 10, 16, 20, 24, 28, 32, 40, 48, 56, 64]:
-    # for thread_num in [1]:
+    ## ----------------------------------------------
+    ## EXECUTE
+    ## ----------------------------------------------
+    for thread_num in thread_counts:
         prepare_parameters()
         scale_factor = thread_num
         start_bench()
         result_dir_name = "tpcc_collected_data_%d_%d_%d_%d_%d_%d_%d" % (new_order_ratio, payment_ratio, order_status_ratio, delivery_ratio, stock_level_ratio, scale_factor, thread_num)
         collect_data(result_dir_name)
+## MAIN

--- a/script/oltpbenchmark/testbed/measure-performance-tpcc.py
+++ b/script/oltpbenchmark/testbed/measure-performance-tpcc.py
@@ -27,7 +27,8 @@ test_time = 60
 
 # Requires that peloton-testbed is in the home directory
 config_filename = "tpcc_config.xml"
-start_benchmark_script = "%s/oltpbenchmark -b tpcc -c " % (OLTP_HOME) + cwd + "/" + config_filename + " --histograms  --create=true --load=true --execute=true -s 5 -o "
+start_benchmark_script = "%s/oltpbenchmark -b tpcc -c " % (OLTP_HOME) + \
+                         cwd + "/" + config_filename + " --histograms  --create=true --load=true --execute=true -s 5 -o "
 
 parameters={}
 
@@ -54,7 +55,10 @@ def prepare_parameters():
 
 def get_result_path():
   global cwd
-  return "%s/outputfile_%d_%d_%d_%d_%d_%d" % (cwd, new_order_ratio, payment_ratio, order_status_ratio, delivery_ratio, stock_level_ratio, scale_factor)
+  base_dir = "%s/results/" % cwd
+  if not os.path.exists(base_dir):
+      os.mkdir(base_dir)
+  return base_dir + "outputfile_%d_%d_%d_%d_%d_%d" % (new_order_ratio, payment_ratio, order_status_ratio, delivery_ratio, stock_level_ratio, scale_factor)
 
 def start_bench():
     # go to oltpbench directory
@@ -62,6 +66,7 @@ def start_bench():
     # call("git pull origin master", shell=True)
     call("ant", shell=True)
     cmd = start_benchmark_script + get_result_path() + " 2>&1 | tee %s.log" % (get_result_path())
+    print cmd
     call(cmd, shell=True)
 
 def collect_data(result_dir_name):
@@ -78,11 +83,8 @@ if __name__ == "__main__":
     aparser.add_argument('db_port', help='DB Port')
     args = vars(aparser.parse_args())
     
-    
-    
     db_host = str(args['db_host'])
     db_port = str(args['db_port'])
-    
     
     # 45:43:4:4:4
     # thread_num = 20

--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -80,7 +80,7 @@ static void AddIndex(storage::DataTable* table,
   index_metadata->SetUtility(intial_utility_ratio);
 
   std::shared_ptr<index::Index> adhoc_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
 
   // Add index
   table->AddIndex(adhoc_index);

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -207,7 +207,7 @@ Result Catalog::CreatePrimaryIndex(const std::string &database_name,
         unique_keys);
 
     std::shared_ptr<index::Index> pkey_index(
-        index::IndexFactory::GetInstance(index_metadata));
+        index::IndexFactory::GetIndex(index_metadata));
     table->AddIndex(pkey_index);
 
     LOG_TRACE("Successfully add primary key index for table %s",
@@ -270,7 +270,7 @@ Result Catalog::CreateIndex(const std::string &database_name,
 
     // Add index to table
     std::shared_ptr<index::Index> key_index(
-        index::IndexFactory::GetInstance(index_metadata));
+        index::IndexFactory::GetIndex(index_metadata));
     table->AddIndex(key_index);
 
     LOG_TRACE("Successfully add index for table %s", table->GetName().c_str());

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -9,16 +9,17 @@
 // Copyright (c) 2015-16, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
+#include "catalog/catalog.h"
 
 #include <iostream>
 
-#include "catalog/catalog.h"
 #include "catalog/manager.h"
 #include "common/exception.h"
 #include "common/macros.h"
 #include "expression/string_functions.h"
 #include "expression/date_functions.h"
 #include "index/index_factory.h"
+#include "util/string_util.h"
 
 namespace peloton {
 namespace catalog {
@@ -199,9 +200,12 @@ Result Catalog::CreatePrimaryIndex(const std::string &database_name,
     key_schema = catalog::Schema::CopySchema(schema, key_attrs);
     key_schema->SetIndexedColumns(key_attrs);
 
+    std::string index_name = table->GetName() + "_PKEY";
+
     bool unique_keys = true;
 
-    index_metadata = new index::IndexMetadata("customer_pkey", GetNextOid(),
+    index_metadata = new index::IndexMetadata(
+        StringUtil::Upper(index_name), GetNextOid(),
         table->GetOid(), database->GetOid(), INDEX_TYPE_BWTREE,
         INDEX_CONSTRAINT_TYPE_PRIMARY_KEY, schema, key_schema, key_attrs,
         unique_keys);
@@ -210,8 +214,8 @@ Result Catalog::CreatePrimaryIndex(const std::string &database_name,
         index::IndexFactory::GetIndex(index_metadata));
     table->AddIndex(pkey_index);
 
-    LOG_TRACE("Successfully add primary key index for table %s",
-        table->GetName().c_str());
+    LOG_TRACE("Successfully created primary key index '%s' for table '%s'",
+              pkey_index->GetName().c_str(), table->GetName().c_str());
     return Result::RESULT_SUCCESS;
   } else {
     LOG_TRACE("Could not find a database with name %s", database_name.c_str());
@@ -517,7 +521,8 @@ std::unique_ptr<catalog::Schema> Catalog::InitializeTablesSchema() {
   const std::string not_null_constraint_name = "not_null";
 
   auto id_column = catalog::Column(type::Type::INTEGER,
-      type::Type::GetTypeSize(type::Type::INTEGER), "table_id", true);
+                                   type::Type::GetTypeSize(type::Type::INTEGER),
+                                   "table_id", true);
   id_column.AddConstraint(
       catalog::Constraint(CONSTRAINT_TYPE_NOTNULL, not_null_constraint_name));
 
@@ -547,7 +552,9 @@ std::unique_ptr<catalog::Schema> Catalog::InitializeDatabaseSchema() {
   const std::string not_null_constraint_name = "not_null";
 
   auto id_column = catalog::Column(type::Type::INTEGER,
-      type::Type::GetTypeSize(type::Type::INTEGER), "database_id", true);
+                                   type::Type::GetTypeSize(type::Type::INTEGER),
+                                   "database_id", true);
+>>>>>>> 3eec96d... Fixed Catalog::CreatePrimaryIndex() so that we don't hardcode the name of every pkey index to be for the 'customer' table #431
   id_column.AddConstraint(
       catalog::Constraint(CONSTRAINT_TYPE_NOTNULL, not_null_constraint_name));
   auto name_column = catalog::Column(type::Type::VARCHAR, max_name_size,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -554,7 +554,6 @@ std::unique_ptr<catalog::Schema> Catalog::InitializeDatabaseSchema() {
   auto id_column = catalog::Column(type::Type::INTEGER,
                                    type::Type::GetTypeSize(type::Type::INTEGER),
                                    "database_id", true);
->>>>>>> 3eec96d... Fixed Catalog::CreatePrimaryIndex() so that we don't hardcode the name of every pkey index to be for the 'customer' table #431
   id_column.AddConstraint(
       catalog::Constraint(CONSTRAINT_TYPE_NOTNULL, not_null_constraint_name));
   auto name_column = catalog::Column(type::Type::VARCHAR, max_name_size,

--- a/src/include/catalog/column.h
+++ b/src/include/catalog/column.h
@@ -12,10 +12,10 @@
 
 #pragma once
 
-#include "common/printable.h"
 #include "catalog/constraint.h"
-#include "type/type.h"
 #include "common/macros.h"
+#include "common/printable.h"
+#include "type/type.h"
 
 namespace peloton {
 namespace catalog {
@@ -28,12 +28,15 @@ class Column : public Printable {
   friend class Constraint;
 
  public:
-  Column() {};
+  Column() : column_type(type::Type::INVALID), fixed_length(INVALID_OID) {
+    // Nothing to see...
+  }
 
   Column(type::Type::TypeId value_type, oid_t column_length,
          std::string column_name, bool is_inlined = false,
          oid_t column_offset = INVALID_OID)
       : column_type(value_type),
+        fixed_length(INVALID_OID),
         column_name(column_name),
         is_inlined(is_inlined),
         column_offset(column_offset) {
@@ -72,11 +75,11 @@ class Column : public Printable {
 
   oid_t GetVariableLength() const { return variable_length; }
 
-  type::Type::TypeId GetType() const { return column_type; }
+  inline type::Type::TypeId GetType() const { return column_type; }
 
-  bool IsInlined() const { return is_inlined; }
+  inline bool IsInlined() const { return is_inlined; }
 
-  bool IsPrimary() const { return is_primary_; }
+  inline bool IsPrimary() const { return is_primary_; }
 
   // Add a constraint to the column
   void AddConstraint(const catalog::Constraint &constraint) {
@@ -105,12 +108,16 @@ class Column : public Printable {
   // MEMBERS
   //===--------------------------------------------------------------------===//
 
+ private:
   // value type of column
-  type::Type::TypeId column_type = type::Type::INVALID;
+  type::Type::TypeId column_type;  //  = type::Type::INVALID;
 
   // if the column is not inlined, this is set to pointer size
   // else, it is set to length of the fixed length column
-  oid_t fixed_length = INVALID_OID;
+  oid_t fixed_length;  //  = INVALID_OID;
+
+ public:
+  // TODO: These should all be made private
 
   // if the column is inlined, this is set to 0
   // else, it is set to length of the variable length column

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -10,13 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
-#include "common/printable.h"
-#include "catalog/column.h"
-#include "type/type.h"
 #include <memory>
+#include "catalog/column.h"
+#include "common/printable.h"
+#include "type/type.h"
 
 namespace peloton {
 namespace catalog {
@@ -56,7 +55,7 @@ class Schema : public Printable {
   // Copy subset of columns in the given schema
   static Schema *CopySchema(const Schema *schema,
                             const std::vector<oid_t> &index_list);
-                            
+
   static Schema *FilterSchema(const Schema *schema,
                               const std::vector<oid_t> &set);
 
@@ -87,16 +86,16 @@ class Schema : public Printable {
   //===--------------------------------------------------------------------===//
 
   inline size_t GetOffset(const oid_t column_id) const {
-    return columns[column_id].column_offset;
+    return columns[column_id].GetOffset();
   }
 
   inline type::Type::TypeId GetType(const oid_t column_id) const {
-    return columns[column_id].column_type;
+    return columns[column_id].GetType();
   }
 
   // Return appropriate length based on whether column is inlined
   inline size_t GetAppropriateLength(const oid_t column_id) const {
-    auto is_inlined = columns[column_id].is_inlined;
+    auto is_inlined = columns[column_id].IsInlined();
     size_t column_length;
 
     if (is_inlined) {
@@ -110,25 +109,25 @@ class Schema : public Printable {
 
   // Returns fixed length
   inline size_t GetLength(const oid_t column_id) const {
-    return columns[column_id].fixed_length;
+    return columns[column_id].GetFixedLength();
   }
 
   inline size_t GetVariableLength(const oid_t column_id) const {
-    return columns[column_id].variable_length;
+    return columns[column_id].GetVariableLength();
   }
 
   inline bool IsInlined(const oid_t column_id) const {
-    return columns[column_id].is_inlined;
+    return columns[column_id].IsInlined();
   }
 
   inline const Column GetColumn(const oid_t column_id) const {
     return columns[column_id];
   }
 
-  inline oid_t GetColumnID(std::string col_name) const{
+  inline oid_t GetColumnID(std::string col_name) const {
     oid_t index = -1;
     for (oid_t i = 0; i < columns.size(); ++i) {
-      if (columns[i].column_name == col_name) {
+      if (columns[i].GetName() == col_name) {
         index = i;
         break;
       }
@@ -165,7 +164,7 @@ class Schema : public Printable {
 
   // Get the nullability of the column at a given index.
   inline bool AllowNull(const oid_t column_id) const {
-    for (auto constraint : columns[column_id].constraints) {
+    for (auto constraint : columns[column_id].GetConstraints()) {
       if (constraint.GetType() == CONSTRAINT_TYPE_NOTNULL) return false;
     }
     return true;
@@ -181,7 +180,7 @@ class Schema : public Printable {
   inline void AddConstraint(std::string column_name,
                             const catalog::Constraint &constraint) {
     for (size_t column_itr = 0; column_itr < columns.size(); column_itr++) {
-      if (columns[column_itr].column_name == column_name) {
+      if (columns[column_itr].GetName() == column_name) {
         columns[column_itr].AddConstraint(constraint);
       }
     }

--- a/src/include/common/timer.h
+++ b/src/include/common/timer.h
@@ -10,11 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
-#include <iostream>
 #include <chrono>
+#include <iostream>
+
+#include "common/printable.h"
 
 //===--------------------------------------------------------------------===//
 // Timer
@@ -25,34 +26,51 @@ typedef std::chrono::high_resolution_clock clock_;
 typedef std::chrono::time_point<clock_> time_point_;
 
 template <typename ResolutionRatio = std::ratio<1> >
-class Timer {
+class Timer : public peloton::Printable {
  public:
-  Timer() : elapsed(0) {}
+  Timer() : elapsed_(0), invocations_(0) {}
 
-  void Start() { begin = clock_::now(); }
+  inline void Start() { begin_ = clock_::now(); }
 
-  void Stop() {
-    end = clock_::now();
+  inline void Stop() {
+    end_ = clock_::now();
 
-    double duration = std::chrono::duration_cast<
-                          std::chrono::duration<double, ResolutionRatio> >(
-                          end - begin).count();
+    double duration =
+        std::chrono::duration_cast<
+            std::chrono::duration<double, ResolutionRatio> >(end_ - begin_)
+            .count();
 
-    elapsed += duration;
+    elapsed_ += duration;
+    invocations_++;
   }
 
-  void Reset() { elapsed = 0; }
+  inline void Reset() { elapsed_ = 0; }
 
   // Get Elapsed duration
-  double GetDuration() const { return elapsed; }
+  inline double GetDuration() const { return elapsed_; }
+
+  // Get Number of invocations
+  inline int GetInvocations() const { return invocations_; }
+
+  // Get a string representation for debugging
+  inline const std::string GetInfo() const {
+    std::ostringstream os;
+    os << "Timer["
+       << "elapsed=" << elapsed_ << ", "
+       << "invocations=" << invocations_ << "]";
+    return (os.str());
+  }
 
  private:
   // Start
-  time_point_ begin;
+  time_point_ begin_;
 
   // End
-  time_point_ end;
+  time_point_ end_;
 
   // Elapsed time (with desired resolution)
-  double elapsed;
+  double elapsed_;
+
+  // Number of invocations
+  int invocations_;
 };

--- a/src/include/index/btree_index.h
+++ b/src/include/index/btree_index.h
@@ -10,20 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
-#include <vector>
 #include <map>
 #include <string>
+#include <vector>
 
 #include "catalog/manager.h"
 #include "common/platform.h"
-#include "type/types.h"
 #include "index/index.h"
+#include "type/types.h"
 
-#include "stx/btree_multimap.h"
 #include "index/scan_optimizer.h"
+#include "stx/btree_multimap.h"
 
 namespace peloton {
 namespace index {
@@ -69,14 +68,10 @@ class BTreeIndex : public Index {
   bool Cleanup() { return true; }
 
   size_t GetMemoryFootprint() { return container.GetMemoryFootprint(); }
-  
-  bool NeedGC() {
-    return false;
-  }
 
-  void PerformGC() {
-    return;
-  }
+  bool NeedGC() { return false; }
+
+  void PerformGC() { return; }
 
  protected:
   MapType container;

--- a/src/include/index/index_factory.h
+++ b/src/include/index/index_factory.h
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
+
+#include <string>
 
 #include "index/index.h"
 
@@ -26,6 +27,26 @@ class IndexFactory {
  public:
   // Get an index with required attributes
   static Index *GetIndex(IndexMetadata *metadata);
+
+ private:
+  static std::string GetInfo(IndexMetadata *metadata,
+                             std::string comparatorType);
+
+  //===--------------------------------------------------------------------===//
+  // STX::BTREE
+  //===--------------------------------------------------------------------===//
+
+  static Index *GetBTreeIntsKeyIndex(IndexMetadata *metadata);
+
+  static Index *GetBTreeGenericKeyIndex(IndexMetadata *metadata);
+
+  //===--------------------------------------------------------------------===//
+  // PELOTON::BWTREE
+  //===--------------------------------------------------------------------===//
+
+  static Index *GetBwTreeIntsKeyIndex(IndexMetadata *metadata);
+
+  static Index *GetBwTreeGenericKeyIndex(IndexMetadata *metadata);
 };
 
 }  // End index namespace

--- a/src/include/index/index_factory.h
+++ b/src/include/index/index_factory.h
@@ -25,7 +25,7 @@ namespace index {
 class IndexFactory {
  public:
   // Get an index with required attributes
-  static Index *GetInstance(IndexMetadata *metadata);
+  static Index *GetIndex(IndexMetadata *metadata);
 };
 
 }  // End index namespace

--- a/src/include/index/ints_key.h
+++ b/src/include/index/ints_key.h
@@ -22,25 +22,24 @@ namespace index {
  * the specified signed type. The max signed value for that type is supplied as
  * the TargetTypeMaxValue template parameter.
  */
-template <typename TargetType, 
-          int64_t TargetTypeMaxValue>
+template <typename TargetType, int64_t TargetTypeMaxValue>
 inline static TargetType ConvertUnsignedValueToSignedValue(uint64_t value) {
   return static_cast<TargetType>(value - TargetTypeMaxValue + 1UL);
 }
 
 /*
  * ConvertUnsignedValueToSignedValue() - As name suggests
- * 
- * This function is a template specialization of 
- * ConvertUnsignedValueToSignedValue with int64_t, since with int64_t 
+ *
+ * This function is a template specialization of
+ * ConvertUnsignedValueToSignedValue with int64_t, since with int64_t
  * computation it is possible that overflow appearing
  */
 template <>
-inline int64_t 
-ConvertUnsignedValueToSignedValue<int64_t, INT64_MAX>(uint64_t value) {
-  return (value > static_cast<uint64_t>(INT64_MAX) + 1) ? \
-         (static_cast<int64_t>(value - INT64_MAX - 1)) : \
-         (static_cast<int64_t>(value) - INT64_MAX - 1);
+inline int64_t ConvertUnsignedValueToSignedValue<int64_t, INT64_MAX>(
+    uint64_t value) {
+  return (value > static_cast<uint64_t>(INT64_MAX) + 1)
+             ? (static_cast<int64_t>(value - INT64_MAX - 1))
+             : (static_cast<int64_t>(value) - INT64_MAX - 1);
 }
 
 /*
@@ -50,26 +49,24 @@ ConvertUnsignedValueToSignedValue<int64_t, INT64_MAX>(uint64_t value) {
  * is supplied as a template
  * parameter. int64_t is used for all types to prevent overflow.
  */
-template <int64_t TypeMaxValue, 
-          typename SignedValueType,
+template <int64_t TypeMaxValue, typename SignedValueType,
           typename UnsignedValueType>
-inline static 
-UnsignedValueType ConvertSignedValueToUnsignedValue(SignedValueType value) {
+inline static UnsignedValueType ConvertSignedValueToUnsignedValue(
+    SignedValueType value) {
   return static_cast<UnsignedValueType>(value + TypeMaxValue + 1);
 }
 
 /*
  * ConvertSignedValueToUnsignedValue() - As name suggests
  *
- * This is a template specialization to prevent integer oveflow for 
+ * This is a template specialization to prevent integer oveflow for
  * int64_t value type.
  */
 template <>
-inline uint64_t 
-ConvertSignedValueToUnsignedValue<INT64_MAX, int64_t, uint64_t>(int64_t value) {
-  return (value < 0) ? \
-         (static_cast<uint64_t>(value + INT64_MAX + 1)) : \
-         (static_cast<uint64_t>(value) + INT64_MAX + 1);
+inline uint64_t ConvertSignedValueToUnsignedValue<INT64_MAX, int64_t, uint64_t>(
+    int64_t value) {
+  return (value < 0) ? (static_cast<uint64_t>(value + INT64_MAX + 1))
+                     : (static_cast<uint64_t>(value) + INT64_MAX + 1);
 }
 
 /*
@@ -85,19 +82,18 @@ ConvertSignedValueToUnsignedValue<INT64_MAX, int64_t, uint64_t>(int64_t value) {
 template <std::size_t KeySize>
 class IntsKey {
  public:
-   
   /*
-   * InsertKeyValue() - Adding bytes from a key into the data array 
+   * InsertKeyValue() - Adding bytes from a key into the data array
    *
    * This function assumes:
    *   1. The length of key is always aligned to bytes
-   *   2. Caller initializes key_offset and intra_key_offset to 0 and 
+   *   2. Caller initializes key_offset and intra_key_offset to 0 and
    *      sizeof(uint64_t) - 1 (i.e. highest byte in a uint64_t)
    *      and will not change it outside this function; they will be
    *      modified inside this function
    *   3. Even if length of the key exceeds uint64_t size, users cuold only
    *      pass in uint64_t, representing MSB of the key
-   *   4. Length of the entire key is fixed, but whenever we push a key into 
+   *   4. Length of the entire key is fixed, but whenever we push a key into
    *      the key we could change it
    *   5. KeySize is the number of uint64_t in this object, not bytes
    *
@@ -105,34 +101,32 @@ class IntsKey {
    * key_value will be pushed into the data array byte wise from MSB to LSB
    */
   template <typename KeyValueType>
-  inline void InsertKeyValue(int &key_offset, 
-                             int &intra_key_offset,
+  inline void InsertKeyValue(int &key_offset, int &intra_key_offset,
                              uint64_t key_value) {
-                               
     // Loop from the MSB to LSB of the key value and extract each byte
     // bytes will be pushed into the data array one by one
     for (int ii = static_cast<int>(sizeof(KeyValueType)) - 1; ii >= 0; ii--) {
       // Extract the current byte we are working on
       // Since ii always drcreses from high low, we extract MSB first
       uint64_t current_byte = (0xFF & (key_value >> (ii * 8)));
-      
+
       // This is the byte in the current element of uint64_t array
       uint64_t byte_in_data = current_byte << (intra_key_offset * 8);
-      
+
       // Plug the byte in data into the array
       data[key_offset] |= byte_in_data;
-                         
+
       // Adjust the next byte we will put into uint64_t (we also put into
-      // uint64_t from high to low) 
+      // uint64_t from high to low)
       intra_key_offset--;
-      
+
       // If the current uint64_t runs out we just switch to the next uint64_t
       if (intra_key_offset < 0) {
         intra_key_offset = sizeof(uint64_t) - 1;
         key_offset++;
       }
     }
-    
+
     return;
   }
 
@@ -145,22 +139,22 @@ class IntsKey {
                                   int &intra_key_offset) const {
     // Must set it to 0 first
     uint64_t retval = 0x0;
-    
+
     // Loop from the MSB to LSB for return value
     for (int ii = static_cast<int>(sizeof(KeyValueType)) - 1; ii >= 0; ii--) {
       // Note that the precedence of & is lower than >> and <<
-      uint64_t current_byte = \
-        0xFF & ((data[key_offset] >> (intra_key_offset * 8)));
-        
+      uint64_t current_byte =
+          0xFF & ((data[key_offset] >> (intra_key_offset * 8)));
+
       // Get the byte to MSB first and then LSB between iterations
-      uint64_t byte_in_result = current_byte << (ii * 8); 
-      
+      uint64_t byte_in_result = current_byte << (ii * 8);
+
       // Plug byte in the result
       retval |= byte_in_result;
-      
+
       // Go to lower byte in data array
       intra_key_offset--;
-      
+
       // If we have run out of bytes in the current uint64_t just go to
       // the next uint64_t
       if (intra_key_offset < 0) {
@@ -168,55 +162,55 @@ class IntsKey {
         key_offset++;
       }
     }
-    
+
     return retval;
   }
 
   /*
-   * GetTupleForComparison() - This is not supported yet
+   * GetTupleForComparison()
    */
   const storage::Tuple GetTupleForComparison(
-      UNUSED_ATTRIBUTE const catalog::Schema *key_schema) const {
-    throw IndexException("Tuple conversion not supported");
-  }
-
-  /*
-   * Debug() - Get a debugging string from the object
-   */
-  std::string Debug(const catalog::Schema *key_schema) const {
-    std::ostringstream buffer;
-    int key_offset = 0;
+      const catalog::Schema *key_schema) const {
     int intra_key_offset = sizeof(uint64_t) - 1;
-    const int GetColumnCount = key_schema->GetColumnCount();
-    for (int ii = 0; ii < GetColumnCount; ii++) {
-      switch (key_schema->GetColumn(ii).column_type) {
+    int key_offset = 0;
+    storage::Tuple tuple(key_schema, true);
+    for (int i = 0, num_cols = key_schema->GetColumnCount(); i < num_cols;
+         i++) {
+      switch (key_schema->GetColumn(i).GetType()) {
         case type::Type::BIGINT: {
           const uint64_t key_value =
               ExtractKeyValue<uint64_t>(key_offset, intra_key_offset);
-          buffer << ConvertUnsignedValueToSignedValue<int64_t, INT64_MAX>(
-                        key_value) << ",";
+          tuple.SetValue(
+              i, type::ValueFactory::GetBigIntValue(
+                     ConvertUnsignedValueToSignedValue<int64_t, INT64_MAX>(
+                         key_value)));
           break;
         }
         case type::Type::INTEGER: {
           const uint64_t key_value =
               ExtractKeyValue<uint32_t>(key_offset, intra_key_offset);
-          buffer << ConvertUnsignedValueToSignedValue<int32_t, INT32_MAX>(
-                        key_value) << ",";
+          tuple.SetValue(
+              i, type::ValueFactory::GetIntegerValue(
+                     ConvertUnsignedValueToSignedValue<int32_t, INT32_MAX>(
+                         key_value)));
           break;
         }
         case type::Type::SMALLINT: {
           const uint64_t key_value =
               ExtractKeyValue<uint16_t>(key_offset, intra_key_offset);
-          buffer << ConvertUnsignedValueToSignedValue<int16_t, INT16_MAX>(
-                        key_value) << ",";
+          tuple.SetValue(
+              i, type::ValueFactory::GetSmallIntValue(
+                     ConvertUnsignedValueToSignedValue<int16_t, INT16_MAX>(
+                         key_value)));
           break;
         }
         case type::Type::TINYINT: {
           const uint64_t key_value =
               ExtractKeyValue<uint8_t>(key_offset, intra_key_offset);
-          buffer << static_cast<int64_t>(
-                        ConvertUnsignedValueToSignedValue<int8_t, INT8_MAX>(
-                            key_value)) << ",";
+          tuple.SetValue(
+              i, type::ValueFactory::GetTinyIntValue(
+                     ConvertUnsignedValueToSignedValue<int8_t, INT8_MAX>(
+                         key_value)));
           break;
         }
         default:
@@ -224,9 +218,9 @@ class IntsKey {
               "We currently only support a specific set of "
               "column index sizes...");
           break;
-      }
-    }
-    return std::string(buffer.str());
+      }  // SWITCH
+    }    // FOR
+    return (tuple);
   }
 
   /*
@@ -240,25 +234,25 @@ class IntsKey {
   inline void SetFromKey(const storage::Tuple *tuple) {
     // Must clear previous result first
     PL_MEMSET(data, 0, KeySize * sizeof(uint64_t));
-    
+
     PL_ASSERT(tuple);
-    
+
     // This returns schema of the tuple
     // Note that the schema must contain only integral type
     const catalog::Schema *key_schema = tuple->GetSchema();
-    
+
     // Need this to loop through columns
     const int column_count = key_schema->GetColumnCount();
-    
+
     // Init start with the first uint64_t element in data array, and also
     // start with the highest byte of the integer such that comparison using
     // the integer yields correct result
     int key_offset = 0;
     int intra_key_offset = sizeof(uint64_t) - 1;
-    
+
     // Loop from most significant column to least significant column
     for (int ii = 0; ii < column_count; ii++) {
-      switch (key_schema->GetColumn(ii).column_type) {
+      switch (key_schema->GetColumn(ii).GetType()) {
         case type::Type::BIGINT: {
           type::Value val = tuple->GetValue(ii);
           const int64_t value = type::ValuePeeker::PeekBigInt(val);
@@ -311,7 +305,7 @@ class IntsKey {
     int key_offset = 0;
     int intra_key_offset = sizeof(uint64_t) - 1;
     for (int ii = 0; ii < GetColumnCount; ii++) {
-      switch (key_schema->GetColumn(ii).column_type) {
+      switch (key_schema->GetColumn(ii).GetType()) {
         case type::Type::BIGINT: {
           type::Value val = tuple->GetValue(indices[ii]);
           const int64_t value = type::ValuePeeker::PeekBigInt(val);
@@ -323,8 +317,7 @@ class IntsKey {
         }
         case type::Type::INTEGER: {
           type::Value val = tuple->GetValue(indices[ii]);
-          const int32_t value =
-              type::ValuePeeker::PeekInteger(val);
+          const int32_t value = type::ValuePeeker::PeekInteger(val);
           const uint32_t key_value =
               ConvertSignedValueToUnsignedValue<INT32_MAX, int32_t, uint32_t>(
                   value);
@@ -356,6 +349,59 @@ class IntsKey {
           break;
       }
     }
+  }
+
+  /*
+   * Debug() - Get a debugging string from the object
+   */
+  std::string Debug(const catalog::Schema *key_schema) const {
+    std::ostringstream buffer;
+    int key_offset = 0;
+    int intra_key_offset = sizeof(uint64_t) - 1;
+    const int num_cols = key_schema->GetColumnCount();
+    for (int ii = 0; ii < num_cols; ii++) {
+      switch (key_schema->GetColumn(ii).GetType()) {
+        case type::Type::BIGINT: {
+          const uint64_t key_value =
+              ExtractKeyValue<uint64_t>(key_offset, intra_key_offset);
+          buffer << ConvertUnsignedValueToSignedValue<int64_t, INT64_MAX>(
+                        key_value)
+                 << ",";
+          break;
+        }
+        case type::Type::INTEGER: {
+          const uint64_t key_value =
+              ExtractKeyValue<uint32_t>(key_offset, intra_key_offset);
+          buffer << ConvertUnsignedValueToSignedValue<int32_t, INT32_MAX>(
+                        key_value)
+                 << ",";
+          break;
+        }
+        case type::Type::SMALLINT: {
+          const uint64_t key_value =
+              ExtractKeyValue<uint16_t>(key_offset, intra_key_offset);
+          buffer << ConvertUnsignedValueToSignedValue<int16_t, INT16_MAX>(
+                        key_value)
+                 << ",";
+          break;
+        }
+        case type::Type::TINYINT: {
+          const uint64_t key_value =
+              ExtractKeyValue<uint8_t>(key_offset, intra_key_offset);
+          buffer << static_cast<int64_t>(
+                        ConvertUnsignedValueToSignedValue<int8_t, INT8_MAX>(
+                            key_value))
+                 << ",";
+          break;
+        }
+        default:
+          throw IndexException(
+              "We currently only support a specific set of "
+              "column index sizes...");
+          break;
+      }
+    }
+    return std::string(buffer.str());
   }
 
   // actual location of data
@@ -437,8 +483,8 @@ class IntsEqualityChecker {
     return true;
   }
 
-  IntsEqualityChecker(const IntsEqualityChecker &) {};
-  IntsEqualityChecker() {};
+  IntsEqualityChecker(const IntsEqualityChecker &){};
+  IntsEqualityChecker(){};
 };
 
 /**
@@ -460,7 +506,7 @@ struct IntsHasher : std::unary_function<IntsKey<KeySize>, std::size_t> {
   const catalog::Schema *schema;
 
   IntsHasher(const IntsHasher &) {}
-  IntsHasher() {};
+  IntsHasher(){};
 };
 
 }  // End index namespace

--- a/src/include/index/ints_key.h
+++ b/src/include/index/ints_key.h
@@ -15,6 +15,10 @@
 namespace peloton {
 namespace index {
 
+// This is the maximum number of 8-byte slots that we will pack into a single
+// IntsKey template. You should not instantiate anything with more than this
+#define INTSKEY_MAX_SLOTS 4
+
 /*
  * ConvertUnsignedValueToSignedValue() - As name suggests
  *

--- a/src/include/util/string_util.h
+++ b/src/include/util/string_util.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <iomanip>
 #include <sstream>
 #include <string>
@@ -134,6 +135,16 @@ class StringUtil {
     std::ostringstream os;
     os << SET_BOLD_TEXT << str << SET_PLAIN_TEXT;
     return (os.str());
+  }
+
+  /**
+   * Convert a string to its uppercase form
+   */
+  static std::string Upper(const std::string &str) {
+    std::string copy(str);
+    std::transform(copy.begin(), copy.end(), copy.begin(),
+                   [](unsigned char c) { return std::toupper(c); });
+    return (copy);
   }
 };
 

--- a/src/index/btree_index.cpp
+++ b/src/index/btree_index.cpp
@@ -310,6 +310,10 @@ template class BTreeIndex<GenericKey<12>, ItemPointer *, GenericComparator<12>,
                           GenericEqualityChecker<12>>;
 template class BTreeIndex<GenericKey<16>, ItemPointer *, GenericComparator<16>,
                           GenericEqualityChecker<16>>;
+template class BTreeIndex<GenericKey<24>, ItemPointer *, GenericComparator<24>,
+                          GenericEqualityChecker<24>>;
+template class BTreeIndex<GenericKey<32>, ItemPointer *, GenericComparator<32>,
+                          GenericEqualityChecker<32>>;
 template class BTreeIndex<GenericKey<64>, ItemPointer *, GenericComparator<64>,
                           GenericEqualityChecker<64>>;
 template class BTreeIndex<GenericKey<256>, ItemPointer *,

--- a/src/index/btree_index.cpp
+++ b/src/index/btree_index.cpp
@@ -11,11 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "index/btree_index.h"
+#include "common/logger.h"
 #include "index/index_key.h"
 #include "index/index_util.h"
-#include "common/logger.h"
-#include "storage/tuple.h"
 #include "statistics/stats_aggregator.h"
+#include "storage/tuple.h"
 
 namespace peloton {
 namespace index {
@@ -99,10 +99,9 @@ bool BTREE_TEMPLATE_TYPE::DeleteEntry(const storage::Tuple *key,
 }
 
 BTREE_TEMPLATE_ARGUMENT
-bool BTREE_TEMPLATE_TYPE::CondInsertEntry(const storage::Tuple *key,
-                                          ItemPointer *value,
-                                          std::function<bool(const void *)> predicate) {
-
+bool BTREE_TEMPLATE_TYPE::CondInsertEntry(
+    const storage::Tuple *key, ItemPointer *value,
+    std::function<bool(const void *)> predicate) {
   KeyType index_key;
   index_key.SetFromKey(key);
 
@@ -123,8 +122,7 @@ bool BTREE_TEMPLATE_TYPE::CondInsertEntry(const storage::Tuple *key,
     }
 
     // Insert the key, val pair
-    container.insert(
-        std::pair<KeyType, ValueType>(index_key, value));
+    container.insert(std::pair<KeyType, ValueType>(index_key, value));
 
     index_lock.Unlock();
   }
@@ -147,7 +145,6 @@ void BTREE_TEMPLATE_TYPE::Scan(const std::vector<type::Value> &value_list,
                                const ScanDirectionType &scan_direction,
                                std::vector<ValueType> &result,
                                const ConjunctionScanPredicate *csp_p) {
-
   // First make sure all three components of the scan predicate are
   // of the same length
   // Since there is a 1-to-1 correspondense between these three vectors
@@ -234,8 +231,8 @@ void BTREE_TEMPLATE_TYPE::Scan(const std::vector<type::Value> &value_list,
   index_lock.Unlock();
 
   if (FLAGS_stats_mode != STATS_TYPE_INVALID) {
-    stats::BackendStatsContext::GetInstance()->IncrementIndexReads(result.size(),
-                                                                  metadata);
+    stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
+        result.size(), metadata);
   }
   return;
 }
@@ -258,8 +255,8 @@ void BTREE_TEMPLATE_TYPE::ScanAllKeys(std::vector<ValueType> &result) {
   }
 
   if (FLAGS_stats_mode != STATS_TYPE_INVALID) {
-    stats::BackendStatsContext::GetInstance()->IncrementIndexReads(result.size(),
-                                                                  metadata);
+    stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
+        result.size(), metadata);
   }
 }
 
@@ -284,8 +281,8 @@ void BTREE_TEMPLATE_TYPE::ScanKey(const storage::Tuple *key,
     index_lock.Unlock();
   }
   if (FLAGS_stats_mode != STATS_TYPE_INVALID) {
-    stats::BackendStatsContext::GetInstance()->IncrementIndexReads(result.size(),
-                                                                  metadata);
+    stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
+        result.size(), metadata);
   }
 }
 
@@ -296,10 +293,21 @@ std::string BTREE_TEMPLATE_TYPE::GetTypeName() const { return "Btree"; }
 
 // Explicit template instantiation
 
+template class BTreeIndex<IntsKey<1>, ItemPointer *, IntsComparator<1>,
+                          IntsEqualityChecker<1>>;
+template class BTreeIndex<IntsKey<2>, ItemPointer *, IntsComparator<2>,
+                          IntsEqualityChecker<2>>;
+template class BTreeIndex<IntsKey<3>, ItemPointer *, IntsComparator<3>,
+                          IntsEqualityChecker<3>>;
+template class BTreeIndex<IntsKey<4>, ItemPointer *, IntsComparator<4>,
+                          IntsEqualityChecker<4>>;
+
 template class BTreeIndex<GenericKey<4>, ItemPointer *, GenericComparator<4>,
                           GenericEqualityChecker<4>>;
 template class BTreeIndex<GenericKey<8>, ItemPointer *, GenericComparator<8>,
                           GenericEqualityChecker<8>>;
+template class BTreeIndex<GenericKey<12>, ItemPointer *, GenericComparator<12>,
+                          GenericEqualityChecker<12>>;
 template class BTreeIndex<GenericKey<16>, ItemPointer *, GenericComparator<16>,
                           GenericEqualityChecker<16>>;
 template class BTreeIndex<GenericKey<64>, ItemPointer *, GenericComparator<64>,

--- a/src/index/btree_index.cpp
+++ b/src/index/btree_index.cpp
@@ -293,6 +293,8 @@ std::string BTREE_TEMPLATE_TYPE::GetTypeName() const { return "Btree"; }
 
 // Explicit template instantiation
 
+// IMPORTANT: Make sure you don't exceed INTSKEY_MAX_SLOTS
+
 template class BTreeIndex<IntsKey<1>, ItemPointer *, IntsComparator<1>,
                           IntsEqualityChecker<1>>;
 template class BTreeIndex<IntsKey<2>, ItemPointer *, IntsComparator<2>,
@@ -306,12 +308,8 @@ template class BTreeIndex<GenericKey<4>, ItemPointer *, GenericComparator<4>,
                           GenericEqualityChecker<4>>;
 template class BTreeIndex<GenericKey<8>, ItemPointer *, GenericComparator<8>,
                           GenericEqualityChecker<8>>;
-template class BTreeIndex<GenericKey<12>, ItemPointer *, GenericComparator<12>,
-                          GenericEqualityChecker<12>>;
 template class BTreeIndex<GenericKey<16>, ItemPointer *, GenericComparator<16>,
                           GenericEqualityChecker<16>>;
-template class BTreeIndex<GenericKey<24>, ItemPointer *, GenericComparator<24>,
-                          GenericEqualityChecker<24>>;
 template class BTreeIndex<GenericKey<32>, ItemPointer *, GenericComparator<32>,
                           GenericEqualityChecker<32>>;
 template class BTreeIndex<GenericKey<64>, ItemPointer *, GenericComparator<64>,

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -9,22 +9,20 @@
 // Copyright (c) 2015-16, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
+#include "index/bwtree_index.h"
 
 #include "common/logger.h"
-#include "index/bwtree_index.h"
 #include "index/index_key.h"
-#include "storage/tuple.h"
-
 #include "index/scan_optimizer.h"
 #include "statistics/stats_aggregator.h"
+#include "storage/tuple.h"
 
 namespace peloton {
 namespace index {
 
 BWTREE_TEMPLATE_ARGUMENTS
 BWTREE_INDEX_TYPE::BWTreeIndex(IndexMetadata *metadata)
-    :
-      // Base class
+    :  // Base class
       Index{metadata},
       // Key "less than" relation comparator
       comparator{},
@@ -38,7 +36,6 @@ BWTREE_INDEX_TYPE::BWTreeIndex(IndexMetadata *metadata)
       // NOTE 2: We set the first parameter to false to disable automatic GC
       //
       container{false, comparator, equals, hash_func} {
-
   return;
 }
 
@@ -91,7 +88,7 @@ bool BWTREE_INDEX_TYPE::DeleteEntry(const storage::Tuple *key,
 BWTREE_TEMPLATE_ARGUMENTS
 bool BWTREE_INDEX_TYPE::CondInsertEntry(
     const storage::Tuple *key, ItemPointer *value,
-    std::function<bool(const void*)> predicate) {
+    std::function<bool(const void *)> predicate) {
   KeyType index_key;
   index_key.SetFromKey(key);
 
@@ -153,7 +150,6 @@ void BWTREE_INDEX_TYPE::Scan(const std::vector<type::Value> &value_list,
     // optimized and super fast
     container.GetValue(point_query_key, result);
   } else if (csp_p->IsFullIndexScan() == true) {
-
     // If it is a full index scan, then just do the scan
     // until we have reached the end of the index by the same
     // we take the snapshot of the last leaf node
@@ -192,7 +188,7 @@ void BWTREE_INDEX_TYPE::Scan(const std::vector<type::Value> &value_list,
     // or we have seen a key higher than the high key
     for (auto scan_itr = container.Begin(index_low_key);
          (scan_itr.IsEnd() == false) &&
-             (container.KeyCmpLessEqual(scan_itr->first, index_high_key));
+         (container.KeyCmpLessEqual(scan_itr->first, index_high_key));
          scan_itr++) {
       auto scan_current_key = scan_itr->first;
       auto tuple =
@@ -205,8 +201,8 @@ void BWTREE_INDEX_TYPE::Scan(const std::vector<type::Value> &value_list,
   }  // if is full scan
 
   if (FLAGS_stats_mode != STATS_TYPE_INVALID) {
-    stats::BackendStatsContext::GetInstance()->IncrementIndexReads(result.size(),
-                                                                  metadata);
+    stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
+        result.size(), metadata);
   }
   return;
 }
@@ -222,8 +218,8 @@ void BWTREE_INDEX_TYPE::ScanAllKeys(std::vector<ValueType> &result) {
   }
 
   if (FLAGS_stats_mode != STATS_TYPE_INVALID) {
-    stats::BackendStatsContext::GetInstance()->IncrementIndexReads(result.size(),
-                                                                  metadata);
+    stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
+        result.size(), metadata);
   }
   return;
 }
@@ -238,8 +234,8 @@ void BWTREE_INDEX_TYPE::ScanKey(const storage::Tuple *key,
   container.GetValue(index_key, result);
 
   if (FLAGS_stats_mode != STATS_TYPE_INVALID) {
-    stats::BackendStatsContext::GetInstance()->IncrementIndexReads(result.size(),
-                                                                  metadata);
+    stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
+        result.size(), metadata);
   }
 
   return;
@@ -252,36 +248,18 @@ std::string BWTREE_INDEX_TYPE::GetTypeName() const { return "BWTree"; }
 // the following in order to instanciation the template before it is
 // linked in linking stage
 
-/*
-template class BWTreeIndex<IntsKey<1>,
-                           ItemPointer *,
-                           IntsComparator<1>,
-                           IntsEqualityChecker<1>,
-                           IntsHasher<1>,
-                           ItemPointerComparator,
-                           ItemPointerHashFunc>;
-template class BWTreeIndex<IntsKey<2>,
-                           ItemPointer *,
-                           IntsComparator<2>,
-                           IntsEqualityChecker<2>,
-                           IntsHasher<2>,
-                           ItemPointerComparator,
-                           ItemPointerHashFunc>;
-template class BWTreeIndex<IntsKey<3>,
-                           ItemPointer *,
-                           IntsComparator<3>,
-                           IntsEqualityChecker<3>,
-                           IntsHasher<3>,
-                           ItemPointerComparator,
-                           ItemPointerHashFunc>;
-template class BWTreeIndex<IntsKey<4>,
-                           ItemPointer *,
-                           IntsComparator<4>,
-                           IntsEqualityChecker<4>,
-                           IntsHasher<4>,
-                           ItemPointerComparator,
-                           ItemPointerHashFunc>;
-*/
+template class BWTreeIndex<IntsKey<1>, ItemPointer *, IntsComparator<1>,
+                           IntsEqualityChecker<1>, IntsHasher<1>,
+                           ItemPointerComparator, ItemPointerHashFunc>;
+template class BWTreeIndex<IntsKey<2>, ItemPointer *, IntsComparator<2>,
+                           IntsEqualityChecker<2>, IntsHasher<2>,
+                           ItemPointerComparator, ItemPointerHashFunc>;
+template class BWTreeIndex<IntsKey<3>, ItemPointer *, IntsComparator<3>,
+                           IntsEqualityChecker<3>, IntsHasher<3>,
+                           ItemPointerComparator, ItemPointerHashFunc>;
+template class BWTreeIndex<IntsKey<4>, ItemPointer *, IntsComparator<4>,
+                           IntsEqualityChecker<4>, IntsHasher<4>,
+                           ItemPointerComparator, ItemPointerHashFunc>;
 
 // Generic key
 template class BWTreeIndex<GenericKey<4>, ItemPointer *, GenericComparator<4>,
@@ -289,6 +267,9 @@ template class BWTreeIndex<GenericKey<4>, ItemPointer *, GenericComparator<4>,
                            ItemPointerComparator, ItemPointerHashFunc>;
 template class BWTreeIndex<GenericKey<8>, ItemPointer *, GenericComparator<8>,
                            GenericEqualityChecker<8>, GenericHasher<8>,
+                           ItemPointerComparator, ItemPointerHashFunc>;
+template class BWTreeIndex<GenericKey<12>, ItemPointer *, GenericComparator<12>,
+                           GenericEqualityChecker<12>, GenericHasher<12>,
                            ItemPointerComparator, ItemPointerHashFunc>;
 template class BWTreeIndex<GenericKey<16>, ItemPointer *, GenericComparator<16>,
                            GenericEqualityChecker<16>, GenericHasher<16>,

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -248,6 +248,8 @@ std::string BWTREE_INDEX_TYPE::GetTypeName() const { return "BWTree"; }
 // the following in order to instanciation the template before it is
 // linked in linking stage
 
+// IMPORTANT: Make sure you don't exceed INTSKEY_MAX_SLOTS
+
 template class BWTreeIndex<IntsKey<1>, ItemPointer *, IntsComparator<1>,
                            IntsEqualityChecker<1>, IntsHasher<1>,
                            ItemPointerComparator, ItemPointerHashFunc>;
@@ -267,9 +269,6 @@ template class BWTreeIndex<GenericKey<4>, ItemPointer *, GenericComparator<4>,
                            ItemPointerComparator, ItemPointerHashFunc>;
 template class BWTreeIndex<GenericKey<8>, ItemPointer *, GenericComparator<8>,
                            GenericEqualityChecker<8>, GenericHasher<8>,
-                           ItemPointerComparator, ItemPointerHashFunc>;
-template class BWTreeIndex<GenericKey<12>, ItemPointer *, GenericComparator<12>,
-                           GenericEqualityChecker<12>, GenericHasher<12>,
                            ItemPointerComparator, ItemPointerHashFunc>;
 template class BWTreeIndex<GenericKey<16>, ItemPointer *, GenericComparator<16>,
                            GenericEqualityChecker<16>, GenericHasher<16>,

--- a/src/index/index_factory.cpp
+++ b/src/index/index_factory.cpp
@@ -50,7 +50,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
   Index *index = nullptr;
   LOG_TRACE("Index type : %d", index_type);
 
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
   std::string comparatorType;
 #endif
 
@@ -60,13 +60,13 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
   if (index_type == INDEX_TYPE_BTREE) {
     if (key_size <= 4) {
       if (ints_only) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "IntsKey<1>";
 #endif
         index = new BTreeIndex<IntsKey<1>, ItemPointer *, IntsComparator<1>,
                                IntsEqualityChecker<1>>(metadata);
       } else {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "GenericKey<4>";
 #endif
         index =
@@ -75,13 +75,13 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
       }
     } else if (key_size <= 8) {
       if (ints_only) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "IntsKey<2>";
 #endif
         index = new BTreeIndex<IntsKey<2>, ItemPointer *, IntsComparator<2>,
                                IntsEqualityChecker<2>>(metadata);
       } else {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "GenericKey<8>";
 #endif
         index =
@@ -90,13 +90,13 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
       }
     } else if (key_size <= 12) {
       if (ints_only) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "IntsKey<3>";
 #endif
         index = new BTreeIndex<IntsKey<3>, ItemPointer *, IntsComparator<3>,
                                IntsEqualityChecker<3>>(metadata);
       } else {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "GenericKey<12>";
 #endif
         index =
@@ -105,13 +105,13 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
       }
     } else if (key_size <= 16) {
       if (ints_only) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "IntsKey<4>";
 #endif
         index = new BTreeIndex<IntsKey<4>, ItemPointer *, IntsComparator<4>,
                                IntsEqualityChecker<4>>(metadata);
       } else {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "GenericKey<16>";
 #endif
         index =
@@ -119,35 +119,35 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                            GenericEqualityChecker<16>>(metadata);
       }
     } else if (key_size <= 24) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
       comparatorType = "GenericKey<24>";
 #endif
       index =
           new BTreeIndex<GenericKey<24>, ItemPointer *, GenericComparator<24>,
                          GenericEqualityChecker<24>>(metadata);
     } else if (key_size <= 32) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
       comparatorType = "GenericKey<32>";
 #endif
       index =
           new BTreeIndex<GenericKey<32>, ItemPointer *, GenericComparator<32>,
                          GenericEqualityChecker<32>>(metadata);
     } else if (key_size <= 64) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
       comparatorType = "GenericKey<64>";
 #endif
       index =
           new BTreeIndex<GenericKey<64>, ItemPointer *, GenericComparator<64>,
                          GenericEqualityChecker<64>>(metadata);
     } else if (key_size <= 256) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
       comparatorType = "GenericKey<256>";
 #endif
       index =
           new BTreeIndex<GenericKey<256>, ItemPointer *, GenericComparator<256>,
                          GenericEqualityChecker<256>>(metadata);
     } else {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
       comparatorType = "TupleKey";
 #endif
       index = new BTreeIndex<TupleKey, ItemPointer *, TupleKeyComparator,
@@ -160,7 +160,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
   } else if (index_type == INDEX_TYPE_BWTREE) {
     if (key_size <= 4) {
       if (ints_only) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "IntsKey<1>";
 #endif
         index = new BWTreeIndex<IntsKey<1>, ItemPointer *, IntsComparator<1>,
@@ -168,7 +168,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                                 ItemPointerComparator, ItemPointerHashFunc>(
             metadata);
       } else {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "GenericKey<4>";
 #endif
         index =
@@ -179,7 +179,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
       }
     } else if (key_size <= 8) {
       if (ints_only) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "IntsKey<2>";
 #endif
         index = new BWTreeIndex<IntsKey<2>, ItemPointer *, IntsComparator<2>,
@@ -187,7 +187,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                                 ItemPointerComparator, ItemPointerHashFunc>(
             metadata);
       } else {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "GenericKey<8>";
 #endif
         index =
@@ -198,7 +198,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
       }
     } else if (key_size <= 12) {
       if (ints_only) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "IntsKey<3>";
 #endif
         index = new BWTreeIndex<IntsKey<3>, ItemPointer *, IntsComparator<3>,
@@ -206,7 +206,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                                 ItemPointerComparator, ItemPointerHashFunc>(
             metadata);
       } else {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "GenericKey<12>";
 #endif
         index =
@@ -217,7 +217,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
       }
     } else if (key_size <= 16) {
       if (ints_only) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "IntsKey<4>";
 #endif
         index = new BWTreeIndex<IntsKey<4>, ItemPointer *, IntsComparator<4>,
@@ -225,7 +225,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                                 ItemPointerComparator, ItemPointerHashFunc>(
             metadata);
       } else {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
         comparatorType = "GenericKey<16>";
 #endif
         index =
@@ -235,7 +235,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                             ItemPointerHashFunc>(metadata);
       }
     } else if (key_size <= 64) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
       comparatorType = "GenericKey<64>";
 #endif
       index =
@@ -243,7 +243,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                           GenericEqualityChecker<64>, GenericHasher<64>,
                           ItemPointerComparator, ItemPointerHashFunc>(metadata);
     } else if (key_size <= 256) {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
       comparatorType = "GenericKey<256>";
 #endif
       index =
@@ -252,7 +252,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                           GenericHasher<256>, ItemPointerComparator,
                           ItemPointerHashFunc>(metadata);
     } else {
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
       comparatorType = "TupleKey";
 #endif
       index =
@@ -263,7 +263,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
   } else {
     throw IndexException("Unsupported index scheme.");
   }
-#ifdef LOG_DEBUG_ENABLED
+#ifdef LOG_TRACE_ENABLED
   std::ostringstream os;
   os << "Index '" << metadata->GetName() << "' => "
      << IndexTypeToString(index_type) << "::" << comparatorType << "(";

--- a/src/index/index_factory.cpp
+++ b/src/index/index_factory.cpp
@@ -35,7 +35,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
   // Check whether the index key only has ints.
   // If so, then we can rock a specialized IntsKeyComparator
   // that is faster than the GenericComparator
-  bool ints_only = true;
+  bool ints_only = false; // FIXME: Re-enable this once the new IntsKey is working
   for (auto column : metadata->key_schema->GetColumns()) {
     auto col_type = column.GetType();
     if (col_type != type::Type::TINYINT && col_type != type::Type::SMALLINT &&

--- a/src/index/index_factory.cpp
+++ b/src/index/index_factory.cpp
@@ -23,7 +23,7 @@
 namespace peloton {
 namespace index {
 
-Index *IndexFactory::GetInstance(IndexMetadata *metadata) {
+Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
   LOG_INFO("Creating index %s", metadata->GetName().c_str());
 
   // The size of the key in bytes

--- a/src/index/index_factory.cpp
+++ b/src/index/index_factory.cpp
@@ -12,88 +12,264 @@
 
 #include <iostream>
 
-#include "type/types.h"
 #include "common/logger.h"
 #include "common/macros.h"
-#include "index/index_factory.h"
-#include "index/index_key.h"
 #include "index/btree_index.h"
 #include "index/bwtree_index.h"
+#include "index/index_factory.h"
+#include "index/index_key.h"
+#include "type/types.h"
 
 namespace peloton {
 namespace index {
 
 Index *IndexFactory::GetInstance(IndexMetadata *metadata) {
+  LOG_INFO("Creating index %s", metadata->GetName().c_str());
 
-  LOG_TRACE("Creating index %s", metadata->GetName().c_str());
+  // The size of the key in bytes
   const auto key_size = metadata->key_schema->GetLength();
   LOG_TRACE("key_size : %d", key_size);
   LOG_TRACE("Indexed column count: %ld",
             metadata->key_schema->GetIndexedColumns().size());
 
+  // Check whether the index key only has ints.
+  // If so, then we can rock a specialized IntsKeyComparator
+  // that is faster than the GenericComparator
+  bool ints_only = true;
+  for (auto column : metadata->key_schema->GetColumns()) {
+    // TODO: We need to see whether we can also support
+    // TINYINT and SMALLINT keys
+    auto col_type = column.GetType();
+    if (col_type != type::Type::INTEGER) {
+      ints_only = false;
+      break;
+    }
+  }  // FOR
+
   auto index_type = metadata->GetIndexMethodType();
+  Index *index = nullptr;
   LOG_TRACE("Index type : %d", index_type);
 
+#ifdef LOG_DEBUG_ENABLED
+  std::string comparatorType;
+#endif
+
+  // -----------------------
+  // B+TREE
+  // -----------------------
   if (index_type == INDEX_TYPE_BTREE) {
     if (key_size <= 4) {
-      return new BTreeIndex<GenericKey<4>, ItemPointer *, GenericComparator<4>,
-                            GenericEqualityChecker<4>>(metadata);
+      if (ints_only) {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "IntsKey<1>";
+#endif
+        index = new BTreeIndex<IntsKey<1>, ItemPointer *, IntsComparator<1>,
+                               IntsEqualityChecker<1>>(metadata);
+      } else {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "GenericKey<4>";
+#endif
+        index =
+            new BTreeIndex<GenericKey<4>, ItemPointer *, GenericComparator<4>,
+                           GenericEqualityChecker<4>>(metadata);
+      }
     } else if (key_size <= 8) {
-      return new BTreeIndex<GenericKey<8>, ItemPointer *, GenericComparator<8>,
-                            GenericEqualityChecker<8>>(metadata);
+      if (ints_only) {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "IntsKey<2>";
+#endif
+        index = new BTreeIndex<IntsKey<2>, ItemPointer *, IntsComparator<2>,
+                               IntsEqualityChecker<2>>(metadata);
+      } else {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "GenericKey<8>";
+#endif
+        index =
+            new BTreeIndex<GenericKey<8>, ItemPointer *, GenericComparator<8>,
+                           GenericEqualityChecker<8>>(metadata);
+      }
+    } else if (key_size <= 12) {
+      if (ints_only) {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "IntsKey<3>";
+#endif
+        index = new BTreeIndex<IntsKey<3>, ItemPointer *, IntsComparator<3>,
+                               IntsEqualityChecker<3>>(metadata);
+      } else {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "GenericKey<12>";
+#endif
+        index =
+            new BTreeIndex<GenericKey<12>, ItemPointer *, GenericComparator<12>,
+                           GenericEqualityChecker<12>>(metadata);
+      }
     } else if (key_size <= 16) {
-      return new BTreeIndex<GenericKey<16>, ItemPointer *,
-                            GenericComparator<16>, GenericEqualityChecker<16>>(
-          metadata);
+      if (ints_only) {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "IntsKey<4>";
+#endif
+        index = new BTreeIndex<IntsKey<4>, ItemPointer *, IntsComparator<4>,
+                               IntsEqualityChecker<4>>(metadata);
+      } else {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "GenericKey<16>";
+#endif
+        index =
+            new BTreeIndex<GenericKey<16>, ItemPointer *, GenericComparator<16>,
+                           GenericEqualityChecker<16>>(metadata);
+      }
+    } else if (key_size <= 24) {
+#ifdef LOG_DEBUG_ENABLED
+      comparatorType = "GenericKey<24>";
+#endif
+      index =
+          new BTreeIndex<GenericKey<24>, ItemPointer *, GenericComparator<24>,
+                         GenericEqualityChecker<24>>(metadata);
+    } else if (key_size <= 32) {
+#ifdef LOG_DEBUG_ENABLED
+      comparatorType = "GenericKey<32>";
+#endif
+      index =
+          new BTreeIndex<GenericKey<32>, ItemPointer *, GenericComparator<32>,
+                         GenericEqualityChecker<32>>(metadata);
     } else if (key_size <= 64) {
-      return new BTreeIndex<GenericKey<64>, ItemPointer *,
-                            GenericComparator<64>, GenericEqualityChecker<64>>(
-          metadata);
+#ifdef LOG_DEBUG_ENABLED
+      comparatorType = "GenericKey<64>";
+#endif
+      index =
+          new BTreeIndex<GenericKey<64>, ItemPointer *, GenericComparator<64>,
+                         GenericEqualityChecker<64>>(metadata);
     } else if (key_size <= 256) {
-      return new BTreeIndex<GenericKey<256>, ItemPointer *,
-                            GenericComparator<256>,
-                            GenericEqualityChecker<256>>(metadata);
+#ifdef LOG_DEBUG_ENABLED
+      comparatorType = "GenericKey<256>";
+#endif
+      index =
+          new BTreeIndex<GenericKey<256>, ItemPointer *, GenericComparator<256>,
+                         GenericEqualityChecker<256>>(metadata);
     } else {
-      return new BTreeIndex<TupleKey, ItemPointer *, TupleKeyComparator,
-                            TupleKeyEqualityChecker>(metadata);
+#ifdef LOG_DEBUG_ENABLED
+      comparatorType = "TupleKey";
+#endif
+      index = new BTreeIndex<TupleKey, ItemPointer *, TupleKeyComparator,
+                             TupleKeyEqualityChecker>(metadata);
     }
+
+    // -----------------------
+    // BW-TREE
+    // -----------------------
   } else if (index_type == INDEX_TYPE_BWTREE) {
     if (key_size <= 4) {
-      return new BWTreeIndex<GenericKey<4>, ItemPointer *, GenericComparator<4>,
-                             GenericEqualityChecker<4>, GenericHasher<4>,
-                             ItemPointerComparator, ItemPointerHashFunc>(
-          metadata);
-
+      if (ints_only) {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "IntsKey<1>";
+#endif
+        index = new BWTreeIndex<IntsKey<1>, ItemPointer *, IntsComparator<1>,
+                                IntsEqualityChecker<1>, IntsHasher<1>,
+                                ItemPointerComparator, ItemPointerHashFunc>(
+            metadata);
+      } else {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "GenericKey<4>";
+#endif
+        index =
+            new BWTreeIndex<GenericKey<4>, ItemPointer *, GenericComparator<4>,
+                            GenericEqualityChecker<4>, GenericHasher<4>,
+                            ItemPointerComparator, ItemPointerHashFunc>(
+                metadata);
+      }
     } else if (key_size <= 8) {
-      return new BWTreeIndex<GenericKey<8>, ItemPointer *, GenericComparator<8>,
-                             GenericEqualityChecker<8>, GenericHasher<8>,
-                             ItemPointerComparator, ItemPointerHashFunc>(
-          metadata);
+      if (ints_only) {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "IntsKey<2>";
+#endif
+        index = new BWTreeIndex<IntsKey<2>, ItemPointer *, IntsComparator<2>,
+                                IntsEqualityChecker<2>, IntsHasher<2>,
+                                ItemPointerComparator, ItemPointerHashFunc>(
+            metadata);
+      } else {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "GenericKey<8>";
+#endif
+        index =
+            new BWTreeIndex<GenericKey<8>, ItemPointer *, GenericComparator<8>,
+                            GenericEqualityChecker<8>, GenericHasher<8>,
+                            ItemPointerComparator, ItemPointerHashFunc>(
+                metadata);
+      }
+    } else if (key_size <= 12) {
+      if (ints_only) {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "IntsKey<3>";
+#endif
+        index = new BWTreeIndex<IntsKey<3>, ItemPointer *, IntsComparator<3>,
+                                IntsEqualityChecker<3>, IntsHasher<3>,
+                                ItemPointerComparator, ItemPointerHashFunc>(
+            metadata);
+      } else {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "GenericKey<12>";
+#endif
+        index =
+            new BWTreeIndex<GenericKey<12>, ItemPointer *,
+                            GenericComparator<12>, GenericEqualityChecker<12>,
+                            GenericHasher<12>, ItemPointerComparator,
+                            ItemPointerHashFunc>(metadata);
+      }
     } else if (key_size <= 16) {
-      return new BWTreeIndex<GenericKey<16>, ItemPointer *,
-                             GenericComparator<16>, GenericEqualityChecker<16>,
-                             GenericHasher<16>, ItemPointerComparator,
-                             ItemPointerHashFunc>(metadata);
+      if (ints_only) {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "IntsKey<4>";
+#endif
+        index = new BWTreeIndex<IntsKey<4>, ItemPointer *, IntsComparator<4>,
+                                IntsEqualityChecker<4>, IntsHasher<4>,
+                                ItemPointerComparator, ItemPointerHashFunc>(
+            metadata);
+      } else {
+#ifdef LOG_DEBUG_ENABLED
+        comparatorType = "GenericKey<16>";
+#endif
+        index =
+            new BWTreeIndex<GenericKey<16>, ItemPointer *,
+                            GenericComparator<16>, GenericEqualityChecker<16>,
+                            GenericHasher<16>, ItemPointerComparator,
+                            ItemPointerHashFunc>(metadata);
+      }
     } else if (key_size <= 64) {
-      return new BWTreeIndex<GenericKey<64>, ItemPointer *,
-                             GenericComparator<64>, GenericEqualityChecker<64>,
-                             GenericHasher<64>, ItemPointerComparator,
-                             ItemPointerHashFunc>(metadata);
+#ifdef LOG_DEBUG_ENABLED
+      comparatorType = "GenericKey<64>";
+#endif
+      index =
+          new BWTreeIndex<GenericKey<64>, ItemPointer *, GenericComparator<64>,
+                          GenericEqualityChecker<64>, GenericHasher<64>,
+                          ItemPointerComparator, ItemPointerHashFunc>(metadata);
     } else if (key_size <= 256) {
-      return new BWTreeIndex<
-          GenericKey<256>, ItemPointer *, GenericComparator<256>,
-          GenericEqualityChecker<256>, GenericHasher<256>,
-          ItemPointerComparator, ItemPointerHashFunc>(metadata);
+#ifdef LOG_DEBUG_ENABLED
+      comparatorType = "GenericKey<256>";
+#endif
+      index =
+          new BWTreeIndex<GenericKey<256>, ItemPointer *,
+                          GenericComparator<256>, GenericEqualityChecker<256>,
+                          GenericHasher<256>, ItemPointerComparator,
+                          ItemPointerHashFunc>(metadata);
     } else {
-      return new BWTreeIndex<
-          TupleKey, ItemPointer *, TupleKeyComparator, TupleKeyEqualityChecker,
-          TupleKeyHasher, ItemPointerComparator, ItemPointerHashFunc>(metadata);
+#ifdef LOG_DEBUG_ENABLED
+      comparatorType = "TupleKey";
+#endif
+      index =
+          new BWTreeIndex<TupleKey, ItemPointer *, TupleKeyComparator,
+                          TupleKeyEqualityChecker, TupleKeyHasher,
+                          ItemPointerComparator, ItemPointerHashFunc>(metadata);
     }
   } else {
     throw IndexException("Unsupported index scheme.");
   }
+#ifdef LOG_DEBUG_ENABLED
+  LOG_DEBUG("%s Index: %s<%s>(%s)", metadata->GetName().c_str(),
+            IndexTypeToString(index_type).c_str(), comparatorType.c_str(),
+            metadata->key_schema->GetInfo().c_str());
+#endif
 
-  return NULL;
+  return (index);
 }
 
 }  // End index namespace

--- a/src/index/index_factory.cpp
+++ b/src/index/index_factory.cpp
@@ -50,7 +50,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
   Index *index = nullptr;
   LOG_TRACE("Index type : %d", index_type);
 
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
   std::string comparatorType;
 #endif
 
@@ -60,13 +60,13 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
   if (index_type == INDEX_TYPE_BTREE) {
     if (key_size <= 4) {
       if (ints_only) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "IntsKey<1>";
 #endif
         index = new BTreeIndex<IntsKey<1>, ItemPointer *, IntsComparator<1>,
                                IntsEqualityChecker<1>>(metadata);
       } else {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "GenericKey<4>";
 #endif
         index =
@@ -75,13 +75,13 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
       }
     } else if (key_size <= 8) {
       if (ints_only) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "IntsKey<2>";
 #endif
         index = new BTreeIndex<IntsKey<2>, ItemPointer *, IntsComparator<2>,
                                IntsEqualityChecker<2>>(metadata);
       } else {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "GenericKey<8>";
 #endif
         index =
@@ -90,13 +90,13 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
       }
     } else if (key_size <= 12) {
       if (ints_only) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "IntsKey<3>";
 #endif
         index = new BTreeIndex<IntsKey<3>, ItemPointer *, IntsComparator<3>,
                                IntsEqualityChecker<3>>(metadata);
       } else {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "GenericKey<12>";
 #endif
         index =
@@ -105,13 +105,13 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
       }
     } else if (key_size <= 16) {
       if (ints_only) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "IntsKey<4>";
 #endif
         index = new BTreeIndex<IntsKey<4>, ItemPointer *, IntsComparator<4>,
                                IntsEqualityChecker<4>>(metadata);
       } else {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "GenericKey<16>";
 #endif
         index =
@@ -119,35 +119,35 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                            GenericEqualityChecker<16>>(metadata);
       }
     } else if (key_size <= 24) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
       comparatorType = "GenericKey<24>";
 #endif
       index =
           new BTreeIndex<GenericKey<24>, ItemPointer *, GenericComparator<24>,
                          GenericEqualityChecker<24>>(metadata);
     } else if (key_size <= 32) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
       comparatorType = "GenericKey<32>";
 #endif
       index =
           new BTreeIndex<GenericKey<32>, ItemPointer *, GenericComparator<32>,
                          GenericEqualityChecker<32>>(metadata);
     } else if (key_size <= 64) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
       comparatorType = "GenericKey<64>";
 #endif
       index =
           new BTreeIndex<GenericKey<64>, ItemPointer *, GenericComparator<64>,
                          GenericEqualityChecker<64>>(metadata);
     } else if (key_size <= 256) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
       comparatorType = "GenericKey<256>";
 #endif
       index =
           new BTreeIndex<GenericKey<256>, ItemPointer *, GenericComparator<256>,
                          GenericEqualityChecker<256>>(metadata);
     } else {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
       comparatorType = "TupleKey";
 #endif
       index = new BTreeIndex<TupleKey, ItemPointer *, TupleKeyComparator,
@@ -160,7 +160,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
   } else if (index_type == INDEX_TYPE_BWTREE) {
     if (key_size <= 4) {
       if (ints_only) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "IntsKey<1>";
 #endif
         index = new BWTreeIndex<IntsKey<1>, ItemPointer *, IntsComparator<1>,
@@ -168,7 +168,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                                 ItemPointerComparator, ItemPointerHashFunc>(
             metadata);
       } else {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "GenericKey<4>";
 #endif
         index =
@@ -179,7 +179,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
       }
     } else if (key_size <= 8) {
       if (ints_only) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "IntsKey<2>";
 #endif
         index = new BWTreeIndex<IntsKey<2>, ItemPointer *, IntsComparator<2>,
@@ -187,7 +187,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                                 ItemPointerComparator, ItemPointerHashFunc>(
             metadata);
       } else {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "GenericKey<8>";
 #endif
         index =
@@ -198,7 +198,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
       }
     } else if (key_size <= 12) {
       if (ints_only) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "IntsKey<3>";
 #endif
         index = new BWTreeIndex<IntsKey<3>, ItemPointer *, IntsComparator<3>,
@@ -206,7 +206,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                                 ItemPointerComparator, ItemPointerHashFunc>(
             metadata);
       } else {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "GenericKey<12>";
 #endif
         index =
@@ -217,7 +217,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
       }
     } else if (key_size <= 16) {
       if (ints_only) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "IntsKey<4>";
 #endif
         index = new BWTreeIndex<IntsKey<4>, ItemPointer *, IntsComparator<4>,
@@ -225,7 +225,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                                 ItemPointerComparator, ItemPointerHashFunc>(
             metadata);
       } else {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
         comparatorType = "GenericKey<16>";
 #endif
         index =
@@ -235,7 +235,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                             ItemPointerHashFunc>(metadata);
       }
     } else if (key_size <= 64) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
       comparatorType = "GenericKey<64>";
 #endif
       index =
@@ -243,7 +243,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                           GenericEqualityChecker<64>, GenericHasher<64>,
                           ItemPointerComparator, ItemPointerHashFunc>(metadata);
     } else if (key_size <= 256) {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
       comparatorType = "GenericKey<256>";
 #endif
       index =
@@ -252,7 +252,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
                           GenericHasher<256>, ItemPointerComparator,
                           ItemPointerHashFunc>(metadata);
     } else {
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
       comparatorType = "TupleKey";
 #endif
       index =
@@ -263,7 +263,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
   } else {
     throw IndexException("Unsupported index scheme.");
   }
-#ifdef LOG_TRACE_ENABLED
+#ifdef LOG_DEBUG_ENABLED
   std::ostringstream os;
   os << "Index '" << metadata->GetName() << "' => "
      << IndexTypeToString(index_type) << "::" << comparatorType << "(";

--- a/src/index/index_factory.cpp
+++ b/src/index/index_factory.cpp
@@ -264,9 +264,17 @@ Index *IndexFactory::GetInstance(IndexMetadata *metadata) {
     throw IndexException("Unsupported index scheme.");
   }
 #ifdef LOG_DEBUG_ENABLED
-  LOG_DEBUG("%s Index: %s<%s>(%s)", metadata->GetName().c_str(),
-            IndexTypeToString(index_type).c_str(), comparatorType.c_str(),
-            metadata->key_schema->GetInfo().c_str());
+  std::ostringstream os;
+  os << "Index '" << metadata->GetName() << "' => "
+     << IndexTypeToString(index_type) << "::" << comparatorType << "(";
+  bool first = true;
+  for (auto column : metadata->key_schema->GetColumns()) {
+    if (first == false) os << ", ";
+    os << column.GetName();
+    first = false;
+  }
+  os << ")";
+  LOG_DEBUG("%s", os.str().c_str());
 #endif
 
   return (index);

--- a/src/index/index_factory.cpp
+++ b/src/index/index_factory.cpp
@@ -24,7 +24,7 @@ namespace peloton {
 namespace index {
 
 Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
-  LOG_INFO("Creating index %s", metadata->GetName().c_str());
+  LOG_TRACE("Creating index %s", metadata->GetName().c_str());
 
   // The size of the key in bytes
   const auto key_size = metadata->key_schema->GetLength();

--- a/src/main/tpcc/tpcc_loader.cpp
+++ b/src/main/tpcc/tpcc_loader.cpp
@@ -219,7 +219,7 @@ void CreateWarehouseTable() {
     tuple_schema, key_schema, key_attrs, unique);
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
 
   warehouse_table->AddIndex(pkey_index);
 }
@@ -306,7 +306,7 @@ void CreateDistrictTable() {
       unique);
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
 
   district_table->AddIndex(pkey_index);
 }
@@ -367,7 +367,7 @@ void CreateItemTable() {
       key_schema, key_attrs, unique);
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
   item_table->AddIndex(pkey_index);
 }
 
@@ -504,7 +504,7 @@ void CreateCustomerTable() {
     tuple_schema, key_schema, key_attrs, true);
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
   customer_table->AddIndex(pkey_index);
 
   // Secondary index on C_W_ID, C_D_ID, C_LAST
@@ -518,7 +518,7 @@ void CreateCustomerTable() {
       tuple_schema, key_schema, key_attrs, false);
 
   std::shared_ptr<index::Index> skey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
   customer_table->AddIndex(skey_index);
 }
 
@@ -693,7 +693,7 @@ void CreateStockTable() {
       tuple_schema, key_schema, key_attrs, unique);
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
   stock_table->AddIndex(pkey_index);
 }
 
@@ -777,7 +777,7 @@ void CreateOrdersTable() {
 
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
   orders_table->AddIndex(pkey_index);
 
   // Secondary index on O_C_ID, O_D_ID, O_W_ID
@@ -791,7 +791,7 @@ void CreateOrdersTable() {
       tuple_schema, key_schema, key_attrs, false);
 
   std::shared_ptr<index::Index> skey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
   orders_table->AddIndex(skey_index);
 }
 
@@ -847,7 +847,7 @@ void CreateNewOrderTable() {
     tuple_schema, key_schema, key_attrs, unique);
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
   new_order_table->AddIndex(pkey_index);
 }
 
@@ -943,7 +943,7 @@ void CreateOrderLineTable() {
 
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
   order_line_table->AddIndex(pkey_index);
 
   // Secondary index on OL_O_ID, OL_D_ID, OL_W_ID
@@ -957,7 +957,7 @@ void CreateOrderLineTable() {
       tuple_schema, key_schema, key_attrs, false);
 
   std::shared_ptr<index::Index> skey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
   order_line_table->AddIndex(skey_index);
 }
 

--- a/src/main/ycsb/ycsb_loader.cpp
+++ b/src/main/ycsb/ycsb_loader.cpp
@@ -119,7 +119,7 @@ void CreateYCSBDatabase() {
     tuple_schema, key_schema, key_attrs, unique);
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
   user_table->AddIndex(pkey_index);
 }
 

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -360,8 +360,8 @@ std::vector<FieldInfoType> TrafficCop::GenerateTupleDescriptor(
         auto &table_columns = target_table->GetSchema()->GetColumns();
         for (auto column : table_columns) {
           LOG_DEBUG("Column name: %s", column.column_name.c_str());
-          tuple_descriptor.push_back(GetColumnFieldForValueType(
-              column.column_name, column.column_type));
+          tuple_descriptor.push_back(
+              GetColumnFieldForValueType(column.GetName(), column.GetType()));
         }
       }
     } else {

--- a/test/catalog/constraints_tests_util.cpp
+++ b/test/catalog/constraints_tests_util.cpp
@@ -217,7 +217,7 @@ storage::DataTable *ConstraintsTestsUtil::CreateTable(
         key_schema, key_attrs, unique);
 
     std::shared_ptr<index::Index> pkey_index(
-        index::IndexFactory::GetInstance(index_metadata));
+        index::IndexFactory::GetIndex(index_metadata));
 
     table->AddIndex(pkey_index);
 
@@ -232,7 +232,7 @@ storage::DataTable *ConstraintsTestsUtil::CreateTable(
         INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_DEFAULT, tuple_schema,
         key_schema, key_attrs, unique);
     std::shared_ptr<index::Index> sec_index(
-        index::IndexFactory::GetInstance(index_metadata));
+        index::IndexFactory::GetIndex(index_metadata));
 
     table->AddIndex(sec_index);
 
@@ -247,7 +247,7 @@ storage::DataTable *ConstraintsTestsUtil::CreateTable(
         INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_UNIQUE, tuple_schema,
         key_schema, key_attrs, unique);
     std::shared_ptr<index::Index> unique_index(
-        index::IndexFactory::GetInstance(index_metadata));
+        index::IndexFactory::GetIndex(index_metadata));
 
     table->AddIndex(unique_index);
   }

--- a/test/concurrency/transaction_tests_util.cpp
+++ b/test/concurrency/transaction_tests_util.cpp
@@ -69,7 +69,7 @@ storage::DataTable *TransactionTestsUtil::CreateCombinedPrimaryKeyTable() {
       unique);
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
 
   table->AddIndex(pkey_index);
 
@@ -114,7 +114,7 @@ storage::DataTable *TransactionTestsUtil::CreatePrimaryKeyUniqueKeyTable() {
       unique);
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
 
   table->AddIndex(pkey_index);
 
@@ -130,7 +130,7 @@ storage::DataTable *TransactionTestsUtil::CreatePrimaryKeyUniqueKeyTable() {
       unique2);
 
   std::shared_ptr<index::Index> ukey_index(
-      index::IndexFactory::GetInstance(index_metadata2));
+      index::IndexFactory::GetIndex(index_metadata2));
 
   table->AddIndex(ukey_index);
 
@@ -176,7 +176,7 @@ storage::DataTable *TransactionTestsUtil::CreateTable(
       tuple_schema, key_schema, key_attrs, unique);
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
 
   table->AddIndex(pkey_index);
 

--- a/test/executor/executor_tests_util.cpp
+++ b/test/executor/executor_tests_util.cpp
@@ -381,7 +381,7 @@ storage::DataTable *ExecutorTestsUtil::CreateTable(
         unique);
 
     std::shared_ptr<index::Index> pkey_index(
-        index::IndexFactory::GetInstance(index_metadata));
+        index::IndexFactory::GetIndex(index_metadata));
 
     table->AddIndex(pkey_index);
 
@@ -399,7 +399,7 @@ storage::DataTable *ExecutorTestsUtil::CreateTable(
         INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_DEFAULT, tuple_schema,
         key_schema, key_attrs, unique);
     std::shared_ptr<index::Index> sec_index(
-        index::IndexFactory::GetInstance(index_metadata));
+        index::IndexFactory::GetIndex(index_metadata));
 
     table->AddIndex(sec_index);
   }

--- a/test/executor/tile_group_layout_test.cpp
+++ b/test/executor/tile_group_layout_test.cpp
@@ -112,7 +112,7 @@ void ExecuteTileGroupTest() {
         unique);
 
     std::shared_ptr<index::Index> pkey_index(
-        index::IndexFactory::GetInstance(index_metadata));
+        index::IndexFactory::GetIndex(index_metadata));
     table->AddIndex(pkey_index);
   }
 

--- a/test/index/hybrid_index_test.cpp
+++ b/test/index/hybrid_index_test.cpp
@@ -116,7 +116,7 @@ void CreateTable(std::unique_ptr<storage::DataTable> &hyadapt_table,
         unique);
 
     std::shared_ptr<index::Index> pkey_index(
-        index::IndexFactory::GetInstance(index_metadata));
+        index::IndexFactory::GetIndex(index_metadata));
 
     hyadapt_table->AddIndex(pkey_index);
   }
@@ -459,7 +459,7 @@ TEST_F(HybridIndexTests, HybridScanTest) {
       unique);
 
   std::shared_ptr<index::Index> pkey_index(
-      index::IndexFactory::GetInstance(index_metadata));
+      index::IndexFactory::GetIndex(index_metadata));
 
   hyadapt_table->AddIndex(pkey_index);
 

--- a/test/index/index_intskey_test.cpp
+++ b/test/index/index_intskey_test.cpp
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// index_test.cpp
+//
+// Identification: test/index/index_test.cpp
+//
+// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/harness.h"
+#include "gtest/gtest.h"
+
+#include "common/logger.h"
+#include "common/platform.h"
+#include "index/index_factory.h"
+#include "storage/tuple.h"
+
+namespace peloton {
+namespace test {
+
+//===--------------------------------------------------------------------===//
+// Index IntsKey Tests
+//===--------------------------------------------------------------------===//
+
+class IndexIntsKeyTests : public PelotonTest {};
+
+catalog::Schema *key_schema = nullptr;
+catalog::Schema *tuple_schema = nullptr;
+
+std::shared_ptr<ItemPointer> item0(new ItemPointer(120, 5));
+std::shared_ptr<ItemPointer> item1(new ItemPointer(120, 7));
+std::shared_ptr<ItemPointer> item2(new ItemPointer(123, 19));
+
+// Since we need index type to determine the result
+// of the test, this needs to be made as a global static
+static IndexType index_type = INDEX_TYPE_BWTREE;
+
+/*
+ * BuildIndex()
+ */
+index::Index *BuildIndex(const bool unique_keys, int num_cols) {
+  // Build tuple and key schema
+  std::vector<catalog::Column> column_list;
+  std::vector<oid_t> key_attrs;
+
+  char column_char = 'A';
+  for (int i = 0; i < num_cols; i++) {
+    std::ostringstream os;
+    os << static_cast<char>((int)column_char + i);
+
+    catalog::Column column(type::Type::INTEGER,
+                           type::Type::GetTypeSize(type::Type::INTEGER),
+                           os.str(), true);
+    column_list.push_back(column);
+    key_attrs.push_back(i);
+  }  // FOR
+  key_schema = new catalog::Schema(column_list);
+  key_schema->SetIndexedColumns(key_attrs);
+  tuple_schema = new catalog::Schema(column_list);
+
+  // Build index metadata
+  //
+  // NOTE: Since here we use a relatively small key (size = 12)
+  // so index_test is only testing with a certain kind of key
+  // (most likely, GenericKey)
+  //
+  // For testing IntsKey and TupleKey we need more test cases
+  index::IndexMetadata *index_metadata = new index::IndexMetadata(
+      "MAGIC_TEST_INDEX", 125,  // Index oid
+      INVALID_OID, INVALID_OID, index_type, INDEX_CONSTRAINT_TYPE_DEFAULT,
+      tuple_schema, key_schema, key_attrs, unique_keys);
+
+  // Build index
+  // The type of index key has been chosen inside this function, but we are
+  // unable to know the exact type of key it has chosen
+  index::Index *index = index::IndexFactory::GetIndex(index_metadata);
+
+  // Actually this will never be hit since if index creation fails an exception
+  // would be raised (maybe out of memory would result in a nullptr? Anyway
+  // leave it here)
+  EXPECT_TRUE(index != NULL);
+
+  return index;
+}
+
+TEST_F(IndexIntsKeyTests, BasicTest) {
+  auto pool = TestingHarness::GetInstance().GetTestingPool();
+
+  // Scale up the number of integers that we have
+  // in the index
+  for (int num_cols = 1; num_cols <= 4; num_cols++) {
+    // INDEX
+    std::unique_ptr<index::Index> index(BuildIndex(false, num_cols));
+    std::unique_ptr<storage::Tuple> key0(new storage::Tuple(key_schema, true));
+    for (int col_idx = 0; col_idx < num_cols; col_idx++) {
+      int val = (10 * num_cols) + col_idx;
+      key0->SetValue(0, type::ValueFactory::GetIntegerValue(val), pool);
+    }
+
+    // INSERT
+    index->InsertEntry(key0.get(), item0.get());
+
+    // SCAN
+    std::vector<ItemPointer *> location_ptrs;
+    index->ScanKey(key0.get(), location_ptrs);
+    EXPECT_EQ(location_ptrs.size(), 1);
+    EXPECT_EQ(location_ptrs[0]->block, item0->block);
+    location_ptrs.clear();
+
+    // DELETE
+    index->DeleteEntry(key0.get(), item0.get());
+
+    index->ScanKey(key0.get(), location_ptrs);
+    EXPECT_EQ(location_ptrs.size(), 0);
+    location_ptrs.clear();
+
+    delete tuple_schema;
+  }  // FOR
+}
+
+}  // End test namespace
+}  // End peloton namespace

--- a/test/index/index_intskey_test.cpp
+++ b/test/index/index_intskey_test.cpp
@@ -34,14 +34,11 @@ std::shared_ptr<ItemPointer> item0(new ItemPointer(120, 5));
 std::shared_ptr<ItemPointer> item1(new ItemPointer(120, 7));
 std::shared_ptr<ItemPointer> item2(new ItemPointer(123, 19));
 
-// Since we need index type to determine the result
-// of the test, this needs to be made as a global static
-static IndexType index_type = INDEX_TYPE_BWTREE;
-
 /*
  * BuildIndex()
  */
-index::Index *BuildIndex(const bool unique_keys, int num_cols) {
+index::Index *BuildIndex(IndexType index_type, const bool unique_keys,
+                         int num_cols) {
   // Build tuple and key schema
   std::vector<catalog::Column> column_list;
   std::vector<oid_t> key_attrs;
@@ -86,14 +83,15 @@ index::Index *BuildIndex(const bool unique_keys, int num_cols) {
   return index;
 }
 
-TEST_F(IndexIntsKeyTests, BasicTest) {
+void IndexIntsKeyHelper(IndexType index_type) {
   auto pool = TestingHarness::GetInstance().GetTestingPool();
 
   // Scale up the number of integers that we have
   // in the index
   for (int num_cols = 1; num_cols <= 4; num_cols++) {
     // INDEX
-    std::unique_ptr<index::Index> index(BuildIndex(false, num_cols));
+    std::unique_ptr<index::Index> index(
+        BuildIndex(index_type, false, num_cols));
     std::unique_ptr<storage::Tuple> key0(new storage::Tuple(key_schema, true));
     for (int col_idx = 0; col_idx < num_cols; col_idx++) {
       int val = (10 * num_cols) + col_idx;
@@ -120,6 +118,13 @@ TEST_F(IndexIntsKeyTests, BasicTest) {
     delete tuple_schema;
   }  // FOR
 }
+
+TEST_F(IndexIntsKeyTests, BwTreeTest) { IndexIntsKeyHelper(INDEX_TYPE_BWTREE); }
+
+// FIXME: The B-Tree core dumps. If we're not going to support then we should
+// probably drop it.
+// TEST_F(IndexIntsKeyTests, BTreeTest) { IndexIntsKeyHelper(INDEX_TYPE_BTREE);
+// }
 
 }  // End test namespace
 }  // End peloton namespace

--- a/test/index/index_test.cpp
+++ b/test/index/index_test.cpp
@@ -115,7 +115,7 @@ index::Index *BuildIndex(const bool unique_keys) {
   // and transforms into the correct index key format, so the caller
   // do not need to worry about the actual implementation of the index
   // key, and only passing tuple key suffices
-  index::Index *index = index::IndexFactory::GetInstance(index_metadata);
+  index::Index *index = index::IndexFactory::GetIndex(index_metadata);
 
   // Actually this will never be hit since if index creation fails an exception
   // would be raised (maybe out of memory would result in a nullptr? Anyway
@@ -343,7 +343,7 @@ TEST_F(IndexTests, MultiMapInsertTest) {
 
 #ifdef ALLOW_UNIQUE_KEY
 TEST_F(IndexTests, UniqueKeyDeleteTest) {
-  auto pool = TestingHarness::GetInstance().GetTestingPool();
+  auto pool = TestingHarness::GetIndex().GetTestingPool();
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
@@ -475,7 +475,7 @@ TEST_F(IndexTests, MultiThreadedInsertTest) {
 
 #ifdef ALLOW_UNIQUE_KEY
 TEST_F(IndexTests, UniqueKeyMultiThreadedTest) {
-  auto pool = TestingHarness::GetInstance().GetTestingPool();
+  auto pool = TestingHarness::GetIndex().GetTestingPool();
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX

--- a/test/index/index_test.cpp
+++ b/test/index/index_test.cpp
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "gtest/gtest.h"
 #include "common/harness.h"
+#include "gtest/gtest.h"
 
 #include "common/logger.h"
 #include "common/platform.h"
@@ -38,9 +38,6 @@ std::shared_ptr<ItemPointer> item2(new ItemPointer(123, 19));
 // of the test, this needs to be made as a global static
 static IndexType index_type = INDEX_TYPE_BWTREE;
 
-// Uncomment this to enable BwTree as index being tested
-// static IndexType index_type = INDEX_TYPE_BWTREE;
-
 /*
  * BuildIndex() - Builds an index with 4 columns, the first 2 being indexed
  */
@@ -62,18 +59,21 @@ index::Index *BuildIndex(const bool unique_keys) {
   // The size of the key is:
   //   integer 4 + varchar 8 = total 12
 
-  catalog::Column column1(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
-                          "A", true);
+  catalog::Column column1(type::Type::INTEGER,
+                          type::Type::GetTypeSize(type::Type::INTEGER), "A",
+                          true);
 
   catalog::Column column2(type::Type::VARCHAR, 1024, "B", false);
 
   // The following twoc constitutes tuple schema but does not appear in index
 
-  catalog::Column column3(type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL),
-                          "C", true);
+  catalog::Column column3(type::Type::DECIMAL,
+                          type::Type::GetTypeSize(type::Type::DECIMAL), "C",
+                          true);
 
-  catalog::Column column4(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
-                          "D", true);
+  catalog::Column column4(type::Type::INTEGER,
+                          type::Type::GetTypeSize(type::Type::INTEGER), "D",
+                          true);
 
   // Use the first two columns to build key schema
 
@@ -158,8 +158,8 @@ TEST_F(IndexTests, BasicTest) {
 }
 
 // INSERT HELPER FUNCTION
-void InsertTest(index::Index *index, type::VarlenPool *pool, size_t scale_factor,
-                UNUSED_ATTRIBUTE uint64_t thread_itr) {
+void InsertTest(index::Index *index, type::VarlenPool *pool,
+                size_t scale_factor, UNUSED_ATTRIBUTE uint64_t thread_itr) {
   // Loop based on scale factor
   for (size_t scale_itr = 1; scale_itr <= scale_factor; scale_itr++) {
     // Insert a bunch of keys based on scale itr
@@ -171,15 +171,20 @@ void InsertTest(index::Index *index, type::VarlenPool *pool, size_t scale_factor
     std::unique_ptr<storage::Tuple> keynonce(
         new storage::Tuple(key_schema, true));
 
-    key0->SetValue(0, type::ValueFactory::GetIntegerValue(100 * scale_itr), pool);
+    key0->SetValue(0, type::ValueFactory::GetIntegerValue(100 * scale_itr),
+                   pool);
     key0->SetValue(1, type::ValueFactory::GetVarcharValue("a"), pool);
-    key1->SetValue(0, type::ValueFactory::GetIntegerValue(100 * scale_itr), pool);
+    key1->SetValue(0, type::ValueFactory::GetIntegerValue(100 * scale_itr),
+                   pool);
     key1->SetValue(1, type::ValueFactory::GetVarcharValue("b"), pool);
-    key2->SetValue(0, type::ValueFactory::GetIntegerValue(100 * scale_itr), pool);
+    key2->SetValue(0, type::ValueFactory::GetIntegerValue(100 * scale_itr),
+                   pool);
     key2->SetValue(1, type::ValueFactory::GetVarcharValue("c"), pool);
-    key3->SetValue(0, type::ValueFactory::GetIntegerValue(400 * scale_itr), pool);
+    key3->SetValue(0, type::ValueFactory::GetIntegerValue(400 * scale_itr),
+                   pool);
     key3->SetValue(1, type::ValueFactory::GetVarcharValue("d"), pool);
-    key4->SetValue(0, type::ValueFactory::GetIntegerValue(500 * scale_itr), pool);
+    key4->SetValue(0, type::ValueFactory::GetIntegerValue(500 * scale_itr),
+                   pool);
     key4->SetValue(1, type::ValueFactory::GetVarcharValue(
                           "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
                           "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
@@ -231,8 +236,8 @@ void InsertTest(index::Index *index, type::VarlenPool *pool, size_t scale_factor
 }
 
 // DELETE HELPER FUNCTION
-void DeleteTest(index::Index *index, type::VarlenPool *pool, size_t scale_factor,
-                UNUSED_ATTRIBUTE uint64_t thread_itr) {
+void DeleteTest(index::Index *index, type::VarlenPool *pool,
+                size_t scale_factor, UNUSED_ATTRIBUTE uint64_t thread_itr) {
   // Loop based on scale factor
   for (size_t scale_itr = 1; scale_itr <= scale_factor; scale_itr++) {
     // Delete a bunch of keys based on scale itr
@@ -242,15 +247,20 @@ void DeleteTest(index::Index *index, type::VarlenPool *pool, size_t scale_factor
     std::unique_ptr<storage::Tuple> key3(new storage::Tuple(key_schema, true));
     std::unique_ptr<storage::Tuple> key4(new storage::Tuple(key_schema, true));
 
-    key0->SetValue(0, type::ValueFactory::GetIntegerValue(100 * scale_itr), pool);
+    key0->SetValue(0, type::ValueFactory::GetIntegerValue(100 * scale_itr),
+                   pool);
     key0->SetValue(1, type::ValueFactory::GetVarcharValue("a"), pool);
-    key1->SetValue(0, type::ValueFactory::GetIntegerValue(100 * scale_itr), pool);
+    key1->SetValue(0, type::ValueFactory::GetIntegerValue(100 * scale_itr),
+                   pool);
     key1->SetValue(1, type::ValueFactory::GetVarcharValue("b"), pool);
-    key2->SetValue(0, type::ValueFactory::GetIntegerValue(100 * scale_itr), pool);
+    key2->SetValue(0, type::ValueFactory::GetIntegerValue(100 * scale_itr),
+                   pool);
     key2->SetValue(1, type::ValueFactory::GetVarcharValue("c"), pool);
-    key3->SetValue(0, type::ValueFactory::GetIntegerValue(400 * scale_itr), pool);
+    key3->SetValue(0, type::ValueFactory::GetIntegerValue(400 * scale_itr),
+                   pool);
     key3->SetValue(1, type::ValueFactory::GetVarcharValue("d"), pool);
-    key4->SetValue(0, type::ValueFactory::GetIntegerValue(500 * scale_itr), pool);
+    key4->SetValue(0, type::ValueFactory::GetIntegerValue(500 * scale_itr),
+                   pool);
     key4->SetValue(1, type::ValueFactory::GetVarcharValue(
                           "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
                           "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
@@ -722,9 +732,7 @@ TEST_F(IndexTests, NonUniqueKeyMultiThreadedTest) {
   location_ptrs.clear();
 
   index->ScanTest(
-      {key0_val0, key0_val1,
-       key2_val0, key2_val1},
-      {0, 1, 0, 1},
+      {key0_val0, key0_val1, key2_val0, key2_val1}, {0, 1, 0, 1},
       {EXPRESSION_TYPE_COMPARE_EQUAL, EXPRESSION_TYPE_COMPARE_GREATERTHAN,
        EXPRESSION_TYPE_COMPARE_EQUAL, EXPRESSION_TYPE_COMPARE_LESSTHAN},
       SCAN_DIRECTION_TYPE_FORWARD, location_ptrs);
@@ -737,12 +745,11 @@ TEST_F(IndexTests, NonUniqueKeyMultiThreadedTest) {
 
   location_ptrs.clear();
 
-  index->ScanTest({key0_val0, key0_val1,
-                   key4_val0, key4_val1},
-                  {0, 1, 0, 1}, {EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO,
-                                 EXPRESSION_TYPE_COMPARE_GREATERTHAN,
-                                 EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO,
-                                 EXPRESSION_TYPE_COMPARE_LESSTHAN},
+  index->ScanTest({key0_val0, key0_val1, key4_val0, key4_val1}, {0, 1, 0, 1},
+                  {EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO,
+                   EXPRESSION_TYPE_COMPARE_GREATERTHAN,
+                   EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO,
+                   EXPRESSION_TYPE_COMPARE_LESSTHAN},
                   SCAN_DIRECTION_TYPE_FORWARD, location_ptrs);
 
   if (index_type == INDEX_TYPE_BWTREE) {
@@ -814,9 +821,7 @@ TEST_F(IndexTests, NonUniqueKeyMultiThreadedTest) {
   location_ptrs.clear();
 
   index->ScanTest(
-      {key0_val0, key0_val1,
-       key2_val0, key2_val1},
-      {0, 1, 0, 1},
+      {key0_val0, key0_val1, key2_val0, key2_val1}, {0, 1, 0, 1},
       {EXPRESSION_TYPE_COMPARE_EQUAL, EXPRESSION_TYPE_COMPARE_GREATERTHAN,
        EXPRESSION_TYPE_COMPARE_EQUAL, EXPRESSION_TYPE_COMPARE_LESSTHAN},
       SCAN_DIRECTION_TYPE_BACKWARD, location_ptrs);
@@ -829,12 +834,11 @@ TEST_F(IndexTests, NonUniqueKeyMultiThreadedTest) {
 
   location_ptrs.clear();
 
-  index->ScanTest({key0_val0, key0_val1,
-                   key4_val0, key4_val1},
-                  {0, 1, 0, 1}, {EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO,
-                                 EXPRESSION_TYPE_COMPARE_GREATERTHAN,
-                                 EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO,
-                                 EXPRESSION_TYPE_COMPARE_LESSTHAN},
+  index->ScanTest({key0_val0, key0_val1, key4_val0, key4_val1}, {0, 1, 0, 1},
+                  {EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO,
+                   EXPRESSION_TYPE_COMPARE_GREATERTHAN,
+                   EXPRESSION_TYPE_COMPARE_LESSTHANOREQUALTO,
+                   EXPRESSION_TYPE_COMPARE_LESSTHAN},
                   SCAN_DIRECTION_TYPE_BACKWARD, location_ptrs);
 
   if (index_type == INDEX_TYPE_BWTREE) {

--- a/test/index/index_util_test.cpp
+++ b/test/index/index_util_test.cpp
@@ -111,7 +111,7 @@ static index::Index *BuildIndex() {
       true);  // unique_keys
 
   // Build index
-  index::Index *index = index::IndexFactory::GetInstance(index_metadata);
+  index::Index *index = index::IndexFactory::GetIndex(index_metadata);
 
   // Actually this will never be hit since if index creation fails an exception
   // would be raised (maybe out of memory would result in a nullptr? Anyway

--- a/test/performance/index_performance_test.cpp
+++ b/test/performance/index_performance_test.cpp
@@ -73,7 +73,7 @@ index::Index *BuildIndex(const bool unique_keys, const IndexType index_type) {
       unique_keys);
 
   // Build index
-  index::Index *index = index::IndexFactory::GetInstance(index_metadata);
+  index::Index *index = index::IndexFactory::GetIndex(index_metadata);
   EXPECT_TRUE(index != NULL);
 
   return index;

--- a/test/util/string_util_test.cpp
+++ b/test/util/string_util_test.cpp
@@ -93,5 +93,12 @@ TEST_F(StringUtilTests, FormatSizeTest) {
   }
 }
 
+TEST_F(StringUtilTests, UpperTest) {
+  std::string input = "smoke crack rocks";
+  std::string expected = "SMOKE CRACK ROCKS";
+  std::string result = StringUtil::Upper(input);
+  EXPECT_EQ(expected, result);
+}
+
 }  // End test namespace
 }  // End peloton namespace


### PR DESCRIPTION
This PR re-enables the specialized IntsKey comparators that were commented out for the indexes. I have not tested whether this is fully working but I added a basic test case.

I also fixed it so that we don't hardcode the name of **every** to be `CUSTOMER_PKEY` ☹

This is for #431 