### PR TITLE
Efforts fixing the high contention bug

### DIFF
--- a/src/executor/update_executor.cpp
+++ b/src/executor/update_executor.cpp
@@ -202,8 +202,7 @@ bool UpdateExecutor::DExecute() {
         transaction_manager.PerformUpdate(current_txn, old_location);
       }
     }
-    // if we have already got the
-    // ownership
+    // If we haven't got the ownership
     else {
       // Skip the IsOwnable and AcquireOwnership if we have already got the
       // ownership
@@ -248,6 +247,9 @@ bool UpdateExecutor::DExecute() {
 
           // acquire a version slot from the table.
           ItemPointer new_location = target_table_->AcquireVersion();
+
+          PL_ASSERT(concurrency::EpochManagerFactory::GetInstance().GetMaxDeadTxnCid()
+             < current_txn->GetBeginCommitId());
 
           auto &manager = catalog::Manager::GetInstance();
           auto new_tile_group = manager.GetTileGroup(new_location.block);

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -231,6 +231,8 @@ ItemPointer TransactionLevelGCManager::ReturnFreeSlot(const oid_t &table_id) {
   if (recycle_queue->Dequeue(location) == true) {
     LOG_TRACE("Reuse tuple(%u, %u) in table %u", location.block,
               location.offset, table_id);
+    PL_ASSERT(catalog::Manager::GetInstance().
+      GetTileGroup(location.block)->GetHeader()->GetTransactionId(location.offset) == INVALID_TXN_ID);
     return location;
   }
   return INVALID_ITEMPOINTER;

--- a/src/include/concurrency/transaction_manager.h
+++ b/src/include/concurrency/transaction_manager.h
@@ -53,13 +53,10 @@ class TransactionManager {
   txn_id_t GetNextTransactionId() { return next_txn_id_++; }
 
   cid_t GetNextCommitId() {
-    cid_t temp_cid = next_cid_++;
-    // wait if we do not yet have a grant for this commit id
-    while (temp_cid > maximum_grant_cid_.load())
-      ;
-    return temp_cid;
+    return EpochManagerFactory::GetInstance().GetNextSafeCid();
   }
 
+  // WARNING: THIS IS DEPRECATED! REMOVE IT AFTER WE HAVE NEW LOGGING
   cid_t GetCurrentCommitId() { return next_cid_.load(); }
 
   // This method is used for avoiding concurrent inserts.
@@ -132,8 +129,10 @@ class TransactionManager {
   }
 
   // for use by recovery
+  // WARNING: THIS IS DEPRECATED! REMOVE IT AFTER WE HAVE NEW LOGGING
   void SetNextCid(cid_t cid) { next_cid_ = cid; }
 
+  // WARNING: THIS IS DEPRECATED! REMOVE IT AFTER WE HAVE NEW LOGGING
   void SetMaxGrantCid(cid_t cid) { maximum_grant_cid_ = cid; }
 
   virtual Transaction *BeginTransaction() = 0;
@@ -176,6 +175,7 @@ class TransactionManager {
  private:
   std::atomic<txn_id_t> next_txn_id_;
   std::atomic<cid_t> next_cid_;
+  // WARNING: THIS IS DEPRECATED! REMOVE IT AFTER WE HAVE NEW LOGGING
   std::atomic<cid_t> maximum_grant_cid_;
 };
 }  // End storage namespace

--- a/src/include/type/ephemeral_pool.h
+++ b/src/include/type/ephemeral_pool.h
@@ -61,9 +61,12 @@ public:
   void Free(UNUSED_ATTRIBUTE void *ptr) {
     char *cptr = (char *) ptr;
     pool_lock_.Lock();
-    locations_.erase(cptr);
+    size_t removed = locations_.erase(cptr);
     pool_lock_.Unlock();
-    delete [] cptr;
+
+    if (removed) {
+      delete[] cptr;
+    }
   }
 
 public:

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -881,14 +881,18 @@ typedef uint64_t cid_t;
 
 static const cid_t INVALID_CID = 0;
 
-static const cid_t READ_ONLY_START_CID = 1;
-
 static const cid_t START_CID = 2;
 
 static const cid_t MAX_CID = std::numeric_limits<cid_t>::max();
 
 // For epoch
 static const size_t EPOCH_LENGTH = 40;
+
+static const size_t MIN_EPOCH = 0;
+
+static const size_t RO_BEGIN_EPOCH = 1;
+
+static const size_t RW_BEGIN_EPOCH = 2;
 
 // For threads
 extern size_t QUERY_THREAD_COUNT;


### PR DESCRIPTION
1. Add validation to epoch manager when joining epochs. Ensure that we do join the current epoch.
2. Add validation in VarlenPool::Free(). Ensure that we only free memory allocated from this pool.
3. Refactor the logic of BeginCommitId. Integrate it with epoch manager to ensure that txns in a younger epoch always have greater BeginCommidId.
4. Add more asserts.

Just for code review. Don't merge it.