### PR TITLE
Add support for DISTINCT (#444)

### DIFF
--- a/src/executor/hash_executor.cpp
+++ b/src/executor/hash_executor.cpp
@@ -88,8 +88,14 @@ bool HashExecutor::DExecute() {
       for (oid_t tuple_id : *tile) {
         // Key : container tuple with a subset of tuple attributes
         // Value : < child_tile offset, tuple offset >
-        hash_table_[HashMapType::key_type(tile, tuple_id, &column_ids_)].insert(
-            std::make_pair(child_tile_itr, tuple_id));
+        auto key = HashMapType::key_type(tile, tuple_id, &column_ids_);
+        if (hash_table_.find(key) != hash_table_.end()){
+           //If data is already present, remove from output
+           //but leave data for hash joins.
+           tile->RemoveVisibility(tuple_id);
+        }
+        hash_table_[key].insert(
+                    std::make_pair(child_tile_itr, tuple_id));
       }
     }
 

--- a/src/executor/logical_tile.cpp
+++ b/src/executor/logical_tile.cpp
@@ -164,7 +164,7 @@ storage::Tile *LogicalTile::GetBaseTile(oid_t column_id) {
 type::Value LogicalTile::GetValue(oid_t tuple_id, oid_t column_id) {
   PL_ASSERT(column_id < schema_.size());
   PL_ASSERT(tuple_id < total_tuples_);
-  PL_ASSERT(visible_rows_[tuple_id]);
+  //PL_ASSERT(visible_rows_[tuple_id]);
 
   ColumnInfo &cp = schema_[column_id];
   oid_t base_tuple_id = position_lists_[cp.position_list_idx][tuple_id];

--- a/src/executor/logical_tile.cpp
+++ b/src/executor/logical_tile.cpp
@@ -164,7 +164,6 @@ storage::Tile *LogicalTile::GetBaseTile(oid_t column_id) {
 type::Value LogicalTile::GetValue(oid_t tuple_id, oid_t column_id) {
   PL_ASSERT(column_id < schema_.size());
   PL_ASSERT(tuple_id < total_tuples_);
-  //PL_ASSERT(visible_rows_[tuple_id]);
 
   ColumnInfo &cp = schema_[column_id];
   oid_t base_tuple_id = position_lists_[cp.position_list_idx][tuple_id];

--- a/src/optimizer/simple_optimizer.cpp
+++ b/src/optimizer/simple_optimizer.cpp
@@ -230,8 +230,8 @@ std::shared_ptr<planner::AbstractPlan> SimpleOptimizer::BuildPelotonPlanTree(
             std::vector<std::unique_ptr<const expression::AbstractExpression>> hash_keys;
             for (auto col : *select_stmt->select_list) {
               //Copy column for handling of unique_ptr
-              auto copyCol = col->Copy();
-              hash_keys.emplace_back(copyCol);
+              auto copy_col = col->Copy();
+              hash_keys.emplace_back(copy_col);
             }
             // Create hash plan node
             std::unique_ptr<planner::HashPlan> hash_plan_node(

--- a/test/sql/distinct_sql_test.cpp
+++ b/test/sql/distinct_sql_test.cpp
@@ -80,6 +80,7 @@ TEST_F(DistinctSQLTests, DistinctVarcharTest) {
   // Check the return value
   // Should be: 'abcd', 'abc'
   EXPECT_EQ(0, rows_changed);
+  EXPECT_EQ(2, result.size() / tuple_descriptor.size());
   EXPECT_EQ("abcd", SQLTestsUtil::GetResultValueAsString(result, 0));
   EXPECT_EQ("abc", SQLTestsUtil::GetResultValueAsString(result, 1));
 
@@ -106,6 +107,7 @@ TEST_F(DistinctSQLTests, DistinctTupleTest) {
   // Check the return value
   // Should be: [22,333]; [11,222]
   EXPECT_EQ(0, rows_changed);
+  EXPECT_EQ(2, result.size() / tuple_descriptor.size());
   EXPECT_EQ("22", SQLTestsUtil::GetResultValueAsString(result, 0));
   EXPECT_EQ("333", SQLTestsUtil::GetResultValueAsString(result, 1));
   EXPECT_EQ("11", SQLTestsUtil::GetResultValueAsString(result, 2));
@@ -141,7 +143,7 @@ TEST_F(DistinctSQLTests, DistinctStarTest) {
                                 tuple_descriptor, rows_changed, error_message);
 
   // Check the return value
-  // Should be: [22,333]; [11,222]
+  // Should be: [1,22,333,'abcd']; [1, 22, 222, 'abcd']
   EXPECT_EQ(0, rows_changed);
   EXPECT_EQ(2, result.size() / tuple_descriptor.size());
   EXPECT_EQ("1", SQLTestsUtil::GetResultValueAsString(result, 0));
@@ -149,6 +151,9 @@ TEST_F(DistinctSQLTests, DistinctStarTest) {
   EXPECT_EQ("333", SQLTestsUtil::GetResultValueAsString(result, 2));
   EXPECT_EQ("abcd", SQLTestsUtil::GetResultValueAsString(result, 3));
   EXPECT_EQ("1", SQLTestsUtil::GetResultValueAsString(result, 4));
+  EXPECT_EQ("22", SQLTestsUtil::GetResultValueAsString(result, 5));
+  EXPECT_EQ("222", SQLTestsUtil::GetResultValueAsString(result, 6));
+  EXPECT_EQ("abcd", SQLTestsUtil::GetResultValueAsString(result, 7));
 
   // free the database just created
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();

--- a/test/sql/distinct_sql_test.cpp
+++ b/test/sql/distinct_sql_test.cpp
@@ -1,0 +1,121 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// distinct_sql_test.cpp
+//
+// Identification: test/sql/distinct_sql_test.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <memory>
+
+#include "catalog/catalog.h"
+#include "common/harness.h"
+#include "executor/create_executor.h"
+#include "optimizer/simple_optimizer.h"
+#include "planner/create_plan.h"
+#include "sql/sql_tests_util.h"
+
+namespace peloton {
+namespace test {
+
+class DistinctSQLTests : public PelotonTest {};
+
+void CreateAndLoadTable() {
+  // Create a table first
+  SQLTestsUtil::ExecuteSQLQuery(
+      "CREATE TABLE test(a INT PRIMARY KEY, b INT, c INT, d VARCHAR);");
+
+  // Insert tuples into table
+  SQLTestsUtil::ExecuteSQLQuery(
+      "INSERT INTO test VALUES (1, 22, 333, 'abcd');");
+  SQLTestsUtil::ExecuteSQLQuery(
+      "INSERT INTO test VALUES (2, 22, 333, 'abc');");
+  SQLTestsUtil::ExecuteSQLQuery(
+      "INSERT INTO test VALUES (3, 11, 222, 'abcd');");
+}
+
+TEST_F(DistinctSQLTests, DistinctIntTest) {
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, nullptr);
+
+  CreateAndLoadTable();
+
+  std::vector<StatementResult> result;
+  std::vector<FieldInfo> tuple_descriptor;
+  std::string error_message;
+  int rows_changed;
+
+  SQLTestsUtil::ExecuteSQLQuery("SELECT DISTINCT b FROM test;", result,
+                                tuple_descriptor, rows_changed, error_message);
+
+  // Check the return value
+  // Should be: 22, 11
+  EXPECT_EQ(0, rows_changed);
+  EXPECT_EQ("22", SQLTestsUtil::GetResultValueAsString(result, 0));
+  EXPECT_EQ("11", SQLTestsUtil::GetResultValueAsString(result, 1));
+
+  // free the database just created
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+TEST_F(DistinctSQLTests, DistinctVarcharTest) {
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, nullptr);
+
+  CreateAndLoadTable();
+
+  std::vector<StatementResult> result;
+  std::vector<FieldInfo> tuple_descriptor;
+  std::string error_message;
+  int rows_changed;
+
+  SQLTestsUtil::ExecuteSQLQuery("SELECT DISTINCT d FROM test;", result,
+                                tuple_descriptor, rows_changed, error_message);
+
+  // Check the return value
+  // Should be: 'abcd', 'abc'
+  EXPECT_EQ(0, rows_changed);
+  EXPECT_EQ("abcd", SQLTestsUtil::GetResultValueAsString(result, 0));
+  EXPECT_EQ("abc", SQLTestsUtil::GetResultValueAsString(result, 1));
+
+  // free the database just created
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+TEST_F(DistinctSQLTests, DistinctTupleTest) {
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, nullptr);
+
+  CreateAndLoadTable();
+
+  std::vector<StatementResult> result;
+  std::vector<FieldInfo> tuple_descriptor;
+  std::string error_message;
+  int rows_changed;
+
+  SQLTestsUtil::ExecuteSQLQuery("SELECT DISTINCT b, c FROM test;", result,
+                                tuple_descriptor, rows_changed, error_message);
+
+  // Check the return value
+  // Should be: [22,333]; [11,222]
+  EXPECT_EQ(0, rows_changed);
+  EXPECT_EQ("22", SQLTestsUtil::GetResultValueAsString(result, 0));
+  EXPECT_EQ("333", SQLTestsUtil::GetResultValueAsString(result, 1));
+  EXPECT_EQ("11", SQLTestsUtil::GetResultValueAsString(result, 2));
+  EXPECT_EQ("222", SQLTestsUtil::GetResultValueAsString(result, 3));
+
+  // free the database just created
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/sql/distinct_sql_test.cpp
+++ b/test/sql/distinct_sql_test.cpp
@@ -54,6 +54,7 @@ TEST_F(DistinctSQLTests, DistinctIntTest) {
   // Check the return value
   // Should be: 22, 11
   EXPECT_EQ(0, rows_changed);
+  EXPECT_EQ(2, result.size() / tuple_descriptor.size());
   EXPECT_EQ("22", SQLTestsUtil::GetResultValueAsString(result, 0));
   EXPECT_EQ("11", SQLTestsUtil::GetResultValueAsString(result, 1));
 

--- a/test/sql/distinct_sql_test.cpp
+++ b/test/sql/distinct_sql_test.cpp
@@ -63,6 +63,7 @@ TEST_F(DistinctSQLTests, DistinctIntTest) {
   catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
 }
+
 TEST_F(DistinctSQLTests, DistinctVarcharTest) {
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, nullptr);
 
@@ -109,6 +110,45 @@ TEST_F(DistinctSQLTests, DistinctTupleTest) {
   EXPECT_EQ("333", SQLTestsUtil::GetResultValueAsString(result, 1));
   EXPECT_EQ("11", SQLTestsUtil::GetResultValueAsString(result, 2));
   EXPECT_EQ("222", SQLTestsUtil::GetResultValueAsString(result, 3));
+
+  // free the database just created
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+TEST_F(DistinctSQLTests, DistinctStarTest) {
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, nullptr);
+
+  SQLTestsUtil::ExecuteSQLQuery(
+      "CREATE TABLE test(a INT, b INT, c INT, d VARCHAR);");
+
+  // Insert tuples into table
+  SQLTestsUtil::ExecuteSQLQuery(
+      "INSERT INTO test VALUES (1, 22, 333, 'abcd');");
+  SQLTestsUtil::ExecuteSQLQuery(
+      "INSERT INTO test VALUES (1, 22, 333, 'abcd');");
+  SQLTestsUtil::ExecuteSQLQuery(
+      "INSERT INTO test VALUES (1, 22, 222, 'abcd');");
+
+  std::vector<StatementResult> result;
+  std::vector<FieldInfo> tuple_descriptor;
+  std::string error_message;
+  int rows_changed;
+
+  SQLTestsUtil::ExecuteSQLQuery("SELECT DISTINCT * FROM test;", result,
+                                tuple_descriptor, rows_changed, error_message);
+
+  // Check the return value
+  // Should be: [22,333]; [11,222]
+  EXPECT_EQ(0, rows_changed);
+  EXPECT_EQ(2, result.size() / tuple_descriptor.size());
+  EXPECT_EQ("1", SQLTestsUtil::GetResultValueAsString(result, 0));
+  EXPECT_EQ("22", SQLTestsUtil::GetResultValueAsString(result, 1));
+  EXPECT_EQ("333", SQLTestsUtil::GetResultValueAsString(result, 2));
+  EXPECT_EQ("abcd", SQLTestsUtil::GetResultValueAsString(result, 3));
+  EXPECT_EQ("1", SQLTestsUtil::GetResultValueAsString(result, 4));
 
   // free the database just created
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();


### PR DESCRIPTION
This PR adds partial support for `SELECT DISTINCT` queries. There are two scenarios not covered currently.

- <s>`SELECT DISTINCT *` was not implemented due to an assert on the `hash_executor`, but it is a simple fix. </s>
- `DISTINCT` aggregations go through another flow, I suggest opening another issue for it.


EDIT: This PR now supports `SELECT DISTINCT *` queries.
