### PR TITLE
Server-side PreparedStatement Invalidation

### DIFF
--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -207,25 +207,25 @@ bool SampleFrequencyMapEntryComparator(sample_frequency_map_entry a,
 std::vector<sample_frequency_map_entry> GetFrequentSamples(
     const std::vector<brain::Sample>& samples) {
   std::unordered_map<brain::Sample, double> sample_frequency_map;
-  double total_metric = 0;
+  double total_weight = 0;
 
   // Go over all samples
   for (auto sample : samples) {
     if (sample.GetSampleType() == SAMPLE_TYPE_ACCESS) {
       // Update sample count
-      sample_frequency_map[sample] += sample.GetMetric();
-      total_metric += sample.GetMetric();
+      sample_frequency_map[sample] += sample.GetWeight();
+      total_weight += sample.GetWeight();
     } else if (sample.GetSampleType() == SAMPLE_TYPE_UPDATE) {
       // Update sample count
-      sample_frequency_map[sample] += sample.GetMetric();
-      total_metric += sample.GetMetric();
+      sample_frequency_map[sample] += sample.GetWeight();
+      total_weight += sample.GetWeight();
     } else {
       throw Exception("Unknown sample type : " +
                       std::to_string(sample.GetSampleType()));
     }
   }
 
-  PL_ASSERT(total_metric > 0);
+  PL_ASSERT(total_weight > 0);
 
   // Normalize
   std::unordered_map<brain::Sample, double>::iterator sample_frequency_map_itr;
@@ -234,7 +234,7 @@ std::vector<sample_frequency_map_entry> GetFrequentSamples(
        sample_frequency_map_itr != sample_frequency_map.end();
        ++sample_frequency_map_itr) {
     // Normalize sample's utility
-    sample_frequency_map_itr->second /= total_metric;
+    sample_frequency_map_itr->second /= total_weight;
   }
 
   std::vector<sample_frequency_map_entry> sample_frequency_entry_list;

--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -382,10 +382,10 @@ void IndexTuner::AddIndexes(
       auto index = table->GetIndex(index_itr);
       auto index_metadata = index->GetMetadata();
 
-      auto index_is_visible = index_metadata->IsVisible();
+      auto index_is_visible = index_metadata->GetVisibility();
       if(index_is_visible == false){
         LOG_INFO("Enabling index : %s", index_metadata->GetName().c_str());
-        index_metadata->SetVisible(true);
+        index_metadata->SetVisibility(true);
       }
 
     }

--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -16,6 +16,7 @@
 
 #include "brain/clusterer.h"
 #include "catalog/schema.h"
+#include "catalog/catalog.h"
 #include "common/container_tuple.h"
 #include "common/logger.h"
 #include "common/macros.h"
@@ -59,6 +60,7 @@ void IndexTuner::Start() {
 // Add an ad-hoc index
 static void AddIndex(storage::DataTable* table,
                      std::set<oid_t> suggested_index_attrs) {
+
   // Construct index metadata
   std::vector<oid_t> key_attrs(suggested_index_attrs.size());
   std::copy(suggested_index_attrs.begin(), suggested_index_attrs.end(),
@@ -153,7 +155,7 @@ void IndexTuner::BuildIndices(storage::DataTable* table) {
     }
 
     // Build index
-    BuildIndex(table, index);
+    //BuildIndex(table, index);
   }
 }
 
@@ -365,14 +367,27 @@ void IndexTuner::AddIndexes(
     }
 
     // Did we find suggested index ?
-    if (suggested_index_found == false) {
+    if (visibility_mode_ == false && suggested_index_found == false) {
       LOG_TRACE("Did not find suggested index.");
 
       // Add adhoc index with given utility
       AddIndex(table, suggested_index_set);
       constructed_index_itr++;
-    } else {
+    }
+    // Found suggested index, enable it
+    else if(suggested_index_found == true) {
       LOG_TRACE("Found suggested index.");
+
+      // Make it visible if it already isn't
+      auto index = table->GetIndex(index_itr);
+      auto index_metadata = index->GetMetadata();
+
+      auto index_is_visible = index_metadata->IsVisible();
+      if(index_is_visible == false){
+        LOG_INFO("Enabling index : %s", index_metadata->GetName().c_str());
+        index_metadata->SetVisible(true);
+      }
+
     }
   }
 }
@@ -468,15 +483,19 @@ void IndexTuner::Analyze(storage::DataTable* table) {
   auto write_intensive_workload = (average_write_ratio > write_ratio_threshold);
 
   // Skip drop table time
-  if (index_overflow == true || write_intensive_workload == true) {
-    DropIndexes(table);
+  if (visibility_mode_ == false) {
+    if(index_overflow == true || write_intensive_workload == true) {
+      DropIndexes(table);
+    }
   }
 
   // Add indexes if needed
   AddIndexes(table, suggested_indices);
 
   // Update index utility
-  UpdateIndexUtility(table, sample_frequency_entry_list);
+  if (visibility_mode_ == false) {
+    UpdateIndexUtility(table, sample_frequency_entry_list);
+  }
 
   // Display index information
   PrintIndexInformation(table);
@@ -563,6 +582,59 @@ void IndexTuner::ClearTables() {
     std::lock_guard<std::mutex> lock(index_tuner_mutex);
     tables.clear();
   }
+}
+
+void IndexTuner::BootstrapTPCC() {
+
+  // Enable visibility mode
+  SetVisibilityMode();
+
+
+  // Build sample map
+  std::string database_name = "TPCC";
+  std::map<std::string, std::vector<std::vector<double>>> tables_samples;
+
+  tables_samples["CUSTOMER"].push_back({0, 1, 2});
+  tables_samples["CUSTOMER"].push_back({0, 1, 5, 6});
+  tables_samples["DISTRICT"].push_back({0, 1});
+  tables_samples["ITEM"].push_back({0});
+  tables_samples["NEW_ORDER"].push_back({0, 1, 2});
+  tables_samples["ORDERS"].push_back({0, 1, 2});
+  tables_samples["ORDERS"].push_back({0, 1, 2, 3});
+  tables_samples["STOCK"].push_back({0, 1});
+  tables_samples["WAREHOUSE"].push_back({0});
+
+  auto catalog = catalog::Catalog::GetInstance();
+  double sample_weight = 100;
+
+  // Go over set of tables, and add samples
+  for(auto table_samples : tables_samples){
+
+    // Get table name
+    auto table_name = table_samples.first;
+    auto samples = table_samples.second;
+
+    // Locate table in catalog
+    auto table = catalog->GetTableWithName(database_name, table_name);
+    PL_ASSERT(table != nullptr);
+
+    for(auto sample_columns : samples){
+
+      // Construct sample
+      brain::Sample sample(sample_columns,
+                           sample_weight,
+                           brain::SAMPLE_TYPE_ACCESS);
+
+      table->RecordIndexSample(sample);
+    }
+
+    LOG_INFO("Added table to index tuner : %s", table_name.c_str());
+
+    // Attach table to tuner
+    AddTable(table);
+
+  }
+
 }
 
 }  // End brain namespace

--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -541,10 +541,14 @@ void IndexTuner::Tune() {
 
   // Continue till signal is not false
   while (index_tuning_stop == false) {
-    // Go over all tables
+
+    // Go over one table at a time
     for (auto table : tables) {
       // Update indices periodically
       IndexTuneHelper(table);
+
+      LOG_INFO("TUNER PAUSE");
+      std::this_thread::sleep_for(std::chrono::milliseconds(duration_of_pause));
     }
 
     pause_timer.Stop();
@@ -552,7 +556,6 @@ void IndexTuner::Tune() {
 
     // Sleep a bit if needed
     if (duration > duration_between_pauses) {
-      LOG_DEBUG("TUNER PAUSE : %.0lf", duration);
       std::this_thread::sleep_for(std::chrono::milliseconds(duration_of_pause));
       pause_timer.Reset();
       pause_timer.Start();
@@ -588,7 +591,6 @@ void IndexTuner::BootstrapTPCC() {
 
   // Enable visibility mode
   SetVisibilityMode();
-
 
   // Build sample map
   std::string database_name = "TPCC";

--- a/src/brain/layout_tuner.cpp
+++ b/src/brain/layout_tuner.cpp
@@ -37,6 +37,8 @@ void LayoutTuner::Start() {
 
   // Launch thread
   layout_tuner_thread = std::thread(&brain::LayoutTuner::Tune, this);
+
+  LOG_INFO("Started layout tuner");
 }
 
 /**
@@ -172,6 +174,8 @@ void LayoutTuner::Stop() {
 
   // Stop thread
   layout_tuner_thread.join();
+
+  LOG_INFO("Stopped layout tuner");
 }
 
 void LayoutTuner::AddTable(storage::DataTable* table) {

--- a/src/brain/layout_tuner.cpp
+++ b/src/brain/layout_tuner.cpp
@@ -75,6 +75,37 @@ std::string LayoutTuner::GetColumnMapInfo(const column_map_type& column_map) {
   return ss.str();
 }
 
+Sample GetClustererSample(const Sample& sample, oid_t column_count) {
+
+  // Copy over the sample
+  Sample clusterer_sample = sample;
+
+  // Figure out columns accessed, and construct a bitmap
+  auto& columns_accessed = sample.GetColumnsAccessed();
+  std::vector<double> columns_accessed_bitmap;
+
+  for(oid_t column_itr = 0;
+      column_itr < column_count;
+      column_itr++){
+
+    // Append column into sample
+    auto column_found = std::find(columns_accessed.begin(),
+                                  columns_accessed.end(),
+                                  column_itr) != columns_accessed.end();
+
+    if(column_found == true) {
+      columns_accessed_bitmap.push_back(1);
+    } else {
+      columns_accessed_bitmap.push_back(0);
+    }
+  }
+
+  PL_ASSERT(columns_accessed_bitmap.size() == column_count);
+  clusterer_sample.SetColumnsAccessed(columns_accessed_bitmap);
+
+  return clusterer_sample;
+}
+
 void LayoutTuner::UpdateDefaultPartition(storage::DataTable* table) {
   oid_t column_count = table->GetSchema()->GetColumnCount();
 
@@ -93,7 +124,12 @@ void LayoutTuner::UpdateDefaultPartition(storage::DataTable* table) {
     if (sample.GetColumnsAccessed().size() == 0) {
       continue;
     }
-    clusterer.ProcessSample(sample);
+
+    // Transform the regular sample to a bitmap sample for clusterer
+    // {0, 3} => { 1, 0, 0, 1}
+    auto clusterer_sample = GetClustererSample(sample, column_count);
+
+    clusterer.ProcessSample(clusterer_sample);
   }
 
   // Clear all samples in table

--- a/src/brain/sample.cpp
+++ b/src/brain/sample.cpp
@@ -93,7 +93,7 @@ const std::string Sample::GetInfo() const {
 
   for (auto column_value : columns_accessed_) os << column_value << " ";
 
-  os << "  ::  " << std::round(metric_);
+  os << "  ::  " << std::round(weight_);
 
   return os.str();
 }
@@ -102,7 +102,7 @@ const std::string Sample::ToString() const {
   std::ostringstream os;
   // This needs to match expected format in BrainUtil::LoadSamplesFile
   // except for the <NAME>
-  os << weight_ << " " << metric_ << " " << columns_accessed_.size() << " ";
+  os << weight_ << " " << columns_accessed_.size() << " ";
   bool first = true;
   for (auto column_value : columns_accessed_) {
     if (first == false) {
@@ -116,7 +116,6 @@ const std::string Sample::ToString() const {
 
 bool Sample::operator==(const Sample &other) const {
   if (this->weight_ != other.weight_) return false;
-  if (this->metric_ != other.metric_) return false;
   if (this->sample_type_ != other.sample_type_) return false;
 
   auto sample_size = columns_accessed_.size();

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -107,6 +107,15 @@ void Catalog::AddDatabase(storage::Database *database) {
   InsertDatabaseIntoCatalogDatabase(database->GetOid(), database_name, nullptr);
 }
 
+void Catalog::AddDatabase(std::string database_name,
+                          storage::Database *database){
+  database->setDBName(database_name);
+  databases_.push_back(database);
+  LOG_DEBUG("Added database with name: %s", database_name.c_str());
+  InsertDatabaseIntoCatalogDatabase(database->GetOid(), database_name, nullptr);
+}
+
+
 void Catalog::InsertDatabaseIntoCatalogDatabase(oid_t database_id,
     std::string &database_name, concurrency::Transaction *txn) {
   // Update catalog_db with this database info

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -20,6 +20,7 @@
 #include "gc/gc_manager_factory.h"
 #include "storage/data_table.h"
 #include "brain/index_tuner.h"
+#include "brain/layout_tuner.h"
 
 #include <google/protobuf/stubs/common.h>
 
@@ -51,13 +52,14 @@ void PelotonInit::Initialize() {
 
   // start index tuner
   if(FLAGS_index_tuner == true){
-    // Index tuner
     auto& index_tuner = brain::IndexTuner::GetInstance();
-
-    // Start index tuner
     index_tuner.Start();
+  }
 
-    // TODO: Add tables, collect samples, and use constructed indexes
+  // start layout tuner
+  if(FLAGS_layout_tuner == true){
+    auto& layout_tuner = brain::LayoutTuner::GetInstance();
+    layout_tuner.Start();
   }
 
   // initialize the catalog and add the default database, so we don't do this on
@@ -70,9 +72,13 @@ void PelotonInit::Shutdown() {
   // shut down index tuner
   if(FLAGS_index_tuner == true){
     auto& index_tuner = brain::IndexTuner::GetInstance();
-
-    // Stop index tuner
     index_tuner.Stop();
+  }
+
+  // shut down layout tuner
+  if(FLAGS_layout_tuner == true){
+    auto& layout_tuner = brain::LayoutTuner::GetInstance();
+    layout_tuner.Stop();
   }
 
   // shut down GC.

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -16,11 +16,11 @@
 
 #include "configuration/configuration.h"
 
+#include "brain/index_tuner.h"
+#include "brain/layout_tuner.h"
 #include "concurrency/epoch_manager_factory.h"
 #include "gc/gc_manager_factory.h"
 #include "storage/data_table.h"
-#include "brain/index_tuner.h"
-#include "brain/layout_tuner.h"
 
 #include <google/protobuf/stubs/common.h>
 
@@ -31,7 +31,6 @@ namespace peloton {
 ThreadPool thread_pool;
 
 void PelotonInit::Initialize() {
-
   QUERY_THREAD_COUNT = std::thread::hardware_concurrency();
   LOGGING_THREAD_COUNT = 1;
   GC_THREAD_COUNT = 1;
@@ -51,13 +50,15 @@ void PelotonInit::Initialize() {
   gc::GCManagerFactory::GetInstance().StartGC();
 
   // start index tuner
-  if(FLAGS_index_tuner == true){
+  if (FLAGS_index_tuner == true) {
+    // Set the default visibility flag for all indexes to false
+    index::IndexMetadata::SetDefaultVisibleFlag(false);
     auto& index_tuner = brain::IndexTuner::GetInstance();
     index_tuner.Start();
   }
 
   // start layout tuner
-  if(FLAGS_layout_tuner == true){
+  if (FLAGS_layout_tuner == true) {
     auto& layout_tuner = brain::LayoutTuner::GetInstance();
     layout_tuner.Start();
   }
@@ -68,15 +69,14 @@ void PelotonInit::Initialize() {
 }
 
 void PelotonInit::Shutdown() {
-
   // shut down index tuner
-  if(FLAGS_index_tuner == true){
+  if (FLAGS_index_tuner == true) {
     auto& index_tuner = brain::IndexTuner::GetInstance();
     index_tuner.Stop();
   }
 
   // shut down layout tuner
-  if(FLAGS_layout_tuner == true){
+  if (FLAGS_layout_tuner == true) {
     auto& layout_tuner = brain::LayoutTuner::GetInstance();
     layout_tuner.Stop();
   }
@@ -96,12 +96,8 @@ void PelotonInit::Shutdown() {
   ::google::ShutDownCommandLineFlags();
 }
 
-void PelotonInit::SetUpThread() {
+void PelotonInit::SetUpThread() {}
 
-}
-
-void PelotonInit::TearDownThread() {
-
-}
+void PelotonInit::TearDownThread() {}
 
 }  // End peloton namespace

--- a/src/common/statement.cpp
+++ b/src/common/statement.cpp
@@ -78,7 +78,13 @@ const std::shared_ptr<planner::AbstractPlan>& Statement::GetPlanTree() const {
 
 const std::string Statement::GetInfo() const {
   std::ostringstream os;
-  os << "Statement[" << statement_name_ << "] -> " << query_string_ << " (";
+  os << "Statement[";
+  if (statement_name_.empty()) {
+    os << "**UNNAMED**";
+  } else {
+    os << statement_name_;
+  }
+  os << "] -> " << query_string_ << " (";
 
   // Tables Oids Referenced
   os << "TablesRef={";
@@ -89,6 +95,9 @@ const std::string Statement::GetInfo() const {
     first = false;
   }
   os << "}";
+
+  // Replan Flag
+  os << ", ReplanNeeded=" << needs_replan_;
 
   // Query Type
   os << ", QueryType=" << query_type_;

--- a/src/common/statement.cpp
+++ b/src/common/statement.cpp
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cstdio>
 #include "common/statement.h"
+#include <cstdio>
 #include "common/logger.h"
 #include "planner/abstract_plan.h"
 
@@ -25,8 +25,8 @@ Statement::Statement(const std::string& statement_name,
 
 Statement::~Statement() {}
 
-void Statement::ParseQueryType(const std::string &query_string,
-                               std::string &query_type) {
+void Statement::ParseQueryType(const std::string& query_string,
+                               std::string& query_type) {
   std::stringstream stream(query_string);
   stream >> query_type;
 }
@@ -64,8 +64,38 @@ void Statement::SetPlanTree(std::shared_ptr<planner::AbstractPlan> plan_tree) {
   plan_tree_ = std::move(plan_tree);
 }
 
+void Statement::SetReferencedTables(const std::set<oid_t> table_ids) {
+  table_ids_.insert(table_ids.begin(), table_ids.end());
+}
+
+const std::set<oid_t> Statement::GetReferencedTables() const {
+  return (table_ids_);
+}
+
 const std::shared_ptr<planner::AbstractPlan>& Statement::GetPlanTree() const {
   return plan_tree_;
+}
+
+const std::string Statement::GetInfo() const {
+  std::ostringstream os;
+  os << "Statement[" << statement_name_ << "] -> " << query_string_ << " (";
+
+  // Tables Oids Referenced
+  os << "TablesRef={";
+  bool first = true;
+  for (auto t_id : table_ids_) {
+    if (first == false) os << ",";
+    os << t_id;
+    first = false;
+  }
+  os << "}";
+
+  // Query Type
+  os << ", QueryType=" << query_type_;
+
+  os << ")";
+
+  return os.str();
 }
 
 }  // namespace peloton

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -102,6 +102,10 @@ DEFINE_bool(index_tuner,
             false,
             "Enable index tuner (default: false)");
 
+DEFINE_bool(layout_tuner,
+            false,
+            "Enable layout tuner (default: false)");
+
 // Layout mode
 int peloton_layout_mode = peloton::LAYOUT_TYPE_ROW;
 

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -107,6 +107,7 @@ bool IndexScanExecutor::DInit() {
 
   table_ = node.GetTable();
 
+  // PAVLO (2017-01-05): This seems unnecessary and a waste of time
   if (table_ != nullptr) {
     full_column_ids_.resize(table_->GetSchema()->GetColumnCount());
     std::iota(full_column_ids_.begin(), full_column_ids_.end(), 0);
@@ -330,8 +331,8 @@ bool IndexScanExecutor::ExecPrimaryIndexLookup() {
             visible_tuple_locations.size());
 
   for (auto &visible_tuple_location : visible_tuple_locations) {
-    visible_tuples[visible_tuple_location.block]
-        .push_back(visible_tuple_location.offset);
+    visible_tuples[visible_tuple_location.block].push_back(
+        visible_tuple_location.offset);
   }
 
   // Construct a logical tile for each block
@@ -370,7 +371,6 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
   if (0 == key_column_ids_.size()) {
     index_->ScanAllKeys(tuple_location_ptrs);
   } else {
-
     //    // Limit clause accelerate
     if (limit_) {
       // invoke index scan limit
@@ -476,8 +476,9 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
         bool eval = true;
         // if having predicate, then perform evaluation.
         if (predicate_ != nullptr) {
-          eval = predicate_->Evaluate(&candidate_tuple, nullptr,
-                                      executor_context_).IsTrue();
+          eval =
+              predicate_->Evaluate(&candidate_tuple, nullptr, executor_context_)
+                  .IsTrue();
         }
         // if passed evaluation, then perform write.
         if (eval == true) {
@@ -558,8 +559,8 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
   CheckOpenRangeWithReturnedTuples(visible_tuple_locations);
 
   for (auto &visible_tuple_location : visible_tuple_locations) {
-    visible_tuples[visible_tuple_location.block]
-        .push_back(visible_tuple_location.offset);
+    visible_tuples[visible_tuple_location.block].push_back(
+        visible_tuple_location.offset);
   }
 
   // Construct a logical tile for each block
@@ -739,7 +740,6 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
 void IndexScanExecutor::UpdatePredicate(
     const std::vector<oid_t> &column_ids,
     const std::vector<type::Value> &values) {
-
   // Update index predicate
   LOG_TRACE("values_ size %lu", values_.size());
 
@@ -800,8 +800,8 @@ void IndexScanExecutor::UpdatePredicate(
   }
 
   // Update the new value
-  index_predicate_.GetConjunctionListToSetup()[0]
-      .SetTupleColumnValue(index_.get(), key_column_ids, values);
+  index_predicate_.GetConjunctionListToSetup()[0].SetTupleColumnValue(
+      index_.get(), key_column_ids, values);
 }
 
 void IndexScanExecutor::ResetState() {

--- a/src/include/brain/brain_util.h
+++ b/src/include/brain/brain_util.h
@@ -60,8 +60,7 @@ class BrainUtil {
       }
 
       brain::Sample sample(columns, weight, brain::SAMPLE_TYPE_ACCESS);
-      samples.insert(
-          std::map<std::string, brain::Sample>::value_type(name, sample));
+      samples.push_back(std::make_pair(name, sample));
 
     }  // WHILE
     return (samples);

--- a/src/include/brain/brain_util.h
+++ b/src/include/brain/brain_util.h
@@ -45,23 +45,23 @@ class BrainUtil {
       if (line.empty()) continue;
       std::istringstream iss(line);
 
-      // FORMAT: <NAME> <WEIGHT> <METRIC> <NUM_COLS> <COLUMNS...>
+      // FORMAT: <NAME> <WEIGHT> <NUM_COLS> <COLUMNS...>
       // TODO: Need include SAMPLE_TYPE
       std::string name;
       double weight;
-      double metric = 0;
       int num_cols;
       std::vector<double> columns;
 
-      iss >> name >> weight >> metric >> num_cols;
+      iss >> name >> weight >> num_cols;
       for (int i = 0; i < num_cols; i++) {
         int col;
         iss >> col;
         columns.push_back(col);
       }
 
-      brain::Sample sample(columns, weight, brain::SAMPLE_TYPE_ACCESS, metric);
-      samples.push_back(std::make_pair(name, sample));
+      brain::Sample sample(columns, weight, brain::SAMPLE_TYPE_ACCESS);
+      samples.insert(
+          std::map<std::string, brain::Sample>::value_type(name, sample));
 
     }  // WHILE
     return (samples);

--- a/src/include/brain/index_tuner.h
+++ b/src/include/brain/index_tuner.h
@@ -152,7 +152,7 @@ class IndexTuner {
   // Threshold sample count
 
   // duration between pauses (in ms)
-  oid_t duration_between_pauses = 10000;
+  oid_t duration_between_pauses = 1000;
 
   // duration of pause (in ms)
   oid_t duration_of_pause = 1000;

--- a/src/include/brain/index_tuner.h
+++ b/src/include/brain/index_tuner.h
@@ -67,10 +67,6 @@ class IndexTuner {
   // Add table to list of tables whose layout must be tuned
   void AddTable(storage::DataTable *table);
 
-  // Add indexes to table
-  void AddIndexes(storage::DataTable *table,
-                  const std::vector<std::vector<double>> &suggested_indices);
-
   // Clear list
   void ClearTables();
 
@@ -107,7 +103,19 @@ class IndexTuner {
   // Get # of indexes in managed tables
   oid_t GetIndexCount() const;
 
+  // Bootstrap for TPCC
+  void BootstrapTPCC();
+
+  void SetVisibilityMode() {
+    visibility_mode_ = true;
+  }
+
  protected:
+
+  // Add indexes to table
+  void AddIndexes(storage::DataTable *table,
+                  const std::vector<std::vector<double>> &suggested_indices);
+
   // Index tuning helper
   void IndexTuneHelper(storage::DataTable *table);
 
@@ -150,7 +158,7 @@ class IndexTuner {
   oid_t duration_of_pause = 1000;
 
   // frequency with which index analysis happens
-  oid_t analyze_sample_count_threshold = 10;
+  oid_t analyze_sample_count_threshold = 1;
 
   // # of tile groups to be indexed per iteration
   oid_t tile_groups_indexed_per_iteration = 10;
@@ -175,6 +183,9 @@ class IndexTuner {
   double write_ratio_threshold = 0.75;
 
   oid_t tile_groups_indexed_;
+
+  // visibility mode
+  bool visibility_mode_ = false;
 };
 
 }  // End brain namespace

--- a/src/include/brain/sample.h
+++ b/src/include/brain/sample.h
@@ -46,12 +46,10 @@ class Sample : public Printable {
 
   Sample(const std::vector<double> &columns_accessed,
          double weight = DEFAULT_SAMPLE_WEIGHT,
-         SampleType sample_type = SAMPLE_TYPE_ACCESS,
-         double metric = DEFAULT_METRIC_VALUE)
+         SampleType sample_type = SAMPLE_TYPE_ACCESS)
       : columns_accessed_(columns_accessed),
         weight_(weight),
-        sample_type_(sample_type),
-        metric_(metric) {}
+        sample_type_(sample_type) {}
 
   // get the distance from other sample
   double GetDistance(const Sample &other) const;
@@ -70,9 +68,6 @@ class Sample : public Printable {
 
   // the sample type
   inline SampleType GetSampleType() const { return (sample_type_); }
-
-  // the metric for this sample
-  inline double GetMetric() const { return (metric_); }
 
   inline const std::vector<double> GetColumnsAccessed() const {
     return (columns_accessed_);
@@ -108,8 +103,6 @@ class Sample : public Printable {
   // type of sample
   SampleType sample_type_;
 
-  // more info about the sample
-  double metric_ = 0;
 };
 
 }  // End brain namespace

--- a/src/include/brain/sample.h
+++ b/src/include/brain/sample.h
@@ -78,6 +78,11 @@ class Sample : public Printable {
     return (columns_accessed_);
   }
 
+  // set the columns accessed
+  inline void SetColumnsAccessed(const std::vector<double> columns_accessed) {
+    columns_accessed_ = columns_accessed;
+  }
+
   // get enabled columns
   std::vector<oid_t> GetEnabledColumns() const;
 

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -85,6 +85,10 @@ class Catalog {
   // Add a database
   void AddDatabase(storage::Database *database);
 
+  // Add a database with name
+  void AddDatabase(std::string database_name,
+                   storage::Database *database);
+
   // Create a table in a database
   Result CreateTable(std::string database_name, std::string table_name,
                      std::unique_ptr<catalog::Schema>,

--- a/src/include/common/statement.h
+++ b/src/include/common/statement.h
@@ -72,6 +72,10 @@ class Statement : public Printable {
 
   const std::shared_ptr<planner::AbstractPlan>& GetPlanTree() const;
 
+  inline bool GetNeedsPlan() const { return (needs_replan_); }
+
+  inline void SetNeedsPlan(bool replan) { needs_replan_ = replan; }
+
   // Get a string representation for debugging
   const std::string GetInfo() const;
 
@@ -97,6 +101,9 @@ class Statement : public Printable {
   // the oids of the tables referenced by this statement
   // this may be empty
   std::set<oid_t> table_ids_;
+
+  // If this flag is true, then somebody wants us to replan this query
+  bool needs_replan_ = false;
 };
 
 }  // namespace peloton

--- a/src/include/common/statement.h
+++ b/src/include/common/statement.h
@@ -12,10 +12,12 @@
 
 #pragma once
 
+#include <memory>
+#include <set>
 #include <string>
 #include <vector>
-#include <memory>
 
+#include "common/printable.h"
 #include "type/types.h"
 
 namespace peloton {
@@ -29,8 +31,7 @@ typedef std::pair<std::vector<unsigned char>, std::vector<unsigned char>>
 // FIELD INFO TYPE : field name, oid (data type), size
 typedef std::tuple<std::string, oid_t, size_t> FieldInfoType;
 
-class Statement {
-
+class Statement : public Printable {
  public:
   Statement() = delete;
   Statement(const Statement&) = delete;
@@ -42,7 +43,7 @@ class Statement {
 
   ~Statement();
 
-  static void ParseQueryType(const std::string &query_string,
+  static void ParseQueryType(const std::string& query_string,
                              std::string& query_type);
 
   std::vector<FieldInfoType> GetTupleDescriptor() const;
@@ -63,9 +64,16 @@ class Statement {
 
   void SetTupleDescriptor(const std::vector<FieldInfoType>& tuple_descriptor);
 
+  void SetReferencedTables(const std::set<oid_t> table_ids);
+
+  const std::set<oid_t> GetReferencedTables() const;
+
   void SetPlanTree(std::shared_ptr<planner::AbstractPlan> plan_tree);
 
   const std::shared_ptr<planner::AbstractPlan>& GetPlanTree() const;
+
+  // Get a string representation for debugging
+  const std::string GetInfo() const;
 
  private:
   // logical name of statement
@@ -85,6 +93,10 @@ class Statement {
 
   // cached plan tree
   std::shared_ptr<planner::AbstractPlan> plan_tree_;
+
+  // the oids of the tables referenced by this statement
+  // this may be empty
+  std::set<oid_t> table_ids_;
 };
 
 }  // namespace peloton

--- a/src/include/configuration/configuration.h
+++ b/src/include/configuration/configuration.h
@@ -64,6 +64,9 @@ DECLARE_uint64(stats_mode);
 // Enable or disable index tuner
 DECLARE_bool(index_tuner);
 
+// Enable or disable layout tuner
+DECLARE_bool(layout_tuner);
+
 //===----------------------------------------------------------------------===//
 // GENERAL
 //===----------------------------------------------------------------------===//

--- a/src/include/index/index.h
+++ b/src/include/index/index.h
@@ -129,6 +129,16 @@ class IndexMetadata : public Printable {
    */
   const std::string GetInfo() const;
 
+  //===--------------------------------------------------------------------===//
+  // STATIC HELPERS
+  //===--------------------------------------------------------------------===//
+
+  static inline void SetDefaultVisibleFlag(bool flag) {
+    LOG_DEBUG("Set IndexMetadata visible flag to '%s'",
+              (flag ? "true" : "false"));
+    index_default_visibility = flag;
+  }
+
   ///////////////////////////////////////////////////////////////////
   // IndexMetadata Data Member Definition
   ///////////////////////////////////////////////////////////////////
@@ -150,10 +160,10 @@ class IndexMetadata : public Printable {
   // of the underlying table schema
   const catalog::Schema *key_schema;
 
+ private:
   // The mapping relation between key schema and tuple schema
   std::vector<oid_t> key_attrs;
 
- private:
   // The mapping relation between tuple schema and key schema
   // i.e. if the column in tuple is not indexed, then it is set to INVALID_OID
   //      if the column in tuple is indexed, then it is the index in index_key
@@ -168,7 +178,10 @@ class IndexMetadata : public Printable {
   double utility_ratio = INVALID_RATIO;
 
   // If set to true, then this index is visible to the planner
-  bool visible_ = true;
+  bool visible_;
+
+  // This is a magic flag that tells us whether new
+  static bool index_default_visibility;
 };
 
 /////////////////////////////////////////////////////////////////////

--- a/src/include/parser/sql_statement.h
+++ b/src/include/parser/sql_statement.h
@@ -32,18 +32,18 @@ class QueryNodeVisitor;
 
 namespace parser {
 
-struct TableInfo{
-
-  ~TableInfo(){
+struct TableInfo {
+  ~TableInfo() {
     delete[] table_name;
     delete[] database_name;
   }
-  char * table_name = nullptr;;
-  char * database_name = nullptr;
+  char* table_name = nullptr;
+  ;
+  char* database_name = nullptr;
 };
 
 // Base class for every SQLStatement
-class SQLStatement {
+class SQLStatement : public Printable {
  public:
   SQLStatement(StatementType type) : stmt_type(type){};
 
@@ -63,14 +63,11 @@ class SQLStatement {
   StatementType stmt_type;
 };
 
-class TableRefStatement : public SQLStatement{
-public:
+class TableRefStatement : public SQLStatement {
+ public:
+  TableRefStatement(StatementType type) : SQLStatement(type) {}
 
-  TableRefStatement(StatementType type) : SQLStatement(type){}
-
-  virtual ~TableRefStatement(){
-    delete table_info_;
-  }
+  virtual ~TableRefStatement() { delete table_info_; }
 
   virtual inline std::string GetTableName() { return table_info_->table_name; }
 
@@ -82,12 +79,12 @@ public:
     return table_info_->database_name;
   }
 
-  TableInfo *table_info_ = nullptr;
+  TableInfo* table_info_ = nullptr;
 };
 
 // Represents the result of the SQLParser.
 // If parsing was successful it is a list of SQLStatement.
-class SQLStatementList {
+class SQLStatementList : public Printable {
  public:
   SQLStatementList()
       : is_valid(true), parser_msg(NULL), error_line(0), error_col(0){};

--- a/src/include/tcop/tcop.h
+++ b/src/include/tcop/tcop.h
@@ -15,8 +15,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <mutex>
-#include <vector>
 #include <stack>
+#include <vector>
 
 #include "common/portal.h"
 #include "common/statement.h"
@@ -42,7 +42,7 @@ class TrafficCop {
   ~TrafficCop();
 
   // static singleton method used by tests
-  static TrafficCop& GetInstance();
+  static TrafficCop &GetInstance();
 
   // reset this object
   void Reset();
@@ -61,7 +61,8 @@ class TrafficCop {
       const std::vector<int> &result_format, std::vector<ResultType> &result,
       int &rows_change, std::string &error_message);
 
-  // ExecutePrepStmt - Helper to handle txn-specifics for the plan-tree of a statement
+  // ExecutePrepStmt - Helper to handle txn-specifics for the plan-tree of a
+  // statement
   bridge::peloton_status ExecuteStatementPlan(
       const planner::AbstractPlan *plan, const std::vector<type::Value> &params,
       std::vector<ResultType> &result, const std::vector<int> &result_format);
@@ -89,13 +90,13 @@ class TrafficCop {
 
   // pair of txn ptr and the result so-far for that txn
   // use a stack to support nested-txns
-  typedef std::pair<concurrency::Transaction*, Result> TcopTxnState;
+  typedef std::pair<concurrency::Transaction *, Result> TcopTxnState;
   std::stack<TcopTxnState> tcop_txn_state_;
 
  private:
-  static TcopTxnState& GetDefaultTxnState();
+  static TcopTxnState &GetDefaultTxnState();
 
-  TcopTxnState& GetCurrentTxnState();
+  TcopTxnState &GetCurrentTxnState();
 
   Result BeginQueryHelper();
 

--- a/src/include/wire/packet_manager.h
+++ b/src/include/wire/packet_manager.h
@@ -62,6 +62,11 @@ class PacketManager {
     return table_statement_cache_[table_id];
   }
 
+  void InvalidatePreparedStatements(oid_t table_id);
+
+  // Ugh... this should not be here but we have no choice...
+  void ReplanPreparedStatement(Statement* statement);
+
   //===--------------------------------------------------------------------===//
   // STATIC HELPERS
   //===--------------------------------------------------------------------===//
@@ -189,7 +194,8 @@ class PacketManager {
   stats::QueryMetric::QueryParamBuf unnamed_stmt_param_types_;
 
   // Parameter types for statements
-  // Warning: the data in the param buffer becomes invalid when the value stored
+  // Warning: the data in the param buffer becomes invalid when the value
+  // stored
   // in stat table is destroyed
   std::unordered_map<std::string, stats::QueryMetric::QueryParamBuf>
       statement_param_types_;

--- a/src/include/wire/packet_manager.h
+++ b/src/include/wire/packet_manager.h
@@ -85,7 +85,7 @@ class PacketManager {
       std::vector<std::pair<int, std::string>>& bind_parameters,
       std::vector<type::Value>& param_values, std::vector<int16_t>& formats);
 
-  static std::vector<const PacketManager*> GetPacketManagers() {
+  static std::vector<PacketManager*> GetPacketManagers() {
     return (PacketManager::packet_managers_);
   }
 
@@ -133,7 +133,7 @@ class PacketManager {
   void MakeHardcodedParameterStatus(
       const std::pair<std::string, std::string>& kv);
 
-  /* SQLite doesn't support "SET" and "SHOW" SQL commands.
+  /* We don't support "SET" and "SHOW" SQL commands yet.
    * Also, duplicate BEGINs and COMMITs shouldn't be executed.
    * This function helps filtering out the execution for such cases
    */
@@ -213,7 +213,7 @@ class PacketManager {
   // HACK: Global list of PacketManager instances
   // We need this in order to reset statement caches when the catalog changes
   // We need to think of a more elegant solution for this
-  static std::vector<const PacketManager*> packet_managers_;
+  static std::vector<PacketManager*> packet_managers_;
   static std::mutex packet_managers_mutex_;
 };
 

--- a/src/index/index.cpp
+++ b/src/index/index.cpp
@@ -81,6 +81,14 @@ IndexMetadata::IndexMetadata(std::string index_name, oid_t index_oid,
     tuple_attrs[tuple_column_id] = i;
   }
 
+  // Just in case somebody forgets they set our flag to default and
+  // was wondering why there indexes weren't working...
+  if (visible_ == false) {
+    LOG_WARN(
+        "Creating IndexMetadata for '%s' but visible flag is set to false.",
+        name_.c_str());
+  }
+
   return;
 }
 

--- a/src/index/index.cpp
+++ b/src/index/index.cpp
@@ -1,6 +1,5 @@
 //===----------------------------------------------------------------------===//
 //
-//                         Peloton
 //
 // index.cpp
 //
@@ -25,6 +24,8 @@
 
 namespace peloton {
 namespace index {
+
+bool IndexMetadata::index_default_visibility = true;
 
 /*
  * GetColumnCount() - Returns the number of indexed columns
@@ -63,7 +64,8 @@ IndexMetadata::IndexMetadata(std::string index_name, oid_t index_oid,
       key_schema(key_schema),
       key_attrs(key_attrs),
       tuple_attrs(),
-      unique_keys(unique_keys) {
+      unique_keys(unique_keys),
+      visible_(IndexMetadata::index_default_visibility) {
   // Push the reverse mapping relation into tuple_attrs which maps
   // tuple key's column into index key's column
   // resize() automatially does allocation, extending and insertion
@@ -109,7 +111,8 @@ const std::string IndexMetadata::GetInfo() const {
      << "Type=" << IndexTypeToString(index_type_) << ", "
      << "ConstraintType=" << IndexConstraintTypeToString(index_constraint_type_)
      << ", "
-     << "UtilityRatio=" << utility_ratio << "]";
+     << "UtilityRatio=" << utility_ratio << ", "
+     << "Visible=" << visible_ << "]";
 
   os << " -> " << key_schema->GetInfo();
 

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -750,7 +750,7 @@ bool SimpleOptimizer::CheckIndexSearchable(
   }
 
   if (!index_searchable) {
-    LOG_DEBUG("No suitable index for %s exists. Skipping...",
+    LOG_DEBUG("No suitable index for table '%s' exists. Skipping...",
               target_table->GetName().c_str());
     return (false);
   }
@@ -761,7 +761,7 @@ bool SimpleOptimizer::CheckIndexSearchable(
   // Check whether the index is visible
   // This is for the IndexTuner demo
   if (index->GetMetadata()->GetVisibility() == false) {
-    LOG_DEBUG("Index %s.%s is not visible. Skipping...",
+    LOG_DEBUG("Index '%s.%s' is not visible. Skipping...",
               target_table->GetName().c_str(), index->GetName().c_str());
     return (false);
   }

--- a/src/parser/sql_statement.cpp
+++ b/src/parser/sql_statement.cpp
@@ -36,10 +36,9 @@ namespace parser {
 const std::string SQLStatement::GetInfo() const {
   std::ostringstream os;
 
-  os << "STATEMENT : Type :: " << stmt_type << "\n";
+  os << "SQLStatement[" << StatementTypeToString(stmt_type) << "]\n";
 
   int indent = 1;
-
   switch (stmt_type) {
     case STATEMENT_TYPE_SELECT:
       GetSelectStatementInfo((SelectStatement*)this, indent);
@@ -53,7 +52,6 @@ const std::string SQLStatement::GetInfo() const {
     default:
       break;
   }
-
   return os.str();
 }
 
@@ -64,8 +62,7 @@ const std::string SQLStatementList::GetInfo() const {
     for (auto stmt : statements) {
       os << stmt->GetInfo();
     }
-  }
-  else {
+  } else {
     os << "Invalid statement list \n";
   }
 

--- a/src/wire/packet_manager.cpp
+++ b/src/wire/packet_manager.cpp
@@ -323,6 +323,9 @@ void PacketManager::ExecParseMessage(InputPacket *pkt) {
   // Prepare statement
   std::shared_ptr<Statement> statement(nullptr);
 
+  LOG_DEBUG("PrepareStatement[%s] => %s", statement_name.c_str(),
+            query_string.c_str());
+
   statement = traffic_cop_->PrepareStatement(statement_name, query_string,
                                              error_message);
   if (statement.get() == nullptr) {
@@ -365,6 +368,10 @@ void PacketManager::ExecParseMessage(InputPacket *pkt) {
   } else {
     auto entry = std::make_pair(statement_name, statement);
     statement_cache_.insert(entry);
+
+    for (auto table_id : statement->GetReferencedTables()) {
+      table_statement_cache_[table_id].push_back(statement.get());
+    }
   }
   // Send Parse complete response
   std::unique_ptr<OutputPacket> response(new OutputPacket());

--- a/test/brain/brain_util_test.cpp
+++ b/test/brain/brain_util_test.cpp
@@ -53,9 +53,9 @@ TEST_F(BrainUtilTests, LoadIndexStatisticsFileTest) {
 
   std::map<std::string, brain::Sample> expected;
   expected.insert(std::map<std::string, brain::Sample>::value_type(
-      "TABLE_X", brain::Sample(cols0, 888, brain::SAMPLE_TYPE_ACCESS, 1.234)));
+      "TABLE_X", brain::Sample(cols0, 888, brain::SAMPLE_TYPE_ACCESS)));
   expected.insert(std::map<std::string, brain::Sample>::value_type(
-      "TABLE_Y", brain::Sample(cols1, 999, brain::SAMPLE_TYPE_ACCESS, 5.6789)));
+      "TABLE_Y", brain::Sample(cols1, 999, brain::SAMPLE_TYPE_ACCESS)));
   EXPECT_FALSE(expected.empty());
 
   // Serialize them to a string and write them out to a temp file

--- a/test/brain/index_tuner_test.cpp
+++ b/test/brain/index_tuner_test.cpp
@@ -26,6 +26,10 @@
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/executor_tests_util.h"
 
+#include "storage/table_factory.h"
+#include "index/index_factory.h"
+#include "catalog/catalog.h"
+
 namespace peloton {
 namespace test {
 
@@ -139,6 +143,1096 @@ TEST_F(IndexTunerTests, BasicTest) {
 
     EXPECT_TRUE(candidate_index_found);
   }
+
+}
+
+/////////////////////////////////////////////////////////
+// Constants
+/////////////////////////////////////////////////////////
+
+const size_t name_length = 32;
+const size_t middle_name_length = 2;
+const size_t data_length = 64;
+const size_t state_length = 16;
+const size_t zip_length = 9;
+const size_t street_length = 32;
+const size_t city_length = 32;
+const size_t credit_length = 2;
+const size_t phone_length = 32;
+const size_t dist_length = 32;
+
+double item_min_price = 1.0;
+double item_max_price = 100.0;
+
+double warehouse_name_length = 16;
+double warehouse_min_tax = 0.0;
+double warehouse_max_tax = 0.2;
+double warehouse_initial_ytd = 300000.00f;
+
+double district_name_length = 16;
+double district_min_tax = 0.0;
+double district_max_tax = 0.2;
+double district_initial_ytd = 30000.00f;
+
+std::string customers_good_credit = "GC";
+std::string customers_bad_credit = "BC";
+double customers_bad_credit_ratio = 0.1;
+double customers_init_credit_lim = 50000.0;
+double customers_min_discount = 0;
+double customers_max_discount = 0.5;
+double customers_init_balance = -10.0;
+double customers_init_ytd = 10.0;
+int customers_init_payment_cnt = 1;
+int customers_init_delivery_cnt = 0;
+
+double history_init_amount = 10.0;
+size_t history_data_length = 32;
+
+int orders_min_ol_cnt = 5;
+int orders_max_ol_cnt = 15;
+int orders_init_all_local = 1;
+int orders_null_carrier_id = 0;
+int orders_min_carrier_id = 1;
+int orders_max_carrier_id = 10;
+
+int new_orders_per_district = 900;  // 900
+
+int order_line_init_quantity = 5;
+int order_line_max_ol_quantity = 10;
+double order_line_min_amount = 0.01;
+size_t order_line_dist_info_length = 32;
+
+double stock_original_ratio = 0.1;
+int stock_min_quantity = 10;
+int stock_max_quantity = 100;
+int stock_dist_count = 10;
+
+double payment_min_amount = 1.0;
+double payment_max_amount = 5000.0;
+
+int stock_min_threshold = 10;
+int stock_max_threshold = 20;
+
+double new_order_remote_txns = 0.01;
+
+
+static const oid_t tpcc_database_oid = 100;
+
+static const oid_t warehouse_table_oid = 1001;
+static const oid_t warehouse_table_pkey_index_oid = 20010;  // W_ID
+
+static const oid_t district_table_oid = 1002;
+static const oid_t district_table_pkey_index_oid = 20021;  // D_ID, D_W_ID
+
+static const oid_t item_table_oid = 1003;
+static const oid_t item_table_pkey_index_oid = 20030;  // I_ID
+
+static const oid_t customer_table_oid = 1004;
+static const oid_t customer_table_pkey_index_oid =
+    20040;  // C_W_ID, C_D_ID, C_ID
+static const oid_t customer_table_skey_index_oid =
+    20041;  // C_W_ID, C_D_ID, C_LAST
+
+static const oid_t history_table_oid = 1005;
+
+static const oid_t stock_table_oid = 1006;
+static const oid_t stock_table_pkey_index_oid = 20060;  // S_W_ID, S_I_ID
+
+static const oid_t orders_table_oid = 1007;
+static const oid_t orders_table_pkey_index_oid = 20070;  // O_W_ID, O_D_ID, O_ID
+static const oid_t orders_table_skey_index_oid =
+    20071;  // O_W_ID, O_D_ID, O_C_ID
+
+static const oid_t new_order_table_oid = 1008;
+static const oid_t new_order_table_pkey_index_oid =
+    20080;  // NO_D_ID, NO_W_ID, NO_O_ID
+
+static const oid_t order_line_table_oid = 1008;
+static const oid_t order_line_table_pkey_index_oid =
+    20080;  // OL_W_ID, OL_D_ID, OL_O_ID, OL_NUMBER
+static const oid_t order_line_table_skey_index_oid =
+    20081;  // OL_W_ID, OL_D_ID, OL_O_ID
+
+//===========
+// Column ids
+//===========
+
+// NEW_ORDER
+#define COL_IDX_NO_O_ID       0
+#define COL_IDX_NO_D_ID       1
+#define COL_IDX_NO_W_ID       2
+
+// ORDERS
+#define COL_IDX_O_ID          0
+#define COL_IDX_O_C_ID        1
+#define COL_IDX_O_D_ID        2
+#define COL_IDX_O_W_ID        3
+#define COL_IDX_O_ENTRY_D     4
+#define COL_IDX_O_CARRIER_ID  5
+#define COL_IDX_O_OL_CNT      6
+#define COL_IDX_O_ALL_LOCAL   7
+
+// ORDER_LINE
+#define COL_IDX_OL_O_ID       0
+#define COL_IDX_OL_D_ID       1
+#define COL_IDX_OL_W_ID       2
+#define COL_IDX_OL_NUMBER     3
+#define COL_IDX_OL_I_ID       4
+#define COL_IDX_OL_SUPPLY_W_ID      5
+#define COL_IDX_OL_DELIVERY_D 6
+#define COL_IDX_OL_QUANTITY   7
+#define COL_IDX_OL_AMOUNT     8
+#define COL_IDX_OL_DIST_INFO  9
+
+// Customer
+#define COL_IDX_C_ID              0
+#define COL_IDX_C_D_ID            1
+#define COL_IDX_C_W_ID            2
+#define COL_IDX_C_FIRST           3
+#define COL_IDX_C_MIDDLE          4
+#define COL_IDX_C_LAST            5
+#define COL_IDX_C_STREET_1        6
+#define COL_IDX_C_STREET_2        7
+#define COL_IDX_C_CITY            8
+#define COL_IDX_C_STATE           9
+#define COL_IDX_C_ZIP             10
+#define COL_IDX_C_PHONE           11
+#define COL_IDX_C_SINCE           12
+#define COL_IDX_C_CREDIT          13
+#define COL_IDX_C_CREDIT_LIM      14
+#define COL_IDX_C_DISCOUNT        15
+#define COL_IDX_C_BALANCE         16
+#define COL_IDX_C_YTD_PAYMENT     17
+#define COL_IDX_C_PAYMENT_CNT     18
+#define COL_IDX_C_DELIVERY_CNT    19
+#define COL_IDX_C_DATA            20
+
+// District
+#define COL_IDX_D_ID              0
+#define COL_IDX_D_W_ID            1
+#define COL_IDX_D_NAME            2
+#define COL_IDX_D_STREET_1        3
+#define COL_IDX_D_STREET_2        4
+#define COL_IDX_D_CITY            5
+#define COL_IDX_D_STATE           6
+#define COL_IDX_D_ZIP             7
+#define COL_IDX_D_TAX             8
+#define COL_IDX_D_YTD             9
+#define COL_IDX_D_NEXT_O_ID       10
+
+// Stock
+#define COL_IDX_S_I_ID            0
+#define COL_IDX_S_W_ID            1
+#define COL_IDX_S_QUANTITY        2
+#define COL_IDX_S_DIST_01         3
+#define COL_IDX_S_DIST_02         4
+#define COL_IDX_S_DIST_03         5
+#define COL_IDX_S_DIST_04         6
+#define COL_IDX_S_DIST_05         7
+#define COL_IDX_S_DIST_06         8
+#define COL_IDX_S_DIST_07         9
+#define COL_IDX_S_DIST_08         10
+#define COL_IDX_S_DIST_09         11
+#define COL_IDX_S_DIST_10         12
+#define COL_IDX_S_YTD             13
+#define COL_IDX_S_ORDER_CNT       14
+#define COL_IDX_S_REMOTE_CNT      15
+#define COL_IDX_S_DATA            16
+
+
+
+/////////////////////////////////////////////////////////
+// Create the tables
+/////////////////////////////////////////////////////////
+
+storage::Database *tpcc_database;
+storage::DataTable *warehouse_table;
+storage::DataTable *district_table;
+storage::DataTable *item_table;
+storage::DataTable *customer_table;
+storage::DataTable *history_table;
+storage::DataTable *stock_table;
+storage::DataTable *orders_table;
+storage::DataTable *new_order_table;
+storage::DataTable *order_line_table;
+
+const bool own_schema = true;
+const bool adapt_table = false;
+const bool is_inlined = false;
+const bool unique_index = false;
+const bool allocate = true;
+
+void CreateWarehouseTable() {
+  /*
+   CREATE TABLE WAREHOUSE (
+   W_ID SMALLINT DEFAULT '0' NOT NULL,
+   W_NAME VARCHAR(16) DEFAULT NULL,
+   W_STREET_1 VARCHAR(32) DEFAULT NULL,
+   W_STREET_2 VARCHAR(32) DEFAULT NULL,
+   W_CITY VARCHAR(32) DEFAULT NULL,
+   W_STATE VARCHAR(2) DEFAULT NULL,
+   W_ZIP VARCHAR(9) DEFAULT NULL,
+   W_TAX FLOAT DEFAULT NULL,
+   W_YTD FLOAT DEFAULT NULL,
+   CONSTRAINT W_PK_ARRAY PRIMARY KEY (W_ID)
+   );
+   */
+
+  // Create schema first
+  std::vector<catalog::Column> warehouse_columns;
+
+  auto w_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "W_ID", is_inlined);
+  warehouse_columns.push_back(w_id_column);
+  auto w_name_column = catalog::Column(
+      type::Type::VARCHAR, warehouse_name_length, "W_NAME", is_inlined);
+  warehouse_columns.push_back(w_name_column);
+  auto w_street_1_column = catalog::Column(type::Type::VARCHAR, street_length,
+                                           "W_STREET_1", is_inlined);
+  warehouse_columns.push_back(w_street_1_column);
+  auto w_street_2_column = catalog::Column(type::Type::VARCHAR, street_length,
+                                           "W_STREET_2", is_inlined);
+  warehouse_columns.push_back(w_street_2_column);
+  auto w_city_column =
+      catalog::Column(type::Type::VARCHAR, city_length, "W_CITY", is_inlined);
+  warehouse_columns.push_back(w_city_column);
+  auto w_state_column =
+      catalog::Column(type::Type::VARCHAR, state_length, "W_STATE", is_inlined);
+  warehouse_columns.push_back(w_state_column);
+  auto w_zip_column =
+      catalog::Column(type::Type::VARCHAR, zip_length, "W_ZIP", is_inlined);
+  warehouse_columns.push_back(w_zip_column);
+  auto w_tax_column = catalog::Column(
+      type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL), "W_TAX", is_inlined);
+  warehouse_columns.push_back(w_tax_column);
+  auto w_ytd_column = catalog::Column(
+      type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL), "W_YTD", is_inlined);
+  warehouse_columns.push_back(w_ytd_column);
+
+  catalog::Schema *table_schema = new catalog::Schema(warehouse_columns);
+  std::string table_name("WAREHOUSE");
+
+  warehouse_table = storage::TableFactory::GetDataTable(
+      tpcc_database_oid, warehouse_table_oid, table_schema, table_name,
+      DEFAULT_TUPLES_PER_TILEGROUP, own_schema, adapt_table);
+
+  tpcc_database->AddTable(warehouse_table);
+
+  // Primary index on W_ID
+  std::vector<oid_t> key_attrs = {0};
+
+  auto tuple_schema = warehouse_table->GetSchema();
+  catalog::Schema *key_schema =
+      catalog::Schema::CopySchema(tuple_schema, key_attrs);
+  key_schema->SetIndexedColumns(key_attrs);
+  bool unique = true;
+
+  index::IndexMetadata *index_metadata = new index::IndexMetadata(
+    "warehouse_pkey", warehouse_table_pkey_index_oid, warehouse_table_oid,
+    tpcc_database_oid, INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_PRIMARY_KEY,
+    tuple_schema, key_schema, key_attrs, unique);
+
+  std::shared_ptr<index::Index> pkey_index(
+      index::IndexFactory::GetIndex(index_metadata));
+
+  warehouse_table->AddIndex(pkey_index);
+}
+
+void CreateDistrictTable() {
+  /*
+   CREATE TABLE DISTRICT (
+   D_ID TINYINT DEFAULT '0' NOT NULL,
+   D_W_ID SMALLINT DEFAULT '0' NOT NULL REFERENCES WAREHOUSE (W_ID),
+   D_NAME VARCHAR(16) DEFAULT NULL,
+   D_STREET_1 VARCHAR(32) DEFAULT NULL,
+   D_STREET_2 VARCHAR(32) DEFAULT NULL,
+   D_CITY VARCHAR(32) DEFAULT NULL,
+   D_STATE VARCHAR(2) DEFAULT NULL,
+   D_ZIP VARCHAR(9) DEFAULT NULL,
+   D_TAX FLOAT DEFAULT NULL,
+   D_YTD FLOAT DEFAULT NULL,
+   D_NEXT_O_ID INT DEFAULT NULL,
+   PRIMARY KEY (D_W_ID,D_ID)
+   );
+   */
+
+  // Create schema first
+  std::vector<catalog::Column> district_columns;
+
+  auto d_id_column = catalog::Column(
+      type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER), "D_ID", is_inlined);
+  district_columns.push_back(d_id_column);
+  auto d_w_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "D_W_ID", is_inlined);
+  district_columns.push_back(d_w_id_column);
+  auto d_name_column = catalog::Column(type::Type::VARCHAR, district_name_length,
+                                       "D_NAME", is_inlined);
+  district_columns.push_back(d_name_column);
+  auto d_street_1_column = catalog::Column(type::Type::VARCHAR, street_length,
+                                           "D_STREET_1", is_inlined);
+  district_columns.push_back(d_street_1_column);
+  auto d_street_2_column = catalog::Column(type::Type::VARCHAR, street_length,
+                                           "D_STREET_2", is_inlined);
+  district_columns.push_back(d_street_2_column);
+  auto d_city_column =
+      catalog::Column(type::Type::VARCHAR, city_length, "D_CITY", is_inlined);
+  district_columns.push_back(d_city_column);
+  auto d_state_column =
+      catalog::Column(type::Type::VARCHAR, state_length, "D_STATE", is_inlined);
+  district_columns.push_back(d_state_column);
+  auto d_zip_column =
+      catalog::Column(type::Type::VARCHAR, zip_length, "D_ZIP", is_inlined);
+  district_columns.push_back(d_zip_column);
+  auto d_tax_column = catalog::Column(
+      type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL), "D_TAX", is_inlined);
+  district_columns.push_back(d_tax_column);
+  auto d_ytd_column = catalog::Column(
+      type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL), "D_YTD", is_inlined);
+  district_columns.push_back(d_ytd_column);
+  auto d_next_o_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "D_NEXT_O_ID", is_inlined);
+  district_columns.push_back(d_next_o_id_column);
+
+  catalog::Schema *table_schema = new catalog::Schema(district_columns);
+  std::string table_name("DISTRICT");
+
+  district_table = storage::TableFactory::GetDataTable(
+      tpcc_database_oid, district_table_oid, table_schema, table_name,
+      DEFAULT_TUPLES_PER_TILEGROUP, own_schema, adapt_table);
+
+  tpcc_database->AddTable(district_table);
+
+  // Primary index on D_ID, D_W_ID
+  std::vector<oid_t> key_attrs = {0, 1};
+
+  auto tuple_schema = district_table->GetSchema();
+  catalog::Schema *key_schema =
+      catalog::Schema::CopySchema(tuple_schema, key_attrs);
+  key_schema->SetIndexedColumns(key_attrs);
+  bool unique = true;
+
+  index::IndexMetadata *index_metadata = new index::IndexMetadata(
+      "district_pkey", district_table_pkey_index_oid,
+      district_table_pkey_index_oid, district_table_oid, INDEX_TYPE_BWTREE,
+      INDEX_CONSTRAINT_TYPE_PRIMARY_KEY, tuple_schema, key_schema, key_attrs,
+      unique);
+
+  std::shared_ptr<index::Index> pkey_index(
+      index::IndexFactory::GetIndex(index_metadata));
+
+  district_table->AddIndex(pkey_index);
+}
+
+void CreateItemTable() {
+  /*
+   CREATE TABLE ITEM (
+   I_ID INTEGER DEFAULT '0' NOT NULL,
+   I_IM_ID INTEGER DEFAULT NULL,
+   I_NAME VARCHAR(32) DEFAULT NULL,
+   I_PRICE FLOAT DEFAULT NULL,
+   I_DATA VARCHAR(64) DEFAULT NULL,
+   CONSTRAINT I_PK_ARRAY PRIMARY KEY (I_ID)
+   );
+   */
+
+  // Create schema first
+  std::vector<catalog::Column> item_columns;
+
+  auto i_id_column = catalog::Column(
+      type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER), "I_ID", is_inlined);
+  item_columns.push_back(i_id_column);
+  auto i_im_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "I_IM_ID", is_inlined);
+  item_columns.push_back(i_im_id_column);
+  auto i_name_column =
+      catalog::Column(type::Type::VARCHAR, name_length, "I_NAME", is_inlined);
+  item_columns.push_back(i_name_column);
+  auto i_price_column = catalog::Column(
+      type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL), "I_PRICE", is_inlined);
+  item_columns.push_back(i_price_column);
+  auto i_data_column =
+      catalog::Column(type::Type::VARCHAR, data_length, "I_DATA", is_inlined);
+  item_columns.push_back(i_data_column);
+
+  catalog::Schema *table_schema = new catalog::Schema(item_columns);
+  std::string table_name("ITEM");
+
+  item_table = storage::TableFactory::GetDataTable(
+      tpcc_database_oid, item_table_oid, table_schema, table_name,
+      DEFAULT_TUPLES_PER_TILEGROUP, own_schema, adapt_table);
+
+  tpcc_database->AddTable(item_table);
+
+  // Primary index on I_ID
+  std::vector<oid_t> key_attrs = {0};
+
+  auto tuple_schema = item_table->GetSchema();
+  catalog::Schema *key_schema =
+      catalog::Schema::CopySchema(tuple_schema, key_attrs);
+  key_schema->SetIndexedColumns(key_attrs);
+  bool unique = true;
+
+  index::IndexMetadata *index_metadata = new index::IndexMetadata(
+      "item_pkey", item_table_pkey_index_oid, item_table_oid, tpcc_database_oid,
+      INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_PRIMARY_KEY, tuple_schema,
+      key_schema, key_attrs, unique);
+
+  std::shared_ptr<index::Index> pkey_index(
+      index::IndexFactory::GetIndex(index_metadata));
+  item_table->AddIndex(pkey_index);
+}
+
+void CreateCustomerTable() {
+  /*
+     CREATE TABLE CUSTOMER (
+     C_ID INTEGER DEFAULT '0' NOT NULL,
+     C_D_ID TINYINT DEFAULT '0' NOT NULL,
+     C_W_ID SMALLINT DEFAULT '0' NOT NULL,
+     C_FIRST VARCHAR(32) DEFAULT NULL,
+     C_MIDDLE VARCHAR(2) DEFAULT NULL,
+     C_LAST VARCHAR(32) DEFAULT NULL,
+     C_STREET_1 VARCHAR(32) DEFAULT NULL,
+     C_STREET_2 VARCHAR(32) DEFAULT NULL,
+     C_CITY VARCHAR(32) DEFAULT NULL,
+     C_STATE VARCHAR(2) DEFAULT NULL,
+     C_ZIP VARCHAR(9) DEFAULT NULL,
+     C_PHONE VARCHAR(32) DEFAULT NULL,
+     C_SINCE TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+     C_CREDIT VARCHAR(2) DEFAULT NULL,
+     C_CREDIT_LIM FLOAT DEFAULT NULL,
+     C_DISCOUNT FLOAT DEFAULT NULL,
+     C_BALANCE FLOAT DEFAULT NULL,
+     C_YTD_PAYMENT FLOAT DEFAULT NULL,
+     C_PAYMENT_CNT INTEGER DEFAULT NULL,
+     C_DELIVERY_CNT INTEGER DEFAULT NULL,
+     C_DATA VARCHAR(500),
+     PRIMARY KEY (C_W_ID,C_D_ID,C_ID),
+     UNIQUE (C_W_ID,C_D_ID,C_LAST,C_FIRST),
+     CONSTRAINT C_FKEY_D FOREIGN KEY (C_D_ID, C_W_ID) REFERENCES DISTRICT (D_ID,
+     D_W_ID)
+     );
+     CREATE INDEX IDX_CUSTOMER ON CUSTOMER (C_W_ID,C_D_ID,C_LAST);
+   */
+
+  // Create schema first
+  std::vector<catalog::Column> customer_columns;
+
+  auto c_id_column = catalog::Column(
+      type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER), "C_ID", is_inlined);
+  customer_columns.push_back(c_id_column);
+  auto c_d_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "C_D_ID", is_inlined);
+  customer_columns.push_back(c_d_id_column);
+  auto c_w_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "C_W_ID", is_inlined);
+  customer_columns.push_back(c_w_id_column);
+  auto c_first_name_column =
+      catalog::Column(type::Type::VARCHAR, name_length, "C_FIRST", is_inlined);
+  customer_columns.push_back(c_first_name_column);
+  auto c_middle_name_column = catalog::Column(
+      type::Type::VARCHAR, middle_name_length, "C_MIDDLE", is_inlined);
+  customer_columns.push_back(c_middle_name_column);
+  auto c_last_name_column =
+      catalog::Column(type::Type::VARCHAR, name_length, "C_LAST", is_inlined);
+  customer_columns.push_back(c_last_name_column);
+  auto c_street_1_column = catalog::Column(type::Type::VARCHAR, street_length,
+                                           "C_STREET_1", is_inlined);
+  customer_columns.push_back(c_street_1_column);
+  auto c_street_2_column = catalog::Column(type::Type::VARCHAR, street_length,
+                                           "C_STREET_2", is_inlined);
+  customer_columns.push_back(c_street_2_column);
+  auto c_city_column =
+      catalog::Column(type::Type::VARCHAR, city_length, "C_CITY", is_inlined);
+  customer_columns.push_back(c_city_column);
+  auto c_state_column =
+      catalog::Column(type::Type::VARCHAR, state_length, "C_STATE", is_inlined);
+  customer_columns.push_back(c_state_column);
+  auto c_zip_column =
+      catalog::Column(type::Type::VARCHAR, zip_length, "C_ZIP", is_inlined);
+  customer_columns.push_back(c_zip_column);
+  auto c_phone_column =
+      catalog::Column(type::Type::VARCHAR, phone_length, "C_PHONE", is_inlined);
+  customer_columns.push_back(c_phone_column);
+  auto c_since_column =
+      catalog::Column(type::Type::TIMESTAMP, type::Type::GetTypeSize(type::Type::TIMESTAMP),
+                      "C_SINCE", is_inlined);
+  customer_columns.push_back(c_since_column);
+  auto c_credit_column = catalog::Column(type::Type::VARCHAR, credit_length,
+                                         "C_CREDIT", is_inlined);
+  customer_columns.push_back(c_credit_column);
+  auto c_credit_lim_column =
+      catalog::Column(type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL),
+                      "C_CREDIT_LIM", is_inlined);
+  customer_columns.push_back(c_credit_lim_column);
+  auto c_discount_column =
+      catalog::Column(type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL),
+                      "C_DISCOUNT", is_inlined);
+  customer_columns.push_back(c_discount_column);
+  auto c_balance_column =
+      catalog::Column(type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL),
+                      "C_BALANCE", is_inlined);
+  customer_columns.push_back(c_balance_column);
+  auto c_ytd_payment_column =
+      catalog::Column(type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL),
+                      "C_YTD_PAYMENT", is_inlined);
+  customer_columns.push_back(c_ytd_payment_column);
+  auto c_payment_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "C_PAYMENT_CNT", is_inlined);
+  customer_columns.push_back(c_payment_column);
+  auto c_delivery_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "C_DELIVERY_CNT", is_inlined);
+  customer_columns.push_back(c_delivery_column);
+  auto c_data_column =
+      catalog::Column(type::Type::VARCHAR, data_length, "C_DATA", is_inlined);
+  customer_columns.push_back(c_data_column);
+
+  catalog::Schema *table_schema = new catalog::Schema(customer_columns);
+  std::string table_name("CUSTOMER");
+
+  customer_table = storage::TableFactory::GetDataTable(
+      tpcc_database_oid, customer_table_oid, table_schema, table_name,
+      DEFAULT_TUPLES_PER_TILEGROUP, own_schema, adapt_table);
+
+  tpcc_database->AddTable(customer_table);
+
+  auto tuple_schema = customer_table->GetSchema();
+  std::vector<oid_t> key_attrs;
+  catalog::Schema *key_schema = nullptr;
+  index::IndexMetadata *index_metadata = nullptr;
+
+  // Primary index on C_ID, C_D_ID, C_W_ID
+  key_attrs = {0, 1, 2};
+  key_schema = catalog::Schema::CopySchema(tuple_schema, key_attrs);
+  key_schema->SetIndexedColumns(key_attrs);
+
+  index_metadata = new index::IndexMetadata(
+    "customer_pkey", customer_table_pkey_index_oid, customer_table_oid,
+    tpcc_database_oid, INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_PRIMARY_KEY,
+    tuple_schema, key_schema, key_attrs, true);
+
+  std::shared_ptr<index::Index> pkey_index(
+      index::IndexFactory::GetIndex(index_metadata));
+  customer_table->AddIndex(pkey_index);
+
+  // Secondary index on C_W_ID, C_D_ID, C_LAST
+  key_attrs = {1, 2, 5};
+  key_schema = catalog::Schema::CopySchema(tuple_schema, key_attrs);
+  key_schema->SetIndexedColumns(key_attrs);
+
+  index_metadata = new index::IndexMetadata(
+      "customer_skey", customer_table_skey_index_oid, customer_table_oid,
+      tpcc_database_oid, INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_INVALID,
+      tuple_schema, key_schema, key_attrs, false);
+
+  std::shared_ptr<index::Index> skey_index(
+      index::IndexFactory::GetIndex(index_metadata));
+  customer_table->AddIndex(skey_index);
+}
+
+void CreateHistoryTable() {
+  /*
+    CREATE TABLE HISTORY (
+    H_C_ID INTEGER DEFAULT NULL,
+    H_C_D_ID TINYINT DEFAULT NULL,
+    H_C_W_ID SMALLINT DEFAULT NULL,
+    H_D_ID TINYINT DEFAULT NULL,
+    H_W_ID SMALLINT DEFAULT '0' NOT NULL,
+    H_DATE TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    H_AMOUNT FLOAT DEFAULT NULL,
+    H_DATA VARCHAR(32) DEFAULT NULL,
+    CONSTRAINT H_FKEY_C FOREIGN KEY (H_C_ID, H_C_D_ID, H_C_W_ID) REFERENCES
+    CUSTOMER (C_ID, C_D_ID, C_W_ID),
+    CONSTRAINT H_FKEY_D FOREIGN KEY (H_D_ID, H_W_ID) REFERENCES DISTRICT (D_ID,
+    D_W_ID)
+    );
+   */
+
+  // Create schema first
+  std::vector<catalog::Column> history_columns;
+
+  auto h_c_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "H_C_ID", is_inlined);
+  history_columns.push_back(h_c_id_column);
+  auto h_c_d_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "H_C_D_ID", is_inlined);
+  history_columns.push_back(h_c_d_id_column);
+  auto h_c_w_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "H_C_W_ID", is_inlined);
+  history_columns.push_back(h_c_w_id_column);
+  auto h_d_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "H_D_ID", is_inlined);
+  history_columns.push_back(h_d_id_column);
+  auto h_w_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "H_W_ID", is_inlined);
+  history_columns.push_back(h_w_id_column);
+  auto h_date_column =
+      catalog::Column(type::Type::TIMESTAMP, type::Type::GetTypeSize(type::Type::TIMESTAMP),
+                      "H_DATE", is_inlined);
+  history_columns.push_back(h_date_column);
+  auto h_amount_column =
+      catalog::Column(type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL),
+                      "H_AMOUNT", is_inlined);
+  history_columns.push_back(h_amount_column);
+  auto h_data_column = catalog::Column(type::Type::VARCHAR, history_data_length,
+                                       "H_DATA", is_inlined);
+  history_columns.push_back(h_data_column);
+
+  catalog::Schema *table_schema = new catalog::Schema(history_columns);
+  std::string table_name("HISTORY");
+
+  history_table = storage::TableFactory::GetDataTable(
+      tpcc_database_oid, history_table_oid, table_schema, table_name,
+      DEFAULT_TUPLES_PER_TILEGROUP, own_schema, adapt_table);
+
+  tpcc_database->AddTable(history_table);
+}
+
+void CreateStockTable() {
+  /*
+   CREATE TABLE STOCK (
+   S_I_ID INTEGER DEFAULT '0' NOT NULL REFERENCES ITEM (I_ID),
+   S_W_ID SMALLINT DEFAULT '0 ' NOT NULL REFERENCES WAREHOUSE (W_ID),
+   S_QUANTITY INTEGER DEFAULT '0' NOT NULL,
+   S_DIST_01 VARCHAR(32) DEFAULT NULL,
+   S_DIST_02 VARCHAR(32) DEFAULT NULL,
+   S_DIST_03 VARCHAR(32) DEFAULT NULL,
+   S_DIST_04 VARCHAR(32) DEFAULT NULL,
+   S_DIST_05 VARCHAR(32) DEFAULT NULL,
+   S_DIST_06 VARCHAR(32) DEFAULT NULL,
+   S_DIST_07 VARCHAR(32) DEFAULT NULL,
+   S_DIST_08 VARCHAR(32) DEFAULT NULL,
+   S_DIST_09 VARCHAR(32) DEFAULT NULL,
+   S_DIST_10 VARCHAR(32) DEFAULT NULL,
+   S_YTD INTEGER DEFAULT NULL,
+   S_ORDER_CNT INTEGER DEFAULT NULL,
+   S_REMOTE_CNT INTEGER DEFAULT NULL,
+   S_DATA VARCHAR(64) DEFAULT NULL,
+   PRIMARY KEY (S_W_ID,S_I_ID)
+   );
+   */
+
+  // Create schema first
+  std::vector<catalog::Column> stock_columns;
+
+  auto s_i_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "S_I_ID", is_inlined);
+  stock_columns.push_back(s_i_id_column);
+  auto s_w_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "S_W_ID", is_inlined);
+  stock_columns.push_back(s_w_id_column);
+  auto s_quantity_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "S_QUANTITY", is_inlined);
+  stock_columns.push_back(s_quantity_column);
+  auto s_dist_01_column =
+      catalog::Column(type::Type::VARCHAR, dist_length, "S_DIST_01", is_inlined);
+  stock_columns.push_back(s_dist_01_column);
+  auto s_dist_02_column =
+      catalog::Column(type::Type::VARCHAR, dist_length, "S_DIST_02", is_inlined);
+  stock_columns.push_back(s_dist_02_column);
+  auto s_dist_03_column =
+      catalog::Column(type::Type::VARCHAR, dist_length, "S_DIST_03", is_inlined);
+  stock_columns.push_back(s_dist_03_column);
+  auto s_dist_04_column =
+      catalog::Column(type::Type::VARCHAR, dist_length, "S_DIST_04", is_inlined);
+  stock_columns.push_back(s_dist_04_column);
+  auto s_dist_05_column =
+      catalog::Column(type::Type::VARCHAR, dist_length, "S_DIST_05", is_inlined);
+  stock_columns.push_back(s_dist_05_column);
+  auto s_dist_06_column =
+      catalog::Column(type::Type::VARCHAR, dist_length, "S_DIST_06", is_inlined);
+  stock_columns.push_back(s_dist_06_column);
+  auto s_dist_07_column =
+      catalog::Column(type::Type::VARCHAR, dist_length, "S_DIST_07", is_inlined);
+  stock_columns.push_back(s_dist_07_column);
+  auto s_dist_08_column =
+      catalog::Column(type::Type::VARCHAR, dist_length, "S_DIST_08", is_inlined);
+  stock_columns.push_back(s_dist_08_column);
+  auto s_dist_09_column =
+      catalog::Column(type::Type::VARCHAR, dist_length, "S_DIST_09", is_inlined);
+  stock_columns.push_back(s_dist_09_column);
+  auto s_dist_10_column =
+      catalog::Column(type::Type::VARCHAR, dist_length, "S_DIST_10", is_inlined);
+  stock_columns.push_back(s_dist_10_column);
+  auto s_ytd_column = catalog::Column(
+      type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER), "S_YTD", is_inlined);
+  stock_columns.push_back(s_ytd_column);
+  auto s_order_cnt_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "S_ORDER_CNT", is_inlined);
+  stock_columns.push_back(s_order_cnt_column);
+  auto s_discount_cnt_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "S_REMOTE_CNT", is_inlined);
+  stock_columns.push_back(s_discount_cnt_column);
+  auto s_data_column =
+      catalog::Column(type::Type::VARCHAR, data_length, "S_DATA", is_inlined);
+  stock_columns.push_back(s_data_column);
+
+  catalog::Schema *table_schema = new catalog::Schema(stock_columns);
+  std::string table_name("STOCK");
+
+  stock_table = storage::TableFactory::GetDataTable(
+      tpcc_database_oid, stock_table_oid, table_schema, table_name,
+      DEFAULT_TUPLES_PER_TILEGROUP, own_schema, adapt_table);
+
+  tpcc_database->AddTable(stock_table);
+
+  // Primary index on S_I_ID, S_W_ID
+  std::vector<oid_t> key_attrs = {0, 1};
+
+  auto tuple_schema = stock_table->GetSchema();
+  catalog::Schema *key_schema =
+      catalog::Schema::CopySchema(tuple_schema, key_attrs);
+  key_schema->SetIndexedColumns(key_attrs);
+  bool unique = true;
+
+  index::IndexMetadata *index_metadata = new index::IndexMetadata(
+      "stock_pkey", stock_table_pkey_index_oid, stock_table_oid,
+      tpcc_database_oid, INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_PRIMARY_KEY,
+      tuple_schema, key_schema, key_attrs, unique);
+
+  std::shared_ptr<index::Index> pkey_index(
+      index::IndexFactory::GetIndex(index_metadata));
+  stock_table->AddIndex(pkey_index);
+}
+
+void CreateOrdersTable() {
+  /*
+   CREATE TABLE ORDERS (
+   O_ID INTEGER DEFAULT '0' NOT NULL,
+   O_C_ID INTEGER DEFAULT NULL,
+   O_D_ID TINYINT DEFAULT '0' NOT NULL,
+   O_W_ID SMALLINT DEFAULT '0' NOT NULL,
+   O_ENTRY_D TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+   O_CARRIER_ID INTEGER DEFAULT NULL,
+   O_OL_CNT INTEGER DEFAULT NULL,
+   O_ALL_LOCAL INTEGER DEFAULT NULL,
+   PRIMARY KEY (O_W_ID,O_D_ID,O_ID),
+   UNIQUE (O_W_ID,O_D_ID,O_C_ID,O_ID),
+   CONSTRAINT O_FKEY_C FOREIGN KEY (O_C_ID, O_D_ID, O_W_ID) REFERENCES CUSTOMER
+   (C_ID, C_D_ID, C_W_ID)
+   );
+   CREATE INDEX IDX_ORDERS ON ORDERS (O_W_ID,O_D_ID,O_C_ID);
+   */
+
+  // Create schema first
+  std::vector<catalog::Column> orders_columns;
+
+  auto o_id_column = catalog::Column(
+      type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER), "O_ID", is_inlined);
+  orders_columns.push_back(o_id_column);
+  auto o_c_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "O_C_ID", is_inlined);
+  orders_columns.push_back(o_c_id_column);
+  auto o_d_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "O_D_ID", is_inlined);
+  orders_columns.push_back(o_d_id_column);
+  auto o_w_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "O_W_ID", is_inlined);
+  orders_columns.push_back(o_w_id_column);
+  auto o_entry_d_column =
+      catalog::Column(type::Type::TIMESTAMP, type::Type::GetTypeSize(type::Type::TIMESTAMP),
+                      "O_ENTRY_D", is_inlined);
+  orders_columns.push_back(o_entry_d_column);
+  auto o_carrier_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "O_CARRIER_ID", is_inlined);
+  orders_columns.push_back(o_carrier_id_column);
+  auto o_ol_cnt_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "O_OL_CNT", is_inlined);
+  orders_columns.push_back(o_ol_cnt_column);
+  auto o_all_local_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "O_ALL_LOCAL", is_inlined);
+  orders_columns.push_back(o_all_local_column);
+
+  catalog::Schema *table_schema = new catalog::Schema(orders_columns);
+  std::string table_name("ORDERS");
+
+  orders_table = storage::TableFactory::GetDataTable(
+      tpcc_database_oid, orders_table_oid, table_schema, table_name,
+      DEFAULT_TUPLES_PER_TILEGROUP, own_schema, adapt_table);
+
+  tpcc_database->AddTable(orders_table);
+
+  auto tuple_schema = customer_table->GetSchema();
+  std::vector<oid_t> key_attrs;
+  catalog::Schema *key_schema = nullptr;
+  index::IndexMetadata *index_metadata = nullptr;
+
+  // Primary index on O_ID, O_D_ID, O_W_ID
+  key_attrs = {0, 2, 3};
+  key_schema = catalog::Schema::CopySchema(tuple_schema, key_attrs);
+  key_schema->SetIndexedColumns(key_attrs);
+
+  index_metadata = new index::IndexMetadata(
+      "orders_pkey", orders_table_pkey_index_oid, orders_table_oid,
+      tpcc_database_oid, INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_PRIMARY_KEY,
+      tuple_schema, key_schema, key_attrs, true);
+
+
+  std::shared_ptr<index::Index> pkey_index(
+      index::IndexFactory::GetIndex(index_metadata));
+  orders_table->AddIndex(pkey_index);
+
+  // Secondary index on O_C_ID, O_D_ID, O_W_ID
+  key_attrs = {1, 2, 3};
+  key_schema = catalog::Schema::CopySchema(tuple_schema, key_attrs);
+  key_schema->SetIndexedColumns(key_attrs);
+
+  index_metadata = new index::IndexMetadata(
+      "orders_skey", orders_table_skey_index_oid, orders_table_oid,
+      tpcc_database_oid, INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_INVALID,
+      tuple_schema, key_schema, key_attrs, false);
+
+  std::shared_ptr<index::Index> skey_index(
+      index::IndexFactory::GetIndex(index_metadata));
+  orders_table->AddIndex(skey_index);
+}
+
+void CreateNewOrderTable() {
+  /*
+   CREATE TABLE NEW_ORDER (
+   NO_O_ID INTEGER DEFAULT '0' NOT NULL,
+   NO_D_ID TINYINT DEFAULT '0' NOT NULL,
+   NO_W_ID SMALLINT DEFAULT '0' NOT NULL,
+   CONSTRAINT NO_PK_TREE PRIMARY KEY (NO_D_ID,NO_W_ID,NO_O_ID),
+   CONSTRAINT NO_FKEY_O FOREIGN KEY (NO_O_ID, NO_D_ID, NO_W_ID) REFERENCES
+   ORDERS (O_ID, O_D_ID, O_W_ID)
+   );
+   */
+
+  // Create schema first
+  std::vector<catalog::Column> new_order_columns;
+
+  auto no_o_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "NO_O_ID", is_inlined);
+  new_order_columns.push_back(no_o_id_column);
+  auto no_d_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "NO_D_ID", is_inlined);
+  new_order_columns.push_back(no_d_id_column);
+  auto no_w_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "NO_W_ID", is_inlined);
+  new_order_columns.push_back(no_w_id_column);
+
+  catalog::Schema *table_schema = new catalog::Schema(new_order_columns);
+  std::string table_name("NEW_ORDER");
+
+  new_order_table = storage::TableFactory::GetDataTable(
+      tpcc_database_oid, new_order_table_oid, table_schema, table_name,
+      DEFAULT_TUPLES_PER_TILEGROUP, own_schema, adapt_table);
+
+  tpcc_database->AddTable(new_order_table);
+
+  // Primary index on NO_O_ID, NO_D_ID, NO_W_ID
+  std::vector<oid_t> key_attrs = {0, 1, 2};
+
+  auto tuple_schema = new_order_table->GetSchema();
+  catalog::Schema *key_schema =
+      catalog::Schema::CopySchema(tuple_schema, key_attrs);
+  key_schema->SetIndexedColumns(key_attrs);
+  bool unique = true;
+
+  index::IndexMetadata *index_metadata = new index::IndexMetadata(
+    "new_order_pkey", new_order_table_pkey_index_oid, new_order_table_oid,
+    tpcc_database_oid, INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_PRIMARY_KEY,
+    tuple_schema, key_schema, key_attrs, unique);
+
+  std::shared_ptr<index::Index> pkey_index(
+      index::IndexFactory::GetIndex(index_metadata));
+  new_order_table->AddIndex(pkey_index);
+}
+
+void CreateOrderLineTable() {
+  /*
+   CREATE TABLE ORDER_LINE (
+   OL_O_ID INTEGER DEFAULT '0' NOT NULL,
+   OL_D_ID TINYINT DEFAULT '0' NOT NULL,
+   OL_W_ID SMALLINT DEFAULT '0' NOT NULL,
+   OL_NUMBER INTEGER DEFAULT '0' NOT NULL,
+   OL_I_ID INTEGER DEFAULT NULL,
+   OL_SUPPLY_W_ID SMALLINT DEFAULT NULL,
+   OL_DELIVERY_D TIMESTAMP DEFAULT NULL,
+   OL_QUANTITY INTEGER DEFAULT NULL,
+   OL_AMOUNT FLOAT DEFAULT NULL,
+   OL_DIST_INFO VARCHAR(32) DEFAULT NULL,
+   PRIMARY KEY (OL_W_ID,OL_D_ID,OL_O_ID,OL_NUMBER),
+   CONSTRAINT OL_FKEY_O FOREIGN KEY (OL_O_ID, OL_D_ID, OL_W_ID) REFERENCES
+   ORDERS (O_ID, O_D_ID, O_W_ID),
+   CONSTRAINT OL_FKEY_S FOREIGN KEY (OL_I_ID, OL_SUPPLY_W_ID) REFERENCES STOCK
+   (S_I_ID, S_W_ID)
+   );
+   CREATE INDEX IDX_ORDER_LINE_TREE ON ORDER_LINE (OL_W_ID,OL_D_ID,OL_O_ID);
+   */
+
+  // Create schema first
+  std::vector<catalog::Column> order_line_columns;
+
+  auto ol_o_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "OL_O_ID", is_inlined);
+  order_line_columns.push_back(ol_o_id_column);
+  auto ol_d_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "OL_D_ID", is_inlined);
+  order_line_columns.push_back(ol_d_id_column);
+  auto ol_w_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "OL_W_ID", is_inlined);
+  order_line_columns.push_back(ol_w_id_column);
+  auto ol_number_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "OL_NUMBER", is_inlined);
+  order_line_columns.push_back(ol_number_column);
+  auto ol_i_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "OL_I_ID", is_inlined);
+  order_line_columns.push_back(ol_i_id_column);
+  auto ol_supply_w_id_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "OL_SUPPLY_W_ID", is_inlined);
+  order_line_columns.push_back(ol_supply_w_id_column);
+  auto ol_delivery_d_column =
+      catalog::Column(type::Type::TIMESTAMP, type::Type::GetTypeSize(type::Type::TIMESTAMP),
+                      "OL_DELIVERY_D", is_inlined);
+  order_line_columns.push_back(ol_delivery_d_column);
+  auto ol_quantity_column =
+      catalog::Column(type::Type::INTEGER, type::Type::GetTypeSize(type::Type::INTEGER),
+                      "OL_QUANTITY", is_inlined);
+  order_line_columns.push_back(ol_quantity_column);
+  auto ol_amount_column =
+      catalog::Column(type::Type::DECIMAL, type::Type::GetTypeSize(type::Type::DECIMAL),
+                      "OL_AMOUNT", is_inlined);
+  order_line_columns.push_back(ol_amount_column);
+  auto ol_dist_info_column =
+      catalog::Column(type::Type::VARCHAR, order_line_dist_info_length,
+                      "OL_DIST_INFO", is_inlined);
+  order_line_columns.push_back(ol_dist_info_column);
+
+  catalog::Schema *table_schema = new catalog::Schema(order_line_columns);
+  std::string table_name("ORDER_LINE");
+
+  order_line_table = storage::TableFactory::GetDataTable(
+      tpcc_database_oid, order_line_table_oid, table_schema, table_name,
+      DEFAULT_TUPLES_PER_TILEGROUP, own_schema, adapt_table);
+
+  tpcc_database->AddTable(order_line_table);
+
+  auto tuple_schema = order_line_table->GetSchema();
+  std::vector<oid_t> key_attrs;
+  catalog::Schema *key_schema = nullptr;
+  index::IndexMetadata *index_metadata = nullptr;
+
+  // Primary index on OL_O_ID, OL_D_ID, OL_W_ID, OL_NUMBER
+  key_attrs = {0, 1, 2, 3};
+  key_schema = catalog::Schema::CopySchema(tuple_schema, key_attrs);
+  key_schema->SetIndexedColumns(key_attrs);
+
+  index_metadata = new index::IndexMetadata(
+      "order_line_pkey", order_line_table_pkey_index_oid, order_line_table_oid,
+      tpcc_database_oid, INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_PRIMARY_KEY,
+      tuple_schema, key_schema, key_attrs, true);
+
+
+  std::shared_ptr<index::Index> pkey_index(
+      index::IndexFactory::GetIndex(index_metadata));
+  order_line_table->AddIndex(pkey_index);
+
+  // Secondary index on OL_O_ID, OL_D_ID, OL_W_ID
+  key_attrs = {0, 1, 2};
+  key_schema = catalog::Schema::CopySchema(tuple_schema, key_attrs);
+  key_schema->SetIndexedColumns(key_attrs);
+
+  index_metadata = new index::IndexMetadata(
+      "order_line_skey", order_line_table_skey_index_oid, order_line_table_oid,
+      tpcc_database_oid, INDEX_TYPE_BWTREE, INDEX_CONSTRAINT_TYPE_INVALID,
+      tuple_schema, key_schema, key_attrs, false);
+
+  std::shared_ptr<index::Index> skey_index(
+      index::IndexFactory::GetIndex(index_metadata));
+  order_line_table->AddIndex(skey_index);
+}
+
+void CreateTPCCDatabase() {
+  tpcc_database = nullptr;
+  warehouse_table = nullptr;
+  district_table = nullptr;
+  item_table = nullptr;
+  customer_table = nullptr;
+  history_table = nullptr;
+  stock_table = nullptr;
+  orders_table = nullptr;
+  new_order_table = nullptr;
+  order_line_table = nullptr;
+
+  auto catalog = catalog::Catalog::GetInstance();
+  std::string tpcc_database_name = "TPCC";
+  tpcc_database = new storage::Database(tpcc_database_oid);
+  catalog->AddDatabase(tpcc_database_name, tpcc_database);
+
+  CreateWarehouseTable();
+  CreateDistrictTable();
+  CreateItemTable();
+  CreateCustomerTable();
+  CreateHistoryTable();
+  CreateStockTable();
+  CreateOrdersTable();
+  CreateNewOrderTable();
+  CreateOrderLineTable();
+}
+
+void DropTPCCDatabase() {
+
+  // Clean up
+  delete tpcc_database;
+
+}
+
+TEST_F(IndexTunerTests, TPCCTest) {
+
+  // Create TPCC database
+  CreateTPCCDatabase();
+
+  // Index tuner
+  brain::IndexTuner &index_tuner = brain::IndexTuner::GetInstance();
+
+  // Start index tuner
+  index_tuner.Start();
+
+  // Bootstrap TPCC
+  index_tuner.BootstrapTPCC();
+
+  // Wait for tuner to build indexes
+  sleep(1);
+
+  // Stop index tuner
+  index_tuner.Stop();
+
+  // Drop TPCC database
+  DropTPCCDatabase();
 
 }
 

--- a/test/brain/index_tuner_test.cpp
+++ b/test/brain/index_tuner_test.cpp
@@ -72,7 +72,6 @@ TEST_F(IndexTunerTests, BasicTest) {
 
   std::vector<double> columns_accessed(column_count, 0);
   double sample_weight;
-  double selectivity = 0.1;
 
   UniformGenerator generator;
   for (int sample_itr = 0; sample_itr < 10000; sample_itr++) {
@@ -93,8 +92,7 @@ TEST_F(IndexTunerTests, BasicTest) {
     // Indicates the columns present in predicate, query weight, and selectivity
     brain::Sample sample(columns_accessed,
                          sample_weight,
-                         brain::SAMPLE_TYPE_ACCESS,
-                         selectivity);
+                         brain::SAMPLE_TYPE_ACCESS);
 
     // Collect index sample in table
     data_table->RecordIndexSample(sample);

--- a/test/brain/index_tuner_test.cpp
+++ b/test/brain/index_tuner_test.cpp
@@ -107,6 +107,9 @@ TEST_F(IndexTunerTests, BasicTest) {
     }
   }
 
+  // Wait for tuner to build indexes
+  sleep(5);
+
   // Stop index tuner
   index_tuner.Stop();
 
@@ -1219,6 +1222,10 @@ TEST_F(IndexTunerTests, TPCCTest) {
   // Index tuner
   brain::IndexTuner &index_tuner = brain::IndexTuner::GetInstance();
 
+  // Set duration between pauses
+  auto duration = 10000; // in ms
+  index_tuner.SetDurationBetweenPauses(duration);
+
   // Start index tuner
   index_tuner.Start();
 
@@ -1226,7 +1233,7 @@ TEST_F(IndexTunerTests, TPCCTest) {
   index_tuner.BootstrapTPCC();
 
   // Wait for tuner to build indexes
-  sleep(1);
+  sleep(5);
 
   // Stop index tuner
   index_tuner.Stop();

--- a/test/brain/layout_tuner_test.cpp
+++ b/test/brain/layout_tuner_test.cpp
@@ -74,11 +74,11 @@ TEST_F(LayoutTunerTests, BasicTest) {
     auto rng_val = generator.GetSample();
 
     if (rng_val < 0.9) {
-      columns_accessed = {1, 1, 1, 0};
+      columns_accessed = {0, 1, 2};
       sample_weight = 100;
     }
     else {
-      columns_accessed = {0, 0, 0, 1};
+      columns_accessed = {3};
       sample_weight = 10;
     }
 


### PR DESCRIPTION
You can now tell a `PacketManager` that it needs to invalidate the cached query plan for all of its PreparedStatements and then replan them the next time that they are invoked. I am assuming that there is only one `PacketManager` per thread.

This code is nasty. I'm not pleaed with myself. But the `PacketManager` is a mess and there is no easy way to break out the PreparedStatement cache from it for now.

There is no easy way to write a test for this either because the `PacketManager` requires you to start up the libevent code. So I tested it manually (for now) but inserting this chunk of code into `IndexScanExecutor::DExecute()`

```
  // HACK
  LOG_DEBUG(
      "HACK: Telling PacketManagers to invalidate the PreparedStatements for "
      "'%s'",
      table_->GetName().c_str());
  for (auto pm : wire::PacketManager::GetPacketManagers()) {
    pm->InvalidatePreparedStatements(table_->GetOid());
  } 
```

Again, I told you that I am not boasting about this. I just had to get it done.