### PR TITLE
Transaction Rollback Fix in psql

### DIFF
--- a/src/common/statement.cpp
+++ b/src/common/statement.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cstdio>
 #include "common/statement.h"
 #include "common/logger.h"
 #include "planner/abstract_plan.h"
@@ -18,49 +19,48 @@ namespace peloton {
 
 Statement::Statement(const std::string& statement_name,
                      const std::string& query_string)
-    : statement_name(statement_name), query_string(query_string) {}
+    : statement_name_(statement_name), query_string_(query_string) {
+  std::stringstream stream(query_string);
+  stream >> query_type_;
+}
 
 Statement::~Statement() {}
 
 std::vector<FieldInfoType> Statement::GetTupleDescriptor() const {
-  return tuple_descriptor;
+  return tuple_descriptor_;
 }
 
-void Statement::SetStatementName(const std::string& statement_name_) {
-  statement_name = statement_name_;
+void Statement::SetStatementName(const std::string& statement_name) {
+  statement_name_ = statement_name;
 }
 
-std::string Statement::GetStatementName() const { return statement_name; }
+std::string Statement::GetStatementName() const { return statement_name_; }
 
-void Statement::SetQueryString(const std::string& query_string_) {
-  query_string = query_string_;
+void Statement::SetQueryString(const std::string& query_string) {
+  query_string_ = query_string;
 }
 
-std::string Statement::GetQueryString() const { return query_string; }
+std::string Statement::GetQueryString() const { return query_string_; }
 
-void Statement::SetQueryType(const std::string& query_type_) {
-  query_type = query_type_;
+std::string Statement::GetQueryType() const { return query_type_; }
+
+void Statement::SetParamTypes(const std::vector<int32_t>& param_types) {
+  param_types_ = param_types;
 }
 
-std::string Statement::GetQueryType() const { return query_type; }
-
-void Statement::SetParamTypes(const std::vector<int32_t>& param_types_) {
-  param_types = param_types_;
-}
-
-std::vector<int32_t> Statement::GetParamTypes() const { return param_types; }
+std::vector<int32_t> Statement::GetParamTypes() const { return param_types_; }
 
 void Statement::SetTupleDescriptor(
-    const std::vector<FieldInfoType>& tuple_descriptor_) {
-  tuple_descriptor = tuple_descriptor_;
+    const std::vector<FieldInfoType>& tuple_descriptor) {
+  tuple_descriptor_ = tuple_descriptor;
 }
 
-void Statement::SetPlanTree(std::shared_ptr<planner::AbstractPlan> plan_tree_) {
-  plan_tree = std::move(plan_tree_);
+void Statement::SetPlanTree(std::shared_ptr<planner::AbstractPlan> plan_tree) {
+  plan_tree_ = std::move(plan_tree);
 }
 
 const std::shared_ptr<planner::AbstractPlan>& Statement::GetPlanTree() const {
-  return plan_tree;
+  return plan_tree_;
 }
 
 }  // namespace peloton

--- a/src/common/statement.cpp
+++ b/src/common/statement.cpp
@@ -20,11 +20,16 @@ namespace peloton {
 Statement::Statement(const std::string& statement_name,
                      const std::string& query_string)
     : statement_name_(statement_name), query_string_(query_string) {
-  std::stringstream stream(query_string);
-  stream >> query_type_;
+  ParseQueryType(query_string_, query_type_);
 }
 
 Statement::~Statement() {}
+
+void Statement::ParseQueryType(const std::string &query_string,
+                               std::string &query_type) {
+  std::stringstream stream(query_string);
+  stream >> query_type;
+}
 
 std::vector<FieldInfoType> Statement::GetTupleDescriptor() const {
   return tuple_descriptor_;

--- a/src/include/common/statement.h
+++ b/src/include/common/statement.h
@@ -42,6 +42,9 @@ class Statement {
 
   ~Statement();
 
+  static void ParseQueryType(const std::string &query_string,
+                             std::string& query_type);
+
   std::vector<FieldInfoType> GetTupleDescriptor() const;
 
   void SetStatementName(const std::string& statement_name);

--- a/src/include/common/statement.h
+++ b/src/include/common/statement.h
@@ -52,8 +52,6 @@ class Statement {
 
   std::string GetQueryString() const;
 
-  void SetQueryType(const std::string& query_type);
-
   std::string GetQueryType() const;
 
   void SetParamTypes(const std::vector<int32_t>& param_types);
@@ -68,22 +66,22 @@ class Statement {
 
  private:
   // logical name of statement
-  std::string statement_name;
+  std::string statement_name_;
 
   // query string
-  std::string query_string;
+  std::string query_string_;
 
   // first token in query
-  std::string query_type;
+  std::string query_type_;
 
   // format codes of the parameters
-  std::vector<int32_t> param_types;
+  std::vector<int32_t> param_types_;
 
   // schema of result tuple
-  std::vector<FieldInfoType> tuple_descriptor;
+  std::vector<FieldInfoType> tuple_descriptor_;
 
   // cached plan tree
-  std::shared_ptr<planner::AbstractPlan> plan_tree;
+  std::shared_ptr<planner::AbstractPlan> plan_tree_;
 };
 
 }  // namespace peloton

--- a/src/networking/protocol.cpp
+++ b/src/networking/protocol.cpp
@@ -329,7 +329,6 @@ void PacketManager::ExecParseMessage(InputPacket *pkt) {
 
   // Cache the received query
   bool unnamed_query = statement_name.empty();
-  statement->SetQueryType(query_type);
   statement->SetParamTypes(param_types);
 
   // Stat

--- a/src/networking/protocol.cpp
+++ b/src/networking/protocol.cpp
@@ -173,14 +173,6 @@ void PacketManager::SendDataRows(std::vector<ResultType> &results, int colcount,
   rows_affected = numrows;
 }
 
-/* Gets the first token of a query */
-std::string get_query_type(std::string query) {
-  std::string query_type;
-  std::stringstream stream(query);
-  stream >> query_type;
-  return query_type;
-}
-
 void PacketManager::CompleteCommand(const std::string &query_type, int rows) {
   std::unique_ptr<OutputPacket> pkt(new OutputPacket());
   pkt->msg_type = COMMAND_COMPLETE;
@@ -291,7 +283,7 @@ void PacketManager::ExecParseMessage(InputPacket *pkt) {
   // Read query string
   GetStringToken(pkt, query_string);
   skipped_stmt_ = false;
-  query_type = get_query_type(query_string);
+  Statement::ParseQueryType(query_string, query_type);
 
   // For an empty query or a query to be filtered, just send parse complete
   // response and don't execute


### PR DESCRIPTION
Tcop uses the query type (i.e. the first word in the query string) to identify if the query is BEGIN, COMMIT or ROLLBACK to handle the transaction in the backend appropriately. Until now this was done using statement->SetQueryType(). However, the query type is not set while executing the simple query protocol (i.e. while interacting with psql). For this reason, these Transaction switches went unnoticed by tcop. This PR fixes this issue by setting query type on statement construction for the simple query protocol. #435 