### PR TITLE
Update for the new parser

### DIFF
--- a/src/include/expression/abstract_expression.h
+++ b/src/include/expression/abstract_expression.h
@@ -179,4 +179,4 @@ class AbstractExpression : public Printable {
 };
 
 }  // End expression namespace
-}  // End peloton namespace
+}  // End peloton namespace 

--- a/src/include/parser/parsenodes.h
+++ b/src/include/parser/parsenodes.h
@@ -241,3 +241,14 @@ typedef struct FuncCall {
   struct WindowDef *over; /* OVER clause, if any */
   int location;           /* token location, or -1 if unknown */
 } FuncCall;
+
+typedef struct UpdateStmt
+{
+  NodeTag		type;
+  RangeVar   *relation;		/* relation to update */
+  List	   *targetList;		/* the target list (of ResTarget) */
+  Node	   *whereClause;	/* qualifications */
+  List	   *fromClause;		/* optional from clause for more tables */
+  List	   *returningList;	/* list of expressions to return */
+  WithClause *withClause;		/* WITH clause */
+} UpdateStmt;

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -101,6 +101,12 @@ class PostgresParser {
 
   // transform helper for the whole parse list
   std::unique_ptr<parser::SQLStatementList> ListTransform(List* root);
+
+  // transform helper for update statement
+  parser::UpdateStatement* UpdateTransform(UpdateStmt* update_stmt);
+
+  // transform helper for update statement
+  std::vector<parser::UpdateClause*> UpdateTargetTransform(List* root);
 };
 
 }  // End parser namespace

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -106,7 +106,7 @@ class PostgresParser {
   parser::UpdateStatement* UpdateTransform(UpdateStmt* update_stmt);
 
   // transform helper for update statement
-  std::vector<parser::UpdateClause*> UpdateTargetTransform(List* root);
+  std::vector<parser::UpdateClause*>* UpdateTargetTransform(List* root);
 };
 
 }  // End parser namespace

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -642,8 +642,8 @@ std::unique_ptr<parser::SQLStatementList> PostgresParser::ListTransform(
   return std::move(std::unique_ptr<parser::SQLStatementList>(result));
 }
 
-std::vector<parser::UpdateClause*> PostgresParser::UpdateTargetTransform(List *root) {
-  auto result = std::vector<parser::UpdateClause*>();
+std::vector<parser::UpdateClause*>* PostgresParser::UpdateTargetTransform(List *root) {
+  auto result = new std::vector<parser::UpdateClause*>();
   for (auto cell = root->head; cell != NULL; cell = cell->next) {
     auto update_clause = new UpdateClause();
     ResTarget *target = (ResTarget *) (cell->data.ptr_value);
@@ -669,7 +669,7 @@ std::vector<parser::UpdateClause*> PostgresParser::UpdateTargetTransform(List *r
         LOG_ERROR("Target type %d not suported yet...\n", target->val->type);
       }
     }
-    result.push_back(update_clause);
+    result->push_back(update_clause);
   }
   return result;
 }

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -616,6 +616,9 @@ parser::SQLStatement* PostgresParser::NodeTransform(ListCell* stmt) {
           SelectTransform(reinterpret_cast<SelectStmt*>(stmt->data.ptr_value));
       break;
     }
+    case T_UpdateStmt: {
+      result = UpdateTransform((UpdateStmt*)stmt->data.ptr_value);
+    }
     default:
       break;
   }
@@ -637,6 +640,27 @@ std::unique_ptr<parser::SQLStatementList> PostgresParser::ListTransform(
   }
 
   return std::move(std::unique_ptr<parser::SQLStatementList>(result));
+}
+
+std::vector<parser::UpdateClause*> PostgresParser::UpdateTargetTransform(List *root) {
+  auto result = std::vector<parser::UpdateClause*>();
+  for (auto cell = root->head; cell != NULL; cell = cell->next) {
+    auto update_clause = new UpdateClause();
+    ResTarget *target = (ResTarget *) (cell->data.ptr_value);
+    update_clause->column = target->name;
+    switch (target->val->type) {
+    }
+  }
+  return result;
+}
+
+// TODO: Not support with clause, from clause and returning list in update statement in peloton
+parser::UpdateStatement* PostgresParser::UpdateTransform(UpdateStmt *update_stmt) {
+  auto result = new parser::UpdateStatement();
+  result->table = RangeVarTransform(update_stmt->relation);
+  result->where = WhereTransform(update_stmt->whereClause);
+
+
 }
 
 PgQueryInternalParsetreeAndError PostgresParser::ParseSQLString(

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -647,22 +647,22 @@ std::vector<parser::UpdateClause*>* PostgresParser::UpdateTargetTransform(List *
   for (auto cell = root->head; cell != NULL; cell = cell->next) {
     auto update_clause = new UpdateClause();
     ResTarget *target = (ResTarget *) (cell->data.ptr_value);
-    update_clause->column = target->name;
+    update_clause->column = strdup(target->name);
     switch (target->val->type) {
       case T_ColumnRef: {
-        update_clause->value = ColumnRefTransform((ColumnRef*)(target->val));
+        update_clause->value = ColumnRefTransform(reinterpret_cast<ColumnRef*>(target->val));
         break;
       }
       case T_A_Const: {
-        update_clause->value = ConstTransform((A_Const*)(target->val));
+        update_clause->value = ConstTransform(reinterpret_cast<A_Const*>(target->val));
         break;
       }
       case T_FuncCall: {
-        update_clause->value = FuncCallTransform((FuncCall*)(target->val));
+        update_clause->value = FuncCallTransform(reinterpret_cast<FuncCall*>(target->val));
         break;
       }
       case T_A_Expr: {
-        update_clause->value = AExprTransform((A_Expr*)(target->val));
+        update_clause->value = AExprTransform(reinterpret_cast<A_Expr*>(target->val));
         break;
       }
       default: {

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -631,7 +631,7 @@ parser::SQLStatement* PostgresParser::NodeTransform(ListCell* stmt) {
     case T_UpdateStmt: {
       result = UpdateTransform((UpdateStmt*)stmt->data.ptr_value);
       break;
-      
+    }
     case T_DeleteStmt: {
       result = DeleteTransform((DeleteStmt*)stmt->data.ptr_value);
       break;

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -291,17 +291,17 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
 
   // TODO: Uncomment when the AExpressionTransfrom supports operator expression
   // Test First Set Condition
-//  EXPECT_EQ(std::string(update_stmt->updates->at(0)->column), "s_quantity");
-//  auto constant = (expression::ConstantValueExpression*)update_stmt->updates->at(0)->value;
-//  EXPECT_TRUE(constant->GetValue().CompareEquals(type::ValueFactory::GetDecimalValue(48)));
+  EXPECT_EQ(std::string(update_stmt->updates->at(0)->column), "s_quantity");
+  auto constant = (expression::ConstantValueExpression*)update_stmt->updates->at(0)->value;
+  EXPECT_TRUE(constant->GetValue().CompareEquals(type::ValueFactory::GetDecimalValue(48)));
   
   // Test Second Set Condition
-//  EXPECT_EQ(std::string(update_stmt->updates->at(1)->column), "s_ytd");
-//  auto op_expr = (expression::OperatorExpression*)update_stmt->updates->at(1)->value;
-//  auto child1 = (expression::TupleValueExpression*)op_expr->GetChild(0);
-//  EXPECT_EQ(child1->GetColumnName(), "s_ytd");
-//  auto child2 = (expression::ConstantValueExpression*)op_expr->GetChild(1);
-//  EXPECT_TRUE(child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(std::string(update_stmt->updates->at(1)->column), "s_ytd");
+  auto op_expr = (expression::OperatorExpression*)update_stmt->updates->at(1)->value;
+  auto child1 = (expression::TupleValueExpression*)op_expr->GetChild(0);
+  EXPECT_EQ(child1->GetColumnName(), "s_ytd");
+  auto child2 = (expression::ConstantValueExpression*)op_expr->GetChild(1);
+  EXPECT_TRUE(child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
   
   // Test Where clause
   auto where = (expression::OperatorExpression*)update_stmt->where;
@@ -310,7 +310,7 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   EXPECT_EQ(cond1->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
   auto column = (expression::TupleValueExpression*)cond1->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_i_id");
-  auto constant = (expression::ConstantValueExpression*)cond1->GetChild(1);
+  constant = (expression::ConstantValueExpression*)cond1->GetChild(1);
   EXPECT_TRUE(constant->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(68999)));
   auto cond2 = (expression::OperatorExpression*)where->GetChild(1);
   EXPECT_EQ(cond2->GetExpressionType(), ExpressionType::COMPARE_EQUAL);

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -279,7 +279,7 @@ TEST_F(PostgresParserTests, ColumnUpdateTest) {
   }
 }
   
-TEST_F(PostgresParserTests, UpdateTest0) {
+TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   std::string query = "UPDATE STOCK SET S_QUANTITY = 48.0 , S_YTD = S_YTD + 1 "
       "WHERE S_I_ID = 68999 AND S_W_ID = 4";
   auto& parser = parser::PostgresParser::GetInstance();
@@ -288,7 +288,8 @@ TEST_F(PostgresParserTests, UpdateTest0) {
   
   auto update_stmt = (parser::UpdateStatement*)stmt_list->GetStatements()[0];
   EXPECT_EQ(std::string(update_stmt->table->table_info_->table_name), "stock");
-  
+
+  // TODO: Uncomment when the AExpressionTransfrom supports operator expression
   // Test First Set Condition
 //  EXPECT_EQ(std::string(update_stmt->updates->at(0)->column), "s_quantity");
 //  auto constant = (expression::ConstantValueExpression*)update_stmt->updates->at(0)->value;
@@ -309,7 +310,7 @@ TEST_F(PostgresParserTests, UpdateTest0) {
   EXPECT_EQ(cond1->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
   auto column = (expression::TupleValueExpression*)cond1->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_i_id");
-  constant = (expression::ConstantValueExpression*)cond1->GetChild(1);
+  auto constant = (expression::ConstantValueExpression*)cond1->GetChild(1);
   EXPECT_TRUE(constant->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(68999)));
   auto cond2 = (expression::OperatorExpression*)where->GetChild(1);
   EXPECT_EQ(cond2->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
@@ -319,7 +320,7 @@ TEST_F(PostgresParserTests, UpdateTest0) {
   EXPECT_TRUE(constant->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(4)));
 }
 
-TEST_F(PostgresParserTests, UpdateTest1) {
+TEST_F(PostgresParserTests, StringUpdateTest) {
   std::vector<std::string> queries;
 
   // Select with complicated where, tests both BoolExpr and AExpr

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -275,7 +275,7 @@ TEST_F(PostgresParserTests, ColumnUpdateTest) {
     EXPECT_EQ(right_const->GetValue().ToString(), std::string("2"));
 
 
-    //delete stmt_list;
+    delete stmt_list;
   }
 }
   
@@ -318,6 +318,9 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   EXPECT_EQ(column->GetColumnName(), "s_w_id");
   constant = (expression::ConstantValueExpression*)cond2->GetChild(1);
   EXPECT_TRUE(constant->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(4)));
+
+  delete stmt_list;
+
 }
 
 TEST_F(PostgresParserTests, StringUpdateTest) {
@@ -364,6 +367,8 @@ TEST_F(PostgresParserTests, StringUpdateTest) {
   EXPECT_EQ(value->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
   EXPECT_EQ(((expression::ConstantValueExpression*)value)->GetValue().ToString(), "2016-11-15 15:07:37");
   EXPECT_EQ(((expression::ConstantValueExpression*)value)->GetValueType(), type::Type::TypeId::VARCHAR);
+
+  delete stmt_list;
 
 }
 


### PR DESCRIPTION
This PR supports update statement for the new parser. The newly added test cases depends on PR #581 to test OperatorExpression in the SET caluse.