### PR TITLE
Add Worker Pool/ Networking Thread, worker thread separation

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -22,6 +22,7 @@ include(cmake/ProtoBuf.cmake)
 find_package(Libevent REQUIRED)
 include_directories(SYSTEM ${LIBEVENT_INCLUDE_DIRS})
 list(APPEND Peloton_LINKER_LIBS ${LIBEVENT_LIBRARIES})
+list(APPEND Peloton_LINKER_LIBS ${LIBEVENT_PTHREAD_LIBRARIES})
 
 # ---[ Doxygen
 if(BUILD_docs)

--- a/cmake/Modules/FindLibevent.cmake
+++ b/cmake/Modules/FindLibevent.cmake
@@ -17,10 +17,13 @@ endforeach()
 find_path(LIBEVENT_INCLUDE_DIRS event.h PATHS ${LibEvent_INCLUDE_PATHS})
 # "lib" prefix is needed on Windows
 find_library(LIBEVENT_LIBRARIES NAMES event libevent PATHS ${LibEvent_LIBRARIES_PATHS})
+find_library(LIBEVENT_PTHREAD_LIBRARIES NAMES libevent_pthreads event_pthreads PATHS ${LibEvent_LIBRARIES_PATHS})
 
-if (LIBEVENT_LIBRARIES AND LIBEVENT_INCLUDE_DIRS)
+if (LIBEVENT_LIBRARIES AND LIBEVENT_INCLUDE_DIRS AND LIBEVENT_PTHREAD_LIBRARIES)
   set(Libevent_FOUND TRUE)
   set(LIBEVENT_LIBRARIES ${LIBEVENT_LIBRARIES})
+  set(LIBEVENT_PTHREAD_LIBRARIES ${LIBEVENT_PTHREAD_LIBRARIES})
+  message(STATUS "Found libevent pthread (include: ${LIBEVENT_INCLUDE_DIRS}, library: ${LIBEVENT_PTHREAD_LIBRARIES})")
 else ()
   set(Libevent_FOUND FALSE)
 endif ()
@@ -38,5 +41,6 @@ endif ()
 
 mark_as_advanced(
     LIBEVENT_LIBRARIES
+    LIBEVENT_PTHREAD_LIBRARIES
     LIBEVENT_INCLUDE_DIRS
   )

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -25,6 +25,7 @@
 #include <google/protobuf/stubs/common.h>
 
 #include <thread>
+#include <include/task/worker_pool.h>
 
 namespace peloton {
 
@@ -43,6 +44,10 @@ void PelotonInit::Initialize() {
   int parallelism = (std::thread::hardware_concurrency() + 3) / 4;
   storage::DataTable::SetActiveTileGroupCount(parallelism);
   storage::DataTable::SetActiveIndirectionArrayCount(parallelism);
+
+  // start worker thread pool
+  // TODO: this will have to be tuned
+  task::WorkerPool::GetInstance();
 
   // start epoch.
   concurrency::EpochManagerFactory::GetInstance().StartEpoch();

--- a/src/include/task/worker_pool.h
+++ b/src/include/task/worker_pool.h
@@ -25,6 +25,8 @@
 namespace peloton{
 namespace task{
 
+class WorkerPool;
+
 //task to submit to the queue
 class Task {
   friend class WorkerThread;
@@ -43,10 +45,10 @@ private:
 class WorkerThread{
 public:
 
-  void StartThread();
+  void StartThread(WorkerPool* worker_pool);
 
   // poll work queue, until exiting
-  static void PollForWork(WorkerThread* current_thread);
+  static void PollForWork(WorkerThread* current_thread, WorkerPool* current_pool);
 
   // wait for the current task to complete and shutdown the thread;
   void Shutdown();
@@ -70,13 +72,13 @@ public:
 
   void Shutdown();
 
-private:
-  WorkerPool(size_t num_threads, size_t task_queue_size);
 
+  WorkerPool(size_t num_threads, size_t task_queue_size);
+private:
   //TODO: use Bili's work stealing queues?
   peloton::LockFreeQueue<Task> task_queue_;
 
-  std::vector<WorkerThread> worker_threads_;
+  std::vector<std::unique_ptr<WorkerThread>> worker_threads_;
 
 };
 

--- a/src/include/task/worker_pool.h
+++ b/src/include/task/worker_pool.h
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// worker_pool.h
+//
+// Identification: src/include/task/worker_pool.h
+//
+// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <vector>
+#include <thread>
+#include <memory>
+#include "container/lock_free_queue.h"
+
+//TODO: should be configurable
+#define DEFAULT_NUM_WORKER_THREADS (std::thread::hardware_concurrency())
+//TODO: make configurable, choose some more reasonable default value
+#define DEFAULT_TASK_QUEUE_LENGTH (std::thread::hardware_concurrency()*4)
+
+namespace peloton{
+namespace task{
+
+//task to submit to the queue
+class Task {
+  friend class WorkerThread;
+public:
+  inline Task() {};
+  //
+  inline Task(void(*func_ptr)(void *), void *func_args) :
+          func_ptr_(func_ptr), func_args_(func_args) {};
+
+private:
+  void(*func_ptr_)(void *);
+  void *func_args_;
+};
+
+// Data structure wraping worker thread
+class WorkerThread{
+public:
+
+  void StartThread();
+
+  // poll work queue, until exiting
+  static void PollForWork(WorkerThread* current_thread);
+
+  // wait for the current task to complete and shutdown the thread;
+  void Shutdown();
+
+private:
+  volatile bool shutdown_thread_;
+
+  std::thread worker_thread_;
+
+};
+
+// generic pool for executing arbitrary tasks asynchronously
+class WorkerPool {
+
+  friend class WorkerThread;
+public:
+  static WorkerPool& GetInstance();
+
+  // submit a task for asynchronous execution.
+  void SubmitTask(void(*func_ptr)(void *), void *func_args);
+
+  void Shutdown();
+
+private:
+  WorkerPool(size_t num_threads, size_t task_queue_size);
+
+  //TODO: use Bili's work stealing queues?
+  peloton::LockFreeQueue<Task> task_queue_;
+
+  std::vector<WorkerThread> worker_threads_;
+
+};
+
+
+}//task
+}//peloton

--- a/src/include/wire/libevent_server.h
+++ b/src/include/wire/libevent_server.h
@@ -53,6 +53,7 @@ enum ConnState {
   CONN_WRITE,      // State the writes data to the network
   CONN_WAIT,       // State for waiting for some event to happen
   CONN_PROCESS,    // State that runs the wire protocol on received data
+  CONN_EXECUTING,  // State when work is executing in the background
   CONN_CLOSING,    // State for closing the client connection
   CONN_CLOSED,     // State for closed connection
   CONN_INVALID,    // Invalid STate
@@ -157,6 +158,7 @@ class LibeventSocket {
   PacketManager pkt_manager;       // Stores state for this socket
   ConnState state = CONN_INVALID;  // Initial state of connection
   InputPacket rpkt;                // Used for reading a single Postgres packet
+  bool worker_executing;           // true when a worker is executing in the background
 
  private:
 

--- a/src/include/wire/packet_manager.h
+++ b/src/include/wire/packet_manager.h
@@ -45,7 +45,7 @@ class PacketManager {
 
   /* Main switch case wrapper to process every packet apart from the startup
    * packet. Avoid flushing the response for extended protocols. */
-  bool ProcessPacket(InputPacket* pkt, const size_t thread_id);
+  bool ProcessPacket(LibeventSocket * conn);
 
   /* Manage the startup packet */
   //  bool ManageStartupPacket();
@@ -97,6 +97,11 @@ class PacketManager {
   ResponseBuffer responses;
 
  private:
+
+  // conn is a pointer to wire::LibeventSocket
+  static void ExecQueryMessageAsync(void * conn);
+  // conn is a pointer to wire::LibeventSocket
+  static void ExecExecuteMessageAsync(void * conn);
   //===--------------------------------------------------------------------===//
   // PROTOCOL HANDLING FUNCTIONS
   //===--------------------------------------------------------------------===//

--- a/src/networking/tcp_listener.cpp
+++ b/src/networking/tcp_listener.cpp
@@ -68,7 +68,7 @@ void Listener::Run(void *arg) {
 
   // TODO: Fix cmake to link in "-levent_pthreads"
   /* We must specify this function if we use multiple threads*/
-  // evthread_use_pthreads();
+  evthread_use_pthreads();
 
   // TODO: LEV_OPT_THREADSAFE is necessary here?
   listener_ = evconnlistener_new_bind(

--- a/src/task/worker_pool.cpp
+++ b/src/task/worker_pool.cpp
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// worker_pool.cpp
+//
+// Identification: src/task/worker_pool.cpp
+//
+// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "include/task/worker_pool.h"
+#include <unistd.h>
+
+namespace peloton{
+namespace task{
+
+void WorkerThread::StartThread(){
+  shutdown_thread_ = false;
+  worker_thread_ = std::thread(WorkerThread::PollForWork, this);
+}
+
+void WorkerThread::PollForWork(WorkerThread* current_thread){
+  size_t empty_count = 0;
+  Task t;
+  while(!current_thread->shutdown_thread_){
+    // poll the queue
+    if(!WorkerPool::GetInstance().task_queue_.Dequeue(t)){
+      empty_count++;
+      if (empty_count == 10){
+        empty_count = 0;
+        usleep(1);
+      }
+      continue;
+    }
+    // call the task
+    t.func_ptr_(t.func_args_);
+    empty_count = 0;
+  }
+}
+
+void WorkerThread::Shutdown() {
+  shutdown_thread_ = true;
+  worker_thread_.join();
+}
+
+WorkerPool::WorkerPool(size_t num_threads, size_t task_queue_size) :
+        task_queue_(task_queue_size){
+  for (size_t thread_id = 0; thread_id < num_threads; thread_id++){
+    // start thread on construction
+    WorkerThread worker = WorkerThread();
+    worker.StartThread();
+    worker_threads_.push_back(std::move(worker));
+  }
+}
+
+WorkerPool& WorkerPool::GetInstance() {
+  static WorkerPool wp(DEFAULT_NUM_WORKER_THREADS, DEFAULT_TASK_QUEUE_LENGTH);
+  return wp;
+}
+
+void WorkerPool::SubmitTask(void(*func_ptr)(void *), void *func_args) {
+  task_queue_.Enqueue(Task(func_ptr, func_args));
+}
+
+void WorkerPool::Shutdown() {
+  for (auto& thread : worker_threads_){
+    thread.Shutdown();
+  }
+  return;
+}
+
+
+}//task
+}//peloton

--- a/src/wire/libevent_server.cpp
+++ b/src/wire/libevent_server.cpp
@@ -12,6 +12,9 @@
 
 #include "wire/libevent_server.h"
 
+
+#include "event2/thread.h"
+
 #include <fcntl.h>
 #include <inttypes.h>
 #include <sys/socket.h>
@@ -63,7 +66,9 @@ void Signal_Callback(UNUSED_ATTRIBUTE evutil_socket_t fd,
 }
 
 LibeventServer::LibeventServer() {
+  evthread_use_pthreads();
   struct event_base *base = event_base_new();
+  evthread_make_base_notifiable(base);
   struct event *evstop;
 
   // Create our event base

--- a/src/wire/libevent_socket.cpp
+++ b/src/wire/libevent_socket.cpp
@@ -26,7 +26,7 @@ void LibeventSocket::Init(short event_flags, LibeventThread *thread,
   this->state = init_state;
 
   this->thread_id = thread->GetThreadID();
-
+  this->worker_executing = false;
   // clear out packet
   rpkt.Reset();
   if (event == nullptr) {

--- a/test/task/worker_pool_test.cpp
+++ b/test/task/worker_pool_test.cpp
@@ -13,6 +13,7 @@
 #include <unistd.h>
 
 #include "gtest/gtest.h"
+#include "common/logger.h"
 #include "common/harness.h"
 #include "task/worker_pool.h"
 
@@ -23,7 +24,7 @@ class WorkerPoolTest : public PelotonTest {};
 
 static void blah(UNUSED_ATTRIBUTE void* args){
   sleep(2);
-  printf("whatup\n");
+  LOG_INFO("Yingun smells...");
 }
 
 TEST_F(WorkerPoolTest, BasicTest){

--- a/test/task/worker_pool_test.cpp
+++ b/test/task/worker_pool_test.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// worker_pool_test.cpp
+//
+// Identification: test/task/worker_pool_test.cpp
+//
+// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <unistd.h>
+
+#include "gtest/gtest.h"
+#include "common/harness.h"
+#include "task/worker_pool.h"
+
+namespace peloton{
+namespace test{
+
+class WorkerPoolTest : public PelotonTest {};
+
+static void blah(UNUSED_ATTRIBUTE void* args){
+  sleep(2);
+  printf("whatup\n");
+}
+
+TEST_F(WorkerPoolTest, BasicTest){
+  task::WorkerPool pool(2, 8);
+  pool.SubmitTask(blah, nullptr);
+  pool.SubmitTask(blah, nullptr);
+  pool.SubmitTask(blah, nullptr);
+  pool.Shutdown();
+
+
+}
+
+} //test
+} //peloton


### PR DESCRIPTION
This PR is not ready to merge, but I'd like to get feedback from @yingjunwu and other interested parties.

The current implementation has the following known issues:
1. A Client disconnection while worker threads are running queries result in a segfault.
2. The Worker Thread Pool has a single task queue, this may have a negative effect on scalability.
3. The transactional consistency of the separation of networking and worker threads is not well tested.
4. More testing is needed, particularly for the Worker Thread Pool. (Only simple functionality has been tested manually)
5. The number of worker threads/network threads needs tuning.


