### PR TITLE
Fix the issue caused by stock index scan plan

### DIFF
--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -700,7 +700,8 @@ void IndexScanExecutor::UpdatePredicate(
   // Update index predicate
   LOG_TRACE("values_ size %lu", values_.size());
   for (unsigned int j = 0; j < values_.size(); ++j) {
-    LOG_TRACE("BEFORE values: %s", values_[j].GetInfo().c_str());
+    LOG_TRACE("BEFORE, key and value: %d:%s", key_column_ids_[j],
+              values_[j].GetInfo().c_str());
   }
 
   std::vector<oid_t> key_column_ids;
@@ -709,6 +710,9 @@ void IndexScanExecutor::UpdatePredicate(
   // Get the real physical ids
   for (auto column_id : column_ids) {
     key_column_ids.push_back(column_ids_[column_id]);
+
+    LOG_TRACE("Output id is %d---physical column id is %d", column_id,
+              column_ids_[column_id]);
   }
 
   // Update values in index plan node
@@ -720,8 +724,10 @@ void IndexScanExecutor::UpdatePredicate(
     unsigned int current_idx = 0;
     for (; current_idx < values_.size(); current_idx++) {
       if (key_column_ids[new_idx] == key_column_ids_[current_idx]) {
-        LOG_TRACE("Orignial is %s", values_[current_idx].GetInfo().c_str());
-        LOG_TRACE("Changed to %s", values[new_idx].GetInfo().c_str());
+        LOG_TRACE("Orignial is %d:%s", key_column_ids[new_idx],
+                  values_[current_idx].GetInfo().c_str());
+        LOG_TRACE("Changed to %d:%s", key_column_ids[new_idx],
+                  values[new_idx].GetInfo().c_str());
         values_[current_idx] = values[new_idx];
 
         // There should not be two same columns. So when we find a column, we
@@ -731,9 +737,15 @@ void IndexScanExecutor::UpdatePredicate(
     }
 
     // If new value doesn't exist in current value list, add it.
+    // For the current simple optimizer, since all the key column ids must be
+    // initiated when creating index_scan_plan, we don't need to examine whether
+    // the passing column and value exist or not (they definitely exist). But
+    // for the future optimizer, we probably change the logic. So we still keep
+    // the examine code here.
     if (current_idx == values_.size()) {
       LOG_TRACE("Add new column for index predicate:%u-%s",
                 key_column_ids[new_idx], values[new_idx].GetInfo().c_str());
+
       // Add value
       values_.push_back(values[new_idx]);
 
@@ -743,17 +755,19 @@ void IndexScanExecutor::UpdatePredicate(
       // Add column type.
       // TODO: We should add other types in the future
       expr_types_.push_back(ExpressionType::EXPRESSION_TYPE_COMPARE_EQUAL);
+
+      LOG_TRACE("Now index predicate is :");
+
+      for (unsigned int j = 0; j < values_.size(); ++j) {
+        LOG_TRACE("AFTER values: %u-%s", key_column_ids_[j],
+                  values_[j].GetInfo().c_str());
+      }
     }
   }
 
   // Update the new value
   index_predicate_.GetConjunctionListToSetup()[0]
       .SetTupleColumnValue(index_.get(), key_column_ids, values);
-
-  LOG_TRACE("values_ size %lu", values_.size());
-  for (unsigned int j = 0; j < values_.size(); ++j) {
-    LOG_TRACE("AFTER values: %s", values_[j].GetInfo().c_str());
-  }
 }
 
 void IndexScanExecutor::ResetState() {

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -699,10 +699,6 @@ void IndexScanExecutor::UpdatePredicate(
 
   // Update index predicate
   LOG_TRACE("values_ size %lu", values_.size());
-  for (unsigned int j = 0; j < values_.size(); ++j) {
-    LOG_TRACE("BEFORE, key and value: %d:%s", key_column_ids_[j],
-              values_[j].GetInfo().c_str());
-  }
 
   std::vector<oid_t> key_column_ids;
 
@@ -755,13 +751,6 @@ void IndexScanExecutor::UpdatePredicate(
       // Add column type.
       // TODO: We should add other types in the future
       expr_types_.push_back(ExpressionType::EXPRESSION_TYPE_COMPARE_EQUAL);
-
-      LOG_TRACE("Now index predicate is :");
-
-      for (unsigned int j = 0; j < values_.size(); ++j) {
-        LOG_TRACE("AFTER values: %u-%s", key_column_ids_[j],
-                  values_[j].GetInfo().c_str());
-      }
     }
   }
 

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -137,6 +137,7 @@ void BWTREE_INDEX_TYPE::Scan(
             csp_p->IsFullIndexScan());
 
   if (csp_p->IsPointQuery() == true) {
+    LOG_TRACE("This is point query");
     // For point query we construct the key and use equal_range
 
     const storage::Tuple *point_query_key_p = csp_p->GetPointQueryKey();
@@ -177,7 +178,7 @@ void BWTREE_INDEX_TYPE::Scan(
     // or we have seen a key higher than the high key
     for (auto scan_itr = container.Begin(index_low_key);
          (scan_itr.IsEnd() == false) &&
-         (container.KeyCmpLessEqual(scan_itr->first, index_high_key));
+             (container.KeyCmpLessEqual(scan_itr->first, index_high_key));
          scan_itr++) {
       result.push_back(scan_itr->second);
     }

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -980,15 +980,12 @@ SimpleOptimizer::CreateHackingNestedLoopJoinPlan(
   auto predicate12 = new expression::ComparisonExpression(
       EXPRESSION_TYPE_COMPARE_LESSTHAN, s_quantity, params[5]);
 
-  predicate_column_ids = {0, 1};  // S_W_ID
+  predicate_column_ids = {0, 1};  // S_W_ID, S_I_ID
   predicate_expr_types = {EXPRESSION_TYPE_COMPARE_EQUAL,
                           EXPRESSION_TYPE_COMPARE_EQUAL};
 
-  // Hardcode wid=0 and iid=90
-  //  predicate_values = {type::ValueFactory::GetIntegerValue(0).Copy(),
-  //                      type::ValueFactory::GetIntegerValue(90).Copy()};
-
-  // s_w_id the 5th parameter. add s_i_id later
+  // s_w_id the 5th parameter.
+  // s_i_id is a fake value, which will be updated when invoke index_update
   predicate_values = {type::ValueFactory::GetParameterOffsetValue(4).Copy(),
                       type::ValueFactory::GetIntegerValue(0).Copy()};
 

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -980,16 +980,19 @@ SimpleOptimizer::CreateHackingNestedLoopJoinPlan(
   auto predicate12 = new expression::ComparisonExpression(
       EXPRESSION_TYPE_COMPARE_LESSTHAN, s_quantity, params[5]);
 
-  predicate_column_ids = {0};  // S_W_ID
-  predicate_expr_types = {EXPRESSION_TYPE_COMPARE_EQUAL};
+  predicate_column_ids = {0, 1};  // S_W_ID
+  predicate_expr_types = {EXPRESSION_TYPE_COMPARE_EQUAL,
+                          EXPRESSION_TYPE_COMPARE_EQUAL};
 
   // Hardcode wid=0 and iid=90
   //  predicate_values = {type::ValueFactory::GetIntegerValue(0).Copy(),
   //                      type::ValueFactory::GetIntegerValue(90).Copy()};
 
   // s_w_id the 5th parameter. add s_i_id later
-  predicate_values = {type::ValueFactory::GetParameterOffsetValue(4).Copy()};
+  predicate_values = {type::ValueFactory::GetParameterOffsetValue(4).Copy(),
+                      type::ValueFactory::GetIntegerValue(0).Copy()};
 
+  // output of stock
   column_ids = {1};  // S_I_ID
 
   auto index_stock = stock_table->GetIndex(0);  // primary_index


### PR DESCRIPTION
All the key column ids for the index should be initiated even though the corresponding values are fake. The future optimizer should also be careful about this. 