### PR TITLE
Special case comparison on first/last tuple in index range scan

### DIFF
--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -548,7 +548,7 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
 void IndexScanExecutor::CheckOpenRangeWithReturnedTuples(
     std::vector<ItemPointer> &tuple_locations) {
   while (left_open_) {
-    LOG_ERROR("Left open!");
+    LOG_TRACE("Range left open!");
     auto tuple_location_itr = tuple_locations.begin();
 
     if (tuple_location_itr == tuple_locations.end() ||
@@ -559,7 +559,7 @@ void IndexScanExecutor::CheckOpenRangeWithReturnedTuples(
   }
 
   while (right_open_) {
-    LOG_ERROR("Right open!");
+    LOG_TRACE("Range right open!");
     auto tuple_location_itr = tuple_locations.rbegin();
 
     if (tuple_location_itr == tuple_locations.rend() ||
@@ -575,7 +575,7 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
   PL_ASSERT(key_column_ids_.size() == expr_types_.size());
   PL_ASSERT(expr_types_.size() == values_.size());
 
-  LOG_ERROR("This is called!");
+  LOG_TRACE("Examining key conditions for the returned tuple.");
 
   auto &manager = catalog::Manager::GetInstance();
 
@@ -687,7 +687,8 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
     }
   }
 
-  LOG_ERROR("Returning true!");
+  LOG_TRACE("Examination returning true.");
+
   return true;
 }
 

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -289,8 +289,14 @@ bool IndexScanExecutor::ExecPrimaryIndexLookup() {
             index_->GetName().c_str());
 #endif
 
+  LOG_TRACE("%ld tuples before pruning boundaries",
+            visible_tuple_locations.size());
+
   // Check whether the boundaries satisfy the required condition
   CheckOpenRangeWithReturnedTuples(visible_tuple_locations);
+
+  LOG_TRACE("%ld tuples after pruning boundaries",
+            visible_tuple_locations.size());
 
   for (auto &visible_tuple_location : visible_tuple_locations) {
     visible_tuples[visible_tuple_location.block].push_back(
@@ -541,23 +547,23 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
 
 void IndexScanExecutor::CheckOpenRangeWithReturnedTuples(
     std::vector<ItemPointer> &tuple_locations) {
-  // This is guaranteed by the index scan execution logic when we need to call
-  // this function.
-  PL_ASSERT(tuple_locations.size() > 0);
-
   while (left_open_) {
+    LOG_ERROR("Left open!");
     auto tuple_location_itr = tuple_locations.begin();
 
-    if (CheckKeyConditions(*tuple_location_itr) == true)
+    if (tuple_location_itr == tuple_locations.end() ||
+        CheckKeyConditions(*tuple_location_itr) == true)
       left_open_ = false;
     else
       tuple_locations.erase(tuple_location_itr);
   }
 
   while (right_open_) {
+    LOG_ERROR("Right open!");
     auto tuple_location_itr = tuple_locations.rbegin();
 
-    if (CheckKeyConditions(*tuple_location_itr) == true)
+    if (tuple_location_itr == tuple_locations.rend() ||
+        CheckKeyConditions(*tuple_location_itr) == true)
       right_open_ = false;
     else
       tuple_locations.pop_back();

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -27,6 +27,7 @@
 #include "expression/abstract_expression.h"
 #include "gc/gc_manager_factory.h"
 #include "index/index.h"
+#include "planner/index_scan_plan.h"
 #include "storage/data_table.h"
 #include "storage/tile_group.h"
 #include "storage/tile_group_header.h"
@@ -702,6 +703,20 @@ void IndexScanExecutor::UpdatePredicate(
       }
     }
   }
+}
+
+void IndexScanExecutor::ResetState() {
+  result_.clear();
+
+  result_itr_ = START_OID;
+
+  done_ = false;
+
+  const planner::IndexScanPlan &node = GetPlanNode<planner::IndexScanPlan>();
+
+  left_open_ = node.GetLeftOpen();
+
+  right_open_ = node.GetRightOpen();
 }
 
 }  // namespace executor

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -681,6 +681,7 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
     }
   }
 
+  LOG_ERROR("Returning true!");
   return true;
 }
 

--- a/src/include/executor/index_scan_executor.h
+++ b/src/include/executor/index_scan_executor.h
@@ -15,9 +15,12 @@
 #include <vector>
 
 #include "executor/abstract_scan_executor.h"
-#include "planner/index_scan_plan.h"
 
 namespace peloton {
+
+namespace index {
+class Index;
+}
 
 namespace storage {
 class AbstractTable;
@@ -39,19 +42,7 @@ class IndexScanExecutor : public AbstractScanExecutor {
                            UNUSED_ATTRIBUTE,
                        const std::vector<type::Value> &values UNUSED_ATTRIBUTE);
 
-  void ResetState() {
-    result_.clear();
-
-    result_itr_ = START_OID;
-
-    done_ = false;
-
-    const planner::IndexScanPlan &node = GetPlanNode<planner::IndexScanPlan>();
-
-    left_open_ = node.GetLeftOpen();
-
-    right_open_ = node.GetRightOpen();
-  }
+  void ResetState();
 
  protected:
   bool DInit();

--- a/src/include/planner/index_scan_plan.h
+++ b/src/include/planner/index_scan_plan.h
@@ -16,11 +16,11 @@
 #include <string>
 #include <vector>
 
-#include "planner/abstract_scan_plan.h"
-#include "type/types.h"
 #include "expression/abstract_expression.h"
-#include "storage/tuple.h"
 #include "index/scan_optimizer.h"
+#include "planner/abstract_scan_plan.h"
+#include "storage/tuple.h"
+#include "type/types.h"
 
 namespace peloton {
 
@@ -40,7 +40,6 @@ class IndexScanPlan : public AbstractScan {
    * class IndexScanDesc - Stores information to do the index scan
    */
   struct IndexScanDesc {
-
     /*
      * Default Constructor - Set index pointer to empty
      *
@@ -143,6 +142,10 @@ class IndexScanPlan : public AbstractScan {
     return PLAN_NODE_TYPE_INDEXSCAN;
   }
 
+  inline bool GetLeftOpen() const { return left_open_; }
+
+  inline bool GetRightOpen() const { return right_open_; }
+
   const std::string GetInfo() const { return "IndexScan"; }
 
   void SetParameterValues(std::vector<type::Value> *values);
@@ -195,6 +198,12 @@ class IndexScanPlan : public AbstractScan {
   // In the future this might be extended into an array of conjunctive
   // predicates connected by disjunction
   index::IndexScanPredicate index_predicate_;
+
+  // whether the index scan range is left open
+  bool left_open_ = false;
+
+  // whether the index scan range is right open
+  bool right_open_ = false;
 };
 
 }  // namespace planner

--- a/src/index/index.cpp
+++ b/src/index/index.cpp
@@ -15,8 +15,8 @@
 #include "catalog/schema.h"
 #include "common/exception.h"
 #include "common/logger.h"
-#include "type/varlen_pool.h"
 #include "storage/tuple.h"
+#include "type/varlen_pool.h"
 
 #include "index/scan_optimizer.h"
 

--- a/src/planner/index_scan_plan.cpp
+++ b/src/planner/index_scan_plan.cpp
@@ -60,6 +60,17 @@ IndexScanPlan::IndexScanPlan(storage::DataTable *table,
   index_predicate_.AddConjunctionScanPredicate(index_.get(), values_,
                                                key_column_ids_, expr_types_);
 
+  // Check whether the scan range is left/right open. Because the index itself
+  // is not able to handle that exactly, we must have extra logic in
+  // IndexScanExecutor to handle that case.
+  //
+  // TODO: We may also need a flag for "IN" expression after we support "IN".
+  for (auto expr_type : expr_types_) {
+    if (expr_type == EXPRESSION_TYPE_COMPARE_GREATERTHAN) left_open_ = true;
+
+    if (expr_type == EXPRESSION_TYPE_COMPARE_LESSTHAN) right_open_ = true;
+  }
+
   return;
 }
 

--- a/test/common/boolean_value_test.cpp
+++ b/test/common/boolean_value_test.cpp
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "type/boolean_type.h"
 #include "common/harness.h"
+#include "type/boolean_type.h"
 #include "type/value_factory.h"
 
 namespace peloton {
@@ -26,8 +26,7 @@ class BooleanValueTests : public PelotonTest {};
 TEST_F(BooleanValueTests, BasicTest) {
   auto valTrue = type::ValueFactory::GetBooleanValue(true);
   auto valFalse = type::ValueFactory::GetBooleanValue(false);
-  auto valNull =
-      type::ValueFactory::GetNullValueByType(type::Type::BOOLEAN);
+  auto valNull = type::ValueFactory::GetNullValueByType(type::Type::BOOLEAN);
 
   EXPECT_TRUE(valTrue.IsTrue());
   EXPECT_FALSE(valTrue.IsFalse());
@@ -112,7 +111,7 @@ TEST_F(BooleanValueTests, ComparisonTest) {
         }  // SWITCH
         LOG_TRACE("%s %s %s => %d | %d\n", val0.ToString().c_str(),
                   ExpressionTypeToString(etype).c_str(),
-                  val1.ToString().c_str(), expected, result.IsTrue());
+                  val1.ToString().c_str(), expected, result);
 
         if (expected_null) expected = false;
 
@@ -154,8 +153,7 @@ TEST_F(BooleanValueTests, HashTest) {
     if (values[i] == type::PELOTON_BOOLEAN_NULL) {
       val0 = type::ValueFactory::GetNullValueByType(type::Type::BOOLEAN);
     } else {
-      val0 =
-          type::ValueFactory::GetBooleanValue(static_cast<bool>(values[i]));
+      val0 = type::ValueFactory::GetBooleanValue(static_cast<bool>(values[i]));
     }
     for (int j = 0; j < 2; j++) {
       if (values[j] == type::PELOTON_BOOLEAN_NULL) {

--- a/test/common/timestamp_value_test.cpp
+++ b/test/common/timestamp_value_test.cpp
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "type/timestamp_type.h"
 #include "common/harness.h"
+#include "type/timestamp_type.h"
 #include "type/value_factory.h"
 
 namespace peloton {
@@ -47,8 +47,8 @@ TEST_F(TimestampValueTests, ComparisonTest) {
         val0 = type::ValueFactory::GetNullValueByType(type::Type::TIMESTAMP);
         expected_null = true;
       } else {
-        val0 =
-            type::ValueFactory::GetTimestampValue(static_cast<uint64_t>(values[i]));
+        val0 = type::ValueFactory::GetTimestampValue(
+            static_cast<uint64_t>(values[i]));
       }
 
       // VALUE #1
@@ -56,8 +56,8 @@ TEST_F(TimestampValueTests, ComparisonTest) {
         val1 = type::ValueFactory::GetNullValueByType(type::Type::TIMESTAMP);
         expected_null = true;
       } else {
-        val1 =
-            type::ValueFactory::GetTimestampValue(static_cast<uint64_t>(values[j]));
+        val1 = type::ValueFactory::GetTimestampValue(
+            static_cast<uint64_t>(values[j]));
       }
       bool temp = expected_null;
 
@@ -97,12 +97,11 @@ TEST_F(TimestampValueTests, ComparisonTest) {
         }  // SWITCH
         LOG_TRACE("%s %s %s => %d | %d\n", val0.ToString().c_str(),
                   ExpressionTypeToString(etype).c_str(),
-                  val1.ToString().c_str(), expected, result.IsTrue());
+                  val1.ToString().c_str(), expected, result);
 
         if (expected_null) {
           EXPECT_EQ(expected_null, result == type::CMP_NULL);
-        }
-        else {
+        } else {
           EXPECT_EQ(expected, result == type::CMP_TRUE);
           EXPECT_EQ(!expected, result == type::CMP_FALSE);
         }
@@ -112,8 +111,7 @@ TEST_F(TimestampValueTests, ComparisonTest) {
 }
 
 TEST_F(TimestampValueTests, NullToStringTest) {
-  auto valNull =
-      type::ValueFactory::GetNullValueByType(type::Type::TIMESTAMP);
+  auto valNull = type::ValueFactory::GetNullValueByType(type::Type::TIMESTAMP);
 
   EXPECT_EQ(valNull.ToString(), "timestamp_null");
 }
@@ -129,15 +127,15 @@ TEST_F(TimestampValueTests, HashTest) {
     if (values[i] == type::PELOTON_TIMESTAMP_NULL) {
       val0 = type::ValueFactory::GetNullValueByType(type::Type::TIMESTAMP);
     } else {
-      val0 =
-        type::ValueFactory::GetTimestampValue(static_cast<uint64_t>(values[i]));
+      val0 = type::ValueFactory::GetTimestampValue(
+          static_cast<uint64_t>(values[i]));
     }
     for (int j = 0; j < 2; j++) {
       if (values[j] == type::PELOTON_TIMESTAMP_NULL) {
         val1 = type::ValueFactory::GetNullValueByType(type::Type::TIMESTAMP);
       } else {
-        val1 =
-          type::ValueFactory::GetTimestampValue(static_cast<uint64_t>(values[j]));
+        val1 = type::ValueFactory::GetTimestampValue(
+            static_cast<uint64_t>(values[j]));
       }
 
       result = type::ValueFactory::GetBooleanValue(val0.CompareEquals(val1));
@@ -155,7 +153,7 @@ TEST_F(TimestampValueTests, HashTest) {
 
 TEST_F(TimestampValueTests, CopyTest) {
   type::Value val0 =
-    type::ValueFactory::GetTimestampValue(static_cast<uint64_t>(1000000));
+      type::ValueFactory::GetTimestampValue(static_cast<uint64_t>(1000000));
   type::Value val1 = val0.Copy();
   EXPECT_EQ(val0.CompareEquals(val1) == type::CMP_TRUE, true);
 }
@@ -163,10 +161,8 @@ TEST_F(TimestampValueTests, CopyTest) {
 TEST_F(TimestampValueTests, CastTest) {
   type::Value result;
 
-  auto strNull =
-    type::ValueFactory::GetNullValueByType(type::Type::VARCHAR);
-  auto valNull =
-    type::ValueFactory::GetNullValueByType(type::Type::TIMESTAMP);
+  auto strNull = type::ValueFactory::GetNullValueByType(type::Type::VARCHAR);
+  auto valNull = type::ValueFactory::GetNullValueByType(type::Type::TIMESTAMP);
 
   result = valNull.CastAs(type::Type::TIMESTAMP);
   EXPECT_TRUE(result.IsNull());
@@ -178,15 +174,13 @@ TEST_F(TimestampValueTests, CastTest) {
   EXPECT_EQ(result.CompareEquals(strNull) == type::CMP_NULL, true);
   EXPECT_EQ(result.GetTypeId(), strNull.GetTypeId());
 
-  EXPECT_THROW(valNull.CastAs(type::Type::BOOLEAN),
-               peloton::Exception);
+  EXPECT_THROW(valNull.CastAs(type::Type::BOOLEAN), peloton::Exception);
 
   auto valValid =
-    type::ValueFactory::GetTimestampValue(static_cast<uint64_t>(1481746648));
+      type::ValueFactory::GetTimestampValue(static_cast<uint64_t>(1481746648));
   result = valValid.CastAs(type::Type::VARCHAR);
   EXPECT_FALSE(result.IsNull());
 }
-
 
 }  // End test namespace
 }  // End peloton namespace

--- a/test/executor/join_test.cpp
+++ b/test/executor/join_test.cpp
@@ -14,9 +14,9 @@
 
 #include "common/harness.h"
 
-#include "type/types.h"
 #include "executor/logical_tile.h"
 #include "executor/logical_tile_factory.h"
+#include "type/types.h"
 
 #include "executor/hash_executor.h"
 #include "executor/hash_join_executor.h"
@@ -25,11 +25,12 @@
 #include "executor/nested_loop_join_executor.h"
 
 #include "expression/abstract_expression.h"
-#include "expression/tuple_value_expression.h"
 #include "expression/expression_util.h"
+#include "expression/tuple_value_expression.h"
 
 #include "planner/hash_join_plan.h"
 #include "planner/hash_plan.h"
+#include "planner/index_scan_plan.h"
 #include "planner/merge_join_plan.h"
 #include "planner/nested_loop_join_plan.h"
 
@@ -53,21 +54,20 @@ class JoinTests : public PelotonTest {};
 
 std::vector<planner::MergeJoinPlan::JoinClause> CreateJoinClauses() {
   std::vector<planner::MergeJoinPlan::JoinClause> join_clauses;
-  auto left = expression::ExpressionUtil::TupleValueFactory(
-      type::Type::INTEGER, 0, 1);
-  auto right = expression::ExpressionUtil::TupleValueFactory(
-      type::Type::INTEGER, 1, 1);
+  auto left =
+      expression::ExpressionUtil::TupleValueFactory(type::Type::INTEGER, 0, 1);
+  auto right =
+      expression::ExpressionUtil::TupleValueFactory(type::Type::INTEGER, 1, 1);
   bool reversed = false;
   join_clauses.emplace_back(left, right, reversed);
   return join_clauses;
 }
 
 std::shared_ptr<const peloton::catalog::Schema> CreateJoinSchema() {
-  return std::shared_ptr<const peloton::catalog::Schema>(
-      new catalog::Schema({ExecutorTestsUtil::GetColumnInfo(1),
-                           ExecutorTestsUtil::GetColumnInfo(1),
-                           ExecutorTestsUtil::GetColumnInfo(0),
-                           ExecutorTestsUtil::GetColumnInfo(0)}));
+  return std::shared_ptr<const peloton::catalog::Schema>(new catalog::Schema(
+      {ExecutorTestsUtil::GetColumnInfo(1), ExecutorTestsUtil::GetColumnInfo(1),
+       ExecutorTestsUtil::GetColumnInfo(0),
+       ExecutorTestsUtil::GetColumnInfo(0)}));
 }
 
 // PLAN_NODE_TYPE_NESTLOOP is picked out as a separated test
@@ -93,13 +93,13 @@ void ExpectEmptyTileResult(MockExecutor *table_scan_executor);
 
 void ExpectMoreThanOneTileResults(
     MockExecutor *table_scan_executor,
-    std::vector<std::unique_ptr<executor::LogicalTile>> &
-        table_logical_tile_ptrs);
+    std::vector<std::unique_ptr<executor::LogicalTile>>
+        &table_logical_tile_ptrs);
 
-void ExpectNormalTileResults(
-    size_t table_tile_group_count, MockExecutor *table_scan_executor,
-    std::vector<std::unique_ptr<executor::LogicalTile>> &
-        table_logical_tile_ptrs);
+void ExpectNormalTileResults(size_t table_tile_group_count,
+                             MockExecutor *table_scan_executor,
+                             std::vector<std::unique_ptr<executor::LogicalTile>>
+                                 &table_logical_tile_ptrs);
 
 enum JOIN_TEST_TYPE {
   BASIC_TEST = 0,
@@ -113,7 +113,8 @@ enum JOIN_TEST_TYPE {
 TEST_F(JoinTests, BasicTest) {
   // Go over all join algorithms
   for (auto join_algorithm : join_algorithms) {
-    LOG_TRACE("JOIN ALGORITHM :: %s", PlanNodeTypeToString(join_algorithm).c_str());
+    LOG_TRACE("JOIN ALGORITHM :: %s",
+              PlanNodeTypeToString(join_algorithm).c_str());
     ExecuteJoinTest(join_algorithm, JOIN_TYPE_INNER, BASIC_TEST);
   }
 }
@@ -121,7 +122,8 @@ TEST_F(JoinTests, BasicTest) {
 TEST_F(JoinTests, EmptyTablesTest) {
   // Go over all join algorithms
   for (auto join_algorithm : join_algorithms) {
-    LOG_TRACE("JOIN ALGORITHM :: %s", PlanNodeTypeToString(join_algorithm).c_str());
+    LOG_TRACE("JOIN ALGORITHM :: %s",
+              PlanNodeTypeToString(join_algorithm).c_str());
     ExecuteJoinTest(join_algorithm, JOIN_TYPE_INNER, BOTH_TABLES_EMPTY);
   }
 }
@@ -129,7 +131,8 @@ TEST_F(JoinTests, EmptyTablesTest) {
 TEST_F(JoinTests, JoinTypesTest) {
   // Go over all join algorithms
   for (auto join_algorithm : join_algorithms) {
-    LOG_TRACE("JOIN ALGORITHM :: %s", PlanNodeTypeToString(join_algorithm).c_str());
+    LOG_TRACE("JOIN ALGORITHM :: %s",
+              PlanNodeTypeToString(join_algorithm).c_str());
     // Go over all join types
     for (auto join_type : join_types) {
       LOG_TRACE("JOIN TYPE :: %d", join_type);
@@ -142,7 +145,8 @@ TEST_F(JoinTests, JoinTypesTest) {
 TEST_F(JoinTests, ComplicatedTest) {
   // Go over all join algorithms
   for (auto join_algorithm : join_algorithms) {
-    LOG_TRACE("JOIN ALGORITHM :: %s", PlanNodeTypeToString(join_algorithm).c_str());
+    LOG_TRACE("JOIN ALGORITHM :: %s",
+              PlanNodeTypeToString(join_algorithm).c_str());
     // Go over all join types
     for (auto join_type : join_types) {
       LOG_TRACE("JOIN TYPE :: %d", join_type);
@@ -155,7 +159,8 @@ TEST_F(JoinTests, ComplicatedTest) {
 TEST_F(JoinTests, LeftTableEmptyTest) {
   // Go over all join algorithms
   for (auto join_algorithm : join_algorithms) {
-    LOG_TRACE("JOIN ALGORITHM :: %s", PlanNodeTypeToString(join_algorithm).c_str());
+    LOG_TRACE("JOIN ALGORITHM :: %s",
+              PlanNodeTypeToString(join_algorithm).c_str());
     // Go over all join types
     for (auto join_type : join_types) {
       LOG_TRACE("JOIN TYPE :: %d", join_type);
@@ -168,7 +173,8 @@ TEST_F(JoinTests, LeftTableEmptyTest) {
 TEST_F(JoinTests, RightTableEmptyTest) {
   // Go over all join algorithms
   for (auto join_algorithm : join_algorithms) {
-    LOG_TRACE("JOIN ALGORITHM :: %s", PlanNodeTypeToString(join_algorithm).c_str());
+    LOG_TRACE("JOIN ALGORITHM :: %s",
+              PlanNodeTypeToString(join_algorithm).c_str());
     // Go over all join types
     for (auto join_type : join_types) {
       LOG_TRACE("JOIN TYPE :: %d", join_type);
@@ -182,12 +188,14 @@ TEST_F(JoinTests, JoinPredicateTest) {
   oid_t join_test_types = 1;
 
   // Go over all join test types
-  for (oid_t join_test_type = 0; join_test_type < join_test_types; join_test_type++) {
+  for (oid_t join_test_type = 0; join_test_type < join_test_types;
+       join_test_type++) {
     LOG_TRACE("JOIN TEST_F ------------------------ :: %u", join_test_type);
 
     // Go over all join algorithms
     for (auto join_algorithm : join_algorithms) {
-      LOG_TRACE("JOIN ALGORITHM :: %s", PlanNodeTypeToString(join_algorithm).c_str());
+      LOG_TRACE("JOIN ALGORITHM :: %s",
+                PlanNodeTypeToString(join_algorithm).c_str());
       // Go over all join types
       for (auto join_type : join_types) {
         LOG_TRACE("JOIN TYPE :: %d", join_type);
@@ -225,7 +233,6 @@ void PopulateTable(storage::DataTable *table, int num_rows, bool random,
   const bool allocate = true;
   auto testing_pool = TestingHarness::GetInstance().GetTestingPool();
   for (int rowid = 0; rowid < num_rows; rowid++) {
-
     storage::Tuple tuple(schema, allocate);
 
     // First column is unique in this case
@@ -602,7 +609,8 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, PelotonJoinType join_type,
           tuples_with_null +=
               CountTuplesWithNullFields(result_logical_tile.get());
           ValidateJoinLogicalTile(result_logical_tile.get());
-          LOG_TRACE("result tile info: %s", result_logical_tile->GetInfo().c_str());
+          LOG_TRACE("result tile info: %s",
+                    result_logical_tile->GetInfo().c_str());
         }
       }
 
@@ -656,15 +664,13 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, PelotonJoinType join_type,
           left_hash_keys;
       left_hash_keys.emplace_back(
           std::unique_ptr<expression::AbstractExpression>{
-              new expression::TupleValueExpression(type::Type::INTEGER, 0,
-                                                   1)});
+              new expression::TupleValueExpression(type::Type::INTEGER, 0, 1)});
 
       std::vector<std::unique_ptr<const expression::AbstractExpression>>
           right_hash_keys;
       right_hash_keys.emplace_back(
           std::unique_ptr<expression::AbstractExpression>{
-              new expression::TupleValueExpression(type::Type::INTEGER, 1,
-                                                   1)});
+              new expression::TupleValueExpression(type::Type::INTEGER, 1, 1)});
 
       // Create hash plan node
       planner::HashPlan hash_plan_node(hash_keys);
@@ -897,8 +903,9 @@ void ValidateJoinLogicalTile(executor::LogicalTile *logical_tile) {
     // Check the join fields
     type::Value left_tuple_join_attribute_val = (join_tuple.GetValue(0));
     type::Value right_tuple_join_attribute_val = (join_tuple.GetValue(1));
-    type::Value cmp = type::ValueFactory::GetBooleanValue((left_tuple_join_attribute_val.CompareEquals(
-        right_tuple_join_attribute_val)));
+    type::Value cmp = type::ValueFactory::GetBooleanValue(
+        (left_tuple_join_attribute_val.CompareEquals(
+            right_tuple_join_attribute_val)));
     EXPECT_TRUE(cmp.IsNull() || cmp.IsTrue());
   }
 }
@@ -921,8 +928,9 @@ void ValidateNestedLoopJoinLogicalTile(executor::LogicalTile *logical_tile) {
     // Check the join fields
     type::Value left_tuple_join_attribute_val = (join_tuple.GetValue(2));
     type::Value right_tuple_join_attribute_val = (join_tuple.GetValue(3));
-    type::Value cmp = type::ValueFactory::GetBooleanValue((left_tuple_join_attribute_val.CompareEquals(
-        right_tuple_join_attribute_val)));
+    type::Value cmp = type::ValueFactory::GetBooleanValue(
+        (left_tuple_join_attribute_val.CompareEquals(
+            right_tuple_join_attribute_val)));
     EXPECT_TRUE(cmp.IsNull() || cmp.IsTrue());
   }
 }
@@ -934,20 +942,18 @@ void ExpectEmptyTileResult(MockExecutor *table_scan_executor) {
 
 void ExpectMoreThanOneTileResults(
     MockExecutor *table_scan_executor,
-    std::vector<std::unique_ptr<executor::LogicalTile>> &
-        table_logical_tile_ptrs) {
-
+    std::vector<std::unique_ptr<executor::LogicalTile>>
+        &table_logical_tile_ptrs) {
   // Expect more than one result tiles from the child, but only get one of them
   EXPECT_CALL(*table_scan_executor, DExecute()).WillOnce(Return(true));
   EXPECT_CALL(*table_scan_executor, GetOutput())
       .WillOnce(Return(table_logical_tile_ptrs[0].release()));
 }
 
-void ExpectNormalTileResults(
-    size_t table_tile_group_count, MockExecutor *table_scan_executor,
-    std::vector<std::unique_ptr<executor::LogicalTile>> &
-        table_logical_tile_ptrs) {
-
+void ExpectNormalTileResults(size_t table_tile_group_count,
+                             MockExecutor *table_scan_executor,
+                             std::vector<std::unique_ptr<executor::LogicalTile>>
+                                 &table_logical_tile_ptrs) {
   // Return true for the first table_tile_group_count times
   // Then return false after that
   {
@@ -978,7 +984,7 @@ void ExpectNormalTileResults(
       EXPECT_CALL(*table_scan_executor, GetOutput())
           .InSequence(get_output_sequence)
           .WillOnce(
-               Return(table_logical_tile_ptrs[table_tile_group_itr].release()));
+              Return(table_logical_tile_ptrs[table_tile_group_itr].release()));
     }
   }
 }

--- a/test/index/hybrid_index_test.cpp
+++ b/test/index/hybrid_index_test.cpp
@@ -77,9 +77,9 @@ void CreateTable(std::unique_ptr<storage::DataTable> &hyadapt_table,
   std::vector<catalog::Column> columns;
 
   for (oid_t col_itr = 0; col_itr < column_count; col_itr++) {
-    auto column = catalog::Column(
-        type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
-        std::to_string(col_itr), is_inlined);
+    auto column = catalog::Column(type::Type::INTEGER,
+                                  type::Type::GetTypeSize(type::Type::INTEGER),
+                                  std::to_string(col_itr), is_inlined);
     columns.push_back(column);
   }
 
@@ -158,8 +158,7 @@ expression::AbstractExpression *GetPredicate() {
 
   // First, create tuple value expression.
   expression::AbstractExpression *tuple_value_expr_left =
-      expression::ExpressionUtil::TupleValueFactory(type::Type::INTEGER, 0,
-                                                    0);
+      expression::ExpressionUtil::TupleValueFactory(type::Type::INTEGER, 0, 0);
 
   // Second, create constant value expression.
   auto constant_value_left =
@@ -175,8 +174,7 @@ expression::AbstractExpression *GetPredicate() {
           constant_value_expr_left);
 
   expression::AbstractExpression *tuple_value_expr_right =
-      expression::ExpressionUtil::TupleValueFactory(type::Type::INTEGER, 0,
-                                                    0);
+      expression::ExpressionUtil::TupleValueFactory(type::Type::INTEGER, 0, 0);
 
   auto constant_value_right =
       type::ValueFactory::GetIntegerValue(tuple_end_offset);
@@ -374,12 +372,8 @@ void LaunchHybridScan(std::unique_ptr<storage::DataTable> &hyadapt_table) {
   txn_manager.CommitTransaction(txn);
 }
 
-void CopyTuple(const oid_t &tuple_slot_id,
-               storage::Tuple *tuple,
-               storage::TileGroup* tile_group,
-               const size_t column_count) {
-  LOG_TRACE("Tile Group Id :: %u status :: %u out of %u slots ", tile_group_id,
-            tuple_slot_id, num_tuple_slots);
+void CopyTuple(const oid_t &tuple_slot_id, storage::Tuple *tuple,
+               storage::TileGroup *tile_group, const size_t column_count) {
   PL_ASSERT(tuple->GetColumnCount() == column_count);
   for (oid_t col_id = 0; col_id < column_count; ++col_id) {
     type::Value val = tile_group->GetValue(tuple_slot_id, col_id);

--- a/test/sql/index_scan_sql_test.cpp
+++ b/test/sql/index_scan_sql_test.cpp
@@ -76,6 +76,28 @@ TEST_F(IndexScanSQLTests, SQLTest) {
   EXPECT_EQ("2", SQLTestsUtil::GetResultValueAsString(result, 0));
   LOG_INFO("Aggregation selected");
 
+  LOG_INFO("Select COUNT(*)...");
+  SQLTestsUtil::ExecuteSQLQuery(
+      "SELECT COUNT(*) FROM department_table WHERE dept_id > 1;", result);
+  EXPECT_EQ("2", SQLTestsUtil::GetResultValueAsString(result, 0));
+  LOG_INFO("Aggregation selected");
+
+  LOG_INFO("Select COUNT(*)...");
+  SQLTestsUtil::ExecuteSQLQuery(
+      "SELECT COUNT(*) FROM department_table WHERE dept_id < 3 and dept_id > "
+      "1;",
+      result);
+  EXPECT_EQ("1", SQLTestsUtil::GetResultValueAsString(result, 0));
+  LOG_INFO("Aggregation selected");
+
+  LOG_INFO("Select COUNT(*)...");
+  SQLTestsUtil::ExecuteSQLQuery(
+      "SELECT COUNT(*) FROM department_table WHERE dept_id < 3 and dept_id > "
+      "2;",
+      result);
+  EXPECT_EQ("0", SQLTestsUtil::GetResultValueAsString(result, 0));
+  LOG_INFO("Aggregation selected");
+
   LOG_INFO("Select COUNT(*)... with removable predicate");
   SQLTestsUtil::ExecuteSQLQuery(
       "SELECT COUNT(*) FROM department_table WHERE dept_id = 2 and dept_name "


### PR DESCRIPTION
This PR adds the logic to handle left/right open range index scan in the IndexScanExecutor. Special flags will be set when constructing the IndexScanPlan in the optimizer, and then IndexScanExecutor will take the flags in the plan and perform pruning on the head/tail of the return tuple list if the flags indicate so.

We have to do that because the raw index can only return tuples for a close-boundary range. The logic was handled by index::Compare(), but that function will be removed soon by @wangziqi2013 .

@wangziqi2013 After you remove the index::Compare(), it seems to me that we no longer need IndexMetadata::GetTupleToIndexMapping and some related interfaces. Can you double check that and remove unnecessary code? I cannot remove them now since the compilation would fail when we still have index::Compare().