### PR TITLE
IntsKey Tests + GetInfo() Clean-up + In-lining

### DIFF
--- a/script/oltpbenchmark/testbed/measure-performance-tpcc.py
+++ b/script/oltpbenchmark/testbed/measure-performance-tpcc.py
@@ -21,7 +21,7 @@ payment_ratio = 0
 order_status_ratio = 0
 delivery_ratio = 0
 stock_level_ratio = 0
-scale_factor = 1
+SCALE_FACTOR = 1
 TEST_TIME = 20
 # TEST_TIME = 60
 
@@ -40,7 +40,7 @@ def prepare_parameters():
     parameters["$ORDER_STATUS_RATIO"] = str(order_status_ratio)
     parameters["$DELIVERY_RATIO"] = str(delivery_ratio)
     parameters["$STOCK_LEVEL_RATIO"] = str(stock_level_ratio)
-    parameters["$SCALE_FACTOR"] = str(scale_factor)
+    parameters["$SCALE_FACTOR"] = str(SCALE_FACTOR)
     parameters["$IP"] = db_host
     parameters["$PORT"] = db_port
     parameters["$TIME"] = str(TEST_TIME)
@@ -48,8 +48,8 @@ def prepare_parameters():
     template = ""
     with open("tpcc_template.xml") as in_file:
         template = in_file.read()
-    for param in parameters:
-        template = template.replace(param, parameters[param])
+    for param,value in parameters.items():
+        template = template.replace(param, value)
     with open(config_filename, "w") as out_file:
         out_file.write(template)
 
@@ -59,7 +59,7 @@ def get_result_path():
     #if not os.path.exists(base_dir):
         #os.mkdir(base_dir)
     #return base_dir +
-    return "outputfile_%d_%d_%d_%d_%d_%d" % (new_order_ratio, payment_ratio, order_status_ratio, delivery_ratio, stock_level_ratio, scale_factor)
+    return "outputfile_%d_%d_%d_%d_%d_%d" % (new_order_ratio, payment_ratio, order_status_ratio, delivery_ratio, stock_level_ratio, SCALE_FACTOR)
 
 def start_bench():
     global cwd
@@ -125,9 +125,9 @@ if __name__ == "__main__":
     ## EXECUTE
     ## ----------------------------------------------
     for thread_num in thread_counts:
+        SCALE_FACTOR = thread_num
         prepare_parameters()
-        scale_factor = thread_num
         start_bench()
-        result_dir_name = "tpcc_collected_data_%d_%d_%d_%d_%d_%d_%d" % (new_order_ratio, payment_ratio, order_status_ratio, delivery_ratio, stock_level_ratio, scale_factor, thread_num)
+        result_dir_name = "tpcc_collected_data_%d_%d_%d_%d_%d_%d_%d" % (new_order_ratio, payment_ratio, order_status_ratio, delivery_ratio, stock_level_ratio, SCALE_FACTOR, thread_num)
         collect_data(result_dir_name)
 ## MAIN

--- a/script/testing/jdbc/src/PelotonErrorTest.java
+++ b/script/testing/jdbc/src/PelotonErrorTest.java
@@ -1,0 +1,192 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// PelotonTest.java
+//
+// Identification: script/testing/jdbc/src/PelotonErrorTest.java
+//
+// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+import java.sql.*;
+
+public class PelotonErrorTest {
+    private static final int NUM_TUPLES = 2;
+
+    private static final String USERNAME = "postgres";
+    private static final String PASS = "postgres";
+    private static final int LOG_LEVEL = 0;
+
+    private static final String DROP = "DROP TABLE IF EXISTS foo;";
+    private static final String DDL = "CREATE TABLE foo(id integer PRIMARY KEY, year integer);";
+
+    private static Connection makeConnection(String host, int port, String username, String pass) throws SQLException {
+        String url = String.format("jdbc:postgresql://%s:%d/pavlo", host, port);
+        Connection conn = DriverManager.getConnection(url, username, pass);
+        return conn;
+    }
+
+    /**
+     * Drop if exists and create testing database
+     * @throws SQLException
+     */
+    public static void initDB(Connection conn) throws SQLException {
+        System.out.println("Init");
+        conn.setAutoCommit(true);
+        Statement stmt = conn.createStatement();
+        stmt.execute(DROP);
+        stmt.execute(DDL);
+
+        String sql = "INSERT INTO foo VALUES (?, ?)";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+        for (int i = 1; i <= NUM_TUPLES; i++) {
+            pstmt.setInt(1, i);
+            pstmt.setInt(2, i * 100);
+            pstmt.addBatch();
+        }
+        pstmt.executeBatch();
+    }
+    
+    public static void ThreadOne(Connection conn, int targetId) throws SQLException {
+        conn.setAutoCommit(false);
+        String sql = "SELECT * FROM foo WHERE id = ? FOR UPDATE";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+        pstmt.setInt(1, targetId);
+        ResultSet r = pstmt.executeQuery();
+        if (r.next() == false) {
+            throw new RuntimeException("[THREAD1] Failed to find id " + targetId);
+        }
+        
+        // Then we hold....
+        int sleep = 60;
+        System.err.println("[THREAD1] Sleeping for " + sleep + " seconds");
+        try {
+            Thread.sleep(sleep * 1000);
+        } catch (InterruptedException ex) {
+            // ignore
+        }
+        
+        // COMMIT!
+        conn.commit();
+    }
+    
+    public static void ThreadTwo(Connection conn, int targetId) throws Exception {
+        int newYear = 999;
+        String sql = "UPDATE foo SET year = ? WHERE id = ?";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+        // pstmt.setQueryTimeout(5);
+
+        // SLEEP!
+        int sleep = 10;
+        System.err.println("[THREAD2] Sleeping for " + sleep + " seconds");
+        Thread.sleep(sleep * 1000);
+        
+        // UPDATE!
+        conn.setAutoCommit(false);
+        System.err.println("[THREAD2] Awake! Trying to execute query that updates tuple");
+        
+//        Statement setStmt = conn.createStatement();
+//        boolean result = setStmt.execute("SET LOCAL statement_timeout TO 5");
+//        if (result == false) {
+//            System.err.println("[THREAD2] Failed to set 'statement_timeout'");
+//            System.exit(1);
+//        }
+        
+        try {
+            pstmt.setInt(1, newYear);
+            pstmt.setInt(2, targetId);
+            pstmt.execute();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            throw ex;
+        }
+        conn.commit();
+        
+        // CHECK!
+        sql = "SELECT * FROM foo WHERE id = ?";
+        pstmt = conn.prepareStatement(sql);
+        pstmt.setInt(1, targetId);
+        ResultSet r = pstmt.executeQuery();
+        if (r.next() == false) {
+            throw new RuntimeException("[THREAD2] Failed to find id " + targetId);
+        }
+        if (r.getInt(2) != newYear) {
+            throw new RuntimeException("[THREAD2] Failed to properly update id " + targetId + " [year=" + r.getInt(2) + "]");
+        }
+        r.close();
+    }
+    
+    
+    public static void DumpSQLException(SQLException ex) {
+        System.err.println("Failed to execute test. Got " + ex.getClass().getSimpleName());
+        System.err.println(" + Message:    " + ex.getMessage());
+        System.err.println(" + Error Code: " + ex.getErrorCode());
+        System.err.println(" + SQL State:  " + ex.getSQLState());
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 2) {
+            System.err.println("ARGS: [host] [port]");
+            System.exit(1);
+        }
+//        System.err.println("ARGS => " + args);
+//        System.err.println("ARG0: " + args[0]);
+//        System.err.println("ARG1: " + args[1]);
+        
+        final String host = args[0];
+        final int port = Integer.parseInt(args[1]); 
+
+        final int targetId = 2;
+        
+        // Initialize the database!
+        Class.forName("org.postgresql.Driver");
+        if (LOG_LEVEL != 0) {
+            org.postgresql.Driver.setLogLevel(LOG_LEVEL);
+            DriverManager.setLogStream(System.out);
+        }
+        
+        Thread t = null; 
+        
+        try {
+            // Initialize the DB
+            Connection conn = makeConnection(host, port, USERNAME, PASS);
+            initDB(conn);
+            
+//            PreparedStatement pstmt = conn.prepareStatement("SET lock_timeout = 5");
+//            boolean result = pstmt.execute();
+//            if (result == false) {
+//                System.err.println("Failed to set 'lock_timeout'");
+//                pstmt.setQ
+//                System.exit(1);
+//            }
+            
+            // Start the first thread that holds the lock
+            t = new Thread() {
+                public void run() {
+                    try {
+                        Connection conn = makeConnection(host, port, USERNAME, PASS);
+                        ThreadOne(conn, targetId);
+                    } catch (SQLException ex) {
+                        DumpSQLException(ex);
+                    }
+                };
+            };
+            t.start();
+            
+            // Then execute the second txn
+            // This should throw the exception that we want.
+            ThreadTwo(conn, targetId);
+            
+        } catch (SQLException ex) {
+            DumpSQLException(ex);
+            throw ex;
+        } finally {
+            if (t != null) {
+                t.interrupt();
+            }
+        }
+    }
+
+}

--- a/script/testing/jdbc/test_jdbc.sh
+++ b/script/testing/jdbc/test_jdbc.sh
@@ -1,7 +1,7 @@
 mkdir -p lib
 mkdir -p out
 wget -nc -P lib https://jdbc.postgresql.org/download/postgresql-9.4.1209.jre6.jar
-javac -classpath ./lib/postgresql-9.4.1209.jre6.jar -d out src/PelotonTest.java
+javac -classpath ./lib/postgresql-9.4.1209.jre6.jar -d out src/*.java
 jar -cvf out.jar -C out .
 if [ "$#" -ne 2 ]; then
 	java -cp out.jar:./lib/postgresql-9.4.1209.jre6.jar PelotonTest $1 

--- a/src/catalog/column.cpp
+++ b/src/catalog/column.cpp
@@ -46,17 +46,23 @@ const std::string Column::GetInfo() const {
      << "Offset:" << column_offset << ", ";
 
   if (is_inlined) {
-    os << "FixedLength:" << fixed_length << ", ";
+    os << "FixedLength:" << fixed_length;
   } else {
-    os << "VarLength:" << variable_length << ", ";
+    os << "VarLength:" << variable_length;
   }
 
   if (constraints.empty() == false) {
-    os << "*NO CONSTRAINTS*";
-  } else {
+    os << ", {";
+    bool first = true;
     for (auto constraint : constraints) {
+      if (first) {
+        first = false;
+      } else {
+        os << ", ";
+      }
       os << constraint.GetInfo();
     }
+    os << "}";
   }
   os << "]";
 

--- a/src/catalog/column.cpp
+++ b/src/catalog/column.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "catalog/column.h"
 #include "type/types.h"
 
@@ -43,22 +42,25 @@ void Column::SetInlined() {
 const std::string Column::GetInfo() const {
   std::ostringstream os;
 
-  os << " name = " << column_name << ","
-     << " type = " << column_type << ","
-     << " offset = " << column_offset << ","
-     << " fixed length = " << fixed_length << ","
-     << " variable length = " << variable_length << ","
-     << " inlined = " << is_inlined;
+  os << "Column[" << column_name << ", " << TypeIdToString(column_type) << ", "
+     << "Offset:" << column_offset << ", ";
+
+  if (is_inlined) {
+    os << "FixedLength:" << fixed_length << ", ";
+  } else {
+    os << "VarLength:" << variable_length << ", ";
+  }
 
   if (constraints.empty() == false) {
-    os << "\n";
+    os << "*NO CONSTRAINTS*";
+  } else {
+    for (auto constraint : constraints) {
+      os << constraint.GetInfo();
+    }
   }
+  os << "]";
 
-  for (auto constraint : constraints) {
-    os << constraint;
-  }
-
-  return os.str();
+  return (os.str());
 }
 
 }  // End catalog namespace

--- a/src/catalog/constraint.cpp
+++ b/src/catalog/constraint.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "catalog/constraint.h"
 #include "type/types.h"
 
@@ -21,14 +20,8 @@ namespace catalog {
 
 const std::string Constraint::GetInfo() const {
   std::ostringstream os;
-
-  os << "\tCONSTRAINT ";
-
-  os << GetName() << " ";
-  os << ConstraintTypeToString(constraint_type);
-
-  os << "\n\n";
-
+  os << "Constraint[" << GetName() << ", "
+     << ConstraintTypeToString(constraint_type) << "]";
   return os.str();
 }
 

--- a/src/catalog/schema.cpp
+++ b/src/catalog/schema.cpp
@@ -272,15 +272,23 @@ Schema *Schema::AppendSchemaPtrList(
 const std::string Schema::GetInfo() const {
   std::ostringstream os;
 
-  os << "Schema :: "
-     << " column_count = " << column_count
-     << " is_inlined = " << tuple_is_inlined << ","
-     << " length = " << length << ","
-     << " uninlined_column_count = " << uninlined_column_count << std::endl;
+  os << "Schema["
+     << "NumColums:" << column_count << ", "
+     << "IsInlined:" << tuple_is_inlined << ", "
+     << "Length:" << length << ", "
+     << "UninlinedCount:" << uninlined_column_count << "]";
 
-  for (oid_t column_itr = 0; column_itr < column_count; column_itr++) {
-    os << "\t Column " << column_itr << " :: " << columns[column_itr];
+  bool first = true;
+  os << " :: (";
+  for (oid_t i = 0; i < column_count; i++) {
+    if (first) {
+      first = false;
+    } else {
+      os << ", ";
+    }
+    os << columns[i].GetInfo();
   }
+  os << ")";
 
   return os.str();
 }

--- a/src/catalog/schema.cpp
+++ b/src/catalog/schema.cpp
@@ -273,7 +273,7 @@ const std::string Schema::GetInfo() const {
   std::ostringstream os;
 
   os << "Schema["
-     << "NumColums:" << column_count << ", "
+     << "NumColumns:" << column_count << ", "
      << "IsInlined:" << tuple_is_inlined << ", "
      << "Length:" << length << ", "
      << "UninlinedCount:" << uninlined_column_count << "]";

--- a/src/include/index/ints_key.h
+++ b/src/include/index/ints_key.h
@@ -12,6 +12,10 @@
 
 #pragma once
 
+#include <sstream>
+
+#include "util/string_util.h"
+
 namespace peloton {
 namespace index {
 
@@ -21,18 +25,18 @@ namespace index {
 
 /*
  * class CompactIntegerKey - Compact representation of multifield integers
- * 
+ *
  * This class is used for storing multiple integral fields into a compact
- * array representation. This class is largely used as a static object, 
- * because special storage format is used to ensure a fast comparison 
+ * array representation. This class is largely used as a static object,
+ * because special storage format is used to ensure a fast comparison
  * implementation.
  *
  * Integers are stored in a big-endian and sign-magnitute format. Big-endian
  * favors comparison since we could always start comparison using the first few
  * bytes. This gives the compiler opportunities to optimize comparison
- * using advanced techniques such as SIMD or loop unrolling. 
+ * using advanced techniques such as SIMD or loop unrolling.
  *
- * For details of how and why integers must be stored in a big-endian and 
+ * For details of how and why integers must be stored in a big-endian and
  * sign-magnitude format, please refer to adaptive radix tree's key format
  *
  * Note: CompactIntegerKey should always be aligned to 64 bit boundaries; There
@@ -43,13 +47,12 @@ class CompactIntegerKey {
  public:
   // This is the actual byte size of the key
   static constexpr size_t key_size_byte = KeySize * 8UL;
-  
+
  private:
   // This is the array we use for storing integers
   unsigned char key_data[key_size_byte];
- 
+
  private:
-  
   /*
    * TwoBytesToBigEndian() - Change 2 bytes to big endian
    *
@@ -60,9 +63,9 @@ class CompactIntegerKey {
    *      XCHG AH, AL
    */
   inline static uint16_t TwoBytesToBigEndian(uint16_t data) {
-    return htobe16(data);  
+    return htobe16(data);
   }
-  
+
   /*
    * FourBytesToBigEndian() - Change 4 bytes to big endian format
    *
@@ -73,9 +76,9 @@ class CompactIntegerKey {
    *      BSWAP EAX
    */
   inline static uint32_t FourBytesToBigEndian(uint32_t data) {
-    return htobe32(data); 
+    return htobe32(data);
   }
-  
+
   /*
    * EightBytesToBigEndian() - Change 8 bytes to big endian format
    *
@@ -83,105 +86,103 @@ class CompactIntegerKey {
    */
   inline static uint64_t EightBytesToBigEndian(uint64_t data) {
     return htobe64(data);
-  }  
-  
+  }
+
   /*
    * TwoBytesToHostEndian() - Converts back two byte integer to host byte order
    */
   inline static uint16_t TwoBytesToHostEndian(uint16_t data) {
-    return be16toh(data); 
+    return be16toh(data);
   }
-  
+
   /*
-   * FourBytesToHostEndian() - Converts back four byte integer to host byte order
+   * FourBytesToHostEndian() - Converts back four byte integer to host byte
+   * order
    */
   inline static uint32_t FourBytesToHostEndian(uint32_t data) {
-    return be32toh(data); 
+    return be32toh(data);
   }
-  
+
   /*
-   * EightBytesToHostEndian() - Converts back eight byte integer to host byte order
+   * EightBytesToHostEndian() - Converts back eight byte integer to host byte
+   * order
    */
   inline static uint64_t EightBytesToHostEndian(uint64_t data) {
-    return be64toh(data); 
+    return be64toh(data);
   }
-  
+
   /*
    * ToBigEndian() - Overloaded version for all kinds of integral data types
    */
-  
-  inline static uint8_t ToBigEndian(uint8_t data) {
-    return data;
-  }
-  
+
+  inline static uint8_t ToBigEndian(uint8_t data) { return data; }
+
   inline static uint8_t ToBigEndian(int8_t data) {
     return static_cast<uint8_t>(data);
   }
-  
+
   inline static uint16_t ToBigEndian(uint16_t data) {
     return TwoBytesToBigEndian(data);
   }
-  
+
   inline static uint16_t ToBigEndian(int16_t data) {
     return TwoBytesToBigEndian(static_cast<uint16_t>(data));
   }
-  
+
   inline static uint32_t ToBigEndian(uint32_t data) {
     return FourBytesToBigEndian(data);
   }
-  
+
   inline static uint32_t ToBigEndian(int32_t data) {
     return FourBytesToBigEndian(static_cast<uint32_t>(data));
   }
-  
+
   inline static uint64_t ToBigEndian(uint64_t data) {
     return EightBytesToBigEndian(data);
   }
-  
+
   inline static uint64_t ToBigEndian(int64_t data) {
     return EightBytesToBigEndian(static_cast<uint64_t>(data));
   }
-  
+
   /*
    * ToHostEndian() - Converts big endian data to host format
    */
-  
-  static inline uint8_t ToHostEndian(uint8_t data) {
-    return data; 
-  }
-  
+
+  static inline uint8_t ToHostEndian(uint8_t data) { return data; }
+
   static inline uint8_t ToHostEndian(int8_t data) {
-    return static_cast<uint8_t>(data); 
+    return static_cast<uint8_t>(data);
   }
-  
+
   static inline uint16_t ToHostEndian(uint16_t data) {
     return TwoBytesToHostEndian(data);
   }
-  
+
   static inline uint16_t ToHostEndian(int16_t data) {
     return TwoBytesToHostEndian(static_cast<uint16_t>(data));
   }
-  
+
   static inline uint32_t ToHostEndian(uint32_t data) {
     return FourBytesToHostEndian(data);
   }
-  
+
   static inline uint32_t ToHostEndian(int32_t data) {
     return FourBytesToHostEndian(static_cast<uint32_t>(data));
   }
-  
+
   static inline uint64_t ToHostEndian(uint64_t data) {
     return EightBytesToHostEndian(data);
   }
-  
+
   static inline uint64_t ToHostEndian(int64_t data) {
     return EightBytesToHostEndian(static_cast<uint64_t>(data));
   }
-  
+
   /*
    * SignFlip() - Flips the highest bit of a given integral type
    *
-   * This flip is logical, i.e. it happens on the logical highest bit of an 
+   * This flip is logical, i.e. it happens on the logical highest bit of an
    * integer. The actual position on the address space is related to endianess
    * Therefore this should happen first.
    *
@@ -195,37 +196,34 @@ class CompactIntegerKey {
     // otherwise, 0x1 is treated as the signed int type, and after leftshifting
     // if it is extended to larger type then sign extension will be used
     IntType mask = static_cast<IntType>(0x1) << (sizeof(IntType) * 8UL - 1);
-    
+
     return data ^ mask;
   }
-  
+
  public:
-  
   /*
    * Constructor
    */
   CompactIntegerKey() {
     ZeroOut();
-    
+
     return;
   }
-  
+
   /*
    * ZeroOut() - Sets all bits to zero
    */
   inline void ZeroOut() {
     memset(key_data, 0x00, key_size_byte);
-    
+
     return;
   }
-  
+
   /*
    * GetRawData() - Returns the raw data array
    */
-  const unsigned char *GetRawData() const {
-    return key_data;
-  }
-  
+  const unsigned char *GetRawData() const { return key_data; }
+
   /*
    * AddInteger() - Adds a new integer into the compact form
    *
@@ -236,17 +234,17 @@ class CompactIntegerKey {
   template <typename IntType>
   inline void AddInteger(IntType data, size_t offset) {
     IntType sign_flipped = SignFlip<IntType>(data);
-    
+
     // This function always returns the unsigned type
     // so we must use automatic type inference
     auto big_endian = ToBigEndian(sign_flipped);
-    
+
     // This will almost always be optimized into single move
     memcpy(key_data + offset, &big_endian, sizeof(IntType));
-    
+
     return;
   }
-  
+
   /*
    * AddUnsignedInteger() - Adds an unsigned integer of a certain type
    *
@@ -258,13 +256,13 @@ class CompactIntegerKey {
     // This function always returns the unsigned type
     // so we must use automatic type inference
     auto big_endian = ToBigEndian(data);
-    
+
     // This will almost always be optimized into single move
     memcpy(key_data + offset, &big_endian, sizeof(IntType));
-    
+
     return;
   }
-  
+
   /*
    * GetInteger() - Extracts an integer from the given offset
    *
@@ -273,13 +271,13 @@ class CompactIntegerKey {
   template <typename IntType>
   inline IntType GetInteger(size_t offset) const {
     const IntType *ptr = reinterpret_cast<const IntType *>(key_data + offset);
-    
+
     // This always returns an unsigned number
     auto host_endian = ToHostEndian(*ptr);
-    
+
     return SignFlip<IntType>(static_cast<IntType>(host_endian));
   }
-  
+
   /*
    * GetUnsignedInteger() - Extracts an unsigned integer from the given offset
    *
@@ -291,80 +289,68 @@ class CompactIntegerKey {
     auto host_endian = ToHostEndian(*ptr);
     return static_cast<IntType>(host_endian);
   }
-  
+
   /*
    * Compare() - Compares two IntsType object of the same length
    *
-   * This function has the same semantics as memcmp(). Negative result means 
+   * This function has the same semantics as memcmp(). Negative result means
    * less than, positive result means greater than, and 0 means equal
    */
-  static inline int Compare(const CompactIntegerKey<KeySize> &a, 
+  static inline int Compare(const CompactIntegerKey<KeySize> &a,
                             const CompactIntegerKey<KeySize> &b) {
-    return memcmp(a.key_data, 
-                  b.key_data, 
-                  CompactIntegerKey<KeySize>::key_size_byte); 
+    return memcmp(a.key_data, b.key_data,
+                  CompactIntegerKey<KeySize>::key_size_byte);
   }
-  
+
   /*
    * LessThan() - Returns true if first is less than the second
    */
-  static inline bool LessThan(const CompactIntegerKey<KeySize> &a, 
+  static inline bool LessThan(const CompactIntegerKey<KeySize> &a,
                               const CompactIntegerKey<KeySize> &b) {
     return Compare(a, b) < 0;
   }
-  
+
   /*
    * Equals() - Returns true if first is equivalent to the second
    */
-  static inline bool Equals(const CompactIntegerKey<KeySize> &a, 
+  static inline bool Equals(const CompactIntegerKey<KeySize> &a,
                             const CompactIntegerKey<KeySize> &b) {
     return Compare(a, b) == 0;
   }
-  
+
  public:
-  
   /*
    * GetInfo() - Prints the content of this key
-   *
-   * All contents are printed to stderr
    */
-  void GetInfo() {
+  std::string GetInfo() const {
+    std::ostringstream os;
+    os << "CompactIntegerKey<" << KeySize << "> - " << key_size_byte << " bytes"
+       << std::endl;
+
     // This is the current offset we are on printing the key
     int offset = 0;
-    
-    fprintf(stderr, 
-            "CompactIntegerKey<%lu> - %lu bytes\n", 
-            KeySize, 
-            key_size_byte);
-    
-    while(offset < key_size_byte) {
+    while (offset < key_size_byte) {
       constexpr int byte_per_line = 16;
-      
-      fprintf(stderr, "0x%.8X    ", offset);
-      
-      for(int i = 0;i < byte_per_line;i++) {
-        if(offset >= key_size_byte) {
+      os << StringUtil::Format("0x%.8X    ", offset);
+
+      for (int i = 0; i < byte_per_line; i++) {
+        if (offset >= key_size_byte) {
           break;
-        } 
-        
-        fprintf(stderr, "%.2X ", key_data[offset]);
-        
-        // Add a delimiter on the 8th byte
-        if(i == 7) {
-          fprintf(stderr, "   "); 
         }
-        
-        offset++; 
-      }
-      
-      fprintf(stderr, "\n");
-    }
-    
-    return;
+        os << StringUtil::Format("%.2X ", key_data[offset]);
+        // Add a delimiter on the 8th byte
+        if (i == 7) {
+          os << "   ";
+        }
+        offset++;
+      }  // FOR
+      os << std::endl;
+    }  // WHILE
+
+    return (os.str());
   }
- 
+
  private:
-   
   /*
    * SetFromColumn() - Sets the value of a column into a given offset of
    *                   this ints key
@@ -375,46 +361,44 @@ class CompactIntegerKey {
    * to determine the type of the column; another into the tuple to
    * get data
    */
-  inline size_t SetFromColumn(oid_t key_column_id, 
-                              oid_t tuple_column_id,
-                              const catalog::Schema *key_schema, 
-                              const storage::Tuple *tuple, 
-                              size_t offset) {
+  inline size_t SetFromColumn(oid_t key_column_id, oid_t tuple_column_id,
+                              const catalog::Schema *key_schema,
+                              const storage::Tuple *tuple, size_t offset) {
     // We act depending on the length of integer types
-    type::Type::TypeId column_type = \
-      key_schema->GetColumn(key_column_id).GetType();
-    
+    type::Type::TypeId column_type =
+        key_schema->GetColumn(key_column_id).GetType();
+
     switch (column_type) {
       case type::Type::BIGINT: {
         int64_t data = tuple->GetInlinedDataOfType<int64_t>(tuple_column_id);
-        
+
         AddInteger<int64_t>(data, offset);
         offset += sizeof(data);
-        
+
         break;
       }
       case type::Type::INTEGER: {
         int32_t data = tuple->GetInlinedDataOfType<int32_t>(tuple_column_id);
-        
+
         AddInteger<int32_t>(data, offset);
         offset += sizeof(data);
-        
+
         break;
       }
       case type::Type::SMALLINT: {
         int16_t data = tuple->GetInlinedDataOfType<int16_t>(tuple_column_id);
-        
+
         AddInteger<int16_t>(data, offset);
         offset += sizeof(data);
-        
+
         break;
       }
       case type::Type::TINYINT: {
         int8_t data = tuple->GetInlinedDataOfType<int8_t>(tuple_column_id);
-        
+
         AddInteger<int8_t>(data, offset);
         offset += sizeof(data);
-        
+
         break;
       }
       default: {
@@ -422,15 +406,14 @@ class CompactIntegerKey {
             "We currently only support a specific set of "
             "column index sizes...");
         break;
-      } // default
-    } // switch
-    
+      }  // default
+    }    // switch
+
     return offset;
   }
- 
- // The next are functions specific to Peloton
+
+  // The next are functions specific to Peloton
  public:
-  
   /*
    * SetFromKey() - Sets the compact internal storage from a tuple
    *                only comtaining key columns
@@ -441,37 +424,38 @@ class CompactIntegerKey {
    */
   inline void SetFromKey(const storage::Tuple *tuple) {
     PL_ASSERT(tuple != nullptr);
-    
+    PL_ASSERT(tuple->GetSchema() != nullptr);
+
     // Must clear previous result first
     ZeroOut();
-    
+
     // This returns schema of the tuple
     // Note that the schema must contain only integral type
     const catalog::Schema *key_schema = tuple->GetSchema();
 
     // Need this to loop through columns
     oid_t column_count = key_schema->GetColumnCount();
-    
+
     // Use this to arrange bytes into the key
     size_t offset = 0;
-    
+
     // **************************************************************
-    // NOTE: Avoid using tuple->GetValue() 
-    // Because here what we need is: 
-    //   (1) Type of the column; 
+    // NOTE: Avoid using tuple->GetValue()
+    // Because here what we need is:
+    //   (1) Type of the column;
     //   (2) Integer value
     // The former could be obtained in the schema, and the last is directly
     // available from the inlined tuple data
     // **************************************************************
-    
+
     // Loop from most significant column to least significant column
     for (oid_t column_id = 0; column_id < column_count; column_id++) {
       offset = SetFromColumn(column_id, column_id, key_schema, tuple, offset);
-      
+
       // We could either have it just after the array or inside the array
       PL_ASSERT(offset <= key_size_byte);
     }
-    
+
     return;
   }
 
@@ -485,95 +469,84 @@ class CompactIntegerKey {
    * Argument "indices" maps the key column in the corresponding index to a
    * column in the given tuple
    */
-  inline void SetFromTuple(const storage::Tuple *tuple, 
-                           const int *indices,
+  inline void SetFromTuple(const storage::Tuple *tuple, const int *indices,
                            const catalog::Schema *key_schema) {
     PL_ASSERT(tuple != nullptr);
     PL_ASSERT(indices != nullptr);
     PL_ASSERT(key_schema != nullptr);
-    
+
     ZeroOut();
-    
+
     oid_t column_count = key_schema->GetColumnCount();
     size_t offset = 0;
-    
-    for (oid_t key_column_id = 0; 
-         key_column_id < column_count; 
+
+    for (oid_t key_column_id = 0; key_column_id < column_count;
          key_column_id++) {
       // indices array maps key column to tuple column
       // and it must have the same length as key schema
       oid_t tuple_column_id = indices[key_column_id];
-      
-      offset = SetFromColumn(key_column_id, 
-                             tuple_column_id, 
-                             key_schema, 
-                             tuple, 
-                             offset); 
+
+      offset = SetFromColumn(key_column_id, tuple_column_id, key_schema, tuple,
+                             offset);
       PL_ASSERT(offset <= key_size_byte);
     }
-    
+
     return;
   }
-  
+
   /*
    * GetTupleForComparison() - Returns a tuple object for comparing function
    *
    * Given a schema we extract all fields from the compact integer key
    */
-  const storage::Tuple 
-  GetTupleForComparison(const catalog::Schema *key_schema) const {
+  const storage::Tuple GetTupleForComparison(
+      const catalog::Schema *key_schema) const {
     PL_ASSERT(key_schema != nullptr);
-    
+
     size_t offset = 0;
     // Yes the tuple has an allocated chunk of memory and is not just a wrapper
     storage::Tuple tuple(key_schema, true);
     oid_t column_count = key_schema->GetColumnCount();
-    
-    for (oid_t column_id = 0;
-         column_id < column_count;
-         column_id++) {
-      type::Type::TypeId column_type = \
-        key_schema->GetColumn(column_id).GetType();
-        
-      switch(column_type) {
+
+    for (oid_t column_id = 0; column_id < column_count; column_id++) {
+      type::Type::TypeId column_type =
+          key_schema->GetColumn(column_id).GetType();
+
+      switch (column_type) {
         case type::Type::BIGINT: {
           int64_t data = GetInteger<int64_t>(offset);
-          
-          tuple.SetValue(column_id, 
-                         type::ValueFactory::GetBigIntValue(data));
-          
+
+          tuple.SetValue(column_id, type::ValueFactory::GetBigIntValue(data));
+
           offset += sizeof(data);
-          
+
           break;
         }
         case type::Type::INTEGER: {
           int32_t data = GetInteger<int32_t>(offset);
-          
-          tuple.SetValue(column_id, 
-                         type::ValueFactory::GetIntegerValue(data));
-          
+
+          tuple.SetValue(column_id, type::ValueFactory::GetIntegerValue(data));
+
           offset += sizeof(data);
-          
+
           break;
         }
         case type::Type::SMALLINT: {
           int16_t data = GetInteger<int16_t>(offset);
-          
-          tuple.SetValue(column_id, 
-                         type::ValueFactory::GetSmallIntValue(data));
-          
+
+          tuple.SetValue(column_id, type::ValueFactory::GetSmallIntValue(data));
+
           offset += sizeof(data);
-          
+
           break;
         }
         case type::Type::TINYINT: {
           int8_t data = GetInteger<int8_t>(offset);
-          
-          tuple.SetValue(column_id, 
-                         type::ValueFactory::GetTinyIntValue(data));
-          
+
+          tuple.SetValue(column_id, type::ValueFactory::GetTinyIntValue(data));
+
           offset += sizeof(data);
-          
+
           break;
         }
         default: {
@@ -582,9 +555,9 @@ class CompactIntegerKey {
               "column index sizes...");
           break;
         }
-      } // switch
-    } // for
-    
+      }  // switch
+    }    // for
+
     return tuple;
   }
 };
@@ -594,29 +567,29 @@ class CompactIntegerKey {
  */
 template <size_t KeySize>
 class CompactIntsComparator {
- public: 
+ public:
   CompactIntsComparator() {}
   CompactIntsComparator(const CompactIntsComparator &) {}
-  
+
   /*
    * operator()() - Returns true if lhs < rhs
    */
-  inline bool operator()(const CompactIntegerKey<KeySize> &lhs, 
+  inline bool operator()(const CompactIntegerKey<KeySize> &lhs,
                          const CompactIntegerKey<KeySize> &rhs) const {
     return CompactIntegerKey<KeySize>::LessThan(lhs, rhs);
   }
 };
 
 /*
- * class CompactIntsEqualityChecker - Compares whether two integer keys are 
+ * class CompactIntsEqualityChecker - Compares whether two integer keys are
  *                                    equivalent
  */
 template <size_t KeySize>
 class CompactIntsEqualityChecker {
  public:
-  CompactIntsEqualityChecker() {};
-  CompactIntsEqualityChecker(const CompactIntsEqualityChecker &) {}; 
-   
+  CompactIntsEqualityChecker(){};
+  CompactIntsEqualityChecker(const CompactIntsEqualityChecker &){};
+
   inline bool operator()(const CompactIntegerKey<KeySize> &lhs,
                          const CompactIntegerKey<KeySize> &rhs) const {
     return CompactIntegerKey<KeySize>::Equals(lhs, rhs);
@@ -632,36 +605,35 @@ class CompactIntsEqualityChecker {
 template <size_t KeySize>
 class CompactIntsHasher {
  public:
-   
   // Emphasize here that we want a 8 byte aligned object
-  static_assert(sizeof(CompactIntegerKey<KeySize>) % sizeof(uint64_t) == 0, 
+  static_assert(sizeof(CompactIntegerKey<KeySize>) % sizeof(uint64_t) == 0,
                 "Please align the size of compact integer key");
-                
+
   // Make sure there is no other field
-  static_assert(sizeof(CompactIntegerKey<KeySize>) == \
-                       CompactIntegerKey<KeySize>::key_size_byte,
-                       "Extra fields detected in class CompactIntegerKey");
-  
-  CompactIntsHasher() {};
+  static_assert(sizeof(CompactIntegerKey<KeySize>) ==
+                    CompactIntegerKey<KeySize>::key_size_byte,
+                "Extra fields detected in class CompactIntegerKey");
+
+  CompactIntsHasher(){};
   CompactIntsHasher(const CompactIntsHasher &) {}
-                 
+
   /*
    * operator()() - Hashes an object into size_t
    *
-   * This function hashes integer key using 64 bit chunks. Chunks are 
-   * accumulated to the hash one by one. Since 
+   * This function hashes integer key using 64 bit chunks. Chunks are
+   * accumulated to the hash one by one. Since
    */
   inline size_t operator()(CompactIntegerKey<KeySize> const &p) const {
     size_t seed = 0UL;
     const size_t *ptr = reinterpret_cast<const size_t *>(p.GetRawData());
-    
+
     // For every 8 byte word just combine it with the current seed
-    for (size_t i = 0; 
-         i < (CompactIntegerKey<KeySize>::key_size_byte / sizeof(uint64_t)); 
+    for (size_t i = 0;
+         i < (CompactIntegerKey<KeySize>::key_size_byte / sizeof(uint64_t));
          i++) {
       boost::hash_combine(seed, ptr[i]);
     }
-    
+
     return seed;
   }
 };

--- a/src/include/index/ints_key.h
+++ b/src/include/index/ints_key.h
@@ -43,7 +43,7 @@ namespace index {
  * are static assertion to enforce this rule
  */
 template <size_t KeySize>
-class CompactIntegerKey {
+class CompactIntsKey {
  public:
   // This is the actual byte size of the key
   static constexpr size_t key_size_byte = KeySize * 8UL;
@@ -204,7 +204,7 @@ class CompactIntegerKey {
   /*
    * Constructor
    */
-  CompactIntegerKey() {
+  CompactIntsKey() {
     ZeroOut();
 
     return;
@@ -296,25 +296,25 @@ class CompactIntegerKey {
    * This function has the same semantics as memcmp(). Negative result means
    * less than, positive result means greater than, and 0 means equal
    */
-  static inline int Compare(const CompactIntegerKey<KeySize> &a,
-                            const CompactIntegerKey<KeySize> &b) {
+  static inline int Compare(const CompactIntsKey<KeySize> &a,
+                            const CompactIntsKey<KeySize> &b) {
     return memcmp(a.key_data, b.key_data,
-                  CompactIntegerKey<KeySize>::key_size_byte);
+                  CompactIntsKey<KeySize>::key_size_byte);
   }
 
   /*
    * LessThan() - Returns true if first is less than the second
    */
-  static inline bool LessThan(const CompactIntegerKey<KeySize> &a,
-                              const CompactIntegerKey<KeySize> &b) {
+  static inline bool LessThan(const CompactIntsKey<KeySize> &a,
+                              const CompactIntsKey<KeySize> &b) {
     return Compare(a, b) < 0;
   }
 
   /*
    * Equals() - Returns true if first is equivalent to the second
    */
-  static inline bool Equals(const CompactIntegerKey<KeySize> &a,
-                            const CompactIntegerKey<KeySize> &b) {
+  static inline bool Equals(const CompactIntsKey<KeySize> &a,
+                            const CompactIntsKey<KeySize> &b) {
     return Compare(a, b) == 0;
   }
 
@@ -574,9 +574,9 @@ class CompactIntsComparator {
   /*
    * operator()() - Returns true if lhs < rhs
    */
-  inline bool operator()(const CompactIntegerKey<KeySize> &lhs,
-                         const CompactIntegerKey<KeySize> &rhs) const {
-    return CompactIntegerKey<KeySize>::LessThan(lhs, rhs);
+  inline bool operator()(const CompactIntsKey<KeySize> &lhs,
+                         const CompactIntsKey<KeySize> &rhs) const {
+    return CompactIntsKey<KeySize>::LessThan(lhs, rhs);
   }
 };
 
@@ -590,9 +590,9 @@ class CompactIntsEqualityChecker {
   CompactIntsEqualityChecker(){};
   CompactIntsEqualityChecker(const CompactIntsEqualityChecker &){};
 
-  inline bool operator()(const CompactIntegerKey<KeySize> &lhs,
-                         const CompactIntegerKey<KeySize> &rhs) const {
-    return CompactIntegerKey<KeySize>::Equals(lhs, rhs);
+  inline bool operator()(const CompactIntsKey<KeySize> &lhs,
+                         const CompactIntsKey<KeySize> &rhs) const {
+    return CompactIntsKey<KeySize>::Equals(lhs, rhs);
   }
 };
 
@@ -606,12 +606,12 @@ template <size_t KeySize>
 class CompactIntsHasher {
  public:
   // Emphasize here that we want a 8 byte aligned object
-  static_assert(sizeof(CompactIntegerKey<KeySize>) % sizeof(uint64_t) == 0,
+  static_assert(sizeof(CompactIntsKey<KeySize>) % sizeof(uint64_t) == 0,
                 "Please align the size of compact integer key");
 
   // Make sure there is no other field
-  static_assert(sizeof(CompactIntegerKey<KeySize>) ==
-                    CompactIntegerKey<KeySize>::key_size_byte,
+  static_assert(sizeof(CompactIntsKey<KeySize>) ==
+                    CompactIntsKey<KeySize>::key_size_byte,
                 "Extra fields detected in class CompactIntegerKey");
 
   CompactIntsHasher(){};
@@ -623,13 +623,13 @@ class CompactIntsHasher {
    * This function hashes integer key using 64 bit chunks. Chunks are
    * accumulated to the hash one by one. Since
    */
-  inline size_t operator()(CompactIntegerKey<KeySize> const &p) const {
+  inline size_t operator()(CompactIntsKey<KeySize> const &p) const {
     size_t seed = 0UL;
     const size_t *ptr = reinterpret_cast<const size_t *>(p.GetRawData());
 
     // For every 8 byte word just combine it with the current seed
     for (size_t i = 0;
-         i < (CompactIntegerKey<KeySize>::key_size_byte / sizeof(uint64_t));
+         i < (CompactIntsKey<KeySize>::key_size_byte / sizeof(uint64_t));
          i++) {
       boost::hash_combine(seed, ptr[i]);
     }

--- a/src/include/storage/tile_group.h
+++ b/src/include/storage/tile_group.h
@@ -157,8 +157,16 @@ class TileGroup : public Printable {
 
   size_t GetTileCount() const { return tile_count; }
 
-  void LocateTileAndColumn(oid_t column_offset, oid_t &tile_offset,
-                           oid_t &tile_column_offset);
+  // Sets the tile id and column id w.r.t that tile corresponding to
+  // the specified tile group column id.
+  inline void LocateTileAndColumn(oid_t column_offset, oid_t &tile_offset,
+                           oid_t &tile_column_offset) {
+    PL_ASSERT(column_map.count(column_offset) != 0);
+    // get the entry in the column map
+    auto entry = column_map.at(column_offset);
+    tile_offset = entry.first;
+    tile_column_offset = entry.second;
+  }
 
   oid_t GetTileIdFromColumnId(oid_t column_id);
 

--- a/src/include/storage/tile_group.h
+++ b/src/include/storage/tile_group.h
@@ -130,7 +130,11 @@ class TileGroup : public Printable {
   unsigned int NumTiles() const { return tiles.size(); }
 
   // Get the tile at given offset in the tile group
-  Tile *GetTile(const oid_t tile_itr) const;
+  inline Tile *GetTile(const oid_t tile_offset) const {
+    PL_ASSERT(tile_offset < tile_count);
+    Tile *tile = tiles[tile_offset].get();
+    return tile;
+  }
 
   // Get a reference to the tile at the given offset in the tile group
   std::shared_ptr<Tile> GetTileReference(const oid_t tile_offset) const;

--- a/src/include/storage/tuple.h
+++ b/src/include/storage/tuple.h
@@ -38,35 +38,35 @@ class Tuple : public AbstractTuple {
  public:
   // Default constructor (don't use this)
   inline Tuple()
-      : tuple_schema(nullptr), tuple_data(nullptr), allocated(false) {}
+      : tuple_schema_(nullptr), tuple_data_(nullptr), allocated_(false) {}
 
   // Setup the tuple given a table
   inline Tuple(const Tuple &rhs)
-      : tuple_schema(rhs.tuple_schema),
-        tuple_data(rhs.tuple_data),
-        allocated(false) {}
+      : tuple_schema_(rhs.tuple_schema_),
+        tuple_data_(rhs.tuple_data_),
+        allocated_(false) {}
 
   // Setup the tuple given a schema
   inline Tuple(const catalog::Schema *schema)
-      : tuple_schema(schema), tuple_data(nullptr), allocated(false) {
-    PL_ASSERT(tuple_schema);
+      : tuple_schema_(schema), tuple_data_(nullptr), allocated_(false) {
+    PL_ASSERT(tuple_schema_);
   }
 
   // Setup the tuple given a schema and location
   inline Tuple(const catalog::Schema *schema, char *data)
-      : tuple_schema(schema), tuple_data(data), allocated(false) {
-    PL_ASSERT(tuple_schema);
-    PL_ASSERT(tuple_data);
+      : tuple_schema_(schema), tuple_data_(data), allocated_(false) {
+    PL_ASSERT(tuple_schema_);
+    PL_ASSERT(tuple_data_);
   }
 
   // Setup the tuple given a schema and allocate space
   inline Tuple(const catalog::Schema *schema, bool allocate)
-      : tuple_schema(schema), tuple_data(nullptr), allocated(allocate) {
-    PL_ASSERT(tuple_schema);
+      : tuple_schema_(schema), tuple_data_(nullptr), allocated_(allocate) {
+    PL_ASSERT(tuple_schema_);
 
-    if (allocated) {
+    if (allocated_) {
       // initialize heap allocation
-      tuple_data = new char[tuple_schema->GetLength()]();
+      tuple_data_ = new char[tuple_schema_->GetLength()]();
     }
   }
 
@@ -87,7 +87,7 @@ class Tuple : public AbstractTuple {
    * backing store
    */
   inline void Move(void *address) {
-    tuple_data = reinterpret_cast<char *>(address);
+    tuple_data_ = reinterpret_cast<char *>(address);
   }
 
   bool operator==(const Tuple &other) const;
@@ -101,7 +101,7 @@ class Tuple : public AbstractTuple {
   // Getters and Setters
   //===--------------------------------------------------------------------===//
 
-  // This is used to access the internal array to read simple data types 
+  // This is used to access the internal array to read simple data types
   // such as integer type
   template <typename ColumnType>
   inline ColumnType GetInlinedDataOfType(oid_t column_id) const;
@@ -125,7 +125,7 @@ class Tuple : public AbstractTuple {
   // set value without data pool.
   void SetValue(oid_t column_id, const type::Value &value);
 
-  inline int GetLength() const { return tuple_schema->GetLength(); }
+  inline int GetLength() const { return tuple_schema_->GetLength(); }
 
   // Is the column value null ?
   inline bool IsNull(const uint64_t column_id) const {
@@ -134,20 +134,22 @@ class Tuple : public AbstractTuple {
   }
 
   // Is the tuple null ?
-  inline bool IsNull() const { return tuple_data == NULL; }
+  inline bool IsNull() const { return tuple_data_ == NULL; }
 
   // Get the type of a particular column in the tuple
   inline type::Type::TypeId GetType(int column_id) const {
-    return tuple_schema->GetType(column_id);
+    return tuple_schema_->GetType(column_id);
   }
 
-  inline const catalog::Schema *GetSchema() const { return tuple_schema; }
+  inline const catalog::Schema *GetSchema() const { return tuple_schema_; }
 
   // Get the address of this tuple in the table's backing store
-  inline char *GetData() const { return tuple_data; }
+  inline char *GetData() const { return tuple_data_; }
 
   // Return the number of columns in this tuple
-  inline oid_t GetColumnCount() const { return tuple_schema->GetColumnCount(); }
+  inline oid_t GetColumnCount() const {
+    return tuple_schema_->GetColumnCount();
+  }
 
   bool EqualsNoSchemaCheck(const Tuple &other) const;
 
@@ -157,7 +159,7 @@ class Tuple : public AbstractTuple {
   // this does set NULL in addition to clear string count.
   void SetAllNulls();
 
-  void SetNull() { tuple_data = NULL; }
+  void SetNull() { tuple_data_ = NULL; }
 
   // this does set 0 to all values. VarlenValue is set to "0"
   void SetAllZeros();
@@ -174,8 +176,7 @@ class Tuple : public AbstractTuple {
 
   // This sets the relevant columns from the source tuple
   void SetFromTuple(const AbstractTuple *tuple,
-                    const std::vector<oid_t> &columns,
-                    type::VarlenPool *pool);
+                    const std::vector<oid_t> &columns, type::VarlenPool *pool);
 
   // Used to wrap read only tuples in indexing code.
   void MoveToTuple(const void *address);
@@ -211,13 +212,13 @@ class Tuple : public AbstractTuple {
   //===--------------------------------------------------------------------===//
 
   // The types of the columns in the tuple
-  const catalog::Schema *tuple_schema;
+  const catalog::Schema *tuple_schema_;
 
   // The tuple data, padded at the front by the TUPLE_HEADER
-  char *tuple_data;
+  char *tuple_data_;
 
   // Allocated or not ?
-  bool allocated;
+  bool allocated_;
 };
 
 //===--------------------------------------------------------------------===//
@@ -230,21 +231,21 @@ class Tuple : public AbstractTuple {
  *
  * Please note this function simply translates column ID into offsets into
  * the data array. Non-inlined objects and objects that need special treatment
- * could not be copied like this, and they must use a Value object 
+ * could not be copied like this, and they must use a Value object
  *
  * NOTE: It assumes all fileds are inlined. This should be checked elsewhere
  */
 template <typename ColumnType>
 inline ColumnType Tuple::GetInlinedDataOfType(oid_t column_id) const {
   // The requested field must be inlined
-  PL_ASSERT(tuple_schema->IsInlined(column_id) == true);
+  PL_ASSERT(tuple_schema_->IsInlined(column_id) == true);
   PL_ASSERT(column_id < GetColumnCount());
-  
-  // Translates column ID into a pointer and converts it to the 
+
+  // Translates column ID into a pointer and converts it to the
   // requested type
-  const ColumnType *ptr = \
-    reinterpret_cast<const ColumnType *>(GetDataPtr(column_id));
-  
+  const ColumnType *ptr =
+      reinterpret_cast<const ColumnType *>(GetDataPtr(column_id));
+
   return *ptr;
 }
 
@@ -253,13 +254,14 @@ inline Tuple::Tuple(char *data, catalog::Schema *schema) {
   PL_ASSERT(data);
   PL_ASSERT(schema);
 
-  tuple_data = data;
-  tuple_schema = schema;
+  tuple_data_ = data;
+  tuple_schema_ = schema;
+  allocated_ = false;  // ???
 }
 
 inline Tuple &Tuple::operator=(const Tuple &rhs) {
-  tuple_schema = rhs.tuple_schema;
-  tuple_data = rhs.tuple_data;
+  tuple_schema_ = rhs.tuple_schema_;
+  tuple_data_ = rhs.tuple_data_;
   return *this;
 }
 

--- a/src/include/util/string_util.h
+++ b/src/include/util/string_util.h
@@ -13,8 +13,11 @@
 
 #pragma once
 
+#include <stdarg.h>
+#include <string.h>
 #include <algorithm>
 #include <iomanip>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -145,6 +148,32 @@ class StringUtil {
     std::transform(copy.begin(), copy.end(), copy.begin(),
                    [](unsigned char c) { return std::toupper(c); });
     return (copy);
+  }
+
+  /**
+   * Format a string using printf semantics
+   * http://stackoverflow.com/a/8098080
+   */
+  static std::string Format(const std::string fmt_str, ...) {
+    // Reserve two times as much as the length of the fmt_str
+    int final_n, n = ((int)fmt_str.size()) * 2;
+    std::string str;
+    std::unique_ptr<char[]> formatted;
+    va_list ap;
+
+    while (1) {
+      // Wrap the plain char array into the unique_ptr
+      formatted.reset(new char[n]);
+      strcpy(&formatted[0], fmt_str.c_str());
+      va_start(ap, fmt_str);
+      final_n = vsnprintf(&formatted[0], n, fmt_str.c_str(), ap);
+      va_end(ap);
+      if (final_n < 0 || final_n >= n)
+        n += abs(final_n - n + 1);
+      else
+        break;
+    }
+    return std::string(formatted.get());
   }
 };
 

--- a/src/index/btree_index.cpp
+++ b/src/index/btree_index.cpp
@@ -295,19 +295,19 @@ std::string BTREE_TEMPLATE_TYPE::GetTypeName() const { return "Btree"; }
 
 // IMPORTANT: Make sure you don't exceed INTSKEY_MAX_SLOTS
 
-template class BTreeIndex<CompactIntegerKey<1>, 
+template class BTreeIndex<CompactIntsKey<1>, 
                           ItemPointer *, 
                           CompactIntsComparator<1>,
                           CompactIntsEqualityChecker<1>>;
-template class BTreeIndex<CompactIntegerKey<2>, 
+template class BTreeIndex<CompactIntsKey<2>, 
                           ItemPointer *, 
                           CompactIntsComparator<2>,
                           CompactIntsEqualityChecker<2>>;
-template class BTreeIndex<CompactIntegerKey<3>, 
+template class BTreeIndex<CompactIntsKey<3>, 
                           ItemPointer *, 
                           CompactIntsComparator<3>,
                           CompactIntsEqualityChecker<3>>;
-template class BTreeIndex<CompactIntegerKey<4>, 
+template class BTreeIndex<CompactIntsKey<4>, 
                           ItemPointer *, 
                           CompactIntsComparator<4>,
                           CompactIntsEqualityChecker<4>>;

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -250,28 +250,28 @@ std::string BWTREE_INDEX_TYPE::GetTypeName() const { return "BWTree"; }
 
 // IMPORTANT: Make sure you don't exceed CompactIntegerKey_MAX_SLOTS
 
-template class BWTreeIndex<CompactIntegerKey<1>, 
+template class BWTreeIndex<CompactIntsKey<1>, 
                            ItemPointer *, 
                            CompactIntsComparator<1>,
                            CompactIntsEqualityChecker<1>, 
                            CompactIntsHasher<1>,
                            ItemPointerComparator, 
                            ItemPointerHashFunc>;
-template class BWTreeIndex<CompactIntegerKey<2>, 
+template class BWTreeIndex<CompactIntsKey<2>, 
                            ItemPointer *, 
                            CompactIntsComparator<2>,
                            CompactIntsEqualityChecker<2>, 
                            CompactIntsHasher<2>,
                            ItemPointerComparator, 
                            ItemPointerHashFunc>;
-template class BWTreeIndex<CompactIntegerKey<3>, 
+template class BWTreeIndex<CompactIntsKey<3>, 
                            ItemPointer *, 
                            CompactIntsComparator<3>,
                            CompactIntsEqualityChecker<3>, 
                            CompactIntsHasher<3>,
                            ItemPointerComparator, 
                            ItemPointerHashFunc>;
-template class BWTreeIndex<CompactIntegerKey<4>, 
+template class BWTreeIndex<CompactIntsKey<4>, 
                            ItemPointer *, 
                            CompactIntsComparator<4>,
                            CompactIntsEqualityChecker<4>, 

--- a/src/index/index_factory.cpp
+++ b/src/index/index_factory.cpp
@@ -100,33 +100,33 @@ Index *IndexFactory::GetBTreeIntsKeyIndex(IndexMetadata *metadata) {
 
   if (key_size <= sizeof(uint64_t)) {
 #ifdef LOG_TRACE_ENABLED
-    comparatorType = "CompactIntegerKey<1>";
+    comparatorType = "CompactIntsKey<1>";
 #endif
-    index = new BTreeIndex<CompactIntegerKey<1>, 
+    index = new BTreeIndex<CompactIntsKey<1>, 
                            ItemPointer *, 
                            CompactIntsComparator<1>,
                            CompactIntsEqualityChecker<1>>(metadata);
   } else if (key_size <= sizeof(uint64_t) * 2) {
 #ifdef LOG_TRACE_ENABLED
-    comparatorType = "CompactIntegerKey<2>";
+    comparatorType = "CompactIntsKey<2>";
 #endif
-    index = new BTreeIndex<CompactIntegerKey<2>, 
+    index = new BTreeIndex<CompactIntsKey<2>, 
                            ItemPointer *, 
                            CompactIntsComparator<2>,
                            CompactIntsEqualityChecker<2>>(metadata);
   } else if (key_size <= sizeof(uint64_t) * 3) {
 #ifdef LOG_TRACE_ENABLED
-    comparatorType = "CompactIntegerKey<3>";
+    comparatorType = "CompactIntsKey<3>";
 #endif
-    index = new BTreeIndex<CompactIntegerKey<3>, 
+    index = new BTreeIndex<CompactIntsKey<3>, 
                            ItemPointer *, 
                            CompactIntsComparator<3>,
                            CompactIntsEqualityChecker<3>>(metadata);
   } else if (key_size <= sizeof(uint64_t) * 4) {
 #ifdef LOG_TRACE_ENABLED
-    comparatorType = "CompactIntegerKey<4>";
+    comparatorType = "CompactIntsKey<4>";
 #endif
-    index = new BTreeIndex<CompactIntegerKey<4>, 
+    index = new BTreeIndex<CompactIntsKey<4>, 
                            ItemPointer *, 
                            CompactIntsComparator<4>,
                            CompactIntsEqualityChecker<4>>(metadata);
@@ -211,10 +211,10 @@ Index *IndexFactory::GetBwTreeIntsKeyIndex(IndexMetadata *metadata) {
 
   if (key_size <= sizeof(uint64_t)) {
 #ifdef LOG_TRACE_ENABLED
-    comparatorType = "CompactIntegerKey<1>";
+    comparatorType = "CompactIntsKey<1>";
 #endif
     index = \
-        new BWTreeIndex<CompactIntegerKey<1>, 
+        new BWTreeIndex<CompactIntsKey<1>, 
                         ItemPointer *, 
                         CompactIntsComparator<1>,
                         CompactIntsEqualityChecker<1>, 
@@ -223,10 +223,10 @@ Index *IndexFactory::GetBwTreeIntsKeyIndex(IndexMetadata *metadata) {
                         ItemPointerHashFunc>(metadata);
   } else if (key_size <= sizeof(uint64_t) * 2) {
 #ifdef LOG_TRACE_ENABLED
-    comparatorType = "CompactIntegerKey<2>";
+    comparatorType = "CompactIntsKey<2>";
 #endif
     index = \
-        new BWTreeIndex<CompactIntegerKey<2>, 
+        new BWTreeIndex<CompactIntsKey<2>, 
                         ItemPointer *, 
                         CompactIntsComparator<2>,
                         CompactIntsEqualityChecker<2>, 
@@ -235,10 +235,10 @@ Index *IndexFactory::GetBwTreeIntsKeyIndex(IndexMetadata *metadata) {
                         ItemPointerHashFunc>(metadata);
   } else if (key_size <= sizeof(uint64_t) * 3) {
 #ifdef LOG_TRACE_ENABLED
-    comparatorType = "CompactIntegerKey<3>";
+    comparatorType = "CompactIntsKey<3>";
 #endif
     index = \
-        new BWTreeIndex<CompactIntegerKey<3>, 
+        new BWTreeIndex<CompactIntsKey<3>, 
                         ItemPointer *, 
                         CompactIntsComparator<3>,
                         CompactIntsEqualityChecker<3>, 
@@ -247,10 +247,10 @@ Index *IndexFactory::GetBwTreeIntsKeyIndex(IndexMetadata *metadata) {
                         ItemPointerHashFunc>(metadata);
   } else if (key_size <= sizeof(uint64_t) * 4) {
 #ifdef LOG_TRACE_ENABLED
-    comparatorType = "CompactIntegerKey<4>";
+    comparatorType = "CompactIntsKey<4>";
 #endif
     index = \
-        new BWTreeIndex<CompactIntegerKey<4>, 
+        new BWTreeIndex<CompactIntsKey<4>, 
                         ItemPointer *, 
                         CompactIntsComparator<4>,
                         CompactIntsEqualityChecker<4>, 

--- a/src/storage/tile.cpp
+++ b/src/storage/tile.cpp
@@ -99,7 +99,7 @@ void Tile::InsertTuple(const oid_t tuple_offset, Tuple *tuple) {
   char *location = tuple_offset * tuple_length + data;
 
   // Copy over the tuple data into the tuple slot in the tile
-  PL_MEMCPY(location, tuple->tuple_data, tuple_length);
+  PL_MEMCPY(location, tuple->tuple_data_, tuple_length);
 }
 
 /**

--- a/src/storage/tile_group.cpp
+++ b/src/storage/tile_group.cpp
@@ -354,12 +354,6 @@ void TileGroup::CopyColumnValueTo(TileGroup *dest_tg, oid_t dest_tuple_id, oid_t
     dest_tg->GetTile(dest_tile_offset), dest_tuple_id, dest_tile_col_id, src_tuple_id, src_tile_col_id);
 }
 
-Tile *TileGroup::GetTile(const oid_t tile_offset) const {
-  PL_ASSERT(tile_offset < tile_count);
-  Tile *tile = tiles[tile_offset].get();
-  return tile;
-}
-
 std::shared_ptr<Tile> TileGroup::GetTileReference(
     const oid_t tile_offset) const {
   PL_ASSERT(tile_offset < tile_count);

--- a/src/storage/tile_group.cpp
+++ b/src/storage/tile_group.cpp
@@ -314,18 +314,6 @@ oid_t TileGroup::InsertTupleFromCheckpoint(oid_t tuple_slot_id,
   return tuple_slot_id;
 }
 
-// Sets the tile id and column id w.r.t that tile corresponding to
-// the specified tile group column id.
-void TileGroup::LocateTileAndColumn(oid_t column_offset, oid_t &tile_offset,
-                                    oid_t &tile_column_offset) {
-  PL_ASSERT(column_map.count(column_offset) != 0);
-
-  // get the entry in the column map
-  auto entry = column_map.at(column_offset);
-  tile_offset = entry.first;
-  tile_column_offset = entry.second;
-}
-
 oid_t TileGroup::GetTileIdFromColumnId(oid_t column_id) {
   oid_t tile_column_id, tile_offset;
   LocateTileAndColumn(column_id, tile_offset, tile_column_id);

--- a/test/index/index_intskey_test.cpp
+++ b/test/index/index_intskey_test.cpp
@@ -57,12 +57,6 @@ index::Index *BuildIndex(IndexType index_type, const bool unique_keys,
   tuple_schema = new catalog::Schema(column_list);
 
   // Build index metadata
-  //
-  // NOTE: Since here we use a relatively small key (size = 12)
-  // so index_test is only testing with a certain kind of key
-  // (most likely, GenericKey)
-  //
-  // For testing IntsKey and TupleKey we need more test cases
   index::IndexMetadata *index_metadata = new index::IndexMetadata(
       "MAGIC_TEST_INDEX", 125,  // Index oid
       INVALID_OID, INVALID_OID, index_type, INDEX_CONSTRAINT_TYPE_DEFAULT,
@@ -72,6 +66,9 @@ index::Index *BuildIndex(IndexType index_type, const bool unique_keys,
   // The type of index key has been chosen inside this function, but we are
   // unable to know the exact type of key it has chosen
   index::Index *index = index::IndexFactory::GetIndex(index_metadata);
+  
+  // TODO: I don't think there is an easy way to check what kind of key we got.
+  // It would be nice if we could check for an CompactIntsKey
 
   // Actually this will never be hit since if index creation fails an exception
   // would be raised (maybe out of memory would result in a nullptr? Anyway

--- a/test/index/index_intskey_test.cpp
+++ b/test/index/index_intskey_test.cpp
@@ -18,8 +18,6 @@
 #include "index/index_factory.h"
 #include "storage/tuple.h"
 
-#include <iostream>
-
 namespace peloton {
 namespace test {
 
@@ -132,7 +130,6 @@ void IndexIntsKeyTestHelper(IndexType index_type,
     keys.push_back(key);
     items.push_back(item);
   }  // FOR
-  // std::cout << "INDEX: " << index->GetInfo() << std::endl;
 
   // SCAN
   for (int i = 0; i < NUM_TUPLES; i++) {

--- a/test/util/string_util_test.cpp
+++ b/test/util/string_util_test.cpp
@@ -100,5 +100,40 @@ TEST_F(StringUtilTests, UpperTest) {
   EXPECT_EQ(expected, result);
 }
 
+TEST_F(StringUtilTests, FormatIntTest) {
+  int val = 10;
+
+  // <FORMAT, EXPECTED>
+  std::vector<std::pair<std::string, std::string>> data{
+      std::make_pair("%5d", "   10"),   std::make_pair("%-5d", "10   "),
+      std::make_pair("%05d", "00010"),  std::make_pair("%+5d", "  +10"),
+      std::make_pair("%-+5d", "+10  "),
+  };
+
+  for (std::pair<std::string, std::string> x : data) {
+    std::string result = StringUtil::Format(x.first, val);
+    EXPECT_EQ(x.second, result);
+  }
+}
+
+TEST_F(StringUtilTests, FormatFloatTest) {
+  float val = 10.3456;
+
+  // <FORMAT, EXPECTED>
+  std::vector<std::pair<std::string, std::string>> data{
+      std::make_pair("%.1f", "10.3"),
+      std::make_pair("%.2f", "10.35"),
+      std::make_pair("%8.2f", "   10.35"),
+      std::make_pair("%8.4f", " 10.3456"),
+      std::make_pair("%08.2f", "00010.35"),
+      std::make_pair("%-8.2f", "10.35   "),
+  };
+
+  for (std::pair<std::string, std::string> x : data) {
+    std::string result = StringUtil::Format(x.first, val);
+    EXPECT_EQ(x.second, result);
+  }
+}
+
 }  // End test namespace
 }  // End peloton namespace


### PR DESCRIPTION
Lots of random stuff in here.

+ New JDBC test that can cause a txn to abort due to conflict. We don't run this automatically. I just wanted to understand how our server-side errors cause exceptions.
+ Inlining two simple methods.
+ Expanded `IndexIntsKeyTest` to look at all combination of integer types
+ New `StringUtil::Format()` helper method that works just like printf.
+ Cleaned up @wangziqi2013's new `CompactIntsKey`
+ Cleaned up `Tuple`

I'm pushing out this PR in memory of @jessesleeping for always being [dangerous](https://youtu.be/pJk0p-98Xzc) with the 9022 bat.