### PR TITLE
Minor bug fixes in SQL parser

### DIFF
--- a/src/parser/sql_parser.y
+++ b/src/parser/sql_parser.y
@@ -373,7 +373,7 @@ create_statement:
 			$$->index_name = $4;
 			$$->table_info_ = $6;
 			$$->index_attrs = $8;
-			$$->index_type = peloton::StringToIndexType(CharsToStringDestructive($11));
+			$$->index_type = (peloton::IndexType)$11;
 		}
 	;
 

--- a/src/parser/sql_scanner.l
+++ b/src/parser/sql_scanner.l
@@ -209,13 +209,13 @@ BWTREE		TOKEN(BWTREE)
 [-+*/(){},.;<>=^%:?]	{ return yytext[0]; }
 
 
-[0-9]+"."[0-9]* |
+\-?[0-9]+"."[0-9]* |
 "."[0-9]*	{
 	yylval->fval = atof(yytext);
 	return SQL_FLOATVAL;
 }
 
-[0-9]+	{
+\-?[0-9]+	{
 	yylval->ival = atol(yytext);
 	return SQL_INTVAL;
 }


### PR DESCRIPTION
These are minor bug fixes for #518 and a unreported issue: If somebody explicitly sets 'USING BWTREE' or 'USING HASH' while creating an index, a segmentation fault occurs.  The cause of the this issue is an illegal type cast in handling an unsigned integer value. 