### PR TITLE
Fix Min/Max aggregations for Timestamps. Issue #382

### DIFF
--- a/src/include/type/timestamp_type.h
+++ b/src/include/type/timestamp_type.h
@@ -29,6 +29,10 @@ class TimestampType : public Type {
   CmpBool CompareLessThanEquals(const Value& left, const Value &right) const override;
   CmpBool CompareGreaterThan(const Value& left, const Value &right) const override;
   CmpBool CompareGreaterThanEquals(const Value& left, const Value &right) const override;
+  
+  // Other mathematical functions
+  virtual Value Min(const Value& left, const Value &right) const override;
+  virtual Value Max(const Value& left, const Value &right) const override;
 
   bool IsInlined(const Value&) const override { return true; }
 

--- a/src/include/type/varlen_type.h
+++ b/src/include/type/varlen_type.h
@@ -40,6 +40,10 @@ class VarlenType : public Type {
   CmpBool CompareLessThanEquals(const Value& left, const Value &right) const override;
   CmpBool CompareGreaterThan(const Value& left, const Value &right) const override;
   CmpBool CompareGreaterThanEquals(const Value& left, const Value &right) const override;
+  
+  // Other mathematical functions
+  virtual Value Min(const Value& left, const Value &right) const override;
+  virtual Value Max(const Value& left, const Value &right) const override;
 
   Value CastAs(const Value& val, const Type::TypeId type_id) const override;
 

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -490,7 +490,7 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
                     "COL_" + std::to_string(col_cntr_id++),  // COL_A should be
                                                              // used only when
                                                              // there is no AS
-                    true);
+                    false);
 
                 output_schema_columns.push_back(column);
               }

--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -65,6 +65,24 @@ CmpBool TimestampType::CompareGreaterThanEquals(const Value& left, const Value &
   return GetCmpBool(left.GetAs<uint64_t>() >= right.GetAs<uint64_t>());
 }
 
+Value TimestampType::Min(const Value& left, const Value& right) const {
+  PL_ASSERT(left.CheckComparable(right));
+  if (left.IsNull() || right.IsNull())
+    return left.OperateNull(right);
+  if (left.CompareLessThan(right) == CMP_TRUE)
+      return left.Copy();
+  return right.Copy();
+}
+
+Value TimestampType::Max(const Value& left, const Value& right) const {
+    PL_ASSERT(left.CheckComparable(right));
+    if (left.IsNull() || right.IsNull())
+        return left.OperateNull(right);
+    if (left.CompareGreaterThan(right) == CMP_TRUE)
+        return left.Copy();
+    return right.Copy();
+}
+
 // Debug
 std::string TimestampType::ToString(const Value& val) const {
   if (val.IsNull())

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -128,6 +128,24 @@ CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
                                              GetLength(right)) >= 0);
 }
 
+Value VarlenType::Min(const Value& left, const Value& right) const {
+    PL_ASSERT(left.CheckComparable(right));
+    if (left.IsNull() || right.IsNull())
+        return left.OperateNull(right);
+    if (left.CompareLessThan(right) == CMP_TRUE)
+        return left.Copy();
+    return right.Copy();
+}
+
+Value VarlenType::Max(const Value& left, const Value& right) const {
+    PL_ASSERT(left.CheckComparable(right));
+    if (left.IsNull() || right.IsNull())
+        return left.OperateNull(right);
+    if (left.CompareGreaterThan(right) == CMP_TRUE)
+        return left.Copy();
+    return right.Copy();
+}
+
 std::string VarlenType::ToString(const Value &val) const {
   uint32_t len = GetLength(val);
 

--- a/test/sql/aggregate_sql_test.cpp
+++ b/test/sql/aggregate_sql_test.cpp
@@ -174,19 +174,19 @@ TEST_F(AggregateSQLTests, MinMaxTest) {
 
   /*
    * TODO: LM: I commented these out because we will core dump when doing
-             min/max on varchar/timestamp
+             min/max on varchar
   // test varchar
   SQLTestsUtil::ExecuteSQLQuery("SELECT", "SELECT min(g) from test", result);
   EXPECT_EQ(result[0].second[0], '1');
   SQLTestsUtil::ExecuteSQLQuery("SELECT", "SELECT max(g) from test", result);
   EXPECT_EQ(result[0].second[0], '4');
+  */
 
   // test timestamp
-  SQLTestsUtil::ExecuteSQLQuery("SELECT", "SELECT min(h) from test", result);
+  SQLTestsUtil::ExecuteSQLQuery("SELECT min(h) from test", result);
   EXPECT_EQ(result[0].second[18], '1');
-  SQLTestsUtil::ExecuteSQLQuery("SELECT", "SELECT max(h) from test", result);
+  SQLTestsUtil::ExecuteSQLQuery("SELECT max(h) from test", result);
   EXPECT_EQ(result[0].second[18], '4');
-  */
 
   // free the database just created
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();

--- a/test/sql/aggregate_sql_test.cpp
+++ b/test/sql/aggregate_sql_test.cpp
@@ -172,15 +172,11 @@ TEST_F(AggregateSQLTests, MinMaxTest) {
   EXPECT_EQ(static_cast<oid_t>(PostgresValueType::DOUBLE),
             std::get<1>(tuple_descriptor[0]));
 
-  /*
-   * TODO: LM: I commented these out because we will core dump when doing
-             min/max on varchar
   // test varchar
-  SQLTestsUtil::ExecuteSQLQuery("SELECT", "SELECT min(g) from test", result);
+  SQLTestsUtil::ExecuteSQLQuery("SELECT min(g) from test", result);
   EXPECT_EQ(result[0].second[0], '1');
-  SQLTestsUtil::ExecuteSQLQuery("SELECT", "SELECT max(g) from test", result);
+  SQLTestsUtil::ExecuteSQLQuery("SELECT max(g) from test", result);
   EXPECT_EQ(result[0].second[0], '4');
-  */
 
   // test timestamp
   SQLTestsUtil::ExecuteSQLQuery("SELECT min(h) from test", result);


### PR DESCRIPTION
This change Fixes Min/Max aggregations for Timestamps by adding the missing methods.

It is not a total fix for issue #382 because the system still crashes for VARCHAR Min/Max aggregations.

In addition I uncommented the SQL tests for Min/Max aggregations on Timestamps.

Now focusing on varchar.