### PR TITLE
Fix memory leak in varlen pool

### DIFF
--- a/src/gc/gc_manager.cpp
+++ b/src/gc/gc_manager.cpp
@@ -11,10 +11,51 @@
 //===----------------------------------------------------------------------===//
 #include "gc/gc_manager.h"
 
+#include "catalog/schema.h"
+#include "type/types.h"
+#include "type/value.h"
+#include "type/abstract_pool.h"
+#include "storage/tile.h"
+#include "storage/tile_group.h"
+
 namespace peloton {
 namespace gc {
 
+// Check a tuple and reclaim all varlen field
+void GCManager::CheckAndReclaimVarlenColumns(storage::TileGroup *tg, oid_t tuple_id) {
+    oid_t tile_count = tg->tile_count;
+    oid_t tile_col_count;
+    type::Type::TypeId type_id;
+    char *tuple_location;
+    char *field_location;
+    char *varlen_ptr;
 
+      for (oid_t tile_itr = 0; tile_itr < tile_count; tile_itr++) {
+        const catalog::Schema &schema = tg->tile_schemas[tile_itr];
+
+          tile_col_count = schema.GetColumnCount();
+
+          storage::Tile *tile = tg->GetTile(tile_itr);
+        PL_ASSERT(tile);
+        for (oid_t tile_col_itr = 0; tile_col_itr < tile_col_count; ++tile_col_itr) {
+            type_id = schema.GetType(tile_col_itr);
+
+              if ((type_id != type::Type::TypeId::VARCHAR && type_id != type::Type::TypeId::VARBINARY)
+                             || (schema.IsInlined(tile_col_itr) == true)) {
+                // Not of varlen type, or is inlined, skip
+                  continue;
+              }
+            // Get the raw varlen pointer
+              tuple_location = tile->GetTupleLocation(tuple_id);
+            field_location = tuple_location + schema.GetOffset(tile_col_itr);
+            varlen_ptr = type::Value::GetDataFromStorage(type_id, field_location);
+            // Call the corresponding varlen pool free
+              if (varlen_ptr != nullptr) {
+                tile->pool->Free(varlen_ptr);
+              }
+          }
+      }
+  }
 
 }
 }

--- a/src/include/gc/gc_manager.h
+++ b/src/include/gc/gc_manager.h
@@ -20,6 +20,11 @@
 #include "common/logger.h"
 
 namespace peloton {
+
+namespace storage {
+  class TileGroup;
+}
+
 namespace gc {
 
 //===--------------------------------------------------------------------===//
@@ -64,6 +69,9 @@ public:
   virtual void RecycleTransaction(std::shared_ptr<ReadWriteSet> gc_set UNUSED_ATTRIBUTE, 
                                    const cid_t &timestamp UNUSED_ATTRIBUTE,
                                    const GCSetType gc_set_type UNUSED_ATTRIBUTE) {}
+
+protected:
+  void CheckAndReclaimVarlenColumns(storage::TileGroup *tg, oid_t tuple_id);
 
 protected:
   volatile bool is_running_;

--- a/src/include/storage/tile.h
+++ b/src/include/storage/tile.h
@@ -23,6 +23,11 @@
 #include <mutex>
 
 namespace peloton {
+
+namespace gc {
+class GCManager;
+}
+
 namespace storage {
 
 //===--------------------------------------------------------------------===//
@@ -45,6 +50,7 @@ class Tile : public Printable {
   friend class TileFactory;
   friend class TupleIterator;
   friend class TileGroupHeader;
+  friend class gc::GCManager;
 
   Tile() = delete;
   Tile(Tile const &) = delete;

--- a/src/include/storage/tile_group.h
+++ b/src/include/storage/tile_group.h
@@ -32,6 +32,10 @@ class Manager;
 class Schema;
 }
 
+namespace gc {
+class GCManager;
+}
+
 namespace planner {
 class ProjectInfo;
 }
@@ -63,6 +67,7 @@ typedef std::map<oid_t, std::pair<oid_t, oid_t>> column_map_type;
 class TileGroup : public Printable {
   friend class Tile;
   friend class TileGroupFactory;
+  friend class gc::GCManager;
 
   TileGroup() = delete;
   TileGroup(TileGroup const &) = delete;

--- a/src/include/type/ephemeral_pool.h
+++ b/src/include/type/ephemeral_pool.h
@@ -18,6 +18,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <vector>
+#include <unordered_set>
 
 #include "common/platform.h"
 
@@ -50,21 +51,25 @@ public:
     auto location = new char[size];
 
     pool_lock_.Lock();
-    locations_.push_back(location);
+    locations_.insert(location);
     pool_lock_.Unlock();
 
     return location;
   }
 
   // Returns the provided chunk of memory back into the pool
-  void Free(UNUSED_ATTRIBUTE void *ptr){
-
+  void Free(UNUSED_ATTRIBUTE void *ptr) {
+    char *cptr = (char *) ptr;
+    pool_lock_.Lock();
+    locations_.erase(cptr);
+    pool_lock_.Unlock();
+    delete [] cptr;
   }
 
 public:
 
   // Location list
-  std::vector<char*> locations_;
+  std::unordered_set<char*> locations_;
 
   // Spin lock protecting location list
   Spinlock pool_lock_;

--- a/src/include/type/type.h
+++ b/src/include/type/type.h
@@ -145,6 +145,9 @@ class Type {
   // Get the length of the variable length data
   virtual uint32_t GetLength(const Value& val) const;
 
+  // Access the raw varlen data stored from the tuple storage
+  virtual char *GetData(char *storage);
+
   // Get the element at a given index in this array
   virtual Value GetElementAt(const Value& val, uint64_t idx) const;
 

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -266,6 +266,19 @@ class Value : public Printable {
     return Type::GetInstance(type_id_)->GetData(*this);
   }
 
+  // Access the raw variable length data from a pointer pointed to a tuple storage
+  inline static char *GetDataFromStorage(Type::TypeId type_id, char *storage) {
+    switch (type_id) {
+      case Type::VARCHAR:
+      case Type::VARBINARY: {
+        return Type::GetInstance(type_id)->GetData(storage);
+      }
+      default:
+        throw Exception(EXCEPTION_TYPE_INCOMPATIBLE_TYPE,
+                        "Invalid Type for getting raw data pointer");
+    }
+  }
+
   // Get the length of the variable length data
   inline uint32_t GetLength() const {
     return Type::GetInstance(type_id_)->GetLength(*this);

--- a/src/include/type/varlen_type.h
+++ b/src/include/type/varlen_type.h
@@ -27,6 +27,9 @@ class VarlenType : public Type {
   // Access the raw variable length data
   const char *GetData(const Value& val) const;
 
+  // Access the raw varlen data stored from the tuple storage
+  char *GetData(char *storage) override;
+
   // Get the length of the variable length data
   uint32_t GetLength(const Value& val) const;
 

--- a/src/type/type.cpp
+++ b/src/type/type.cpp
@@ -311,6 +311,11 @@ uint32_t Type::GetLength(const Value& val UNUSED_ATTRIBUTE) const {
   throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
 }
 
+// Access the raw varlen data stored from the tuple storage
+char * Type::GetData(char *storage UNUSED_ATTRIBUTE) {
+  throw new Exception(EXCEPTION_TYPE_INVALID, "invalid type");
+}
+
 // Get the element at a given index in this array
 Value Type::GetElementAt(const Value& val UNUSED_ATTRIBUTE,
                          uint64_t idx UNUSED_ATTRIBUTE) const {

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -33,6 +33,12 @@ const char *VarlenType::GetData(const Value &val) const {
 // Get the length of the variable length data
 uint32_t VarlenType::GetLength(const Value &val) const { return val.size_.len; }
 
+// Access the raw varlen data stored from the tuple storage
+char *VarlenType::GetData(char *storage) {
+  char *ptr = *reinterpret_cast<char **>(storage);
+  return ptr;
+}
+
 CmpBool VarlenType::CompareEquals(const Value &left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CMP_NULL;


### PR DESCRIPTION
1. Bring back the logic in GCManager to reclaim varlen pool
2. Tweek the varlen pool implementation to support `Free()`

#442 