### PR TITLE
support for simple CREATE statements

### DIFF
--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -172,8 +172,12 @@ struct CreateStatement : TableRefStatement {
       delete index_attrs;
     }
 
-    free(index_name);
-    free(database_name);
+    if (index_name) {
+      free(index_name);
+    }
+    if (database_name) {
+      free(database_name);
+    }
   }
 
   virtual void Accept(SqlNodeVisitor* v) const override {

--- a/src/include/parser/parsenodes.h
+++ b/src/include/parser/parsenodes.h
@@ -196,7 +196,6 @@ typedef struct SelectStmt {
   /* Eventually add fields for CORRESPONDING spec here */
 } SelectStmt;
 
-<<<<<<< HEAD
 typedef struct TypeName
 {
   NodeTag   type;

--- a/src/include/parser/parsenodes.h
+++ b/src/include/parser/parsenodes.h
@@ -196,6 +196,53 @@ typedef struct SelectStmt {
   /* Eventually add fields for CORRESPONDING spec here */
 } SelectStmt;
 
+typedef struct TypeName
+{
+  NodeTag   type;
+  List     *names;      /* qualified name (list of Value strings) */
+  Oid     typeOid;    /* type identified by OID */
+  bool    setof;      /* is a set? */
+  bool    pct_type;   /* %TYPE specified? */
+  List     *typmods;    /* type modifier expression(s) */
+  int   typemod;    /* prespecified type modifier */
+  List     *arrayBounds;  /* array bounds */
+  int     location;   /* token location, or -1 if unknown */
+} TypeName;
+
+typedef struct ColumnDef
+{
+NodeTag		type;
+char	   *colname;		/* name of column */
+TypeName   *typeName;		/* type of column */
+int			inhcount;		/* number of times column is inherited */
+bool		is_local;		/* column has local (non-inherited) def'n */
+bool		is_not_null;	/* NOT NULL constraint specified? */
+bool		is_from_type;	/* column definition came from table type */
+char		storage;		/* attstorage setting, or 0 for default */
+Node	   *raw_default;	/* default value (untransformed parse tree) */
+Node	   *cooked_default; /* default value (transformed expr tree) */
+Node *collClause;	/* untransformed COLLATE spec, if any */
+Oid			collOid;		/* collation OID (InvalidOid if not set) */
+List	   *constraints;	/* other constraints on column */
+List	   *fdwoptions;		/* per-column FDW options */
+int			location;		/* parse location, or -1 if none/unknown */
+} ColumnDef;
+
+typedef struct CreateStmt
+{
+  NodeTag   type;
+  RangeVar   *relation;   /* relation to create */
+  List     *tableElts;    /* column definitions (list of ColumnDef) */
+  List     *inhRelations; /* relations to inherit from (list of
+                 * inhRelation) */
+  TypeName   *ofTypename;   /* OF typename */
+  List     *constraints;  /* constraints (list of Constraint nodes) */
+  List     *options;    /* options from WITH clause */
+  OnCommitAction oncommit;  /* what do we do at COMMIT? */
+  char     *tablespacename; /* table space to use, or NULL */
+  bool    if_not_exists;  /* just do nothing if it already exists? */
+} CreateStmt;
+
 typedef struct ResTarget {
   NodeTag type;
   char *name;        /* column name or NULL */

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -93,6 +93,12 @@ class PostgresParser {
   // transform helper for order by clauses
   parser::OrderDescription* OrderByTransform(List* order);
 
+  // transform helper for table column definitions
+  parser::ColumnDefinition* ColumnDefTransform(ColumnDef *root);
+
+  // transform helper for create statements
+  parser::SQLStatement* CreateTransform(CreateStmt* root);
+
   // transform helper for select statements
   parser::SQLStatement* SelectTransform(SelectStmt* root);
 

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -590,6 +590,104 @@ expression::AbstractExpression* PostgresParser::WhereTransform(Node* root) {
   return result;
 }
 
+// This helper function takes in a Postgres ColumnDef object and transforms
+// it into a Peloton ColumnDefinition object
+parser::ColumnDefinition* PostgresParser::ColumnDefTransform(ColumnDef* root) {
+  parser::ColumnDefinition::DataType data_type;
+  TypeName* type_name = root->typeName;
+  char* name = (reinterpret_cast<value*>(type_name->names->tail->data.ptr_value)
+                    ->val.str);
+  parser::ColumnDefinition* result = nullptr;
+
+  if ((strcmp(name, "int") == 0) || (strcmp(name, "int4") == 0)) {
+    data_type = ColumnDefinition::DataType::INT;
+  } else if (strcmp(name, "varchar") == 0) {
+    data_type = ColumnDefinition::DataType::VARCHAR;
+  } else if (strcmp(name, "int8") == 0) {
+    data_type = ColumnDefinition::DataType::BIGINT;
+  } else if (strcmp(name, "int2") == 0) {
+    data_type = ColumnDefinition::DataType::SMALLINT;
+  } else if (strcmp(name, "timestamp") == 0) {
+    data_type = ColumnDefinition::DataType::TIMESTAMP;
+  } else if (strcmp(name, "bool") == 0) {
+    data_type = ColumnDefinition::DataType::BOOLEAN;
+  } else if (strcmp(name, "bpchar") == 0) {
+    data_type = ColumnDefinition::DataType::CHAR;
+  } else if ((strcmp(name, "double") == 0) || (strcmp(name, "float8") == 0)) {
+    data_type = ColumnDefinition::DataType::DOUBLE;
+  } else if ((strcmp(name, "real") == 0) || (strcmp(name, "float4") == 0)) {
+    data_type = ColumnDefinition::DataType::FLOAT;
+  } else {
+    LOG_ERROR("Column DataType %s not supported yet...\n", name);
+    throw NotImplementedException("...");
+  }
+
+  result = new ColumnDefinition(strdup(root->colname), data_type);
+  if (type_name->typmods) {
+    Node* node =
+        reinterpret_cast<Node*>(type_name->typmods->head->data.ptr_value);
+    if (node->type == T_A_Const) {
+      if (reinterpret_cast<A_Const*>(node)->val.type != T_Integer) {
+        LOG_ERROR("typmods of type %d not supported yet...\n",
+                  reinterpret_cast<A_Const*>(node)->val.type);
+        delete result;
+        throw NotImplementedException("...");
+      }
+      result->varlen =
+          static_cast<size_t>(reinterpret_cast<A_Const*>(node)->val.val.ival);
+    } else {
+      LOG_ERROR("typmods of type %d not supported yet...\n", node->type);
+      delete result;
+      throw NotImplementedException("...");
+    }
+  }
+  return result;
+}
+
+// This function takes in a Postgres CreateStmt parsenode
+// and transfers into a Peloton CreateStatement parsenode.
+// Please refer to parser/parsenode.h for the definition of
+// CreateStmt parsenodes.
+parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
+  UNUSED_ATTRIBUTE CreateStmt* temp = root;
+  parser::CreateStatement* result =
+      new CreateStatement(CreateStatement::CreateType::kTable);
+  RangeVar* relation = root->relation;
+  result->table_info_ = new parser::TableInfo();
+
+  if (relation->relname) {
+    result->table_info_->table_name = strdup(relation->relname);
+  }
+  if (relation->catalogname) {
+    result->table_info_->database_name = strdup(relation->catalogname);
+  };
+
+  if (root->tableElts->length > 0) {
+    result->columns = new std::vector<ColumnDefinition*>();
+  }
+  for (auto cell = root->tableElts->head; cell != nullptr; cell = cell->next) {
+    Node* node = reinterpret_cast<Node*>(cell->data.ptr_value);
+    if ((node->type) == T_ColumnDef) {
+      ColumnDefinition* temp =
+          ColumnDefTransform(reinterpret_cast<ColumnDef*>(node));
+      temp->table_info_ = new parser::TableInfo();
+      if (relation->relname) {
+        temp->table_info_->table_name = strdup(relation->relname);
+      }
+      if (relation->catalogname) {
+        temp->table_info_->database_name = strdup(relation->catalogname);
+      };
+      result->columns->push_back(temp);
+    } else {
+      LOG_ERROR("tableElt of type %d not supported yet...", node->type);
+      delete result->table_info_;
+      delete result;
+      throw NotImplementedException(".");
+    }
+  }
+  return reinterpret_cast<parser::SQLStatement*>(result);
+}
+
 // This function takes in a Postgres SelectStmt parsenode
 // and transfers into a Peloton SelectStatement parsenode.
 // Please refer to parser/parsenode.h for the definition of
@@ -616,8 +714,16 @@ parser::SQLStatement* PostgresParser::NodeTransform(ListCell* stmt) {
           SelectTransform(reinterpret_cast<SelectStmt*>(stmt->data.ptr_value));
       break;
     }
-    default:
+    case T_CreateStmt: {
+      result =
+          CreateTransform(reinterpret_cast<CreateStmt*>(stmt->data.ptr_value));
       break;
+    }
+    default: {
+      LOG_ERROR("Statement of type %d not supported yet...\n",
+                (reinterpret_cast<List*>(stmt->data.ptr_value))->type);
+      throw NotImplementedException("...");
+    }
   }
   return result;
 }

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -238,5 +238,28 @@ TEST_F(PostgresParserTests, ExprTest) {
   }
 }
 
+TEST_F(PostgresParserTests, CreateTest) {
+  std::vector<std::string> queries;
+
+  // Select with complicated where, tests both BoolExpr and AExpr
+  queries.push_back("CREATE TABLE Persons ("
+                     "PersonID int, LastName varchar(255));");
+//  queries.push_back("CREATE INDEX idx_pname ON Persons (LastName, FirstName);");
+  auto parser = parser::PostgresParser::GetInstance();
+  // Parsing
+  UNUSED_ATTRIBUTE int ii = 0;
+  for (auto query : queries) {
+    auto stmt_list = parser.BuildParseTree(query).release();
+    EXPECT_TRUE(stmt_list->is_valid);
+    if (stmt_list->is_valid == false) {
+      LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
+                stmt_list->error_line, stmt_list->error_col);
+    }
+    // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
+    LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
+    delete stmt_list;
+  }
+}
+
 }  // End test namespace
 }  // End peloton namespace


### PR DESCRIPTION
This PR adds support for transform of simple CREATE statements such as
"CREATE TABLE Persons (PersonID int, LastName varchar(255));"
and fixed some bug in the destructor of Peloton CreateStatement class.