### PR TITLE
FastGenericKeyComparator

### DIFF
--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -142,7 +142,7 @@ class Schema : public Printable {
   inline const std::vector<Column> &GetColumns() const { return columns; }
 
   // Return the number of columns in the schema for the tuple.
-  inline oid_t GetColumnCount() const { return column_count; }
+  inline size_t GetColumnCount() const { return column_count; }
 
   inline oid_t GetUninlinedColumnCount() const {
     return uninlined_column_count;

--- a/src/include/index/generic_key.h
+++ b/src/include/index/generic_key.h
@@ -105,12 +105,13 @@ class FastGenericComparator {
       const char *lhs_data = lhs.GetRawData(schema, col_itr);
       const char *rhs_data = rhs.GetRawData(schema, col_itr);
       type::Type type = schema->GetType(col_itr);
+      bool inlined = schema->IsInlined(col_itr);
 
-      if (type::TypeUtil::CompareLessThanRaw(type, lhs_data, rhs_data) ==
-          type::CMP_TRUE)
+      if (type::TypeUtil::CompareLessThanRaw(type, lhs_data, rhs_data,
+                                             inlined) == type::CMP_TRUE)
         return true;
-      else if (type::TypeUtil::CompareGreaterThanRaw(
-                   type, lhs_data, rhs_data) == type::CMP_TRUE)
+      else if (type::TypeUtil::CompareGreaterThanRaw(type, lhs_data, rhs_data,
+                                                     inlined) == type::CMP_TRUE)
         return false;
     }
 

--- a/src/include/type/type_util.h
+++ b/src/include/type/type_util.h
@@ -47,7 +47,7 @@ class TypeUtil {
    * <B>WARNING:</B> This is dangerous AF. Use at your own risk!!
    */
   static CmpBool CompareEqualsRaw(type::Type type, const char* left,
-                                  const char* right) {
+                                  const char* right, bool inlined) {
     CmpBool result = CmpBool::CMP_NULL;
     switch (type.GetTypeId()) {
       case Type::BOOLEAN:
@@ -96,9 +96,17 @@ class TypeUtil {
       }
       case Type::VARCHAR:
       case Type::VARBINARY: {
-        const char* leftPtr = *reinterpret_cast<const char* const*>(left);
+        const char* leftPtr = left;
+        const char* rightPtr = right;
+        if (inlined == false) {
+          leftPtr = *reinterpret_cast<const char* const*>(left);
+          rightPtr = *reinterpret_cast<const char* const*>(right);
+        }
+        if (leftPtr == nullptr || rightPtr == nullptr) {
+          result = CmpBool::CMP_FALSE;
+          break;
+        }
         uint32_t leftLen = *reinterpret_cast<const uint32_t*>(leftPtr);
-        const char* rightPtr = *reinterpret_cast<const char* const*>(right);
         uint32_t rightLen = *reinterpret_cast<const uint32_t*>(rightPtr);
         result = GetCmpBool(TypeUtil::CompareStrings(
                                 leftPtr + sizeof(uint32_t), leftLen,
@@ -118,7 +126,7 @@ class TypeUtil {
    * <B>WARNING:</B> This is dangerous AF. Use at your own risk!!
    */
   static CmpBool CompareLessThanRaw(const type::Type type, const char* left,
-                                    const char* right) {
+                                    const char* right, bool inlined) {
     CmpBool result = CmpBool::CMP_NULL;
     switch (type.GetTypeId()) {
       case Type::BOOLEAN:
@@ -167,9 +175,17 @@ class TypeUtil {
       }
       case Type::VARCHAR:
       case Type::VARBINARY: {
-        const char* leftPtr = *reinterpret_cast<const char* const*>(left);
+        const char* leftPtr = left;
+        const char* rightPtr = right;
+        if (inlined == false) {
+          leftPtr = *reinterpret_cast<const char* const*>(left);
+          rightPtr = *reinterpret_cast<const char* const*>(right);
+        }
+        if (leftPtr == nullptr || rightPtr == nullptr) {
+          result = CmpBool::CMP_FALSE;
+          break;
+        }
         uint32_t leftLen = *reinterpret_cast<const uint32_t*>(leftPtr);
-        const char* rightPtr = *reinterpret_cast<const char* const*>(right);
         uint32_t rightLen = *reinterpret_cast<const uint32_t*>(rightPtr);
         result = GetCmpBool(TypeUtil::CompareStrings(
                                 leftPtr + sizeof(uint32_t), leftLen,
@@ -189,7 +205,7 @@ class TypeUtil {
    * <B>WARNING:</B> This is dangerous AF. Use at your own risk!!
    */
   static CmpBool CompareGreaterThanRaw(const type::Type type, const char* left,
-                                       const char* right) {
+                                       const char* right, bool inlined) {
     CmpBool result = CmpBool::CMP_NULL;
     switch (type.GetTypeId()) {
       case Type::BOOLEAN:
@@ -238,9 +254,17 @@ class TypeUtil {
       }
       case Type::VARCHAR:
       case Type::VARBINARY: {
-        const char* leftPtr = *reinterpret_cast<const char* const*>(left);
+        const char* leftPtr = left;
+        const char* rightPtr = right;
+        if (inlined == false) {
+          leftPtr = *reinterpret_cast<const char* const*>(left);
+          rightPtr = *reinterpret_cast<const char* const*>(right);
+        }
+        if (leftPtr == nullptr || rightPtr == nullptr) {
+          result = CmpBool::CMP_FALSE;
+          break;
+        }
         uint32_t leftLen = *reinterpret_cast<const uint32_t*>(leftPtr);
-        const char* rightPtr = *reinterpret_cast<const char* const*>(right);
         uint32_t rightLen = *reinterpret_cast<const uint32_t*>(rightPtr);
         result = GetCmpBool(TypeUtil::CompareStrings(
                                 leftPtr + sizeof(uint32_t), leftLen,

--- a/src/index/btree_index.cpp
+++ b/src/index/btree_index.cpp
@@ -312,18 +312,18 @@ template class BTreeIndex<CompactIntsKey<4>,
                           CompactIntsComparator<4>,
                           CompactIntsEqualityChecker<4>>;
 
-template class BTreeIndex<GenericKey<4>, ItemPointer *, GenericComparator<4>,
+template class BTreeIndex<GenericKey<4>, ItemPointer *, FastGenericComparator<4>,
                           GenericEqualityChecker<4>>;
-template class BTreeIndex<GenericKey<8>, ItemPointer *, GenericComparator<8>,
+template class BTreeIndex<GenericKey<8>, ItemPointer *, FastGenericComparator<8>,
                           GenericEqualityChecker<8>>;
-template class BTreeIndex<GenericKey<16>, ItemPointer *, GenericComparator<16>,
+template class BTreeIndex<GenericKey<16>, ItemPointer *, FastGenericComparator<16>,
                           GenericEqualityChecker<16>>;
-template class BTreeIndex<GenericKey<32>, ItemPointer *, GenericComparator<32>,
+template class BTreeIndex<GenericKey<32>, ItemPointer *, FastGenericComparator<32>,
                           GenericEqualityChecker<32>>;
-template class BTreeIndex<GenericKey<64>, ItemPointer *, GenericComparator<64>,
+template class BTreeIndex<GenericKey<64>, ItemPointer *, FastGenericComparator<64>,
                           GenericEqualityChecker<64>>;
 template class BTreeIndex<GenericKey<256>, ItemPointer *,
-                          GenericComparator<256>, GenericEqualityChecker<256>>;
+                          FastGenericComparator<256>, GenericEqualityChecker<256>>;
 
 template class BTreeIndex<TupleKey, ItemPointer *, TupleKeyComparator,
                           TupleKeyEqualityChecker>;

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -249,23 +249,23 @@ template class BWTreeIndex<CompactIntsKey<4>, ItemPointer *,
 
 // Generic key
 template class BWTreeIndex<GenericKey<4>, ItemPointer *,
-                           GenericComparator<4>, GenericEqualityChecker<4>,
+                           FastGenericComparator<4>, GenericEqualityChecker<4>,
                            GenericHasher<4>, ItemPointerComparator,
                            ItemPointerHashFunc>;
 template class BWTreeIndex<GenericKey<8>, ItemPointer *,
-                           GenericComparator<8>, GenericEqualityChecker<8>,
+                           FastGenericComparator<8>, GenericEqualityChecker<8>,
                            GenericHasher<8>, ItemPointerComparator,
                            ItemPointerHashFunc>;
 template class BWTreeIndex<GenericKey<16>, ItemPointer *,
-                           GenericComparator<16>,
+                           FastGenericComparator<16>,
                            GenericEqualityChecker<16>, GenericHasher<16>,
                            ItemPointerComparator, ItemPointerHashFunc>;
 template class BWTreeIndex<GenericKey<64>, ItemPointer *,
-                           GenericComparator<64>,
+                           FastGenericComparator<64>,
                            GenericEqualityChecker<64>, GenericHasher<64>,
                            ItemPointerComparator, ItemPointerHashFunc>;
 template class BWTreeIndex<GenericKey<256>, ItemPointer *,
-                           GenericComparator<256>,
+                           FastGenericComparator<256>,
                            GenericEqualityChecker<256>, GenericHasher<256>,
                            ItemPointerComparator, ItemPointerHashFunc>;
 

--- a/src/index/index_factory.cpp
+++ b/src/index/index_factory.cpp
@@ -298,7 +298,7 @@ Index *IndexFactory::GetBwTreeGenericKeyIndex(IndexMetadata *metadata) {
     index =
         new BWTreeIndex<GenericKey<4>,
                         ItemPointer *,
-                        GenericComparator<4>,
+                        FastGenericComparator<4>,
                         GenericEqualityChecker<4>,
                         GenericHasher<4>,
                         ItemPointerComparator,
@@ -310,7 +310,7 @@ Index *IndexFactory::GetBwTreeGenericKeyIndex(IndexMetadata *metadata) {
     index =
         new BWTreeIndex<GenericKey<8>,
                         ItemPointer *,
-                        GenericComparator<8>,
+                        FastGenericComparator<8>,
                         GenericEqualityChecker<8>, 
                         GenericHasher<8>,
                         ItemPointerComparator, 
@@ -322,7 +322,7 @@ Index *IndexFactory::GetBwTreeGenericKeyIndex(IndexMetadata *metadata) {
     index =
         new BWTreeIndex<GenericKey<16>, 
                         ItemPointer *, 
-                        GenericComparator<16>,
+                        FastGenericComparator<16>,
                         GenericEqualityChecker<16>, 
                         GenericHasher<16>,
                         ItemPointerComparator, 
@@ -334,7 +334,7 @@ Index *IndexFactory::GetBwTreeGenericKeyIndex(IndexMetadata *metadata) {
     index =
         new BWTreeIndex<GenericKey<64>, 
                         ItemPointer *,
-                        GenericComparator<64>,
+                        FastGenericComparator<64>,
                         GenericEqualityChecker<64>,
                         GenericHasher<64>,
                         ItemPointerComparator,
@@ -346,7 +346,7 @@ Index *IndexFactory::GetBwTreeGenericKeyIndex(IndexMetadata *metadata) {
     index =
         new BWTreeIndex<GenericKey<256>,
                         ItemPointer *,
-                        GenericComparator<256>,
+                        FastGenericComparator<256>,
                         GenericEqualityChecker<256>, 
                         GenericHasher<256>,
                         ItemPointerComparator, 

--- a/src/index/index_factory.cpp
+++ b/src/index/index_factory.cpp
@@ -34,7 +34,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
 
   // Check whether the index key only has ints.
   // If so, then we can rock a specialized IntsKeyComparator
-  // that is faster than the GenericComparator
+  // that is faster than the FastGenericComparator
   bool ints_only = true;
   for (auto column : metadata->key_schema->GetColumns()) {
     auto col_type = column.GetType();
@@ -158,7 +158,7 @@ Index *IndexFactory::GetBTreeGenericKeyIndex(IndexMetadata *metadata) {
 #endif
     index = new BTreeIndex<GenericKey<4>,
                            ItemPointer *,
-                           GenericComparator<4>,
+                           FastGenericComparator<4>,
                            GenericEqualityChecker<4>>(metadata);
   } else if (key_size <= 8) {
 #ifdef LOG_TRACE_ENABLED
@@ -166,7 +166,7 @@ Index *IndexFactory::GetBTreeGenericKeyIndex(IndexMetadata *metadata) {
 #endif
     index = new BTreeIndex<GenericKey<8>,
                            ItemPointer *,
-                           GenericComparator<8>,
+                           FastGenericComparator<8>,
                            GenericEqualityChecker<8>>(metadata);
   } else if (key_size <= 16) {
 #ifdef LOG_TRACE_ENABLED
@@ -174,7 +174,7 @@ Index *IndexFactory::GetBTreeGenericKeyIndex(IndexMetadata *metadata) {
 #endif
     index = new BTreeIndex<GenericKey<16>,
                            ItemPointer *,
-                           GenericComparator<16>,
+                           FastGenericComparator<16>,
                            GenericEqualityChecker<16>>(metadata);
   } else if (key_size <= 64) {
 #ifdef LOG_TRACE_ENABLED
@@ -182,7 +182,7 @@ Index *IndexFactory::GetBTreeGenericKeyIndex(IndexMetadata *metadata) {
 #endif
     index = new BTreeIndex<GenericKey<64>,
                            ItemPointer *,
-                           GenericComparator<64>,
+                           FastGenericComparator<64>,
                            GenericEqualityChecker<64>>(metadata);
   } else if (key_size <= 256) {
 #ifdef LOG_TRACE_ENABLED
@@ -191,7 +191,7 @@ Index *IndexFactory::GetBTreeGenericKeyIndex(IndexMetadata *metadata) {
     index =
         new BTreeIndex<GenericKey<256>,
                        ItemPointer *,
-                       GenericComparator<256>,
+                       FastGenericComparator<256>,
                        GenericEqualityChecker<256>>(metadata);
   } else {
 #ifdef LOG_TRACE_ENABLED

--- a/test/index/index_intskey_test.cpp
+++ b/test/index/index_intskey_test.cpp
@@ -31,7 +31,9 @@ class IndexIntsKeyTests : public PelotonTest {};
 catalog::Schema *key_schema = nullptr;
 catalog::Schema *tuple_schema = nullptr;
 
-const int NUM_TUPLES = 100;
+// You can't set this too large because we will
+// have duplicates for the TINYINT keys
+const int NUM_TUPLES = 128;
 
 /*
  * BuildIndex()
@@ -101,10 +103,10 @@ void IndexIntsKeyTestHelper(IndexType index_type,
     std::shared_ptr<ItemPointer> item(new ItemPointer(i, i * i));
 
     for (int col_idx = 0; col_idx < (int)col_types.size(); col_idx++) {
-      int val = (1000 * col_idx) + i;
-      // key->SetValue(col_idx, type::ValueFactory::GetIntegerValue(val), pool);
+      int val = i;
       switch (col_types[col_idx]) {
         case type::Type::TINYINT: {
+          val = val % 128;
           key->SetValue(col_idx, type::ValueFactory::GetTinyIntValue(val),
                         pool);
           break;

--- a/test/index/index_test.cpp
+++ b/test/index/index_test.cpp
@@ -185,28 +185,9 @@ void InsertTest(index::Index *index, type::VarlenPool *pool,
     key3->SetValue(1, type::ValueFactory::GetVarcharValue("d"), pool);
     key4->SetValue(0, type::ValueFactory::GetIntegerValue(500 * scale_itr),
                    pool);
-    key4->SetValue(1, type::ValueFactory::GetVarcharValue(
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-                   pool);
+    key4->SetValue(
+        1, type::ValueFactory::GetVarcharValue(StringUtil::Repeat("e", 1000)),
+        pool);
     keynonce->SetValue(0, type::ValueFactory::GetIntegerValue(1000 * scale_itr),
                        pool);
     keynonce->SetValue(1, type::ValueFactory::GetVarcharValue("f"), pool);
@@ -261,28 +242,9 @@ void DeleteTest(index::Index *index, type::VarlenPool *pool,
     key3->SetValue(1, type::ValueFactory::GetVarcharValue("d"), pool);
     key4->SetValue(0, type::ValueFactory::GetIntegerValue(500 * scale_itr),
                    pool);
-    key4->SetValue(1, type::ValueFactory::GetVarcharValue(
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                          "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-                   pool);
+    key4->SetValue(
+        1, type::ValueFactory::GetVarcharValue(StringUtil::Repeat("e", 1000)),
+        pool);
 
     // DELETE
     // key0 1 (100, a)   item0
@@ -607,28 +569,9 @@ TEST_F(IndexTests, NonUniqueKeyMultiThreadedTest) {
   key2->SetValue(0, type::ValueFactory::GetIntegerValue(100), pool);
   key2->SetValue(1, type::ValueFactory::GetVarcharValue("c"), pool);
   key4->SetValue(0, type::ValueFactory::GetIntegerValue(500), pool);
-  key4->SetValue(1, type::ValueFactory::GetVarcharValue(
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                        "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
-                 pool);
+  key4->SetValue(
+      1, type::ValueFactory::GetVarcharValue(StringUtil::Repeat("e", 1000)),
+      pool);
 
   index->ScanKey(key0.get(), location_ptrs);
   EXPECT_EQ(0, location_ptrs.size());

--- a/test/performance/index_performance_test.cpp
+++ b/test/performance/index_performance_test.cpp
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "gtest/gtest.h"
 #include "common/harness.h"
+#include "gtest/gtest.h"
 
-#include <vector>
 #include <thread>
+#include <vector>
 
 #include "common/logger.h"
 #include "common/platform.h"
@@ -34,7 +34,6 @@ class IndexPerformanceTests : public PelotonTest {};
 catalog::Schema *key_schema = nullptr;
 catalog::Schema *tuple_schema = nullptr;
 
-
 std::shared_ptr<ItemPointer> item(new ItemPointer(120, 5));
 
 index::Index *BuildIndex(const bool unique_keys, const IndexType index_type) {
@@ -43,14 +42,18 @@ index::Index *BuildIndex(const bool unique_keys, const IndexType index_type) {
   std::vector<catalog::Column> columns;
   std::vector<catalog::Schema *> schemas;
 
-  catalog::Column column1(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
-                          "A", true);
-  catalog::Column column2(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
-                          "B", true);
-  catalog::Column column3(type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL),
-                          "C", true);
-  catalog::Column column4(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
-                          "D", true);
+  catalog::Column column1(type::Type::INTEGER,
+                          type::Type::GetTypeSize(type::Type::INTEGER), "A",
+                          true);
+  catalog::Column column2(type::Type::INTEGER,
+                          type::Type::GetTypeSize(type::Type::INTEGER), "B",
+                          true);
+  catalog::Column column3(type::Type::DECIMAL,
+                          type::Type::GetTypeSize(type::Type::DECIMAL), "C",
+                          true);
+  catalog::Column column4(type::Type::INTEGER,
+                          type::Type::GetTypeSize(type::Type::INTEGER), "D",
+                          true);
 
   columns.push_back(column1);
   columns.push_back(column2);
@@ -105,11 +108,11 @@ static void InsertTest1(index::Index *index, size_t num_thread, size_t num_key,
   std::unique_ptr<storage::Tuple> key(new storage::Tuple(key_schema, true));
 
   // Set the non-indexed column of the key to avoid undefined behaviour
-  //key->SetValue(2, type::ValueFactory::GetDoubleValue(1.11), nullptr);
-  //key->SetValue(3, type::ValueFactory::GetIntegerValue(12345), nullptr);
+  // key->SetValue(2, type::ValueFactory::GetDoubleValue(1.11), nullptr);
+  // key->SetValue(3, type::ValueFactory::GetIntegerValue(12345), nullptr);
 
-  for (size_t i = start_key;i < end_key;i++) {
-    auto key_value =  type::ValueFactory::GetIntegerValue(i);
+  for (size_t i = start_key; i < end_key; i++) {
+    auto key_value = type::ValueFactory::GetIntegerValue(i);
 
     key->SetValue(0, key_value, nullptr);
     key->SetValue(1, key_value, nullptr);
@@ -147,11 +150,11 @@ static void DeleteTest1(index::Index *index, size_t num_thread, size_t num_key,
   std::unique_ptr<storage::Tuple> key(new storage::Tuple(key_schema, true));
 
   // Set the non-indexed column of the key to avoid undefined behaviour
-  //key->SetValue(2, type::ValueFactory::GetDoubleValue(1.11), nullptr);
-  //key->SetValue(3, type::ValueFactory::GetIntegerValue(12345), nullptr);
+  // key->SetValue(2, type::ValueFactory::GetDoubleValue(1.11), nullptr);
+  // key->SetValue(3, type::ValueFactory::GetIntegerValue(12345), nullptr);
 
-  for (size_t i = start_key;i < end_key;i++) {
-    auto key_value =  type::ValueFactory::GetIntegerValue(i);
+  for (size_t i = start_key; i < end_key; i++) {
+    auto key_value = type::ValueFactory::GetIntegerValue(i);
 
     key->SetValue(0, key_value, nullptr);
     key->SetValue(1, key_value, nullptr);
@@ -186,12 +189,12 @@ static void InsertTest2(index::Index *index, size_t num_thread, size_t num_key,
   std::unique_ptr<storage::Tuple> key(new storage::Tuple(key_schema, true));
 
   // Set the non-indexed column of the key to avoid undefined behaviour
-  //key->SetValue(2, type::ValueFactory::GetDoubleValue(1.11), nullptr);
-  //key->SetValue(3, type::ValueFactory::GetIntegerValue(12345), nullptr);
+  // key->SetValue(2, type::ValueFactory::GetDoubleValue(1.11), nullptr);
+  // key->SetValue(3, type::ValueFactory::GetIntegerValue(12345), nullptr);
 
   size_t j = 0;
-  for (size_t i = thread_id;j < num_key;(i += num_thread), j++) {
-    auto key_value =  type::ValueFactory::GetIntegerValue(i);
+  for (size_t i = thread_id; j < num_key; (i += num_thread), j++) {
+    auto key_value = type::ValueFactory::GetIntegerValue(i);
 
     key->SetValue(0, key_value, nullptr);
     key->SetValue(1, key_value, nullptr);
@@ -226,12 +229,12 @@ static void DeleteTest2(index::Index *index, size_t num_thread, size_t num_key,
   std::unique_ptr<storage::Tuple> key(new storage::Tuple(key_schema, true));
 
   // Set the non-indexed column of the key to avoid undefined behaviour
-  //key->SetValue(2, type::ValueFactory::GetDoubleValue(1.11), nullptr);
-  //key->SetValue(3, type::ValueFactory::GetIntegerValue(12345), nullptr);
+  // key->SetValue(2, type::ValueFactory::GetDoubleValue(1.11), nullptr);
+  // key->SetValue(3, type::ValueFactory::GetIntegerValue(12345), nullptr);
 
   size_t j = 0;
-  for (size_t i = thread_id;j < num_key;(i += num_thread), j++) {
-    auto key_value =  type::ValueFactory::GetIntegerValue(i);
+  for (size_t i = thread_id; j < num_key; (i += num_thread), j++) {
+    auto key_value = type::ValueFactory::GetIntegerValue(i);
 
     key->SetValue(0, key_value, nullptr);
     key->SetValue(1, key_value, nullptr);
@@ -250,7 +253,6 @@ static void DeleteTest2(index::Index *index, size_t num_thread, size_t num_key,
  * key scan
  */
 static void TestIndexPerformance(const IndexType &index_type) {
-
   // This is where we read all values in and verify them
   std::vector<ItemPointer *> location_ptrs;
 
@@ -283,78 +285,75 @@ static void TestIndexPerformance(const IndexType &index_type) {
   }
 
   index->ScanAllKeys(location_ptrs);
-  EXPECT_EQ(location_ptrs.size(), num_thread * num_key);
+  EXPECT_EQ(num_thread * num_key, location_ptrs.size());
   location_ptrs.clear();
 
   timer.Stop();
-  LOG_INFO("Test = InsertTest1; Type = %d; Duration = %.2lf", (int)index_type,
-           timer.GetDuration());
+  LOG_INFO("InsertTest1 :: Type=%s; Duration=%.2lf",
+           IndexTypeToString(index_type).c_str(), timer.GetDuration());
 
   ///////////////////////////////////////////////////////////////////
   // Start DeleteTest1
   ///////////////////////////////////////////////////////////////////
 
-    timer.Start();
+  timer.Start();
 
-    LaunchParallelTest(num_thread, DeleteTest1, index.get(), num_thread,
-                       num_key);
+  LaunchParallelTest(num_thread, DeleteTest1, index.get(), num_thread, num_key);
 
-    // Perform garbage collection
-    if (index->NeedGC() == true) {
-      index->PerformGC();
-    }
+  // Perform garbage collection
+  if (index->NeedGC() == true) {
+    index->PerformGC();
+  }
 
-    index->ScanAllKeys(location_ptrs);
-    EXPECT_EQ(location_ptrs.size(), 0);
-    location_ptrs.clear();
+  index->ScanAllKeys(location_ptrs);
+  EXPECT_EQ(0, location_ptrs.size());
+  location_ptrs.clear();
 
-    timer.Stop();
-    LOG_INFO("Test = DeleteTest1; Type = %d; Duration = %.2lf", (int)index_type,
-             timer.GetDuration());
+  timer.Stop();
+  LOG_INFO("DeleteTest1 :: Type=%s; Duration=%.2lf",
+           IndexTypeToString(index_type).c_str(), timer.GetDuration());
 
   ///////////////////////////////////////////////////////////////////
   // Start InsertTest2
   ///////////////////////////////////////////////////////////////////
 
-    timer.Start();
+  timer.Start();
 
-    LaunchParallelTest(num_thread, InsertTest2, index.get(), num_thread,
-                       num_key);
+  LaunchParallelTest(num_thread, InsertTest2, index.get(), num_thread, num_key);
 
-    // Perform garbage collection
-    if (index->NeedGC() == true) {
-      index->PerformGC();
-    }
+  // Perform garbage collection
+  if (index->NeedGC() == true) {
+    index->PerformGC();
+  }
 
-    index->ScanAllKeys(location_ptrs);
-    EXPECT_EQ(location_ptrs.size(), num_thread * num_key);
-    location_ptrs.clear();
+  index->ScanAllKeys(location_ptrs);
+  EXPECT_EQ(num_thread * num_key, location_ptrs.size());
+  location_ptrs.clear();
 
-    timer.Stop();
-    LOG_INFO("Test = InsertTest2; Type = %d; Duration = %.2lf", (int)index_type,
-             timer.GetDuration());
+  timer.Stop();
+  LOG_INFO("InsertTest2 :: Type=%s; Duration=%.2lf",
+           IndexTypeToString(index_type).c_str(), timer.GetDuration());
 
   ///////////////////////////////////////////////////////////////////
   // Start DeleteTest2
   ///////////////////////////////////////////////////////////////////
 
-    timer.Start();
+  timer.Start();
 
-    LaunchParallelTest(num_thread, DeleteTest2, index.get(), num_thread,
-                       num_key);
+  LaunchParallelTest(num_thread, DeleteTest2, index.get(), num_thread, num_key);
 
-    // Perform garbage collection
-    if (index->NeedGC() == true) {
-      index->PerformGC();
-    }
+  // Perform garbage collection
+  if (index->NeedGC() == true) {
+    index->PerformGC();
+  }
 
-    index->ScanAllKeys(location_ptrs);
-    EXPECT_EQ(location_ptrs.size(), 0);
-    location_ptrs.clear();
+  index->ScanAllKeys(location_ptrs);
+  EXPECT_EQ(0, location_ptrs.size());
+  location_ptrs.clear();
 
-    timer.Stop();
-    LOG_INFO("Test = DeleteTest1; Type = %d; Duration = %.2lf", (int)index_type,
-             timer.GetDuration());
+  timer.Stop();
+  LOG_INFO("DeleteTest :: Type=%s; Duration=%.2lf",
+           IndexTypeToString(index_type).c_str(), timer.GetDuration());
 
   ///////////////////////////////////////////////////////////////////
   // End of all tests
@@ -366,22 +365,12 @@ static void TestIndexPerformance(const IndexType &index_type) {
 }
 
 TEST_F(IndexPerformanceTests, BwTreeMultiThreadedTest) {
-  std::vector<IndexType> index_types = {
-      INDEX_TYPE_BWTREE,
-  };
-  for (auto index_type : index_types) {
-    TestIndexPerformance(index_type);
-  }
+  TestIndexPerformance(INDEX_TYPE_BWTREE);
 }
 
 // TEST_F(IndexPerformanceTests, BTreeMultiThreadedTest) {
-//   std::vector<IndexType> index_types = {
-//       INDEX_TYPE_BTREE
-//   };
-//   for (auto index_type : index_types) {
-//     TestIndexPerformance(index_type);
-//   }
-// }
+//  TestIndexPerformance(INDEX_TYPE_BTREE);
+//}
 
 }  // End test namespace
 }  // End peloton namespace

--- a/test/performance/index_performance_test.cpp
+++ b/test/performance/index_performance_test.cpp
@@ -294,7 +294,6 @@ static void TestIndexPerformance(const IndexType &index_type) {
   // Start DeleteTest1
   ///////////////////////////////////////////////////////////////////
 
-  if (index_type != INDEX_TYPE_BWTREE) {
     timer.Start();
 
     LaunchParallelTest(num_thread, DeleteTest1, index.get(), num_thread,
@@ -312,18 +311,11 @@ static void TestIndexPerformance(const IndexType &index_type) {
     timer.Stop();
     LOG_INFO("Test = DeleteTest1; Type = %d; Duration = %.2lf", (int)index_type,
              timer.GetDuration());
-  } else {
-    LOG_INFO(
-        "INDEX_TYPE_BWTREE (type = %d) does not"
-        " support the following tests",
-        (int)index_type);
-  }
 
   ///////////////////////////////////////////////////////////////////
   // Start InsertTest2
   ///////////////////////////////////////////////////////////////////
 
-  if (index_type != INDEX_TYPE_BWTREE) {
     timer.Start();
 
     LaunchParallelTest(num_thread, InsertTest2, index.get(), num_thread,
@@ -341,18 +333,11 @@ static void TestIndexPerformance(const IndexType &index_type) {
     timer.Stop();
     LOG_INFO("Test = InsertTest2; Type = %d; Duration = %.2lf", (int)index_type,
              timer.GetDuration());
-  } else {
-    LOG_INFO(
-        "INDEX_TYPE_BWTREE (type = %d) does not"
-        " support the following tests",
-        (int)index_type);
-  }
 
   ///////////////////////////////////////////////////////////////////
   // Start DeleteTest2
   ///////////////////////////////////////////////////////////////////
 
-  if (index_type != INDEX_TYPE_BWTREE) {
     timer.Start();
 
     LaunchParallelTest(num_thread, DeleteTest2, index.get(), num_thread,
@@ -370,12 +355,6 @@ static void TestIndexPerformance(const IndexType &index_type) {
     timer.Stop();
     LOG_INFO("Test = DeleteTest1; Type = %d; Duration = %.2lf", (int)index_type,
              timer.GetDuration());
-  } else {
-    LOG_INFO(
-        "INDEX_TYPE_BWTREE (type = %d) does not"
-        " support the following tests",
-        (int)index_type);
-  }
 
   ///////////////////////////////////////////////////////////////////
   // End of all tests
@@ -386,14 +365,23 @@ static void TestIndexPerformance(const IndexType &index_type) {
   return;
 }
 
-TEST_F(IndexPerformanceTests, MultiThreadedTest) {
-  std::vector<IndexType> index_types = {INDEX_TYPE_BWTREE};
-
-  // Run the test suite for each types of index
+TEST_F(IndexPerformanceTests, BwTreeMultiThreadedTest) {
+  std::vector<IndexType> index_types = {
+      INDEX_TYPE_BWTREE,
+  };
   for (auto index_type : index_types) {
     TestIndexPerformance(index_type);
   }
 }
+
+// TEST_F(IndexPerformanceTests, BTreeMultiThreadedTest) {
+//   std::vector<IndexType> index_types = {
+//       INDEX_TYPE_BTREE
+//   };
+//   for (auto index_type : index_types) {
+//     TestIndexPerformance(index_type);
+//   }
+// }
 
 }  // End test namespace
 }  // End peloton namespace

--- a/test/type/type_util_test.cpp
+++ b/test/type/type_util_test.cpp
@@ -135,7 +135,8 @@ TEST_F(TypeUtilTests, CompareEqualsRawTest) {
       const char* val0 = tuples[0]->GetDataPtr(i);
       const char* val1 = tuples[tuple_idx]->GetDataPtr(i);
       auto type = schema->GetColumn(i).GetType();
-      bool result = type::TypeUtil::CompareEqualsRaw(type, val0, val1);
+      bool inlined = schema->IsInlined(i);
+      bool result = type::TypeUtil::CompareEqualsRaw(type, val0, val1, inlined);
 
       LOG_TRACE(
           "'%s'=='%s' => Expected:%s / Result:%s",
@@ -164,7 +165,9 @@ TEST_F(TypeUtilTests, CompareLessThanRawTest) {
       const char* val0 = tuples[0]->GetDataPtr(i);
       const char* val1 = tuples[tuple_idx]->GetDataPtr(i);
       auto type = schema->GetColumn(i).GetType();
-      bool result = type::TypeUtil::CompareLessThanRaw(type, val0, val1);
+      bool inlined = schema->IsInlined(i);
+      bool result =
+          type::TypeUtil::CompareLessThanRaw(type, val0, val1, inlined);
 
       auto fullVal0 = tuples[0]->GetValue(i);
       auto fullVal1 = tuples[tuple_idx]->GetValue(i);
@@ -191,7 +194,9 @@ TEST_F(TypeUtilTests, CompareGreaterThanRawTest) {
       const char* val0 = tuples[0]->GetDataPtr(i);
       const char* val1 = tuples[tuple_idx]->GetDataPtr(i);
       auto type = schema->GetColumn(i).GetType();
-      bool result = type::TypeUtil::CompareGreaterThanRaw(type, val0, val1);
+      bool inlined = schema->IsInlined(i);
+      bool result =
+          type::TypeUtil::CompareGreaterThanRaw(type, val0, val1, inlined);
 
       auto fullVal0 = tuples[0]->GetValue(i);
       auto fullVal1 = tuples[tuple_idx]->GetValue(i);

--- a/test/type/value_test.cpp
+++ b/test/type/value_test.cpp
@@ -37,8 +37,8 @@ TEST_F(ValueTests, HashTest) {
 
     // Special case for VARCHAR
     if (col_type == type::Type::VARCHAR) {
-      maxVal = type::ValueFactory::GetVarcharValue("XXX", nullptr);
-      minVal = type::ValueFactory::GetVarcharValue("YYY", nullptr);
+      maxVal = type::ValueFactory::GetVarcharValue(std::string("XXX"), nullptr);
+      minVal = type::ValueFactory::GetVarcharValue(std::string("YYY"), nullptr);
     }
     LOG_TRACE("%s => MAX:%s <-> MIN:%s", TypeIdToString(col_type).c_str(),
               maxVal.ToString().c_str(), minVal.ToString().c_str());

--- a/test/type/value_test.cpp
+++ b/test/type/value_test.cpp
@@ -25,6 +25,40 @@ namespace test {
 
 class ValueTests : public PelotonTest {};
 
+const std::vector<type::Type::TypeId> valueTestTypes = {
+    type::Type::BOOLEAN,   type::Type::TINYINT, type::Type::SMALLINT,
+    type::Type::INTEGER,   type::Type::BIGINT,  type::Type::DECIMAL,
+    type::Type::TIMESTAMP, type::Type::VARCHAR};
+
+TEST_F(ValueTests, HashTest) {
+  for (auto col_type : valueTestTypes) {
+    auto maxVal = type::Type::GetMaxValue(col_type);
+    auto minVal = type::Type::GetMinValue(col_type);
+
+    // Special case for VARCHAR
+    if (col_type == type::Type::VARCHAR) {
+      maxVal = type::ValueFactory::GetVarcharValue("XXX", nullptr);
+      minVal = type::ValueFactory::GetVarcharValue("YYY", nullptr);
+    }
+    LOG_TRACE("%s => MAX:%s <-> MIN:%s", TypeIdToString(col_type).c_str(),
+              maxVal.ToString().c_str(), minVal.ToString().c_str());
+
+    // They should not be equal
+    EXPECT_EQ(type::CmpBool::CMP_FALSE, maxVal.CompareEquals(minVal));
+
+    // Nor should their hash values be equal
+    auto maxHash = maxVal.Hash();
+    auto minHash = minVal.Hash();
+    EXPECT_NE(maxHash, minHash);
+
+    // But if I copy the first value then the hashes should be the same
+    auto copyVal = maxVal.Copy();
+    auto copyHash = copyVal.Hash();
+    EXPECT_EQ(type::CmpBool::CMP_TRUE, maxVal.CompareEquals(copyVal));
+    EXPECT_EQ(maxHash, copyHash);
+  }  // FOR
+}
+
 TEST_F(ValueTests, VarcharCopyTest) {
   std::string str = "hello hello world";
 


### PR DESCRIPTION
This PR is for the new `FastGenericKeyComparator`. This allows us to compare the values of `GenericKey` objects from their data pointers rather than having to create `Value` wrappers. This uses the new `TypeUtil::Compare*Raw()` methods from my previous PR (#446).