### PR TITLE
OrderBy Partial Fix Bug #385 and unit tests

### DIFF
--- a/src/executor/order_by_executor.cpp
+++ b/src/executor/order_by_executor.cpp
@@ -56,8 +56,9 @@ bool OrderByExecutor::DExecute() {
   PL_ASSERT(input_schema_.get());
   PL_ASSERT(input_tiles_.size() > 0);
 
-  // Returned tiles must be newly created physical tiles,
-  // which have the same physical schema as input tiles.
+  // Returned tiles must be newly created physical tiles.
+  // NOTE: the schema of these tiles might not match the input tiles when some of the order by columns are not be part of the output schema
+
   size_t tile_size = std::min(size_t(DEFAULT_TUPLES_PER_TILEGROUP),
                               sort_buffer_.size() - num_tuples_returned_);
 
@@ -116,12 +117,19 @@ bool OrderByExecutor::DoSort() {
   descend_flags_ = node.GetDescendFlags();
 
   // Extract the schema for sort keys.
-  input_schema_.reset(input_tiles_[0]->GetPhysicalSchema());
+
+  std::unique_ptr<catalog::Schema> physical_schema;
+  physical_schema.reset(input_tiles_[0]->GetPhysicalSchema());
   std::vector<catalog::Column> sort_key_columns;
+  std::vector<catalog::Column> output_key_columns;
   for (auto id : node.GetSortKeys()) {
-    sort_key_columns.push_back(input_schema_->GetColumn(id));
+    sort_key_columns.push_back(physical_schema->GetColumn(id));
+  }
+  for (auto id : node.GetOutputColumnIds()) {
+    output_key_columns.push_back(physical_schema->GetColumn(id));
   }
   sort_key_tuple_schema_.reset(new catalog::Schema(sort_key_columns));
+  input_schema_.reset(new catalog::Schema(output_key_columns));
   auto executor_pool = executor_context_->GetPool();
 
   // Extract all valid tuples into a single std::vector (the sort buffer)

--- a/test/sql/order_by_queries_sql_test.cpp
+++ b/test/sql/order_by_queries_sql_test.cpp
@@ -1,0 +1,170 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// order_by_queries_sql_test.cpp
+//
+// Identification: test/sql/order_by_queries_sql_test.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <memory>
+
+#include "catalog/catalog.h"
+#include "common/harness.h"
+#include "executor/create_executor.h"
+#include "optimizer/optimizer.h"
+#include "optimizer/simple_optimizer.h"
+#include "planner/create_plan.h"
+
+#include "sql/sql_tests_util.h"
+
+namespace peloton {
+namespace test {
+
+class OrderByQueriesSQLTests : public PelotonTest {};
+
+void CreateAndLoadTable() {
+  // Create a table first
+  SQLTestsUtil::ExecuteSQLQuery(
+      "CREATE TABLE test(a INT PRIMARY KEY, b INT, c INT, d VARCHAR);");
+
+  // Insert tuples into table
+  SQLTestsUtil::ExecuteSQLQuery("INSERT INTO test VALUES (1, 22, 333, 'abcd');");
+  SQLTestsUtil::ExecuteSQLQuery("INSERT INTO test VALUES (2, 33, 111, 'bcda');");
+  SQLTestsUtil::ExecuteSQLQuery("INSERT INTO test VALUES (3, 11, 222, 'bcd');");
+}
+
+TEST_F(OrderByQueriesSQLTests, OrderByWithColumnsTest) {
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, nullptr);
+
+  CreateAndLoadTable();
+
+  std::vector<ResultType> result;
+  std::vector<FieldInfoType> tuple_descriptor;
+  std::string error_message;
+  int rows_changed;
+  std::unique_ptr<optimizer::AbstractOptimizer> optimizer(
+      new optimizer::SimpleOptimizer());
+
+  std::string query("SELECT a, b FROM test ORDER BY b;");
+  auto select_plan = SQLTestsUtil::GeneratePlanWithOptimizer(optimizer, query);
+  EXPECT_EQ(select_plan->GetPlanNodeType(), PLAN_NODE_TYPE_ORDERBY);
+
+  // test small int
+  SQLTestsUtil::ExecuteSQLQueryWithOptimizer(
+      optimizer, query, result, tuple_descriptor, rows_changed, error_message);
+  // Check the return value
+  // Should be: 3, 1, 2
+  EXPECT_EQ(0, rows_changed);
+  EXPECT_EQ("3", SQLTestsUtil::GetResultValueAsString(result, 0));
+  EXPECT_EQ("1", SQLTestsUtil::GetResultValueAsString(result, 2));
+  EXPECT_EQ("2", SQLTestsUtil::GetResultValueAsString(result, 4));
+
+  // free the database just created
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+TEST_F(OrderByQueriesSQLTests, OrderByWithoutColumnsTest) {
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, nullptr);
+
+  CreateAndLoadTable();
+
+  std::vector<ResultType> result;
+  std::vector<FieldInfoType> tuple_descriptor;
+  std::string error_message;
+  int rows_changed;
+  std::unique_ptr<optimizer::AbstractOptimizer> optimizer(
+      new optimizer::SimpleOptimizer());
+
+  std::string query("SELECT a FROM test ORDER BY b;");
+  auto select_plan = SQLTestsUtil::GeneratePlanWithOptimizer(optimizer, query);
+  EXPECT_EQ(select_plan->GetPlanNodeType(), PLAN_NODE_TYPE_ORDERBY);
+
+  // test small int
+  SQLTestsUtil::ExecuteSQLQueryWithOptimizer(
+      optimizer, query, result, tuple_descriptor, rows_changed, error_message);
+  // Check the return value
+  // Should be: 3, 1, 2
+  EXPECT_EQ(0, rows_changed);
+  EXPECT_EQ("3", SQLTestsUtil::GetResultValueAsString(result, 0));
+  EXPECT_EQ("1", SQLTestsUtil::GetResultValueAsString(result, 1));
+  EXPECT_EQ("2", SQLTestsUtil::GetResultValueAsString(result, 2));
+
+  // free the database just created
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+
+TEST_F(OrderByQueriesSQLTests, OrderByWithColumnsAndLimitTest) {
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, nullptr);
+
+  CreateAndLoadTable();
+
+  std::vector<ResultType> result;
+  std::vector<FieldInfoType> tuple_descriptor;
+  std::string error_message;
+  int rows_changed;
+  std::unique_ptr<optimizer::AbstractOptimizer> optimizer(
+      new optimizer::SimpleOptimizer());
+
+  std::string query("SELECT a, b, d FROM test ORDER BY d LIMIT 2;");
+  auto select_plan = SQLTestsUtil::GeneratePlanWithOptimizer(optimizer, query);
+  EXPECT_EQ(select_plan->GetPlanNodeType(), PLAN_NODE_TYPE_LIMIT);
+  EXPECT_EQ(select_plan->GetChildren()[0]->GetPlanNodeType(), PLAN_NODE_TYPE_ORDERBY);
+  // test small int
+  SQLTestsUtil::ExecuteSQLQueryWithOptimizer(
+      optimizer, query, result, tuple_descriptor, rows_changed, error_message);
+  // Check the return value
+  // Should be: 1, 3
+  EXPECT_EQ(0, rows_changed);
+  EXPECT_EQ("1", SQLTestsUtil::GetResultValueAsString(result, 0));
+  EXPECT_EQ("3", SQLTestsUtil::GetResultValueAsString(result, 3));
+
+  // free the database just created
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+TEST_F(OrderByQueriesSQLTests, OrderByWithoutColumnsAndLimitTest) {
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, nullptr);
+
+  CreateAndLoadTable();
+
+  std::vector<ResultType> result;
+  std::vector<FieldInfoType> tuple_descriptor;
+  std::string error_message;
+  int rows_changed;
+  std::unique_ptr<optimizer::AbstractOptimizer> optimizer(
+      new optimizer::SimpleOptimizer());
+
+  std::string query("SELECT a FROM test ORDER BY d LIMIT 2;");
+  auto select_plan = SQLTestsUtil::GeneratePlanWithOptimizer(optimizer, query);
+  EXPECT_EQ(select_plan->GetPlanNodeType(), PLAN_NODE_TYPE_LIMIT);
+  EXPECT_EQ(select_plan->GetChildren()[0]->GetPlanNodeType(), PLAN_NODE_TYPE_ORDERBY);
+
+  SQLTestsUtil::ExecuteSQLQueryWithOptimizer(
+      optimizer, query, result, tuple_descriptor, rows_changed, error_message);
+  // Check the return value
+  // Should be: 1, 3
+  EXPECT_EQ(0, rows_changed);
+  EXPECT_EQ("1", SQLTestsUtil::GetResultValueAsString(result, 0));
+  EXPECT_EQ("3", SQLTestsUtil::GetResultValueAsString(result, 1));
+
+  // free the database just created
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}}  // namespace test
+}  // namespace peloton


### PR DESCRIPTION
This PR resolves issue #385.

InSimpleOptimizer: Adding the order by column explicitely into the column map, to allow materialization and sorting.

In OrderByExecutor: Use only the columns in select for output_schema.

As requested, with unit tests.