### PR TITLE
Orderby/Limit Optimization

### DIFF
--- a/src/executor/abstract_executor.cpp
+++ b/src/executor/abstract_executor.cpp
@@ -101,10 +101,14 @@ void AbstractExecutor::SetContext(type::Value &value) {
 
 void AbstractExecutor::ClearContext() { executor_context_->ClearParams(); }
 
-// TODO: To be implemented in the next PR
-void AbstractExecutor::InitResultOrderFlag(bool &order UNUSED_ATTRIBUTE,
-                                           std::vector<oid_t> &columns
-                                               UNUSED_ATTRIBUTE,
-                                           bool &descend UNUSED_ATTRIBUTE) {}
+// Init all children's flag
+void AbstractExecutor::InitResultOrderFlag(bool &order,
+                                           std::vector<oid_t> &columns,
+                                           bool &descend) {
+  for (auto child : children_) {
+    child->InitResultOrderFlag(order, columns, descend);
+  }
+}
+
 }  // namespace executor
 }  // namespace peloton

--- a/src/executor/abstract_executor.cpp
+++ b/src/executor/abstract_executor.cpp
@@ -101,14 +101,5 @@ void AbstractExecutor::SetContext(type::Value &value) {
 
 void AbstractExecutor::ClearContext() { executor_context_->ClearParams(); }
 
-// Init all children's flag
-void AbstractExecutor::InitResultOrderFlag(bool &order,
-                                           std::vector<oid_t> &columns,
-                                           bool &descend) {
-  for (auto child : children_) {
-    child->InitResultOrderFlag(order, columns, descend);
-  }
-}
-
 }  // namespace executor
 }  // namespace peloton

--- a/src/executor/hybrid_scan_executor.cpp
+++ b/src/executor/hybrid_scan_executor.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include <memory>
 #include <utility>
 #include <vector>
@@ -43,8 +42,8 @@ namespace executor {
 
 HybridScanExecutor::HybridScanExecutor(const planner::AbstractPlan *node,
                                        ExecutorContext *executor_context)
-: AbstractScanExecutor(node, executor_context),
-  indexed_tile_offset_(START_OID) {}
+    : AbstractScanExecutor(node, executor_context),
+      indexed_tile_offset_(START_OID) {}
 
 bool HybridScanExecutor::DInit() {
   auto status = AbstractScanExecutor::DInit();
@@ -104,7 +103,7 @@ bool HybridScanExecutor::DInit() {
     }
 
     if (table_ != nullptr) {
-      LOG_TRACE("Column count : %u", table_->GetSchema()->GetColumnCount());
+      LOG_TRACE("Column count : %lu", table_->GetSchema()->GetColumnCount());
       full_column_ids_.resize(table_->GetSchema()->GetColumnCount());
       std::iota(full_column_ids_.begin(), full_column_ids_.end(), 0);
     }
@@ -215,30 +214,32 @@ bool HybridScanExecutor::SeqScanUtil() {
       }
 
       // Check transaction visibility
-      if (transaction_manager.IsVisible(current_txn, tile_group_header, tuple_id) == VISIBILITY_OK) {
+      if (transaction_manager.IsVisible(current_txn, tile_group_header,
+                                        tuple_id) == VISIBILITY_OK) {
         // If the tuple is visible, then perform predicate evaluation.
         if (predicate_ == nullptr) {
           position_list.push_back(tuple_id);
-        }
-        else {
+        } else {
           expression::ContainerTuple<storage::TileGroup> tuple(tile_group.get(),
                                                                tuple_id);
-          auto eval = predicate_->Evaluate(&tuple, nullptr, executor_context_).IsTrue();
+          auto eval =
+              predicate_->Evaluate(&tuple, nullptr, executor_context_).IsTrue();
           if (eval == true) {
             position_list.push_back(tuple_id);
           }
         }
-      }
-      else {
+      } else {
         expression::ContainerTuple<storage::TileGroup> tuple(tile_group.get(),
                                                              tuple_id);
         auto eval =
             predicate_->Evaluate(&tuple, nullptr, executor_context_).IsTrue();
         if (eval == true) {
           position_list.push_back(tuple_id);
-          auto res = transaction_manager.PerformRead(current_txn, location, acquire_owner);
+          auto res = transaction_manager.PerformRead(current_txn, location,
+                                                     acquire_owner);
           if (!res) {
-            transaction_manager.SetTransactionResult(current_txn, RESULT_FAILURE);
+            transaction_manager.SetTransactionResult(current_txn,
+                                                     RESULT_FAILURE);
             return res;
           }
         }
@@ -272,8 +273,7 @@ bool HybridScanExecutor::IndexScanUtil() {
     if (result_[result_itr_]->GetTupleCount() == 0) {
       result_itr_++;
       continue;
-    }
-    else {
+    } else {
       SetOutput(result_[result_itr_]);
       result_itr_++;
       return true;
@@ -301,8 +301,7 @@ bool HybridScanExecutor::DExecute() {
         if (status == false) {
           return false;
         }
-      }
-      else {
+      } else {
         return false;
       }
     }
@@ -333,7 +332,6 @@ bool HybridScanExecutor::DExecute() {
   else {
     throw Exception("Invalid hybrid scan type : " + std::to_string(type_));
   }
-
 }
 
 bool HybridScanExecutor::ExecPrimaryIndexLookup() {
@@ -354,11 +352,8 @@ bool HybridScanExecutor::ExecPrimaryIndexLookup() {
     index_->ScanAllKeys(tuple_location_ptrs);
   } else {
     LOG_TRACE("Scan");
-    index_->Scan(values_,
-                 key_column_ids_,
-                 expr_type_,
-                 SCAN_DIRECTION_TYPE_FORWARD,
-                 tuple_location_ptrs,
+    index_->Scan(values_, key_column_ids_, expr_type_,
+                 SCAN_DIRECTION_TYPE_FORWARD, tuple_location_ptrs,
                  &node.GetIndexPredicate().GetConjunctionList()[0]);
   }
 
@@ -394,12 +389,14 @@ bool HybridScanExecutor::ExecPrimaryIndexLookup() {
     while (true) {
       ++chain_length;
 
-      auto visibility = transaction_manager.IsVisible(current_txn, tile_group_header, tuple_location.offset);
+      auto visibility = transaction_manager.IsVisible(
+          current_txn, tile_group_header, tuple_location.offset);
 
       if (visibility == VISIBILITY_OK) {
 
         visible_tuples[tuple_location.block].push_back(tuple_location.offset);
-        auto res = transaction_manager.PerformRead(current_txn, tuple_location, acquire_owner);
+        auto res = transaction_manager.PerformRead(current_txn, tuple_location,
+                                                   acquire_owner);
         if (!res) {
           transaction_manager.SetTransactionResult(current_txn, RESULT_FAILURE);
           return res;
@@ -418,12 +415,12 @@ bool HybridScanExecutor::ExecPrimaryIndexLookup() {
         // check whether older version is garbage.
         if (old_end_cid < max_committed_cid) {
           assert(tile_group_header->GetTransactionId(old_item.offset) ==
-              INITIAL_TXN_ID ||
-              tile_group_header->GetTransactionId(old_item.offset) ==
-                  INVALID_TXN_ID);
+                     INITIAL_TXN_ID ||
+                 tile_group_header->GetTransactionId(old_item.offset) ==
+                     INVALID_TXN_ID);
 
           if (tile_group_header->SetAtomicTransactionId(
-              old_item.offset, INVALID_TXN_ID) == true) {
+                  old_item.offset, INVALID_TXN_ID) == true) {
             // atomically swap item pointer held in the index bucket.
             AtomicUpdateItemPointer(tuple_location_ptr, tuple_location);
           }

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -377,11 +377,13 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
     if (limit_) {
       // invoke index scan limit
       if (!descend_) {
+        LOG_TRACE("ASCENDING SCAN LIMIT in Secondary Index");
         index_->ScanLimit(values_, key_column_ids_, expr_types_,
                           SCAN_DIRECTION_TYPE_FORWARD, tuple_location_ptrs,
                           &index_predicate_.GetConjunctionList()[0],
                           limit_number_, limit_offset_);
       } else {
+        LOG_TRACE("DESCENDING SCAN LIMIT in Secondary Index");
         index_->ScanLimit(values_, key_column_ids_, expr_types_,
                           SCAN_DIRECTION_TYPE_BACKWARD, tuple_location_ptrs,
                           &index_predicate_.GetConjunctionList()[0],

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -178,6 +178,8 @@ bool IndexScanExecutor::ExecPrimaryIndexLookup() {
                           SCAN_DIRECTION_TYPE_BACKWARD, tuple_location_ptrs,
                           &index_predicate_.GetConjunctionList()[0],
                           limit_number_, limit_offset_);
+
+        LOG_TRACE("1-Result size is %lu", result_.size());
       }
     }
     // Normal SQL (without limit)
@@ -384,6 +386,8 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
                           SCAN_DIRECTION_TYPE_BACKWARD, tuple_location_ptrs,
                           &index_predicate_.GetConjunctionList()[0],
                           limit_number_, limit_offset_);
+
+        LOG_TRACE("2-Result size is %lu", tuple_location_ptrs.size());
       }
     }
     // Normal SQL (without limit)
@@ -461,6 +465,9 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
         // Further check if the version has the secondary key
         expression::ContainerTuple<storage::TileGroup> candidate_tuple(
             tile_group.get(), tuple_location.offset);
+
+        LOG_TRACE("candidate_tuple size: %s",
+                  candidate_tuple.GetInfo().c_str());
         // Construct the key tuple
         auto &indexed_columns = index_->GetKeySchema()->GetIndexedColumns();
         storage::MaskedTuple key_tuple(&candidate_tuple, indexed_columns);
@@ -486,10 +493,13 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
           if (!res) {
             transaction_manager.SetTransactionResult(current_txn,
                                                      RESULT_FAILURE);
+            LOG_TRACE("passed evaluation, but txn read fails");
             return res;
           }
           // if perform read is successful, then add to visible tuple vector.
           visible_tuple_locations.push_back(tuple_location);
+          LOG_TRACE("passed evaluation, visible_tuple_locations size: %lu",
+                    visible_tuple_locations.size());
         }
 
         break;

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -388,7 +388,7 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
                           limit_number_, limit_offset_);
 
         if (tuple_location_ptrs.size() == 0) {
-          LOG_INFO("2-Result size is %lu", tuple_location_ptrs.size());
+          LOG_TRACE("2-Result size is %lu", tuple_location_ptrs.size());
         }
       }
     }
@@ -455,8 +455,8 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
 
       // if the tuple is deleted
       if (visibility == VISIBILITY_DELETED) {
-        LOG_INFO("encounter deleted tuple: %u, %u", tuple_location.block,
-                 tuple_location.offset);
+        LOG_TRACE("encounter deleted tuple: %u, %u", tuple_location.block,
+                  tuple_location.offset);
         break;
       }
       // if the tuple is visible.
@@ -477,8 +477,8 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
         // Compare the key tuple and the key
         if (index_->Compare(key_tuple, key_column_ids_, expr_types_, values_) ==
             false) {
-          LOG_INFO("Secondary key mismatch: %u, %u\n", tuple_location.block,
-                   tuple_location.offset);
+          LOG_TRACE("Secondary key mismatch: %u, %u\n", tuple_location.block,
+                    tuple_location.offset);
           break;
         }
 
@@ -495,7 +495,7 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
           if (!res) {
             transaction_manager.SetTransactionResult(current_txn,
                                                      RESULT_FAILURE);
-            LOG_INFO("passed evaluation, but txn read fails");
+            LOG_TRACE("passed evaluation, but txn read fails");
             return res;
           }
           // if perform read is successful, then add to visible tuple vector.
@@ -503,7 +503,7 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
           LOG_TRACE("passed evaluation, visible_tuple_locations size: %lu",
                     visible_tuple_locations.size());
         } else {
-          LOG_INFO("predicate evaluate fails");
+          LOG_TRACE("predicate evaluate fails");
         }
 
         break;
@@ -512,8 +512,8 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
       else {
         PL_ASSERT(visibility == VISIBILITY_INVISIBLE);
 
-        LOG_INFO("Invisible read: %u, %u", tuple_location.block,
-                 tuple_location.offset);
+        LOG_TRACE("Invisible read: %u, %u", tuple_location.block,
+                  tuple_location.offset);
 
         bool is_acquired = (tile_group_header->GetTransactionId(
                                 tuple_location.offset) == INITIAL_TXN_ID);

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -169,11 +169,13 @@ bool IndexScanExecutor::ExecPrimaryIndexLookup() {
     if (limit_) {
       // invoke index scan limit
       if (!descend_) {
+        LOG_TRACE("ASCENDING SCAN LIMIT in Primary Index");
         index_->ScanLimit(values_, key_column_ids_, expr_types_,
                           SCAN_DIRECTION_TYPE_FORWARD, tuple_location_ptrs,
                           &index_predicate_.GetConjunctionList()[0],
                           limit_number_, limit_offset_);
       } else {
+        LOG_TRACE("DESCENDING SCAN LIMIT in Primary Index");
         index_->ScanLimit(values_, key_column_ids_, expr_types_,
                           SCAN_DIRECTION_TYPE_BACKWARD, tuple_location_ptrs,
                           &index_predicate_.GetConjunctionList()[0],
@@ -184,6 +186,7 @@ bool IndexScanExecutor::ExecPrimaryIndexLookup() {
     }
     // Normal SQL (without limit)
     else {
+      LOG_TRACE("Index Scan in Primary Index");
       index_->Scan(values_, key_column_ids_, expr_types_,
                    SCAN_DIRECTION_TYPE_FORWARD, tuple_location_ptrs,
                    &index_predicate_.GetConjunctionList()[0]);
@@ -396,6 +399,7 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
     }
     // Normal SQL (without limit)
     else {
+      LOG_TRACE("Index Scan in Primary Index");
       index_->Scan(values_, key_column_ids_, expr_types_,
                    SCAN_DIRECTION_TYPE_FORWARD, tuple_location_ptrs,
                    &index_predicate_.GetConjunctionList()[0]);

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -331,8 +331,8 @@ bool IndexScanExecutor::ExecPrimaryIndexLookup() {
             visible_tuple_locations.size());
 
   for (auto &visible_tuple_location : visible_tuple_locations) {
-    visible_tuples[visible_tuple_location.block].push_back(
-        visible_tuple_location.offset);
+    visible_tuples[visible_tuple_location.block]
+        .push_back(visible_tuple_location.offset);
   }
 
   // Construct a logical tile for each block
@@ -371,7 +371,7 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
   if (0 == key_column_ids_.size()) {
     index_->ScanAllKeys(tuple_location_ptrs);
   } else {
-    //    // Limit clause accelerate
+    // Limit clause accelerate
     if (limit_) {
       // invoke index scan limit
       if (!descend_) {
@@ -476,9 +476,8 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
         bool eval = true;
         // if having predicate, then perform evaluation.
         if (predicate_ != nullptr) {
-          eval =
-              predicate_->Evaluate(&candidate_tuple, nullptr, executor_context_)
-                  .IsTrue();
+          eval = predicate_->Evaluate(&candidate_tuple, nullptr,
+                                      executor_context_).IsTrue();
         }
         // if passed evaluation, then perform write.
         if (eval == true) {
@@ -559,8 +558,8 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
   CheckOpenRangeWithReturnedTuples(visible_tuple_locations);
 
   for (auto &visible_tuple_location : visible_tuple_locations) {
-    visible_tuples[visible_tuple_location.block].push_back(
-        visible_tuple_location.offset);
+    visible_tuples[visible_tuple_location.block]
+        .push_back(visible_tuple_location.offset);
   }
 
   // Construct a logical tile for each block
@@ -800,8 +799,8 @@ void IndexScanExecutor::UpdatePredicate(
   }
 
   // Update the new value
-  index_predicate_.GetConjunctionListToSetup()[0].SetTupleColumnValue(
-      index_.get(), key_column_ids, values);
+  index_predicate_.GetConjunctionListToSetup()[0]
+      .SetTupleColumnValue(index_.get(), key_column_ids, values);
 }
 
 void IndexScanExecutor::ResetState() {

--- a/src/executor/order_by_executor.cpp
+++ b/src/executor/order_by_executor.cpp
@@ -40,9 +40,6 @@ bool OrderByExecutor::DInit() {
   sort_done_ = false;
   num_tuples_returned_ = 0;
 
-  // Recursively init all children
-  InitResultOrderFlag(order_, columns_, descend_);
-
   return true;
 }
 

--- a/src/executor/order_by_executor.cpp
+++ b/src/executor/order_by_executor.cpp
@@ -111,7 +111,7 @@ bool OrderByExecutor::DoSort() {
 
     // Optimization for ordered output
     if (underling_ordered_ && limit_) {
-      // We already get enough tuples
+      // We already get enough tuples, break while
       if (num_tuples_get_ >= (limit_offset_ + limit_number_)) break;
     }
   }
@@ -167,7 +167,8 @@ bool OrderByExecutor::DoSort() {
   // If the underlying result has the same order, it is not necessary to sort
   // the result again. Instead, go to the end.
   if (underling_ordered_) {
-    goto done_;
+    sort_done_ = true;
+    return true;
   }
 
   // Prepare the compare function
@@ -208,8 +209,6 @@ bool OrderByExecutor::DoSort() {
       [&comp](const sort_buffer_entry_t &a, const sort_buffer_entry_t &b) {
         return comp(a.tuple.get(), b.tuple.get());
       });
-
-done_:
 
   sort_done_ = true;
 

--- a/src/executor/order_by_executor.cpp
+++ b/src/executor/order_by_executor.cpp
@@ -123,10 +123,10 @@ bool OrderByExecutor::DoSort() {
 
     // Optimization for ordered output
     if (underling_ordered_ && limit_) {
-      LOG_INFO("underling_ordered and limit both work");
+      LOG_TRACE("underling_ordered and limit both work");
       // We already get enough tuples, break while
       if (num_tuples_get_ >= (limit_offset_ + limit_number_)) {
-        LOG_INFO("num_tuples_get_ (%lu) are enough", num_tuples_get_);
+        LOG_TRACE("num_tuples_get_ (%lu) are enough", num_tuples_get_);
         break;
       }
     }
@@ -183,7 +183,8 @@ bool OrderByExecutor::DoSort() {
   // If the underlying result has the same order, it is not necessary to sort
   // the result again. Instead, go to the end.
   if (underling_ordered_) {
-    LOG_INFO("underling_ordered works and already get all tuples (%lu)", count);
+    LOG_TRACE("underling_ordered works and already get all tuples (%lu)",
+              count);
     sort_done_ = true;
     return true;
   }

--- a/src/executor/order_by_executor.cpp
+++ b/src/executor/order_by_executor.cpp
@@ -123,8 +123,12 @@ bool OrderByExecutor::DoSort() {
 
     // Optimization for ordered output
     if (underling_ordered_ && limit_) {
+      LOG_TRACE("underling_ordered and limit both work");
       // We already get enough tuples, break while
-      if (num_tuples_get_ >= (limit_offset_ + limit_number_)) break;
+      if (num_tuples_get_ >= (limit_offset_ + limit_number_)) {
+        LOG_TRACE("num_tuples_get_ (%lu) are enough", num_tuples_get_);
+        break;
+      }
     }
   }
 
@@ -179,6 +183,7 @@ bool OrderByExecutor::DoSort() {
   // If the underlying result has the same order, it is not necessary to sort
   // the result again. Instead, go to the end.
   if (underling_ordered_) {
+    LOG_TRACE("underling_ordered works and already get all tuples");
     sort_done_ = true;
     return true;
   }

--- a/src/executor/order_by_executor.cpp
+++ b/src/executor/order_by_executor.cpp
@@ -123,10 +123,10 @@ bool OrderByExecutor::DoSort() {
 
     // Optimization for ordered output
     if (underling_ordered_ && limit_) {
-      LOG_TRACE("underling_ordered and limit both work");
+      LOG_INFO("underling_ordered and limit both work");
       // We already get enough tuples, break while
       if (num_tuples_get_ >= (limit_offset_ + limit_number_)) {
-        LOG_TRACE("num_tuples_get_ (%lu) are enough", num_tuples_get_);
+        LOG_INFO("num_tuples_get_ (%lu) are enough", num_tuples_get_);
         break;
       }
     }
@@ -183,7 +183,7 @@ bool OrderByExecutor::DoSort() {
   // If the underlying result has the same order, it is not necessary to sort
   // the result again. Instead, go to the end.
   if (underling_ordered_) {
-    LOG_TRACE("underling_ordered works and already get all tuples");
+    LOG_INFO("underling_ordered works and already get all tuples (%lu)", count);
     sort_done_ = true;
     return true;
   }

--- a/src/executor/order_by_executor.cpp
+++ b/src/executor/order_by_executor.cpp
@@ -40,6 +40,21 @@ bool OrderByExecutor::DInit() {
   sort_done_ = false;
   num_tuples_returned_ = 0;
 
+  // Grab info from plan node and check it
+  const planner::OrderByPlan &node = GetPlanNode<planner::OrderByPlan>();
+
+  // copy from underlying plan
+  underling_ordered_ = node.GetUnderlyingOrder();
+
+  // Whether there is limit clause
+  limit_ = node.GetLimit();
+
+  // Copied from plan node
+  limit_number_ = node.GetLimitNumber();
+
+  // Copied from plan node
+  limit_offset_ = node.GetLimitOffset();
+
   return true;
 }
 

--- a/src/include/executor/abstract_executor.h
+++ b/src/include/executor/abstract_executor.h
@@ -80,13 +80,6 @@ class AbstractExecutor {
   // Used to reset the state. For now it's overloaded by index scan executor
   virtual void ResetState() {}
 
-  // Used to initiate the flag to show that the result is ordered by which
-  // columns. For example, order_by executor will pass a empty column
-  // vector to index scan executor. The passing column vector is a reference.
-  // The index executor will
-  virtual void InitResultOrderFlag(bool &order, std::vector<oid_t> &columns,
-                                   bool &descend);
-
  protected:
   // NOTE: The reason why we keep the plan node separate from the executor
   // context is because we might want to reuse the plan multiple times

--- a/src/include/executor/abstract_executor.h
+++ b/src/include/executor/abstract_executor.h
@@ -84,8 +84,8 @@ class AbstractExecutor {
   // columns. For example, order_by executor will pass a empty column
   // vector to index scan executor. The passing column vector is a reference.
   // The index executor will
-  void InitResultOrderFlag(bool &order, std::vector<oid_t> &columns,
-                           bool &descend);
+  virtual void InitResultOrderFlag(bool &order, std::vector<oid_t> &columns,
+                                   bool &descend);
 
  protected:
   // NOTE: The reason why we keep the plan node separate from the executor

--- a/src/include/executor/order_by_executor.h
+++ b/src/include/executor/order_by_executor.h
@@ -92,6 +92,24 @@ class OrderByExecutor : public AbstractExecutor {
   /** How many tuples have been returned to parent */
   size_t num_tuples_returned_ = 0;
 
+  /** How many tuples have been get from the child */
+  size_t num_tuples_get_ = 0;
+
+  // Copied from plan node
+  // Used to show that whether the output is has the same ordering with order by
+  // expression. If the so, we can directly used the output result without any
+  // additional sorting operation
+  bool underling_ordered_ = false;
+
+  // Whether there is limit clause;
+  bool limit_ = false;
+
+  // Copied from plan node
+  uint64_t limit_number_ = 0;
+
+  // Copied from plan node
+  uint64_t limit_offset_ = 0;
+
   bool order_ = false;
   std::vector<oid_t> columns_;
   bool descend_ = false;

--- a/src/include/executor/order_by_executor.h
+++ b/src/include/executor/order_by_executor.h
@@ -109,10 +109,6 @@ class OrderByExecutor : public AbstractExecutor {
 
   // Copied from plan node
   uint64_t limit_offset_ = 0;
-
-  bool order_ = false;
-  std::vector<oid_t> columns_;
-  bool descend_ = false;
 };
 
 } /* namespace executor */

--- a/src/include/executor/order_by_executor.h
+++ b/src/include/executor/order_by_executor.h
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include "type/types.h"
@@ -92,6 +91,10 @@ class OrderByExecutor : public AbstractExecutor {
 
   /** How many tuples have been returned to parent */
   size_t num_tuples_returned_ = 0;
+
+  bool order_ = false;
+  std::vector<oid_t> columns_;
+  bool descend_ = false;
 };
 
 } /* namespace executor */

--- a/src/include/optimizer/simple_optimizer.h
+++ b/src/include/optimizer/simple_optimizer.h
@@ -102,7 +102,8 @@ class SimpleOptimizer : public AbstractOptimizer {
                                bool descent = false);
 
   static bool UnderlyingSameOrder(planner::AbstractPlan *select_plan,
-                                  oid_t orderby_column_id, bool descending);
+                                  oid_t orderby_column_id,
+                                  bool order_by_descending);
 };
 }  // namespace optimizer
 }  // namespace peloton

--- a/src/include/optimizer/simple_optimizer.h
+++ b/src/include/optimizer/simple_optimizer.h
@@ -100,6 +100,9 @@ class SimpleOptimizer : public AbstractOptimizer {
   static void SetIndexScanFlag(planner::AbstractPlan *select_plan,
                                uint64_t limit, uint64_t offset,
                                bool descent = false);
+
+  static bool UnderlyingSameOrder(planner::AbstractPlan *select_plan,
+                                  oid_t orderby_column_id, bool descending);
 };
 }  // namespace optimizer
 }  // namespace peloton

--- a/src/include/optimizer/simple_optimizer.h
+++ b/src/include/optimizer/simple_optimizer.h
@@ -97,10 +97,23 @@ class SimpleOptimizer : public AbstractOptimizer {
   static std::unique_ptr<planner::AbstractPlan> CreateJoinPlan(
       parser::SelectStatement *select_stmt);
 
+  // This is used for order_by + limit optimization. Let the index scan executor
+  // know order_by flags when create an order_by
+  // plan. This is used when we create a order_by plan and the underlying
+  // plan is index scan. Then we pass these flags to index and index can
+  // output limit number tuples. But now, it only works when limit is 1
   static void SetIndexScanFlag(planner::AbstractPlan *select_plan,
                                uint64_t limit, uint64_t offset,
                                bool descent = false);
 
+  // This is used for order_by optimization. When creating a order_by plan,
+  // it checks whether the underlying plan has the same output order with
+  // order_by plan. Same means: 1) for underlying index scan, its all expression
+  // types are equal, otherwise, it can't guarantee the output has the same
+  // ordering with order_by expression. 2) the underlying output has the same
+  // ascending or descending with order_by plan. 3) order_by column is within
+  // the key column ids (lookup ids) with the underlying plan or order_by column
+  // plus key column ids are the prefix of the index
   static bool UnderlyingSameOrder(planner::AbstractPlan *select_plan,
                                   oid_t orderby_column_id,
                                   bool order_by_descending);

--- a/src/include/planner/order_by_plan.h
+++ b/src/include/planner/order_by_plan.h
@@ -46,7 +46,19 @@ class OrderByPlan : public AbstractPlan {
 
   void SetUnderlyingOrder(bool same_order) { underling_ordered_ = same_order; }
 
-  bool GetUnderlyingOrder() { return underling_ordered_; }
+  void SetLimit(bool limit) { limit_ = limit; }
+
+  void SetLimitNumber(uint64_t limit_number) { limit_number_ = limit_number; }
+
+  void SetLimitOffset(uint64_t limit_offset) { limit_offset_ = limit_offset; }
+
+  bool GetUnderlyingOrder() const { return underling_ordered_; }
+
+  bool GetLimit() const { return limit_; }
+
+  uint64_t GetLimitNumber() const { return limit_number_; }
+
+  uint64_t GetLimitOffset() const { return limit_offset_; }
 
   std::unique_ptr<AbstractPlan> Copy() const {
     return std::unique_ptr<AbstractPlan>(
@@ -72,6 +84,15 @@ class OrderByPlan : public AbstractPlan {
   // expression. If the so, we can directly used the output result without any
   // additional sorting operation
   bool underling_ordered_ = false;
+
+  // Whether there is limit clause;
+  bool limit_ = false;
+
+  // How many tuples denoted by limit clause
+  uint64_t limit_number_ = 0;
+
+  // The point denoted by limit clause
+  uint64_t limit_offset_ = 0;
 };
 }
 }

--- a/src/include/planner/order_by_plan.h
+++ b/src/include/planner/order_by_plan.h
@@ -63,6 +63,11 @@ class OrderByPlan : public AbstractPlan {
    * Now we just output the same schema as input tiles.
    */
   const std::vector<oid_t> output_column_ids_;
+
+  // Used to show that whether the output is has the same ordering with order by
+  // expression. If the so, we can directly used the output result without any
+  // additional sorting operation
+  bool underling_ordered_ = false;
 };
 }
 }

--- a/src/include/planner/order_by_plan.h
+++ b/src/include/planner/order_by_plan.h
@@ -44,6 +44,8 @@ class OrderByPlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "OrderBy"; }
 
+  void SetUnderlyingOrder(bool same_order) {underling_ordered_ = same_order};
+
   std::unique_ptr<AbstractPlan> Copy() const {
     return std::unique_ptr<AbstractPlan>(
         new OrderByPlan(sort_keys_, descend_flags_, output_column_ids_));

--- a/src/include/planner/order_by_plan.h
+++ b/src/include/planner/order_by_plan.h
@@ -46,6 +46,8 @@ class OrderByPlan : public AbstractPlan {
 
   void SetUnderlyingOrder(bool same_order) { underling_ordered_ = same_order; }
 
+  bool GetUnderlyingOrder() { return underling_ordered_; }
+
   std::unique_ptr<AbstractPlan> Copy() const {
     return std::unique_ptr<AbstractPlan>(
         new OrderByPlan(sort_keys_, descend_flags_, output_column_ids_));

--- a/src/include/planner/order_by_plan.h
+++ b/src/include/planner/order_by_plan.h
@@ -44,7 +44,7 @@ class OrderByPlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "OrderBy"; }
 
-  void SetUnderlyingOrder(bool same_order) {underling_ordered_ = same_order};
+  void SetUnderlyingOrder(bool same_order) { underling_ordered_ = same_order; }
 
   std::unique_ptr<AbstractPlan> Copy() const {
     return std::unique_ptr<AbstractPlan>(

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -232,7 +232,9 @@ void BWTREE_INDEX_TYPE::ScanLimit(
 
         result.push_back(scan_itr->second);
       }
-    } else if (scan_direction == SCAN_DIRECTION_TYPE_BACKWARD) {
+    }
+    // descending
+    else if (scan_direction == SCAN_DIRECTION_TYPE_BACKWARD) {
       const storage::Tuple *low_key_p = csp_p->GetLowKey();
       const storage::Tuple *high_key_p = csp_p->GetHighKey();
 
@@ -286,16 +288,23 @@ void BWTREE_INDEX_TYPE::ScanLimit(
       }
 
       // After this we know the iterator is between [low key, high key]
-      // and may be on the high end
-      LOG_TRACE(
-          "ScanLimit() special case (limit = 1; offset = 0; ASCENDING): %s",
-          low_key_p->GetInfo().c_str());
+      // and may be on the high en
+
+      KeyType prev_key = scan_itr->first;
+
+      do {
+        result.push_back(scan_itr->second);
+        scan_itr--;
+      } while (scan_itr.IsREnd() == false &&
+               container.KeyCmpEqual(scan_itr->first, prev_key) == true);
 
       LOG_TRACE("In bewtree, result size is %lu", result.size());
     } else {
-      throw "ScanLimit(): Invalid scan direction!";
+      throw "ScanLimit(): Invalid scan direction";
     }
-  } else {
+  }
+  // Last
+  else {
     Scan(value_list, tuple_column_id_list, expr_list, scan_direction, result,
          csp_p);
   }

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -212,24 +212,88 @@ void BWTREE_INDEX_TYPE::ScanLimit(
   // But still since we could not access tuples in the table
   // the index just fetches the first qualified key without further checking
   // including checking for non-exact bounds!!!
-  if (csp_p->IsPointQuery() == false && limit == 1 && offset == 0 &&
-      scan_direction == SCAN_DIRECTION_TYPE_FORWARD) {
-    const storage::Tuple *low_key_p = csp_p->GetLowKey();
-    const storage::Tuple *high_key_p = csp_p->GetHighKey();
+  if (csp_p->IsPointQuery() == false && limit == 1 && offset == 0) {
+    if (scan_direction == SCAN_DIRECTION_TYPE_FORWARD) {
+      const storage::Tuple *low_key_p = csp_p->GetLowKey();
+      const storage::Tuple *high_key_p = csp_p->GetHighKey();
 
-    LOG_TRACE("ScanLimit() special case (limit = 1; offset = 0; ASCENDING): %s",
-              low_key_p->GetInfo().c_str());
+      LOG_TRACE(
+          "ScanLimit() special case (limit = 1; offset = 0; ASCENDING): %s",
+          low_key_p->GetInfo().c_str());
 
-    KeyType index_low_key;
-    KeyType index_high_key;
-    index_low_key.SetFromKey(low_key_p);
-    index_high_key.SetFromKey(high_key_p);
+      KeyType index_low_key;
+      KeyType index_high_key;
+      index_low_key.SetFromKey(low_key_p);
+      index_high_key.SetFromKey(high_key_p);
 
-    auto scan_itr = container.Begin(index_low_key);
-    if ((scan_itr.IsEnd() == false) &&
-        (container.KeyCmpLessEqual(scan_itr->first, index_high_key))) {
+      auto scan_itr = container.Begin(index_low_key);
+      if ((scan_itr.IsEnd() == false) &&
+          (container.KeyCmpLessEqual(scan_itr->first, index_high_key))) {
 
-      result.push_back(scan_itr->second);
+        result.push_back(scan_itr->second);
+      }
+    } else if (scan_direction == SCAN_DIRECTION_TYPE_BACKWARD) {
+      const storage::Tuple *low_key_p = csp_p->GetLowKey();
+      const storage::Tuple *high_key_p = csp_p->GetHighKey();
+
+      LOG_TRACE(
+          "ScanLimit() special case (limit = 1;"
+          " offset = 0; DESCENDING): %s",
+          high_key_p->GetInfo().c_str());
+
+      KeyType index_low_key;
+      KeyType index_high_key;
+      index_low_key.SetFromKey(low_key_p);
+      index_high_key.SetFromKey(high_key_p);
+
+      // This might or might not reach the high key
+      // If it does not reach high key then the high key does not exist
+      // and we need to move the iterator backward by 1
+      auto scan_itr = container.Begin(index_high_key);
+
+      // It could not be REND since we just use lower_bound
+      // Note that REND < BEGIN <= END
+      // and REND == --BEGIN
+      // and Beein() must return something between [BEGIN, END]
+      // we do not worry about REND
+      // We rely on short circuited logic expression here to make sure
+      // either iterator is END or it is a valid value for testing
+      if (scan_itr.IsEnd() == true ||
+          container.KeyCmpLess(index_high_key, scan_itr->first) == true) {
+        scan_itr--;
+
+        // If after decreament it is REND then return because we could not
+        // test the current element
+        if (scan_itr.IsREnd() == true) {
+          LOG_TRACE("After decreamenting it is REND iterator");
+
+          return;
+        }
+
+        // We must reach a valid key; otherwise we will reach it in
+        // the previous Begin()
+        // But still it might not be exact
+        PL_ASSERT(container.KeyCmpLess(index_high_key, scan_itr->first) ==
+                  false);
+      }
+
+      if (container.KeyCmpLess(scan_itr->first, index_low_key) == true) {
+        LOG_TRACE(
+            "The iterator is not qualified "
+            "because it is smaller than low key");
+
+        return;
+      }
+
+      // After this we know the iterator is between [low key, high key]
+      // and may be on the high end
+      LOG_TRACE(
+          "ScanLimit() special case (limit = 1; offset = 0; ASCENDING): %s",
+          low_key_p->GetInfo().c_str());
+
+      LOG_TRACE("In bewtree, result size is %lu", result.size());
+    } else {
+      throw "ScanLimit(): Invalid scan direction!";
     }
   } else {
     Scan(value_list, tuple_column_id_list, expr_list, scan_direction, result,

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -232,82 +232,14 @@ void BWTREE_INDEX_TYPE::ScanLimit(
 
         result.push_back(scan_itr->second);
       }
-    }
-    // descending
-    else if (scan_direction == SCAN_DIRECTION_TYPE_BACKWARD) {
-      const storage::Tuple *low_key_p = csp_p->GetLowKey();
-      const storage::Tuple *high_key_p = csp_p->GetHighKey();
 
-      LOG_TRACE(
-          "ScanLimit() special case (limit = 1;"
-          " offset = 0; DESCENDING): %s",
-          high_key_p->GetInfo().c_str());
-
-      KeyType index_low_key;
-      KeyType index_high_key;
-      index_low_key.SetFromKey(low_key_p);
-      index_high_key.SetFromKey(high_key_p);
-
-      // This might or might not reach the high key
-      // If it does not reach high key then the high key does not exist
-      // and we need to move the iterator backward by 1
-      auto scan_itr = container.Begin(index_high_key);
-
-      // It could not be REND since we just use lower_bound
-      // Note that REND < BEGIN <= END
-      // and REND == --BEGIN
-      // and Beein() must return something between [BEGIN, END]
-      // we do not worry about REND
-      // We rely on short circuited logic expression here to make sure
-      // either iterator is END or it is a valid value for testing
-      if (scan_itr.IsEnd() == true ||
-          container.KeyCmpLess(index_high_key, scan_itr->first) == true) {
-        scan_itr--;
-
-        // If after decreament it is REND then return because we could not
-        // test the current element
-        if (scan_itr.IsREnd() == true) {
-          LOG_TRACE("After decreamenting it is REND iterator");
-
-          return;
-        }
-
-        // We must reach a valid key; otherwise we will reach it in
-        // the previous Begin()
-        // But still it might not be exact
-        PL_ASSERT(container.KeyCmpLess(index_high_key, scan_itr->first) ==
-                  false);
-      }
-
-      if (container.KeyCmpLess(scan_itr->first, index_low_key) == true) {
-        LOG_TRACE(
-            "The iterator is not qualified "
-            "because it is smaller than low key");
-
-        return;
-      }
-
-      // After this we know the iterator is between [low key, high key]
-      // and may be on the high en
-
-      KeyType prev_key = scan_itr->first;
-
-      do {
-        result.push_back(scan_itr->second);
-        scan_itr--;
-      } while (scan_itr.IsREnd() == false &&
-               container.KeyCmpEqual(scan_itr->first, prev_key) == true);
-
-      LOG_TRACE("In bewtree, result size is %lu", result.size());
-    } else {
-      throw "ScanLimit(): Invalid scan direction";
+      // If the passing is forward and limit 1, return 1 tuple
+      return;
     }
   }
-  // Last
-  else {
-    Scan(value_list, tuple_column_id_list, expr_list, scan_direction, result,
-         csp_p);
-  }
+
+  Scan(value_list, tuple_column_id_list, expr_list, scan_direction, result,
+       csp_p);
 
   return;
 }

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -212,34 +212,29 @@ void BWTREE_INDEX_TYPE::ScanLimit(
   // But still since we could not access tuples in the table
   // the index just fetches the first qualified key without further checking
   // including checking for non-exact bounds!!!
-  if (csp_p->IsPointQuery() == false && limit == 1 && offset == 0) {
-    if (scan_direction == SCAN_DIRECTION_TYPE_FORWARD) {
-      const storage::Tuple *low_key_p = csp_p->GetLowKey();
-      const storage::Tuple *high_key_p = csp_p->GetHighKey();
+  if (csp_p->IsPointQuery() == false && limit == 1 && offset == 0 &&
+      scan_direction == SCAN_DIRECTION_TYPE_FORWARD) {
+    const storage::Tuple *low_key_p = csp_p->GetLowKey();
+    const storage::Tuple *high_key_p = csp_p->GetHighKey();
 
-      LOG_TRACE(
-          "ScanLimit() special case (limit = 1; offset = 0; ASCENDING): %s",
-          low_key_p->GetInfo().c_str());
+    LOG_TRACE("ScanLimit() special case (limit = 1; offset = 0; ASCENDING): %s",
+              low_key_p->GetInfo().c_str());
 
-      KeyType index_low_key;
-      KeyType index_high_key;
-      index_low_key.SetFromKey(low_key_p);
-      index_high_key.SetFromKey(high_key_p);
+    KeyType index_low_key;
+    KeyType index_high_key;
+    index_low_key.SetFromKey(low_key_p);
+    index_high_key.SetFromKey(high_key_p);
 
-      auto scan_itr = container.Begin(index_low_key);
-      if ((scan_itr.IsEnd() == false) &&
-          (container.KeyCmpLessEqual(scan_itr->first, index_high_key))) {
+    auto scan_itr = container.Begin(index_low_key);
+    if ((scan_itr.IsEnd() == false) &&
+        (container.KeyCmpLessEqual(scan_itr->first, index_high_key))) {
 
-        result.push_back(scan_itr->second);
-      }
-
-      // If the passing is forward and limit 1, return 1 tuple
-      return;
+      result.push_back(scan_itr->second);
     }
+  } else {
+    Scan(value_list, tuple_column_id_list, expr_list, scan_direction, result,
+         csp_p);
   }
-
-  Scan(value_list, tuple_column_id_list, expr_list, scan_direction, result,
-       csp_p);
 
   return;
 }

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -127,16 +127,14 @@ void BWTREE_INDEX_TYPE::Scan(
     UNUSED_ATTRIBUTE const std::vector<type::Value> &value_list,
     UNUSED_ATTRIBUTE const std::vector<oid_t> &tuple_column_id_list,
     UNUSED_ATTRIBUTE const std::vector<ExpressionType> &expr_list,
-    ScanDirectionType scan_direction, 
-    std::vector<ValueType> &result,
+    ScanDirectionType scan_direction, std::vector<ValueType> &result,
     const ConjunctionScanPredicate *csp_p) {
   // This is a hack - we do not support backward scan
   if (scan_direction == SCAN_DIRECTION_TYPE_INVALID) {
     throw Exception("Invalid scan direction \n");
   }
 
-  LOG_TRACE("Scan() Point Query = %d; Full Scan = %d ", 
-            csp_p->IsPointQuery(),
+  LOG_TRACE("Scan() Point Query = %d; Full Scan = %d ", csp_p->IsPointQuery(),
             csp_p->IsFullIndexScan());
 
   if (csp_p->IsPointQuery() == true) {
@@ -188,7 +186,7 @@ void BWTREE_INDEX_TYPE::Scan(
     stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
         result.size(), metadata);
   }
-  
+
   return;
 }
 
@@ -206,21 +204,16 @@ void BWTREE_INDEX_TYPE::ScanLimit(
     const std::vector<type::Value> &value_list,
     const std::vector<oid_t> &tuple_column_id_list,
     const std::vector<ExpressionType> &expr_list,
-    ScanDirectionType scan_direction, 
-    std::vector<ValueType> &result,
-    const ConjunctionScanPredicate *csp_p,
-    uint64_t limit,
-    uint64_t offset) {
-      
+    ScanDirectionType scan_direction, std::vector<ValueType> &result,
+    const ConjunctionScanPredicate *csp_p, uint64_t limit, uint64_t offset) {
+
   // Only work with limit == 1 and offset == 0
   // Because that gets translated to "min"
   // But still since we could not access tuples in the table
   // the index just fetches the first qualified key without further checking
   // including checking for non-exact bounds!!!
-  if(csp_p->IsPointQuery() == false && \
-     limit == 1 && \
-     offset == 0 && \
-     scan_direction == SCAN_DIRECTION_TYPE_FORWARD) {
+  if (csp_p->IsPointQuery() == false && limit == 1 && offset == 0 &&
+      scan_direction == SCAN_DIRECTION_TYPE_FORWARD) {
     const storage::Tuple *low_key_p = csp_p->GetLowKey();
     const storage::Tuple *high_key_p = csp_p->GetHighKey();
 
@@ -231,20 +224,16 @@ void BWTREE_INDEX_TYPE::ScanLimit(
     KeyType index_high_key;
     index_low_key.SetFromKey(low_key_p);
     index_high_key.SetFromKey(high_key_p);
-              
+
     auto scan_itr = container.Begin(index_low_key);
-    if((scan_itr.IsEnd() == false) && \
-       (container.KeyCmpLessEqual(scan_itr->first, index_high_key))) {
-        
+    if ((scan_itr.IsEnd() == false) &&
+        (container.KeyCmpLessEqual(scan_itr->first, index_high_key))) {
+
       result.push_back(scan_itr->second);
     }
   } else {
-    Scan(value_list, 
-         tuple_column_id_list,
-         expr_list,
-         scan_direction,
-         result,
-         csp_p); 
+    Scan(value_list, tuple_column_id_list, expr_list, scan_direction, result,
+         csp_p);
   }
 
   return;
@@ -335,4 +324,3 @@ template class BWTreeIndex<TupleKey, ItemPointer *, TupleKeyComparator,
 
 }  // End index namespace
 }  // End peloton namespace
-

--- a/src/networking/peloton_service.cpp
+++ b/src/networking/peloton_service.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "networking/peloton_service.h"
 #include "networking/peloton_endpoint.h"
 #include "networking/rpc_server.h"
@@ -250,7 +249,7 @@ void PelotonService::Heartbeat(::google::protobuf::RpcController* controller,
   // If request is not null, this is a rpc  call, server should handle the
   // reqeust
   if (request != NULL) {
-    LOG_TRACE("Received from client, sender site: %d, last_txn_id: %ld",
+    LOG_TRACE("Received from client, sender site: %d, last_txn_id: %lld",
               request->sender_site(), request->last_transaction_id());
 
     response->set_sender_site(9876);
@@ -331,14 +330,14 @@ void PelotonService::QueryPlan(::google::protobuf::RpcController* controller,
     }
 
     // construct parameter list
-    //int param_num = request->param_num();
+    // int param_num = request->param_num();
     std::string param_list = request->param_list();
-    ReferenceSerializeInput param_input(param_list.c_str(),
-                                        param_list.size());
+    ReferenceSerializeInput param_input(param_list.c_str(), param_list.size());
     std::vector<type::Value> params;
-    //for (int it = 0; it < param_num; it++) {
+    // for (int it = 0; it < param_num; it++) {
     //  // TODO: Make sure why varlen_pool is used as parameter
-    //  std::shared_ptr<type::VarlenPool> pool(new type::VarlenPool(BACKEND_TYPE_MM));
+    //  std::shared_ptr<type::VarlenPool> pool(new
+    // type::VarlenPool(BACKEND_TYPE_MM));
     //  Value value_item;
     //  value_item.DeserializeFromAllocateForStorage(param_input, pool.get());
     //  params.push_back(value_item);
@@ -424,8 +423,7 @@ void PelotonService::QueryPlan(::google::protobuf::RpcController* controller,
     for (int idx = 0; idx < result_size; idx++) {
       // Get the tile bytes
       std::string tile_bytes = response->result(idx);
-      ReferenceSerializeInput tile_input(tile_bytes.c_str(),
-                                         tile_bytes.size());
+      ReferenceSerializeInput tile_input(tile_bytes.c_str(), tile_bytes.size());
 
       // Create a tile or tuple that depends on our protocol.
       // Tuple is prefered, since it voids copying from tile again

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -271,6 +271,10 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
           SetIndexScanFlag(child_SelectPlan.get(), select_stmt->limit->limit,
                            offset, flags.front());
 
+          // Whether underlying child's output has the same order with the
+          // order_by clause.
+          // bool ordered = UnderlyingSameOrder(child_SelectPlan, );
+
           // Create order_by_plan
           std::unique_ptr<planner::OrderByPlan> order_by_plan(
               new planner::OrderByPlan(key, flags, keys));

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -281,20 +281,20 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
 
           // Whether underlying child's output has the same order
           // with the order_by clause
-          //          LOG_TRACE("order by column id is %d",
-          //                    target_table->GetSchema()->GetColumnID(sort_col_name));
-          //          if (UnderlyingSameOrder(
-          //                  child_SelectPlan.get(),
-          //                  target_table->GetSchema()->GetColumnID(sort_col_name),
-          //                  flags.front()) == true) {
-          //            LOG_TRACE(
-          //                "Underlying plan has the same ordering output with"
-          //                "order_by plan with limit");
-          //            order_by_plan->SetUnderlyingOrder(true);
-          //            order_by_plan->SetLimit(true);
-          //            order_by_plan->SetLimitNumber(select_stmt->limit->limit);
-          //            order_by_plan->SetLimitOffset(offset);
-          //          }
+          LOG_TRACE("order by column id is %d",
+                    target_table->GetSchema()->GetColumnID(sort_col_name));
+          if (UnderlyingSameOrder(
+                  child_SelectPlan.get(),
+                  target_table->GetSchema()->GetColumnID(sort_col_name),
+                  flags.front()) == true) {
+            LOG_TRACE(
+                "Underlying plan has the same ordering output with"
+                "order_by plan with limit");
+            order_by_plan->SetUnderlyingOrder(true);
+            order_by_plan->SetLimit(true);
+            order_by_plan->SetLimitNumber(select_stmt->limit->limit);
+            order_by_plan->SetLimitOffset(offset);
+          }
 
           order_by_plan->AddChild(std::move(child_SelectPlan));
 
@@ -348,17 +348,17 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
 
           // Whether underlying child's output has the same order with the
           // order_by clause.
-          //          LOG_TRACE("order by column id is %d",
-          //                    target_table->GetSchema()->GetColumnID(sort_col_name));
-          //          if (UnderlyingSameOrder(
-          //                  child_SelectPlan.get(),
-          //                  target_table->GetSchema()->GetColumnID(sort_col_name),
-          //                  flags.front()) == true) {
-          //            LOG_TRACE(
-          //                "Underlying plan has the same ordering output with"
-          //                "order_by plan without limit");
-          //            order_by_plan->SetUnderlyingOrder(true);
-          //          }
+          LOG_TRACE("order by column id is %d",
+                    target_table->GetSchema()->GetColumnID(sort_col_name));
+          if (UnderlyingSameOrder(
+                  child_SelectPlan.get(),
+                  target_table->GetSchema()->GetColumnID(sort_col_name),
+                  flags.front()) == true) {
+            LOG_TRACE(
+                "Underlying plan has the same ordering output with"
+                "order_by plan without limit");
+            order_by_plan->SetUnderlyingOrder(true);
+          }
 
           order_by_plan->AddChild(std::move(child_SelectPlan));
           child_plan = std::move(order_by_plan);

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -290,7 +290,7 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
             LOG_TRACE(
                 "Underlying plan has the same ordering output with"
                 "order_by plan with limit");
-            order_by_plan->SetUnderlyingOrder(false);
+            order_by_plan->SetUnderlyingOrder(true);
             order_by_plan->SetLimit(true);
             order_by_plan->SetLimitNumber(select_stmt->limit->limit);
             order_by_plan->SetLimitOffset(offset);
@@ -357,7 +357,7 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
             LOG_TRACE(
                 "Underlying plan has the same ordering output with"
                 "order_by plan without limit");
-            order_by_plan->SetUnderlyingOrder(false);
+            order_by_plan->SetUnderlyingOrder(true);
           }
 
           order_by_plan->AddChild(std::move(child_SelectPlan));

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -52,9 +52,9 @@ class AbstractPlan;
 }
 namespace optimizer {
 
-SimpleOptimizer::SimpleOptimizer(){};
+SimpleOptimizer::SimpleOptimizer() {};
 
-SimpleOptimizer::~SimpleOptimizer(){};
+SimpleOptimizer::~SimpleOptimizer() {};
 
 std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
     const std::unique_ptr<parser::SQLStatementList>& parse_tree) {
@@ -107,7 +107,8 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
           auto child_SelectPlan = CreateHackingNestedLoopJoinPlan(select_stmt);
           child_plan = std::move(child_SelectPlan);
           break;
-        } catch (Exception& e) {
+        }
+        catch (Exception& e) {
           throw NotImplementedException("Error: Joins are not implemented yet");
         }
       }
@@ -150,13 +151,13 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
                                                         needs_projection);
       }
 
-      //Adds order by column to column ids if it was not added through select_list
-      //No problem given that the underlying structure is a map.
-      if(select_stmt->order != nullptr) {
+      // Adds order by column to column ids if it was not added through
+      // select_list
+      // No problem given that the underlying structure is a map.
+      if (select_stmt->order != nullptr) {
 
         expression::ExpressionUtil::TransformExpression(
             column_ids, select_stmt->order->expr, schema, needs_projection);
-
       }
 
       // Check if there are any aggregate functions
@@ -242,15 +243,18 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
               ((expression::TupleValueExpression*)select_stmt->order->expr)
                   ->GetColumnName());
           auto schema_columns = target_table->GetSchema()->GetColumns();
-          for (size_t column_ctr = 0;
-               column_ctr < schema_columns.size(); column_ctr++) {
+          for (size_t column_ctr = 0; column_ctr < schema_columns.size();
+               column_ctr++) {
             std::string col_name(schema_columns.at(column_ctr).GetName());
             if (col_name == sort_col_name) {
-                //The column_ctr is not reliable anymore given that we are looking to the whole schema.
-                //Since the columns were added in the column_ids, it is safe to retrieve only those indexes.
-                auto iter = find(column_ids.begin(), column_ids.end(), column_ctr);
-                auto column_offset = std::distance(column_ids.begin(), iter);
-                key.push_back(column_offset);
+              // The column_ctr is not reliable anymore given that we are
+              // looking to the whole schema.
+              // Since the columns were added in the column_ids, it is safe to
+              // retrieve only those indexes.
+              auto iter =
+                  find(column_ids.begin(), column_ids.end(), column_ctr);
+              auto column_offset = std::distance(column_ids.begin(), iter);
+              key.push_back(column_offset);
             }
           }
           if (key.size() == 0) {
@@ -275,21 +279,22 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
           std::unique_ptr<planner::OrderByPlan> order_by_plan(
               new planner::OrderByPlan(key, flags, keys));
 
-          //          // Whether underlying child's output has the same order
-          // with the
-          //          // order_by clause.
-          //          LOG_TRACE("order by column id is %d",
-          //                    target_table->GetSchema()->GetColumnID(sort_col_name));
-          //          if (UnderlyingSameOrder(
-          //                  child_SelectPlan.get(),
-          //                  target_table->GetSchema()->GetColumnID(sort_col_name),
-          //                  flags.front()) == true) {
-          //            LOG_TRACE(
-          //                "Underlying plan has the same ordering output with
-          // order_by "
-          //                "plan with limit");
-          //            order_by_plan->SetUnderlyingOrder(false);
-          //          }
+          // Whether underlying child's output has the same order
+          // with the order_by clause
+          LOG_TRACE("order by column id is %d",
+                    target_table->GetSchema()->GetColumnID(sort_col_name));
+          if (UnderlyingSameOrder(
+                  child_SelectPlan.get(),
+                  target_table->GetSchema()->GetColumnID(sort_col_name),
+                  flags.front()) == true) {
+            LOG_TRACE(
+                "Underlying plan has the same ordering output with"
+                "order_by plan with limit");
+            order_by_plan->SetUnderlyingOrder(false);
+            order_by_plan->SetLimit(true);
+            order_by_plan->SetLimitNumber(select_stmt->limit->limit);
+            order_by_plan->SetLimitOffset(offset);
+          }
 
           order_by_plan->AddChild(std::move(child_SelectPlan));
 
@@ -318,15 +323,18 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
               ((expression::TupleValueExpression*)select_stmt->order->expr)
                   ->GetColumnName());
           auto schema_columns = target_table->GetSchema()->GetColumns();
-          for (size_t column_ctr = 0;
-               column_ctr < schema_columns.size(); column_ctr++) {
+          for (size_t column_ctr = 0; column_ctr < schema_columns.size();
+               column_ctr++) {
             std::string col_name(schema_columns.at(column_ctr).GetName());
             if (col_name == sort_col_name) {
-                //The column_ctr is not reliable anymore given that we are looking to the whole schema.
-                //Since the columns were added in the column_ids, it is safe to retrieve only those indexes.
-                auto iter = find(column_ids.begin(), column_ids.end(), column_ctr);
-                auto column_offset = std::distance(column_ids.begin(), iter);
-                key.push_back(column_offset);
+              // The column_ctr is not reliable anymore given that we are
+              // looking to the whole schema.
+              // Since the columns were added in the column_ids, it is safe to
+              // retrieve only those indexes.
+              auto iter =
+                  find(column_ids.begin(), column_ids.end(), column_ctr);
+              auto column_offset = std::distance(column_ids.begin(), iter);
+              key.push_back(column_offset);
             }
           }
           if (key.size() == 0) {
@@ -340,18 +348,17 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
 
           // Whether underlying child's output has the same order with the
           // order_by clause.
-          //          LOG_TRACE("order by column id is %d",
-          //                    target_table->GetSchema()->GetColumnID(sort_col_name));
-          //          if (UnderlyingSameOrder(
-          //                  child_SelectPlan.get(),
-          //                  target_table->GetSchema()->GetColumnID(sort_col_name),
-          //                  flags.front()) == true) {
-          //            LOG_TRACE(
-          //                "Underlying plan has the same ordering output with
-          // order_by "
-          //                "plan without limit");
-          //            order_by_plan->SetUnderlyingOrder(false);
-          //          }
+          LOG_TRACE("order by column id is %d",
+                    target_table->GetSchema()->GetColumnID(sort_col_name));
+          if (UnderlyingSameOrder(
+                  child_SelectPlan.get(),
+                  target_table->GetSchema()->GetColumnID(sort_col_name),
+                  flags.front()) == true) {
+            LOG_TRACE(
+                "Underlying plan has the same ordering output with"
+                "order_by plan without limit");
+            order_by_plan->SetUnderlyingOrder(false);
+          }
 
           order_by_plan->AddChild(std::move(child_SelectPlan));
           child_plan = std::move(order_by_plan);
@@ -412,11 +419,10 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
               LOG_TRACE("Function name: %s",
                         ((expression::TupleValueExpression*)agg_expr)
                             ->GetExpressionName());
-              LOG_TRACE(
-                  "Aggregate type: %s",
-                  ExpressionTypeToString(ParserExpressionNameToExpressionType(
-                                             expr->GetExpressionName()))
-                      .c_str());
+              LOG_TRACE("Aggregate type: %s",
+                        ExpressionTypeToString(
+                            ParserExpressionNameToExpressionType(
+                                expr->GetExpressionName())).c_str());
               planner::AggregatePlan::AggTerm agg_term(
                   agg_expr->GetExpressionType(), agg_over->Copy(),
                   agg_expr->distinct_);
@@ -930,19 +936,14 @@ void SimpleOptimizer::GetPredicateColumns(
       // (constant_value_expression.h:40)
       if (right_type == EXPRESSION_TYPE_VALUE_CONSTANT) {
         values.push_back(reinterpret_cast<expression::ConstantValueExpression*>(
-                             expression->GetModifiableChild(1))
-                             ->GetValue());
+            expression->GetModifiableChild(1))->GetValue());
         LOG_TRACE("Value Type: %d",
                   reinterpret_cast<expression::ConstantValueExpression*>(
-                      expression->GetModifiableChild(1))
-                      ->GetValueType());
+                      expression->GetModifiableChild(1))->GetValueType());
       } else
-        values.push_back(
-            type::ValueFactory::GetParameterOffsetValue(
-                reinterpret_cast<expression::ParameterValueExpression*>(
-                    expression->GetModifiableChild(1))
-                    ->GetValueIdx())
-                .Copy());
+        values.push_back(type::ValueFactory::GetParameterOffsetValue(
+            reinterpret_cast<expression::ParameterValueExpression*>(
+                expression->GetModifiableChild(1))->GetValueIdx()).Copy());
       LOG_TRACE("Parameter offset: %s", (*values.rbegin()).GetInfo().c_str());
     }
   } else if (expression->GetChild(1)->GetExpressionType() ==
@@ -960,19 +961,14 @@ void SimpleOptimizer::GetPredicateColumns(
 
       if (left_type == EXPRESSION_TYPE_VALUE_CONSTANT) {
         values.push_back(reinterpret_cast<expression::ConstantValueExpression*>(
-                             expression->GetModifiableChild(1))
-                             ->GetValue());
+            expression->GetModifiableChild(1))->GetValue());
         LOG_TRACE("Value Type: %d",
                   reinterpret_cast<expression::ConstantValueExpression*>(
-                      expression->GetModifiableChild(0))
-                      ->GetValueType());
+                      expression->GetModifiableChild(0))->GetValueType());
       } else
-        values.push_back(
-            type::ValueFactory::GetParameterOffsetValue(
-                reinterpret_cast<expression::ParameterValueExpression*>(
-                    expression->GetModifiableChild(0))
-                    ->GetValueIdx())
-                .Copy());
+        values.push_back(type::ValueFactory::GetParameterOffsetValue(
+            reinterpret_cast<expression::ParameterValueExpression*>(
+                expression->GetModifiableChild(0))->GetValueIdx()).Copy());
       LOG_TRACE("Parameter offset: %s", (*values.rbegin()).GetInfo().c_str());
     }
   } else {
@@ -1221,12 +1217,10 @@ std::unique_ptr<planner::AbstractPlan> SimpleOptimizer::CreateJoinPlan(
 
   // Get the key column name based on the join condition
   auto right_key_col_name = static_cast<expression::TupleValueExpression*>(
-                                join_condition->GetModifiableChild(0))
-                                ->GetColumnName();
-  if (right_schema->GetColumnID(right_key_col_name) == (oid_t)-1)
+      join_condition->GetModifiableChild(0))->GetColumnName();
+  if (right_schema->GetColumnID(right_key_col_name) == (oid_t) - 1)
     right_key_col_name = static_cast<expression::TupleValueExpression*>(
-                             join_condition->GetModifiableChild(1))
-                             ->GetColumnName();
+        join_condition->GetModifiableChild(1))->GetColumnName();
   // Generate hash for right table
   auto right_key = expression::ExpressionUtil::ConvertToTupleValueExpression(
       right_schema, right_key_col_name);
@@ -1279,7 +1273,7 @@ std::unique_ptr<planner::AbstractPlan> SimpleOptimizer::CreateJoinPlan(
         for (int schema_index = 0; schema_index < 2; schema_index++) {
           auto& schema = schemas[schema_index];
           old_col_id = schema->GetColumnID(tup_expr->GetColumnName());
-          if (old_col_id != (oid_t)-1) {
+          if (old_col_id != (oid_t) - 1) {
             column = schema->GetColumn(old_col_id);
             output_table_columns.push_back(column);
             dml.push_back(
@@ -1365,7 +1359,7 @@ void SimpleOptimizer::SetIndexScanFlag(planner::AbstractPlan* select_plan,
 
 bool SimpleOptimizer::UnderlyingSameOrder(planner::AbstractPlan* select_plan,
                                           oid_t orderby_column_id,
-                                          bool descending) {
+                                          bool order_by_descending) {
   planner::IndexScanPlan* index_scan_plan = nullptr;
 
   // Check whether underlying node is index scan
@@ -1393,7 +1387,7 @@ bool SimpleOptimizer::UnderlyingSameOrder(planner::AbstractPlan* select_plan,
   }
 
   // Check whether index scan output has the same ordering with order_by
-  if (index_scan_plan->GetDescend() != descending) {
+  if (index_scan_plan->GetDescend() != order_by_descending) {
     LOG_TRACE("index scan output does not have the same ordering");
     return false;
   }

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -222,6 +222,7 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
         }
 
         if (select_stmt->order != NULL && select_stmt->limit != NULL) {
+          LOG_TRACE("OrderBy + Limit query");
           std::vector<oid_t> keys;
           // Add all selected columns to the output
           // We already generated the "real" physical output schema in the scan
@@ -231,6 +232,7 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
             keys.push_back(column_ctr);
           }
 
+          LOG_TRACE("Get and set OrderBy descending");
           std::vector<bool> flags;
           if (select_stmt->order->type == 0) {
             flags.push_back(false);
@@ -239,6 +241,7 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
           }
           std::vector<oid_t> key;
 
+          LOG_TRACE("Set OrderBy expr");
           std::string sort_col_name(
               ((expression::TupleValueExpression*)select_stmt->order->expr)
                   ->GetColumnName());
@@ -263,6 +266,7 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
                 "list!");
           }
 
+          LOG_TRACE("Set order by offset");
           // Get offset
           int offset = select_stmt->limit->offset;
           if (offset < 0) {
@@ -1328,6 +1332,7 @@ std::unique_ptr<planner::AbstractPlan> SimpleOptimizer::CreateJoinPlan(
 void SimpleOptimizer::SetIndexScanFlag(planner::AbstractPlan* select_plan,
                                        uint64_t limit, uint64_t offset,
                                        bool descent) {
+  LOG_TRACE("Setting index scan flag.");
   // Set the flag for the underlying index scan plan
   planner::IndexScanPlan* index_scan_plan = nullptr;
 
@@ -1355,6 +1360,8 @@ void SimpleOptimizer::SetIndexScanFlag(planner::AbstractPlan* select_plan,
     index_scan_plan->SetLimitOffset(offset);
     index_scan_plan->SetDescend(descent);
   }
+
+  LOG_TRACE("Set Index scan flag is done.");
 }
 
 bool SimpleOptimizer::UnderlyingSameOrder(planner::AbstractPlan* select_plan,

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -285,20 +285,20 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
 
           // Whether underlying child's output has the same order
           // with the order_by clause
-          //          LOG_TRACE("order by column id is %d",
-          //                    target_table->GetSchema()->GetColumnID(sort_col_name));
-          //          if (UnderlyingSameOrder(
-          //                  child_SelectPlan.get(),
-          //                  target_table->GetSchema()->GetColumnID(sort_col_name),
-          //                  flags.front()) == true) {
-          //            LOG_TRACE(
-          //                "Underlying plan has the same ordering output with"
-          //                "order_by plan with limit");
-          //            order_by_plan->SetUnderlyingOrder(true);
-          //            order_by_plan->SetLimit(true);
-          //            order_by_plan->SetLimitNumber(select_stmt->limit->limit);
-          //            order_by_plan->SetLimitOffset(offset);
-          //          }
+          LOG_TRACE("order by column id is %d",
+                    target_table->GetSchema()->GetColumnID(sort_col_name));
+          if (UnderlyingSameOrder(
+                  child_SelectPlan.get(),
+                  target_table->GetSchema()->GetColumnID(sort_col_name),
+                  flags.front()) == true) {
+            LOG_TRACE(
+                "Underlying plan has the same ordering output with"
+                "order_by plan with limit");
+            order_by_plan->SetUnderlyingOrder(true);
+            order_by_plan->SetLimit(true);
+            order_by_plan->SetLimitNumber(select_stmt->limit->limit);
+            order_by_plan->SetLimitOffset(offset);
+          }
 
           order_by_plan->AddChild(std::move(child_SelectPlan));
 

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -281,20 +281,20 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
 
           // Whether underlying child's output has the same order
           // with the order_by clause
-          LOG_TRACE("order by column id is %d",
-                    target_table->GetSchema()->GetColumnID(sort_col_name));
-          if (UnderlyingSameOrder(
-                  child_SelectPlan.get(),
-                  target_table->GetSchema()->GetColumnID(sort_col_name),
-                  flags.front()) == true) {
-            LOG_TRACE(
-                "Underlying plan has the same ordering output with"
-                "order_by plan with limit");
-            order_by_plan->SetUnderlyingOrder(true);
-            order_by_plan->SetLimit(true);
-            order_by_plan->SetLimitNumber(select_stmt->limit->limit);
-            order_by_plan->SetLimitOffset(offset);
-          }
+          //          LOG_TRACE("order by column id is %d",
+          //                    target_table->GetSchema()->GetColumnID(sort_col_name));
+          //          if (UnderlyingSameOrder(
+          //                  child_SelectPlan.get(),
+          //                  target_table->GetSchema()->GetColumnID(sort_col_name),
+          //                  flags.front()) == true) {
+          //            LOG_TRACE(
+          //                "Underlying plan has the same ordering output with"
+          //                "order_by plan with limit");
+          //            order_by_plan->SetUnderlyingOrder(true);
+          //            order_by_plan->SetLimit(true);
+          //            order_by_plan->SetLimitNumber(select_stmt->limit->limit);
+          //            order_by_plan->SetLimitOffset(offset);
+          //          }
 
           order_by_plan->AddChild(std::move(child_SelectPlan));
 
@@ -348,17 +348,17 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
 
           // Whether underlying child's output has the same order with the
           // order_by clause.
-          LOG_TRACE("order by column id is %d",
-                    target_table->GetSchema()->GetColumnID(sort_col_name));
-          if (UnderlyingSameOrder(
-                  child_SelectPlan.get(),
-                  target_table->GetSchema()->GetColumnID(sort_col_name),
-                  flags.front()) == true) {
-            LOG_TRACE(
-                "Underlying plan has the same ordering output with"
-                "order_by plan without limit");
-            order_by_plan->SetUnderlyingOrder(true);
-          }
+          //          LOG_TRACE("order by column id is %d",
+          //                    target_table->GetSchema()->GetColumnID(sort_col_name));
+          //          if (UnderlyingSameOrder(
+          //                  child_SelectPlan.get(),
+          //                  target_table->GetSchema()->GetColumnID(sort_col_name),
+          //                  flags.front()) == true) {
+          //            LOG_TRACE(
+          //                "Underlying plan has the same ordering output with"
+          //                "order_by plan without limit");
+          //            order_by_plan->SetUnderlyingOrder(true);
+          //          }
 
           order_by_plan->AddChild(std::move(child_SelectPlan));
           child_plan = std::move(order_by_plan);

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -285,20 +285,20 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
 
           // Whether underlying child's output has the same order
           // with the order_by clause
-          LOG_TRACE("order by column id is %d",
-                    target_table->GetSchema()->GetColumnID(sort_col_name));
-          if (UnderlyingSameOrder(
-                  child_SelectPlan.get(),
-                  target_table->GetSchema()->GetColumnID(sort_col_name),
-                  flags.front()) == true) {
-            LOG_TRACE(
-                "Underlying plan has the same ordering output with"
-                "order_by plan with limit");
-            order_by_plan->SetUnderlyingOrder(true);
-            order_by_plan->SetLimit(true);
-            order_by_plan->SetLimitNumber(select_stmt->limit->limit);
-            order_by_plan->SetLimitOffset(offset);
-          }
+          //          LOG_TRACE("order by column id is %d",
+          //                    target_table->GetSchema()->GetColumnID(sort_col_name));
+          //          if (UnderlyingSameOrder(
+          //                  child_SelectPlan.get(),
+          //                  target_table->GetSchema()->GetColumnID(sort_col_name),
+          //                  flags.front()) == true) {
+          //            LOG_TRACE(
+          //                "Underlying plan has the same ordering output with"
+          //                "order_by plan with limit");
+          //            order_by_plan->SetUnderlyingOrder(true);
+          //            order_by_plan->SetLimit(true);
+          //            order_by_plan->SetLimitNumber(select_stmt->limit->limit);
+          //            order_by_plan->SetLimitOffset(offset);
+          //          }
 
           order_by_plan->AddChild(std::move(child_SelectPlan));
 

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -192,7 +192,8 @@ Result TrafficCop::ExecuteStatement(
       rows_changed = status.m_processed;
       return status.m_result;
     }
-  } catch (Exception &e) {
+  }
+  catch (Exception &e) {
     error_message = e.what();
     return Result::RESULT_FAILURE;
   }
@@ -262,8 +263,8 @@ bridge::peloton_status TrafficCop::ExecuteStatementPlan(
 std::shared_ptr<Statement> TrafficCop::PrepareStatement(
     const std::string &statement_name, const std::string &query_string,
     UNUSED_ATTRIBUTE std::string &error_message) {
-  LOG_DEBUG("Prepare Statement name: %s", statement_name.c_str());
-  LOG_DEBUG("Prepare Statement query: %s", query_string.c_str());
+  LOG_TRACE("Prepare Statement name: %s", statement_name.c_str());
+  LOG_TRACE("Prepare Statement query: %s", query_string.c_str());
 
   std::shared_ptr<Statement> statement(
       new Statement(statement_name, query_string));
@@ -298,7 +299,8 @@ std::shared_ptr<Statement> TrafficCop::PrepareStatement(
     }
 #endif
     return std::move(statement);
-  } catch (Exception &e) {
+  }
+  catch (Exception &e) {
     error_message = e.what();
     return nullptr;
   }

--- a/test/include/sql/sql_tests_util.h
+++ b/test/include/sql/sql_tests_util.h
@@ -76,6 +76,9 @@ class SQLTestsUtil {
     return std::move(value);
   }
 
+  // Create a random number
+  static int GetRandomInteger(const int lower_bound, const int upper_bound);
+
   static tcop::TrafficCop traffic_cop_;
 };
 }  // namespace test

--- a/test/sql/order_by_sql_test.cpp
+++ b/test/sql/order_by_sql_test.cpp
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// order_by_sql_test.cpp
+//
+// Identification: test/sql/order_by_sql_test.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <memory>
+
+#include "catalog/catalog.h"
+#include "common/harness.h"
+#include "executor/create_executor.h"
+#include "optimizer/simple_optimizer.h"
+#include "planner/create_plan.h"
+
+#include "sql/sql_tests_util.h"
+
+namespace peloton {
+namespace test {
+
+class OrderBySQLTests : public PelotonTest {};
+
+TEST_F(OrderBySQLTests, PerformanceTest) {
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, nullptr);
+
+  // Create a table first
+  SQLTestsUtil::ExecuteSQLQuery(
+      "CREATE TABLE test(a INT PRIMARY KEY, b INT, c "
+      "INT, d INT, e TIMESTAMP);");
+
+  SQLTestsUtil::ExecuteSQLQuery("CREATE INDEX idx_order ON test (b,c);");
+
+  // Load table
+  int table_size = 100000;
+  int min = 1;
+  int max = 100;
+  std::string insert_prefix = "INSERT INTO test VALUES (";
+  for (int count = 0; count < table_size; count++) {
+    int c_value = SQLTestsUtil::GetRandomInteger(min, max);
+    std::string insert_statement = insert_prefix + std::to_string(count) + "," +
+                                   "1" + "," + std::to_string(c_value) + "," +
+                                   std::to_string(count) + "," +
+                                   "'2016-12-06 00:00:02-04'" + ");";
+    SQLTestsUtil::ExecuteSQLQuery(insert_statement);
+  }
+
+  SQLTestsUtil::ShowTable(DEFAULT_DB_NAME, "test");
+
+  std::vector<ResultType> result;
+  std::vector<FieldInfoType> tuple_descriptor;
+  std::string error_message;
+  int rows_affected;
+  optimizer::SimpleOptimizer optimizer;
+
+  std::chrono::system_clock::time_point start_time =
+      std::chrono::system_clock::now();
+
+  // test OrderBy Limit
+  SQLTestsUtil::ExecuteSQLQuery(
+      "SELECT c from test WHERE b=1 ORDER BY c LIMIT 10", result,
+      tuple_descriptor, rows_affected, error_message);
+
+  std::chrono::system_clock::time_point end_time =
+      std::chrono::system_clock::now();
+
+  auto latency = std::chrono::duration_cast<std::chrono::milliseconds>(
+      end_time - start_time).count();
+
+  LOG_INFO(
+      "OrderBy Query (table size:%d) with Limit 10 Execution Time is: %lu ms",
+      table_size, latency);
+
+  // Check the return value
+  EXPECT_EQ(result[0].second[0], '1');
+
+  // test OrderBy without Limit
+  start_time = std::chrono::system_clock::now();
+
+  SQLTestsUtil::ExecuteSQLQuery("SELECT c from test WHERE b=1 ORDER BY c",
+                                result, tuple_descriptor, rows_affected,
+                                error_message);
+
+  end_time = std::chrono::system_clock::now();
+
+  latency = std::chrono::duration_cast<std::chrono::milliseconds>(
+      end_time - start_time).count();
+
+  LOG_INFO("OrderBy Query (table size:%d) Execution Time is: %lu ms",
+           table_size, latency);
+
+  // free the database just created
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/sql/order_by_sql_test.cpp
+++ b/test/sql/order_by_sql_test.cpp
@@ -76,9 +76,6 @@ TEST_F(OrderBySQLTests, PerformanceTest) {
       "OrderBy Query (table size:%d) with Limit 10 Execution Time is: %lu ms",
       table_size, latency);
 
-  // Check the return value
-  EXPECT_EQ(result[0].second[0], '1');
-
   // test OrderBy without Limit
   start_time = std::chrono::system_clock::now();
 

--- a/test/sql/order_by_sql_test.cpp
+++ b/test/sql/order_by_sql_test.cpp
@@ -36,7 +36,8 @@ TEST_F(OrderBySQLTests, PerformanceTest) {
   SQLTestsUtil::ExecuteSQLQuery("CREATE INDEX idx_order ON test (b,c);");
 
   // Load table
-  int table_size = 100000;
+  // You can increase the size of the table to test large result
+  int table_size = 100;
   int min = 1;
   int max = 100;
   std::string insert_prefix = "INSERT INTO test VALUES (";

--- a/test/sql/sql_tests_util.cpp
+++ b/test/sql/sql_tests_util.cpp
@@ -28,6 +28,18 @@ namespace peloton {
 
 namespace test {
 
+std::random_device rd;
+std::mt19937 rng(rd());
+
+// Create a uniform random number
+int SQLTestsUtil::GetRandomInteger(const int lower_bound,
+                                   const int upper_bound) {
+  std::uniform_int_distribution<> dist(lower_bound, upper_bound);
+
+  int sample = dist(rng);
+  return sample;
+}
+
 // Show the content in the specific table in the specific database
 // Note: In order to see the content from the command line, you have to
 // turn-on LOG_TRACE.
@@ -65,13 +77,13 @@ Result SQLTestsUtil::ExecuteSQLQueryWithOptimizer(
 
   try {
     LOG_DEBUG("%s", planner::PlanUtil::GetInfo(plan.get()).c_str());
-    auto status = traffic_cop_.ExecuteStatementPlan(plan.get(), params,
-                                                    result, result_format);
+    auto status = traffic_cop_.ExecuteStatementPlan(plan.get(), params, result,
+                                                    result_format);
     rows_changed = status.m_processed;
     LOG_INFO("Statement executed. Result: %d", status.m_result);
     return status.m_result;
-
-  } catch (Exception &e) {
+  }
+  catch (Exception &e) {
     error_message = e.what();
     return Result::RESULT_FAILURE;
   }

--- a/test/sql/sql_tests_util.cpp
+++ b/test/sql/sql_tests_util.cpp
@@ -20,6 +20,8 @@
 #include "planner/plan_util.h"
 #include "tcop/tcop.h"
 
+#include <random>
+
 namespace peloton {
 
 //===--------------------------------------------------------------------===//


### PR DESCRIPTION
This PR includes the optimization for order_by and limit. When the underlying plan has the same ordering with the order_by expression, order_by executor doesn't perform sort operation. Order_by executor also utilizes the limit number and offset to decrease invoking the underlying executor. Performance test has been done. It is ~1620 txns/sec on my local desk top. After the rebase with master, the throughput is ~1540 txns/sec. 