### PR TITLE
Creates populate index planner/executor

### DIFF
--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -339,7 +339,10 @@ executor::AbstractExecutor *BuildExecutorTree(
       LOG_TRACE("Adding Copy Executer");
       child_executor = new executor::CopyExecutor(plan, executor_context);
       break;
-
+    case PlanNodeType::POPULATE_INDEX:
+      LOG_TRACE("Adding PopulateIndex Executor");
+      child_executor = new executor::PopulateIndexExecutor(plan, executor_context);
+      break;
     default:
       LOG_ERROR("Unsupported plan node type : %s",
                 PlanNodeTypeToString(plan_node_type).c_str());

--- a/src/executor/populate_index_executor.cpp
+++ b/src/executor/populate_index_executor.cpp
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// populate_index_executor.cpp
+//
+// Identification: src/executor/populate_index_executor.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <utility>
+#include <vector>
+
+#include "common/logger.h"
+#include "type/value.h"
+#include "executor/logical_tile.h"
+#include "executor/populate_index_executor.h"
+#include "executor/executor_context.h"
+#include "planner/populate_index_plan.h"
+#include "expression/tuple_value_expression.h"
+#include "storage/data_table.h"
+#include "storage/tile.h"
+
+namespace peloton {
+namespace executor {
+
+/**
+ * @brief Constructor
+ */
+PopulateIndexExecutor::PopulateIndexExecutor(const planner::AbstractPlan *node,
+                                             ExecutorContext *executor_context)
+    : AbstractExecutor(node, executor_context) {}
+
+/**
+ * @brief Do some basic checks and initialize executor state.
+ * @return true on success, false otherwise.
+ */
+bool PopulateIndexExecutor::DInit() {
+  PL_ASSERT(children_.size() == 1);
+  PL_ASSERT(executor_context_);
+
+  // Initialize executor state
+  const planner::PopulateIndexPlan &node =
+      GetPlanNode<planner::PopulateIndexPlan>();
+  target_table_ = node.GetTable();
+  column_ids_ = node.GetColumnIds();
+  done_ = false;
+
+  return true;
+}
+
+bool PopulateIndexExecutor::DExecute() {
+  LOG_TRACE("Populate Index Executor");
+  PL_ASSERT(executor_context_ != nullptr);
+  auto current_txn = executor_context_->GetTransaction();
+  auto executor_pool = executor_context_->GetPool();
+  if (done_ == false) {
+    //Get the output from seq_scan
+    while (children_[0]->Execute()) {
+      child_tiles_.emplace_back(children_[0]->GetOutput());
+    }
+
+    if (child_tiles_.size() == 0) {
+      LOG_TRACE("PopulateIndex Executor : false -- no child tiles ");
+      return false;
+    }
+
+    auto target_table_schema = target_table_->GetSchema();
+
+    std::unique_ptr<storage::Tuple> tuple(
+        new storage::Tuple(target_table_schema, true));
+
+    // Go over the logical tile and insert in the index the values
+    for (size_t child_tile_itr = 0; child_tile_itr < child_tiles_.size();
+         child_tile_itr++) {
+      auto tile = child_tiles_[child_tile_itr].get();
+
+      // Go over all tuples in the logical tile
+      for (oid_t tuple_id : *tile) {
+        expression::ContainerTuple<LogicalTile> cur_tuple(tile, tuple_id);
+
+        // Materialize the logical tile tuple
+        for (oid_t column_itr = 0; column_itr < column_ids_.size();
+             column_itr++) {
+          type::Value val = (cur_tuple.GetValue(column_itr));
+          tuple->SetValue(column_ids_[column_itr], val, executor_pool);
+        }
+
+        ItemPointer location(tile->GetBaseTile(0)->GetTileGroup()->GetTileGroupId(),
+                             tuple_id);
+
+        // insert tuple into the index.
+        ItemPointer *index_entry_ptr = nullptr;
+        target_table_->InsertInIndexes(tuple.get(), location, current_txn,
+                                       &index_entry_ptr);
+      }
+    }
+
+    done_ = true;
+  }
+  LOG_TRACE("Populate Index Executor : false -- done ");
+  return false;
+}
+
+} /* namespace executor */
+} /* namespace peloton */

--- a/src/executor/seq_scan_executor.cpp
+++ b/src/executor/seq_scan_executor.cpp
@@ -23,6 +23,7 @@
 #include "executor/executor_context.h"
 #include "expression/abstract_expression.h"
 #include "common/container_tuple.h"
+#include "planner/create_plan.h"
 #include "storage/data_table.h"
 #include "storage/tile_group_header.h"
 #include "storage/tile.h"
@@ -54,7 +55,7 @@ bool SeqScanExecutor::DInit() {
   const planner::SeqScanPlan &node = GetPlanNode<planner::SeqScanPlan>();
 
   target_table_ = node.GetTable();
-  
+
   current_tile_group_offset_ = START_OID;
 
   if (target_table_ != nullptr) {
@@ -75,7 +76,14 @@ bool SeqScanExecutor::DInit() {
  */
 bool SeqScanExecutor::DExecute() {
   // Scanning over a logical tile.
-  if (children_.size() == 1) {
+  if (children_.size() == 1 &&
+      //There will be a child node on the create index scenario,
+      //but we don't want to use this execution flow
+      !(GetRawNode()->GetChildren().size() > 0 &&
+        GetRawNode()->GetChildren()[0].get()->GetPlanNodeType() ==
+            PlanNodeType::CREATE &&
+        ((planner::CreatePlan *)GetRawNode()->GetChildren()[0].get())
+                ->GetCreateType() == CreateType::INDEX)) {
     // FIXME Check all requirements for children_.size() == 0 case.
     LOG_TRACE("Seq Scan executor :: 1 child ");
 
@@ -91,8 +99,8 @@ bool SeqScanExecutor::DExecute() {
           expression::ContainerTuple<LogicalTile> tuple(tile.get(), tuple_id);
           auto eval = predicate_->Evaluate(&tuple, nullptr, executor_context_);
           if (eval.IsFalse()) {
-          //if (predicate_->Evaluate(&tuple, nullptr, executor_context_)
-          //        .IsFalse()) {
+            // if (predicate_->Evaluate(&tuple, nullptr, executor_context_)
+            //        .IsFalse()) {
             tile->RemoveVisibility(tuple_id);
           }
         }
@@ -109,12 +117,30 @@ bool SeqScanExecutor::DExecute() {
     return false;
   }
   // Scanning a table
-  else if (children_.size() == 0) {
+  else if (children_.size() == 0 ||
+           //If we are creating an index, there will be a child
+           (children_.size() == 1 &&
+            //This check is only needed to pass seq_scan_test
+            //unless it is possible to add a executor child
+            //without a corresponding plan.
+            GetRawNode()->GetChildren().size() > 0 &&
+            //Check if the plan is what we actually expect.
+            GetRawNode()->GetChildren()[0].get()->GetPlanNodeType() ==
+                PlanNodeType::CREATE &&
+            //If it is, confirm it is for indexes
+            ((planner::CreatePlan *)GetRawNode()->GetChildren()[0].get())
+                    ->GetCreateType() == CreateType::INDEX)) {
     LOG_TRACE("Seq Scan executor :: 0 child ");
 
     PL_ASSERT(target_table_ != nullptr);
     PL_ASSERT(column_ids_.size() > 0);
-
+    if (children_.size() > 0 && !index_done_) {
+      children_[0]->Execute();
+      //This stops continuous executions due to
+      //a parent and avoids multiple creations
+      //of the same index.
+      index_done_ = true;
+    }
     // Force to use occ txn manager if dirty read is forbidden
     concurrency::TransactionManager &transaction_manager =
         concurrency::TransactionManagerFactory::GetInstance();
@@ -136,30 +162,35 @@ bool SeqScanExecutor::DExecute() {
       for (oid_t tuple_id = 0; tuple_id < active_tuple_count; tuple_id++) {
         ItemPointer location(tile_group->GetTileGroupId(), tuple_id);
 
-
-        auto visibility = transaction_manager.IsVisible(current_txn, tile_group_header, tuple_id);
+        auto visibility = transaction_manager.IsVisible(
+            current_txn, tile_group_header, tuple_id);
 
         // check transaction visibility
         if (visibility == VisibilityType::OK) {
           // if the tuple is visible, then perform predicate evaluation.
           if (predicate_ == nullptr) {
             position_list.push_back(tuple_id);
-            auto res = transaction_manager.PerformRead(current_txn, location, acquire_owner);
+            auto res = transaction_manager.PerformRead(current_txn, location,
+                                                       acquire_owner);
             if (!res) {
-              transaction_manager.SetTransactionResult(current_txn, ResultType::FAILURE);
+              transaction_manager.SetTransactionResult(current_txn,
+                                                       ResultType::FAILURE);
               return res;
             }
           } else {
             expression::ContainerTuple<storage::TileGroup> tuple(
                 tile_group.get(), tuple_id);
             LOG_TRACE("Evaluate predicate for a tuple");
-            auto eval = predicate_->Evaluate(&tuple, nullptr, executor_context_);
+            auto eval =
+                predicate_->Evaluate(&tuple, nullptr, executor_context_);
             LOG_TRACE("Evaluation result: %s", eval.GetInfo().c_str());
             if (eval.IsTrue()) {
               position_list.push_back(tuple_id);
-              auto res = transaction_manager.PerformRead(current_txn, location, acquire_owner);
+              auto res = transaction_manager.PerformRead(current_txn, location,
+                                                         acquire_owner);
               if (!res) {
-                transaction_manager.SetTransactionResult(current_txn, ResultType::FAILURE);
+                transaction_manager.SetTransactionResult(current_txn,
+                                                         ResultType::FAILURE);
                 return res;
               } else {
                 LOG_TRACE("Sequential Scan Predicate Satisfied");

--- a/src/include/executor/executors.h
+++ b/src/include/executor/executors.h
@@ -33,3 +33,4 @@
 #include "executor/append_executor.h"
 #include "executor/projection_executor.h"
 #include "executor/copy_executor.h"
+#include "executor/populate_index_executor.h"

--- a/src/include/executor/populate_index_executor.h
+++ b/src/include/executor/populate_index_executor.h
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// populate_index_executor.h
+//
+// Identification: src/include/executor/populate_index_executor.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "type/types.h"
+#include "executor/abstract_executor.h"
+#include "executor/logical_tile.h"
+#include "common/container_tuple.h"
+#include "storage/data_table.h"
+
+namespace peloton {
+namespace executor {
+
+class PopulateIndexExecutor : public AbstractExecutor {
+ public:
+  PopulateIndexExecutor(const PopulateIndexExecutor &) = delete;
+  PopulateIndexExecutor &operator=(const PopulateIndexExecutor &) = delete;
+  PopulateIndexExecutor(const PopulateIndexExecutor &&) = delete;
+  PopulateIndexExecutor &operator=(const PopulateIndexExecutor &&) = delete;
+
+  explicit PopulateIndexExecutor(const planner::AbstractPlan *node,
+                                 ExecutorContext *executor_context);
+  inline storage::DataTable *GetTable() const { return target_table_; }
+
+ protected:
+  bool DInit();
+
+  bool DExecute();
+
+ private:
+  /** @brief Input tiles from child node */
+  std::vector<std::unique_ptr<LogicalTile>> child_tiles_;
+
+  //===--------------------------------------------------------------------===//
+  // Plan Info
+  //===--------------------------------------------------------------------===//
+
+  /** @brief Pointer to table to scan from. */
+  storage::DataTable *target_table_ = nullptr;
+  std::vector<oid_t> column_ids_;
+  bool done_ = false;
+};
+
+} /* namespace executor */
+} /* namespace peloton */

--- a/src/include/executor/populate_index_executor.h
+++ b/src/include/executor/populate_index_executor.h
@@ -24,6 +24,12 @@
 namespace peloton {
 namespace executor {
 
+/**
+ * The executor class that populates a newly created index
+ *
+ * It should have a SeqScanExecutor as a child, for retrieving data
+ * to be inputted the index. 
+ */
 class PopulateIndexExecutor : public AbstractExecutor {
  public:
   PopulateIndexExecutor(const PopulateIndexExecutor &) = delete;

--- a/src/include/executor/seq_scan_executor.h
+++ b/src/include/executor/seq_scan_executor.h
@@ -50,6 +50,8 @@ class SeqScanExecutor : public AbstractScanExecutor {
   // Plan Info
   //===--------------------------------------------------------------------===//
 
+  bool index_done_ = false;
+
   /** @brief Pointer to table to scan from. */
   storage::DataTable *target_table_ = nullptr;
 };

--- a/src/include/planner/plan_util.h
+++ b/src/include/planner/plan_util.h
@@ -90,6 +90,12 @@ class PlanUtil {
         table_ids.insert(insert_node->GetTable()->GetOid());
         break;
       }
+      /*case PlanNodeType::POPULATE_INDEX: {
+        const planner::PopulateIndexPlan *populate_index_node =
+                reinterpret_cast<const planner::PopulateIndexPlan *>(plan);
+        table_ids.insert(populate_index_node->GetTable()->GetOid());
+        break;
+      }*/
       default: {
         // Nothing to do, nothing to see...
         break;

--- a/src/include/planner/plan_util.h
+++ b/src/include/planner/plan_util.h
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "planner/abstract_plan.h"
+#include "planner/populate_index_plan.h"
 #include "util/string_util.h"
 
 namespace peloton {
@@ -90,12 +91,12 @@ class PlanUtil {
         table_ids.insert(insert_node->GetTable()->GetOid());
         break;
       }
-      /*case PlanNodeType::POPULATE_INDEX: {
+      case PlanNodeType::POPULATE_INDEX: {
         const planner::PopulateIndexPlan *populate_index_node =
                 reinterpret_cast<const planner::PopulateIndexPlan *>(plan);
         table_ids.insert(populate_index_node->GetTable()->GetOid());
         break;
-      }*/
+      }
       default: {
         // Nothing to do, nothing to see...
         break;

--- a/src/include/planner/populate_index_plan.h
+++ b/src/include/planner/populate_index_plan.h
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// populate_index_plan.h
+//
+// Identification: src/include/planner/populate_index_plan.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "planner/abstract_plan.h"
+
+namespace peloton {
+
+namespace storage {
+class DataTable;
+// class Tuple;
+}
+
+namespace planner {
+
+/**
+ * IMPORTANT All tiles got from child must have the same physical schema.
+ */
+
+class PopulateIndexPlan : public AbstractPlan {
+ public:
+  PopulateIndexPlan(const PopulateIndexPlan &) = delete;
+  PopulateIndexPlan &operator=(const PopulateIndexPlan &) = delete;
+  PopulateIndexPlan(const PopulateIndexPlan &&) = delete;
+  PopulateIndexPlan &operator=(const PopulateIndexPlan &&) = delete;
+
+  explicit PopulateIndexPlan(storage::DataTable *table,
+                             std::vector<oid_t> column_ids);
+
+  inline PlanNodeType GetPlanNodeType() const {
+    return PlanNodeType::POPULATE_INDEX;
+  }
+
+  inline const std::vector<oid_t> &GetColumnIds() const { return column_ids_; }
+
+  const std::string GetInfo() const { return "PopulateIndex"; }
+
+  storage::DataTable *GetTable() const { return target_table_; }
+
+  std::unique_ptr<AbstractPlan> Copy() const {
+    return std::unique_ptr<AbstractPlan>(
+        new PopulateIndexPlan(target_table_, column_ids_));
+  }
+
+ private:
+  /** @brief Target table. */
+  storage::DataTable *target_table_ = nullptr;
+  /** @brief Column Ids. */
+  std::vector<oid_t> column_ids_;
+
+};
+}
+}

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -524,6 +524,7 @@ enum class PlanNodeType {
   // DDL Nodes
   DROP = 33,
   CREATE = 34,
+  POPULATE_INDEX = 35,
 
   // Communication Nodes
   SEND = 40,

--- a/src/planner/populate_index_plan.cpp
+++ b/src/planner/populate_index_plan.cpp
@@ -1,0 +1,25 @@
+
+//===----------------------------------------------------------------------===//
+//
+//                         PelotonDB
+//
+// populate_index_plan.cpp
+//
+// Identification: /peloton/src/planner/populate_index_plan.cpp
+//
+// Copyright (c) 2015, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "planner/populate_index_plan.h"
+
+#include "type/types.h"
+#include "expression/abstract_expression.h"
+
+namespace peloton {
+namespace planner {
+PopulateIndexPlan::PopulateIndexPlan(storage::DataTable *table,
+                                     std::vector<oid_t> column_ids)
+    : target_table_(table), column_ids_(column_ids) {}
+}
+}

--- a/src/type/types.cpp
+++ b/src/type/types.cpp
@@ -1031,6 +1031,9 @@ std::string PlanNodeTypeToString(PlanNodeType type) {
     case PlanNodeType::MOCK: {
       return ("MOCK");
     }
+    case PlanNodeType::POPULATE_INDEX: {
+      return ("POPULATE_INDEX");
+    }
     default: {
       throw ConversionException(
           StringUtil::Format("No string conversion for PlanNodeType value '%d'",


### PR DESCRIPTION
This PR fixes big #529.

As suggested, a `PopulateIndexExecutor` that consumes the output of a `SeqScanExecutor` was created.

I accept suggestions on how to refactor the conditions on `SeqScanExecutor`.