### PR TITLE
GC problem quick hacking

### DIFF
--- a/src/include/concurrency/epoch_manager.h
+++ b/src/include/concurrency/epoch_manager.h
@@ -139,6 +139,11 @@ public:
   cid_t GetMaxDeadTxnCid() {
     IncreaseQueueTail();
     IncreaseReclaimTail();
+
+    if (current_epoch_ - queue_tail_ > 10) {
+      size_t epoch_idx = queue_tail_ % epoch_queue_size_;
+      epoch_queue_[epoch_idx].rw_txn_ref_count_ = 0;
+    }
     return max_cid_gc_;
   }
 

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -888,7 +888,7 @@ static const cid_t START_CID = 2;
 static const cid_t MAX_CID = std::numeric_limits<cid_t>::max();
 
 // For epoch
-static const size_t EPOCH_LENGTH = 10;
+static const size_t EPOCH_LENGTH = 40;
 
 // For threads
 extern size_t QUERY_THREAD_COUNT;


### PR DESCRIPTION
This PR provides a fast fix for the GC problem in the current version of Peloton. In some cases, the current version of Peloton cannot guarantee that the number of started transactions equals to the number of ended transactions. That is, there exists certain transactions that never terminate. This causes the GC to suspend because the GC reclaims expired versions only if all the transactions in an expired epoch have been committed. The current fix is to timeout those outstanding transactions. 

Please note that a better solution must be made to fully address this problem.