### PR TITLE
Support Insert statement for the new parser

### DIFF
--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -26,11 +26,12 @@ namespace parser {
  */
 struct InsertStatement : SQLStatement {
   InsertStatement(InsertType type)
-      : TableRefStatement(StatementType::INSERT),
+      : SQLStatement(StatementType::INSERT),
         type(type),
         columns(NULL),
         insert_values(NULL),
-        select(NULL) {}
+        select(NULL),
+        table_ref_(nullptr) {}
 
   virtual ~InsertStatement() {
     if (columns) {
@@ -53,6 +54,11 @@ struct InsertStatement : SQLStatement {
   }
 
   virtual void Accept(SqlNodeVisitor* v) const override { v->Visit(this); }
+
+  inline std::string GetTableName() const { return table_ref_->GetTableName(); }
+  inline std::string GetDatabaseName() const {
+    return table_ref_->GetDatabaseName();
+  }
 
   InsertType type;
   std::vector<char*>* columns;

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -12,8 +12,8 @@
 
 #pragma once
 
-#include "parser/sql_statement.h"
 #include "common/sql_node_visitor.h"
+#include "parser/sql_statement.h"
 #include "select_statement.h"
 
 namespace peloton {
@@ -33,7 +33,6 @@ struct InsertStatement : SQLStatement {
         select(NULL) {}
 
   virtual ~InsertStatement() {
-
     if (columns) {
       for (auto col : *columns) free(col);
       delete columns;
@@ -62,6 +61,9 @@ struct InsertStatement : SQLStatement {
   SelectStatement* select;
 
   TableInfo* table_info_ = nullptr;
+
+  // Which table are we inserting into
+  TableRef* table_ref_;
 };
 
 }  // End parser namespace

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -66,6 +66,8 @@ struct InsertStatement : SQLStatement {
       insert_values;
   SelectStatement* select;
 
+  // FIXME: This is here for compilation purpose. Need to remove after the
+  // Hyrise parser is removed!!!
   TableInfo* table_info_ = nullptr;
 
   // Which table are we inserting into

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -24,7 +24,7 @@ namespace parser {
  * @brief Represents "INSERT INTO students VALUES ('Max', 1112233,
  * 'Musterhausen', 2.3)"
  */
-struct InsertStatement : TableRefStatement {
+struct InsertStatement : SQLStatement {
   InsertStatement(InsertType type)
       : TableRefStatement(StatementType::INSERT),
         type(type),
@@ -41,7 +41,7 @@ struct InsertStatement : TableRefStatement {
 
     if (insert_values) {
       for (auto tuple : *insert_values) {
-        for( auto expr : *tuple){
+        for (auto expr : *tuple) {
           if (expr->GetExpressionType() != ExpressionType::VALUE_PARAMETER)
             delete expr;
         }
@@ -53,15 +53,15 @@ struct InsertStatement : TableRefStatement {
     delete select;
   }
 
-
-  virtual void Accept(SqlNodeVisitor* v) const override {
-    v->Visit(this);
-  }
+  virtual void Accept(SqlNodeVisitor* v) const override { v->Visit(this); }
 
   InsertType type;
   std::vector<char*>* columns;
-  std::vector<std::vector<peloton::expression::AbstractExpression*>*>* insert_values;
+  std::vector<std::vector<peloton::expression::AbstractExpression*>*>*
+      insert_values;
   SelectStatement* select;
+
+  TableInfo* table_info_ = nullptr;
 };
 
 }  // End parser namespace

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -50,6 +50,10 @@ struct InsertStatement : SQLStatement {
       delete insert_values;
     }
 
+    // FIXME: This is here for compilation purpose. Need to remove after the
+    // Hyrise parser is removed!!!
+    delete table_info_;
+
     delete select;
   }
 

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -55,6 +55,8 @@ struct InsertStatement : SQLStatement {
     delete table_info_;
 
     delete select;
+
+    delete table_ref_;
   }
 
   virtual void Accept(SqlNodeVisitor* v) const override { v->Visit(this); }

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -59,9 +59,20 @@ struct InsertStatement : SQLStatement {
 
   virtual void Accept(SqlNodeVisitor* v) const override { v->Visit(this); }
 
-  inline std::string GetTableName() const { return table_ref_->GetTableName(); }
+  inline std::string GetTableName() const {
+    if (table_info_ != nullptr)
+      return table_info_->table_name;
+    else
+      return table_ref_->GetTableName();
+  }
   inline std::string GetDatabaseName() const {
-    return table_ref_->GetDatabaseName();
+    if (table_info_ != nullptr) {
+      if (table_info_->database_name == nullptr) {
+        return DEFAULT_DB_NAME;
+      }
+      return table_info_->database_name;
+    } else
+      return table_ref_->GetDatabaseName();
   }
 
   InsertType type;

--- a/src/include/parser/parsenodes.h
+++ b/src/include/parser/parsenodes.h
@@ -32,9 +32,15 @@ typedef enum InhOption {
   INH_DEFAULT /* Use current SQL_inheritance option */
 } InhOption;
 
-typedef enum BoolExprType { AND_EXPR, OR_EXPR, NOT_EXPR } BoolExprType;
+typedef enum BoolExprType {
+  AND_EXPR,
+  OR_EXPR,
+  NOT_EXPR
+} BoolExprType;
 
-typedef struct Expr { NodeTag type; } Expr;
+typedef struct Expr {
+  NodeTag type;
+} Expr;
 
 typedef struct BoolExpr {
   Expr xpr;
@@ -82,21 +88,20 @@ typedef struct JoinExpr {
   int rtindex;       /* RT index assigned for join, or 0 */
 } JoinExpr;
 
-typedef struct RangeSubselect
-{
-NodeTag		type;
-bool		lateral;		/* does it have LATERAL prefix? */
-Node	   *subquery;		/* the untransformed sub-select clause */
-Alias	   *alias;			/* table alias & optional column aliases */
+typedef struct RangeSubselect {
+  NodeTag type;
+  bool lateral;   /* does it have LATERAL prefix? */
+  Node *subquery; /* the untransformed sub-select clause */
+  Alias *alias;   /* table alias & optional column aliases */
 } RangeSubselect;
 
 typedef struct RangeVar {
   NodeTag type;
-  char *catalogname;   /* the catalog (database) name, or NULL */
-  char *schemaname;    /* the schema name, or NULL */
-  char *relname;       /* the relation/sequence name */
-  InhOption inhOpt;    /* expand rel by inheritance? recursively act
-                * on children? */
+  char *catalogname; /* the catalog (database) name, or NULL */
+  char *schemaname;  /* the schema name, or NULL */
+  char *relname;     /* the relation/sequence name */
+  InhOption inhOpt;  /* expand rel by inheritance? recursively act
+        * on children? */
   char relpersistence; /* see RELPERSISTENCE_* in pg_class.h */
   Alias *alias;        /* table alias & optional column aliases */
   int location;        /* token location, or -1 if unknown */
@@ -150,14 +155,41 @@ typedef struct SortBy {
   int location;             /* operator location, or -1 if none/unknown */
 } SortBy;
 
+typedef struct InferClause {
+  NodeTag type;
+  List *indexElems;  /* IndexElems to infer unique index */
+  Node *whereClause; /* qualification (partial-index predicate) */
+  char *conname;     /* Constraint name, or NULL if unnamed */
+  int location;      /* token location, or -1 if unknown */
+} InferClause;
+
+typedef struct OnConflictClause {
+  NodeTag type;
+  OnConflictAction action; /* DO NOTHING or UPDATE? */
+  InferClause *infer;      /* Optional index inference clause */
+  List *targetList;        /* the target list (of ResTarget) */
+  Node *whereClause;       /* qualifications */
+  int location;            /* token location, or -1 if unknown */
+} OnConflictClause;
+
+typedef struct InsertStmt {
+  NodeTag type;
+  RangeVar *relation; /* relation to insert into */
+  List *cols;         /* optional: names of the target columns */
+  Node *selectStmt;   /* the source SELECT/VALUES, or NULL */
+  OnConflictClause *onConflictClause; /* ON CONFLICT clause */
+  List *returningList;                /* list of expressions to return */
+  WithClause *withClause;             /* WITH clause */
+} InsertStmt;
+
 typedef struct SelectStmt {
   NodeTag type;
 
   /*
    * These fields are used only in "leaf" SelectStmts.
    */
-  List *distinctClause;   /* NULL, list of DISTINCT ON exprs, or
-               * lcons(NIL,NIL) for all (SELECT DISTINCT) */
+  List *distinctClause; /* NULL, list of DISTINCT ON exprs, or
+             * lcons(NIL,NIL) for all (SELECT DISTINCT) */
   IntoClause *intoClause; /* target for SELECT INTO */
   List *targetList;       /* the target list (of ResTarget) */
   List *fromClause;       /* the FROM clause */

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -93,6 +93,9 @@ class PostgresParser {
   // transform helper for order by clauses
   parser::OrderDescription* OrderByTransform(List* order);
 
+  // transform helper for column name (for insert statement)
+  std::vector<char*>* PostgresParser::ColumnNameTransform(List* root);
+
   // transform helper for insert statements
   parser::SQLStatement* InsertTransform(InsertStmt* root);
 

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -93,6 +93,9 @@ class PostgresParser {
   // transform helper for order by clauses
   parser::OrderDescription* OrderByTransform(List* order);
 
+  // transform helper for insert statements
+  parser::SQLStatement* InsertTransform(InsertStmt* root);
+
   // transform helper for select statements
   parser::SQLStatement* SelectTransform(SelectStmt* root);
 

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -96,6 +96,10 @@ class PostgresParser {
   // transform helper for column name (for insert statement)
   std::vector<char*>* ColumnNameTransform(List* root);
 
+  // transform helper for ListsTransform (insert multiple rows)
+  std::vector<std::vector<expression::AbstractExpression*>*>*
+      ValueListsTransform(List* root);
+
   // transform helper for insert statements
   parser::SQLStatement* InsertTransform(InsertStmt* root);
 

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -94,7 +94,7 @@ class PostgresParser {
   parser::OrderDescription* OrderByTransform(List* order);
 
   // transform helper for column name (for insert statement)
-  std::vector<char*>* PostgresParser::ColumnNameTransform(List* root);
+  std::vector<char*>* ColumnNameTransform(List* root);
 
   // transform helper for insert statements
   parser::SQLStatement* InsertTransform(InsertStmt* root);

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -598,9 +598,13 @@ expression::AbstractExpression* PostgresParser::WhereTransform(Node* root) {
 parser::SQLStatement* PostgresParser::InsertTransform(InsertStmt* root) {
   PL_ASSERT(root->selectStmt != NULL);
 
+  auto select_stmt = reinterpret_cast<SelectStmt*>(root->selectStmt);
+
   parser::InsertStatement* result = nullptr;
-  if (root->selectStmt)
-    result = new parser::InsertStatement(InsertType::INVALID);
+  if (select_stmt->fromClause != NULL)
+    result = new parser::InsertStatement(InsertType::SELECT);
+  else
+    result = new parser::InsertStatement(InsertType::VALUES);
 
   result->table_ref_ = RangeVarTransform((RangeVar*)(root->relation));
 

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -596,8 +596,14 @@ expression::AbstractExpression* PostgresParser::WhereTransform(Node* root) {
 // Please refer to parser/parsenode.h for the definition of
 // SelectStmt parsenodes.
 parser::SQLStatement* PostgresParser::InsertTransform(InsertStmt* root) {
-  parser::InsertStatement* result = new parser::InsertStatement();
+  PL_ASSERT(root->selectStmt != NULL);
+
+  parser::InsertStatement* result = nullptr;
+  if (root->selectStmt)
+    result = new parser::InsertStatement(InsertType::INVALID);
+
   result->table_ref_ = RangeVarTransform((RangeVar*)(root->relation));
+
   //  result->select_list = TargetTransform(root->targetList);
   //  result->from_table = FromTransform(root->fromClause);
   //  result->group_by = GroupByTransform(root->groupClause,

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -591,8 +591,8 @@ expression::AbstractExpression* PostgresParser::WhereTransform(Node* root) {
   return result;
 }
 
-// This function takes in a Postgres SelectStmt parsenode
-// and transfers into a Peloton SelectStatement parsenode.
+// This function takes in a Postgres InsertStmt parsenode
+// and transfers into a Peloton InsertStatement.
 // Please refer to parser/parsenode.h for the definition of
 // SelectStmt parsenodes.
 parser::SQLStatement* PostgresParser::InsertTransform(InsertStmt* root) {

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -591,11 +591,25 @@ expression::AbstractExpression* PostgresParser::WhereTransform(Node* root) {
   return result;
 }
 
+std::vector<char*>* PostgresParser::ColumnNameTransform(List* root) {
+  if (root == nullptr) return nullptr;
+
+  std::vector<char*>* result = new std::vector<char*>();
+
+  for (auto cell = root->head; cell != NULL; cell = cell->next) {
+    ResTarget* target = (ResTarget*)(cell->data.ptr_value);
+    result->push_back(target->name);
+  }
+
+  return result;
+}
+
 // This function takes in a Postgres InsertStmt parsenode
 // and transfers into a Peloton InsertStatement.
 // Please refer to parser/parsenode.h for the definition of
 // SelectStmt parsenodes.
 parser::SQLStatement* PostgresParser::InsertTransform(InsertStmt* root) {
+
   PL_ASSERT(root->selectStmt != NULL);
 
   auto select_stmt = reinterpret_cast<SelectStmt*>(root->selectStmt);
@@ -611,6 +625,7 @@ parser::SQLStatement* PostgresParser::InsertTransform(InsertStmt* root) {
 
   result->table_ref_ = RangeVarTransform((RangeVar*)(root->relation));
 
+  result->columns = ColumnNameTransform(root->cols);
   //  result->select_list = TargetTransform(root->targetList);
   //  result->from_table = FromTransform(root->fromClause);
   //  result->group_by = GroupByTransform(root->groupClause,

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -644,10 +644,10 @@ parser::SQLStatement* PostgresParser::InsertTransform(InsertStmt* root) {
 
   } else {
     result = new parser::InsertStatement(InsertType::VALUES);
-  }
 
-  PL_ASSERT(select_stmt->valuesLists != NULL);
-  result->insert_values = ValueListsTransform(select_stmt->valuesLists);
+    PL_ASSERT(select_stmt->valuesLists != NULL);
+    result->insert_values = ValueListsTransform(select_stmt->valuesLists);
+  }
 
   result->table_ref_ = RangeVarTransform((RangeVar*)(root->relation));
 

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -597,6 +597,7 @@ expression::AbstractExpression* PostgresParser::WhereTransform(Node* root) {
 // SelectStmt parsenodes.
 parser::SQLStatement* PostgresParser::InsertTransform(InsertStmt* root) {
   parser::InsertStatement* result = new parser::InsertStatement();
+  result->table_ref_ = RangeVarTransform((RangeVar*)(root->relation));
   //  result->select_list = TargetTransform(root->targetList);
   //  result->from_table = FromTransform(root->fromClause);
   //  result->group_by = GroupByTransform(root->groupClause,

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -601,10 +601,13 @@ parser::SQLStatement* PostgresParser::InsertTransform(InsertStmt* root) {
   auto select_stmt = reinterpret_cast<SelectStmt*>(root->selectStmt);
 
   parser::InsertStatement* result = nullptr;
-  if (select_stmt->fromClause != NULL)
+  if (select_stmt->fromClause != NULL) {
     result = new parser::InsertStatement(InsertType::SELECT);
-  else
+    result->select = reinterpret_cast<parser::SelectStatement*>(
+        SelectTransform(select_stmt));
+  } else {
     result = new parser::InsertStatement(InsertType::VALUES);
+  }
 
   result->table_ref_ = RangeVarTransform((RangeVar*)(root->relation));
 

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -72,14 +72,19 @@ TEST_F(ParserTests, BasicTest) {
 
   // INSERT
   queries.push_back("INSERT INTO test_table VALUES (1, 2, 'test');");
-  queries.push_back("INSERT INTO test_table VALUES (1, 2, 'test'), (2, 3, 'test2');");
-  queries.push_back("INSERT INTO test_table VALUES (1, 2, 'test'), (2, 3, 'test2'), (3, 4, 'test3');");
+  queries.push_back(
+      "INSERT INTO test_table VALUES (1, 2, 'test'), (2, 3, 'test2');");
+  queries.push_back(
+      "INSERT INTO test_table VALUES (1, 2, 'test'), (2, 3, 'test2'), (3, 4, "
+      "'test3');");
   queries.push_back(
       "INSERT INTO test_table (id, value, name) VALUES (1, 2, 'test');");
   queries.push_back(
-        "INSERT INTO test_table (id, value, name) VALUES (1, 2, 'test'), (2, 3, 'test2');");
+      "INSERT INTO test_table (id, value, name) VALUES (1, 2, 'test'), (2, 3, "
+      "'test2');");
   queries.push_back(
-          "INSERT INTO test_table (id, value, name) VALUES (1, 2, 'test'), (2, 3, 'test2'), (3, 4, 'test3');");
+      "INSERT INTO test_table (id, value, name) VALUES (1, 2, 'test'), (2, 3, "
+      "'test2'), (3, 4, 'test3');");
   queries.push_back("INSERT INTO test_table SELECT * FROM students;");
 
   // DELETE

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -476,6 +476,7 @@ TEST_F(PostgresParserTests, InsertTest) {
   // Insert multiple tuples into the table
   queries.push_back("INSERT INTO foo VALUES (1, 2, 3), (4, 5, 6);");
 
+  auto parser = parser::PostgresParser::GetInstance();
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
     auto stmt_list = parser.BuildParseTree(query).release();

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -481,6 +481,18 @@ TEST_F(PostgresParserTests, InsertTest) {
     LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
               stmt_list->error_line, stmt_list->error_col);
   }
+
+  LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
+
+  EXPECT_EQ(1, stmt_list->GetNumStatements());
+  EXPECT_TRUE(stmt_list->GetStatement(0)->GetType() == StatementType::INSERT);
+  auto insert_stmt = (parser::InsertStatement *)stmt_list->GetStatement(0);
+  EXPECT_EQ("foo", insert_stmt->GetTableName());
+  EXPECT_TRUE(insert_stmt->insert_values != nullptr);
+  EXPECT_TRUE(insert_stmt->select->GetType() == StatementType::SELECT);
+  LOG_ERROR(insert_stmt->select->from_table->GetTableName());
+  EXPECT_EQ("bar", insert_stmt->select->from_table->GetTableName());
+
   // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
   LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
   delete stmt_list;

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -488,7 +488,13 @@ TEST_F(PostgresParserTests, InsertTest) {
   EXPECT_EQ("foo", insert_stmt->GetTableName());
   EXPECT_TRUE(insert_stmt->insert_values != nullptr);
   EXPECT_EQ(2, insert_stmt->insert_values->size());
-  EXPECT_EQ("bar", insert_stmt->select->from_table->GetTableName());
+
+  type::Value five = type::ValueFactory::GetIntegerValue(5);
+  type::CmpBool res = five.CompareEquals(
+      ((expression::ConstantValueExpression *)insert_stmt->insert_values->at(1)
+           ->at(1))
+          ->GetValue());
+  EXPECT_EQ(1, res);
 
   // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
   LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -414,21 +414,6 @@ TEST_F(PostgresParserTests, StringUpdateTest) {
   delete stmt_list;
 }
 
-TEST_F(PostgresParserTests, InsertTest) {
-  std::vector<std::string> queries;
-
-  // Select with complicated where, tests both BoolExpr and AExpr
-  queries.push_back("INSERT INTO foo VALUES(1, 2, 3) WHERE id = 5;");
-  if (stmt_list->is_valid == false) {
-    LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
-              stmt_list->error_line, stmt_list->error_col);
-  }
-  // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
-  LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
-  delete stmt_list;
-}
-}
-
 TEST_F(PostgresParserTests, DeleteTest) {
   std::vector<std::string> queries;
 
@@ -461,13 +446,8 @@ TEST_F(PostgresParserTests, DeleteTest) {
 TEST_F(PostgresParserTests, DeleteTestWithPredicate) {
   std::vector<std::string> queries;
 
-<<<<<<< c5209a2bd4443a1e4d481ed440aa327fceea42ca
   // Delete with a predicate
   queries.push_back("DELETE FROM foo WHERE id=3;");
-=======
-  // Select with complicated where, tests both BoolExpr and AExpr
-  queries.push_back("INSERT INTO foo (1, 2, 3), (4, 5, 6);");
->>>>>>> Add test case for insert into select.
 
   auto parser = parser::PostgresParser::GetInstance();
   // Parsing
@@ -490,6 +470,20 @@ TEST_F(PostgresParserTests, DeleteTestWithPredicate) {
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     delete stmt_list;
   }
+}
+
+TEST_F(PostgresParserTests, InsertTest) {
+  std::vector<std::string> queries;
+
+  // Select with complicated where, tests both BoolExpr and AExpr
+  queries.push_back("INSERT INTO foo VALUES (1,2,3), (4,5,6);");
+  if (stmt_list->is_valid == false) {
+    LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
+              stmt_list->error_line, stmt_list->error_col);
+  }
+  // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
+  LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
+  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, InsertIntoSelectTest) {

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -14,12 +14,12 @@
 #include <vector>
 
 #include "common/harness.h"
-#include "common/macros.h"
 #include "common/logger.h"
-#include "parser/postgresparser.h"
-#include "parser/parser.h"
+#include "common/macros.h"
 #include "expression/operator_expression.h"
 #include "expression/tuple_value_expression.h"
+#include "parser/parser.h"
+#include "parser/postgresparser.h"
 
 namespace peloton {
 namespace test {
@@ -153,10 +153,16 @@ TEST_F(PostgresParserTests, JoinTest) {
   std::vector<std::string> queries;
 
   // Select with join
-  queries.push_back("SELECT * FROM foo INNER JOIN bar ON foo.id=bar.id AND foo.val > bar.val;");
+  queries.push_back(
+      "SELECT * FROM foo INNER JOIN bar ON foo.id=bar.id AND foo.val > "
+      "bar.val;");
   queries.push_back("SELECT * FROM foo LEFT JOIN bar ON foo.id=bar.id;");
-  queries.push_back("SELECT * FROM foo RIGHT JOIN bar ON foo.id=bar.id AND foo.val > bar.val;");
-  queries.push_back("SELECT * FROM foo FULL OUTER JOIN bar ON foo.id=bar.id AND foo.val > bar.val;");
+  queries.push_back(
+      "SELECT * FROM foo RIGHT JOIN bar ON foo.id=bar.id AND foo.val > "
+      "bar.val;");
+  queries.push_back(
+      "SELECT * FROM foo FULL OUTER JOIN bar ON foo.id=bar.id AND foo.val > "
+      "bar.val;");
 
   auto parser = parser::PostgresParser::GetInstance();
   // Parsing
@@ -200,7 +206,9 @@ TEST_F(PostgresParserTests, MultiTableTest) {
   std::vector<std::string> queries;
 
   // Select from multiple tables
-  queries.push_back("SELECT foo.name FROM (SELECT * FROM bar) as b, foo, bar WHERE foo.id = b.id;");
+  queries.push_back(
+      "SELECT foo.name FROM (SELECT * FROM bar) as b, foo, bar WHERE foo.id = "
+      "b.id;");
 
   auto parser = parser::PostgresParser::GetInstance();
   // Parsing
@@ -238,26 +246,32 @@ TEST_F(PostgresParserTests, ColumnUpdateTest) {
     auto sql_stmt = stmt_list->statements[0];
 
     EXPECT_EQ(sql_stmt->GetType(), StatementType::UPDATE);
-    auto update_stmt = (parser::UpdateStatement*)(sql_stmt);
+    auto update_stmt = (parser::UpdateStatement *)(sql_stmt);
     auto table = update_stmt->table;
     auto updates = update_stmt->updates;
     auto where_clause = update_stmt->where;
-    
+
     EXPECT_NE(table, nullptr);
     EXPECT_NE(table->table_info_, nullptr);
     EXPECT_NE(table->table_info_->table_name, nullptr);
-    EXPECT_EQ(std::string(table->table_info_->table_name), std::string("customer"));
-    
+    EXPECT_EQ(std::string(table->table_info_->table_name),
+              std::string("customer"));
+
     EXPECT_NE(updates, nullptr);
     EXPECT_EQ(updates->size(), 2);
     EXPECT_EQ(std::string((*updates)[0]->column), std::string("c_balance"));
-    EXPECT_EQ((*updates)[0]->value->GetExpressionType(), ExpressionType::VALUE_TUPLE);
-    expression::TupleValueExpression *column_value_0 = (expression::TupleValueExpression *)((*updates)[0]->value);
+    EXPECT_EQ((*updates)[0]->value->GetExpressionType(),
+              ExpressionType::VALUE_TUPLE);
+    expression::TupleValueExpression *column_value_0 =
+        (expression::TupleValueExpression *)((*updates)[0]->value);
     EXPECT_EQ(column_value_0->GetColumnName(), std::string("c_balance"));
 
-    EXPECT_EQ(std::string((*updates)[1]->column), std::string("c_delivery_cnt"));
-    EXPECT_EQ((*updates)[1]->value->GetExpressionType(), ExpressionType::VALUE_TUPLE);
-    expression::TupleValueExpression *column_value_1 = (expression::TupleValueExpression *)((*updates)[1]->value);
+    EXPECT_EQ(std::string((*updates)[1]->column),
+              std::string("c_delivery_cnt"));
+    EXPECT_EQ((*updates)[1]->value->GetExpressionType(),
+              ExpressionType::VALUE_TUPLE);
+    expression::TupleValueExpression *column_value_1 =
+        (expression::TupleValueExpression *)((*updates)[1]->value);
     EXPECT_EQ(column_value_1->GetColumnName(), std::string("c_delivery_cnt"));
 
     EXPECT_NE(where_clause, nullptr);
@@ -274,53 +288,58 @@ TEST_F(PostgresParserTests, ColumnUpdateTest) {
 
     EXPECT_EQ(right_const->GetValue().ToString(), std::string("2"));
 
-
     delete stmt_list;
   }
 }
-  
+
 TEST_F(PostgresParserTests, ExpressionUpdateTest) {
-  std::string query = "UPDATE STOCK SET S_QUANTITY = 48.0 , S_YTD = S_YTD + 1 "
+  std::string query =
+      "UPDATE STOCK SET S_QUANTITY = 48.0 , S_YTD = S_YTD + 1 "
       "WHERE S_I_ID = 68999 AND S_W_ID = 4";
-  auto& parser = parser::PostgresParser::GetInstance();
-  parser::SQLStatementList* stmt_list = parser.BuildParseTree(query).release();
+  auto &parser = parser::PostgresParser::GetInstance();
+  parser::SQLStatementList *stmt_list = parser.BuildParseTree(query).release();
   EXPECT_TRUE(stmt_list->is_valid);
-  
-  auto update_stmt = (parser::UpdateStatement*)stmt_list->GetStatements()[0];
+
+  auto update_stmt = (parser::UpdateStatement *)stmt_list->GetStatements()[0];
   EXPECT_EQ(std::string(update_stmt->table->table_info_->table_name), "stock");
 
   // TODO: Uncomment when the AExpressionTransfrom supports operator expression
   // Test First Set Condition
   EXPECT_EQ(std::string(update_stmt->updates->at(0)->column), "s_quantity");
-  auto constant = (expression::ConstantValueExpression*)update_stmt->updates->at(0)->value;
-  EXPECT_TRUE(constant->GetValue().CompareEquals(type::ValueFactory::GetDecimalValue(48)));
-  
+  auto constant =
+      (expression::ConstantValueExpression *)update_stmt->updates->at(0)->value;
+  EXPECT_TRUE(constant->GetValue().CompareEquals(
+      type::ValueFactory::GetDecimalValue(48)));
+
   // Test Second Set Condition
   EXPECT_EQ(std::string(update_stmt->updates->at(1)->column), "s_ytd");
-  auto op_expr = (expression::OperatorExpression*)update_stmt->updates->at(1)->value;
-  auto child1 = (expression::TupleValueExpression*)op_expr->GetChild(0);
+  auto op_expr =
+      (expression::OperatorExpression *)update_stmt->updates->at(1)->value;
+  auto child1 = (expression::TupleValueExpression *)op_expr->GetChild(0);
   EXPECT_EQ(child1->GetColumnName(), "s_ytd");
-  auto child2 = (expression::ConstantValueExpression*)op_expr->GetChild(1);
-  EXPECT_TRUE(child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
-  
+  auto child2 = (expression::ConstantValueExpression *)op_expr->GetChild(1);
+  EXPECT_TRUE(
+      child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
+
   // Test Where clause
-  auto where = (expression::OperatorExpression*)update_stmt->where;
+  auto where = (expression::OperatorExpression *)update_stmt->where;
   EXPECT_EQ(where->GetExpressionType(), ExpressionType::CONJUNCTION_AND);
-  auto cond1 = (expression::OperatorExpression*)where->GetChild(0);
+  auto cond1 = (expression::OperatorExpression *)where->GetChild(0);
   EXPECT_EQ(cond1->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
-  auto column = (expression::TupleValueExpression*)cond1->GetChild(0);
+  auto column = (expression::TupleValueExpression *)cond1->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_i_id");
-  constant = (expression::ConstantValueExpression*)cond1->GetChild(1);
-  EXPECT_TRUE(constant->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(68999)));
-  auto cond2 = (expression::OperatorExpression*)where->GetChild(1);
+  constant = (expression::ConstantValueExpression *)cond1->GetChild(1);
+  EXPECT_TRUE(constant->GetValue().CompareEquals(
+      type::ValueFactory::GetIntegerValue(68999)));
+  auto cond2 = (expression::OperatorExpression *)where->GetChild(1);
   EXPECT_EQ(cond2->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
-  column = (expression::TupleValueExpression*)cond2->GetChild(0);
+  column = (expression::TupleValueExpression *)cond2->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_w_id");
-  constant = (expression::ConstantValueExpression*)cond2->GetChild(1);
-  EXPECT_TRUE(constant->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(4)));
+  constant = (expression::ConstantValueExpression *)cond2->GetChild(1);
+  EXPECT_TRUE(constant->GetValue().CompareEquals(
+      type::ValueFactory::GetIntegerValue(4)));
 
   delete stmt_list;
-
 }
 
 TEST_F(PostgresParserTests, StringUpdateTest) {
@@ -328,7 +347,8 @@ TEST_F(PostgresParserTests, StringUpdateTest) {
 
   // Select with complicated where, tests both BoolExpr and AExpr
   queries.push_back(
-      "UPDATE ORDER_LINE SET OL_DELIVERY_D = '2016-11-15 15:07:37' WHERE OL_O_ID = 2101 AND OL_D_ID = 2");
+      "UPDATE ORDER_LINE SET OL_DELIVERY_D = '2016-11-15 15:07:37' WHERE "
+      "OL_O_ID = 2101 AND OL_D_ID = 2");
 
   auto parser = parser::PostgresParser::GetInstance();
   // Parsing
@@ -337,7 +357,7 @@ TEST_F(PostgresParserTests, StringUpdateTest) {
 
   // Check root type
   EXPECT_EQ(stmt->GetType(), StatementType::UPDATE);
-  auto update = (parser::UpdateStatement*)stmt;
+  auto update = (parser::UpdateStatement *)stmt;
 
   // Check table name
   auto table_ref = update->table;
@@ -347,29 +367,66 @@ TEST_F(PostgresParserTests, StringUpdateTest) {
   auto where = update->where;
   EXPECT_EQ(where->GetExpressionType(), ExpressionType::CONJUNCTION_AND);
   EXPECT_EQ(where->GetChildrenSize(), 2);
-  EXPECT_EQ(where->GetChild(0)->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
-  EXPECT_EQ(where->GetChild(1)->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
+  EXPECT_EQ(where->GetChild(0)->GetExpressionType(),
+            ExpressionType::COMPARE_EQUAL);
+  EXPECT_EQ(where->GetChild(1)->GetExpressionType(),
+            ExpressionType::COMPARE_EQUAL);
   EXPECT_EQ(where->GetChild(0)->GetChildrenSize(), 2);
   EXPECT_EQ(where->GetChild(1)->GetChildrenSize(), 2);
-  EXPECT_EQ(where->GetChild(0)->GetChild(0)->GetExpressionType(), ExpressionType::VALUE_TUPLE);
-  EXPECT_EQ(where->GetChild(1)->GetChild(0)->GetExpressionType(), ExpressionType::VALUE_TUPLE);
-  EXPECT_EQ(((expression::TupleValueExpression*)(where->GetChild(0)->GetChild(0)))->GetColumnName(), "ol_o_id");
-  EXPECT_EQ(((expression::TupleValueExpression*)(where->GetChild(1)->GetChild(0)))->GetColumnName(), "ol_d_id");
-  EXPECT_EQ(where->GetChild(0)->GetChild(1)->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
-  EXPECT_EQ(where->GetChild(1)->GetChild(1)->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
-  EXPECT_EQ(((expression::ConstantValueExpression*)(where->GetChild(0)->GetChild(1)))->GetValue().ToString(), "2101");
-  EXPECT_EQ(((expression::ConstantValueExpression*)(where->GetChild(1)->GetChild(1)))->GetValue().ToString(), "2");
+  EXPECT_EQ(where->GetChild(0)->GetChild(0)->GetExpressionType(),
+            ExpressionType::VALUE_TUPLE);
+  EXPECT_EQ(where->GetChild(1)->GetChild(0)->GetExpressionType(),
+            ExpressionType::VALUE_TUPLE);
+  EXPECT_EQ(
+      ((expression::TupleValueExpression *)(where->GetChild(0)->GetChild(0)))
+          ->GetColumnName(),
+      "ol_o_id");
+  EXPECT_EQ(
+      ((expression::TupleValueExpression *)(where->GetChild(1)->GetChild(0)))
+          ->GetColumnName(),
+      "ol_d_id");
+  EXPECT_EQ(where->GetChild(0)->GetChild(1)->GetExpressionType(),
+            ExpressionType::VALUE_CONSTANT);
+  EXPECT_EQ(where->GetChild(1)->GetChild(1)->GetExpressionType(),
+            ExpressionType::VALUE_CONSTANT);
+  EXPECT_EQ(
+      ((expression::ConstantValueExpression *)(where->GetChild(0)->GetChild(1)))
+          ->GetValue()
+          .ToString(),
+      "2101");
+  EXPECT_EQ(
+      ((expression::ConstantValueExpression *)(where->GetChild(1)->GetChild(1)))
+          ->GetValue()
+          .ToString(),
+      "2");
 
   // Check update clause
   auto update_clause = update->updates->at(0);
   EXPECT_EQ(std::string(update_clause->column), "ol_delivery_d");
   auto value = update_clause->value;
   EXPECT_EQ(value->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
-  EXPECT_EQ(((expression::ConstantValueExpression*)value)->GetValue().ToString(), "2016-11-15 15:07:37");
-  EXPECT_EQ(((expression::ConstantValueExpression*)value)->GetValueType(), type::Type::TypeId::VARCHAR);
+  EXPECT_EQ(
+      ((expression::ConstantValueExpression *)value)->GetValue().ToString(),
+      "2016-11-15 15:07:37");
+  EXPECT_EQ(((expression::ConstantValueExpression *)value)->GetValueType(),
+            type::Type::TypeId::VARCHAR);
 
   delete stmt_list;
+}
 
+TEST_F(PostgresParserTests, InsertTest) {
+  std::vector<std::string> queries;
+
+  // Select with complicated where, tests both BoolExpr and AExpr
+  queries.push_back("INSERT INTO foo VALUES(1, 2, 3) WHERE id = 5;");
+  if (stmt_list->is_valid == false) {
+    LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
+              stmt_list->error_line, stmt_list->error_col);
+  }
+  // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
+  LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
+  delete stmt_list;
+}
 }
 
 TEST_F(PostgresParserTests, DeleteTest) {

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -466,8 +466,6 @@ TEST_F(PostgresParserTests, DeleteTestWithPredicate) {
     EXPECT_EQ(delstmt->GetTableName(), "foo");
     EXPECT_TRUE(delstmt->expr != nullptr);
 
-    // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
-    LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     delete stmt_list;
   }
 }
@@ -489,8 +487,7 @@ TEST_F(PostgresParserTests, InsertTest) {
   auto insert_stmt = (parser::InsertStatement *)stmt_list->GetStatement(0);
   EXPECT_EQ("foo", insert_stmt->GetTableName());
   EXPECT_TRUE(insert_stmt->insert_values != nullptr);
-  EXPECT_TRUE(insert_stmt->select->GetType() == StatementType::SELECT);
-  LOG_ERROR(insert_stmt->select->from_table->GetTableName());
+  EXPECT_EQ(2, insert_stmt->insert_values->size());
   EXPECT_EQ("bar", insert_stmt->select->from_table->GetTableName());
 
   // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -501,7 +501,7 @@ TEST_F(PostgresParserTests, InsertTest) {
 TEST_F(PostgresParserTests, InsertIntoSelectTest) {
   std::vector<std::string> queries;
 
-  // Select with complicated where, tests both BoolExpr and AExpr
+  // insert into a table with select sub-query
   queries.push_back("INSERT INTO foo select * from bar where id = 5;");
 
   auto parser = parser::PostgresParser::GetInstance();
@@ -521,8 +521,8 @@ TEST_F(PostgresParserTests, InsertIntoSelectTest) {
     EXPECT_EQ("foo", insert_stmt->GetTableName());
     EXPECT_TRUE(insert_stmt->insert_values == nullptr);
     EXPECT_TRUE(insert_stmt->select->GetType() == StatementType::SELECT);
-    LOG_ERROR(insert_stmt->select->from_table->GetTableName());
-    EXPECT_EQ("bar", insert_stmt->select->from_table->GetTableName());
+    EXPECT_EQ("bar",
+              std::string(insert_stmt->select->from_table->GetTableName()));
 
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());

--- a/test/sql/order_by_sql_test.cpp
+++ b/test/sql/order_by_sql_test.cpp
@@ -69,7 +69,6 @@ TEST_F(OrderBySQLTests, PerformanceTest) {
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
-  optimizer::SimpleOptimizer optimizer;
 
   std::chrono::system_clock::time_point start_time =
       std::chrono::system_clock::now();


### PR DESCRIPTION
Three different types of INSERT statements are all supported:
(1) INSERT INTO foo VALUES (1, 2, 3);
(2) INSERT INTO foo VALUES (1, 2, 3), (4, 5, 6);
(3) INSERT INTO foo select * from bar where id = 5;

table_info_ is added in InsertStatement temporarily to make the old parser be compiled.