### PR TITLE
[FIX] proper parameter indexing in insert plans

### DIFF
--- a/src/planner/insert_plan.cpp
+++ b/src/planner/insert_plan.cpp
@@ -103,6 +103,7 @@ InsertPlan::InsertPlan(
         std::unique_ptr<storage::Tuple> tuple(
             new storage::Tuple(table_schema, true));
         int col_cntr = 0;
+        int param_index = 0;
         auto &table_columns = table_schema->GetColumns();
         auto query_columns = columns;
         for (catalog::Column const &elem : table_columns) {
@@ -132,10 +133,11 @@ InsertPlan::InsertPlan(
             if (values->at(pos)->GetExpressionType() ==
                 ExpressionType::VALUE_PARAMETER) {
               std::tuple<oid_t, oid_t, oid_t> pair =
-                  std::make_tuple(tuple_idx, col_cntr, pos);
+                  std::make_tuple(tuple_idx, col_cntr, param_index);
               parameter_vector_->push_back(pair);
               params_value_type_->push_back(
                   table_schema->GetColumn(col_cntr).GetType());
+              ++param_index;
             } else {
               expression::ConstantValueExpression *const_expr_elem =
                   dynamic_cast<expression::ConstantValueExpression *>(

--- a/test/planner/planner_test.cpp
+++ b/test/planner/planner_test.cpp
@@ -242,5 +242,74 @@ TEST_F(PlannerTests, InsertPlanTestParameter) {
   delete parameter_expr_2;
 }
 
+TEST_F(PlannerTests, InsertPlanTestParameterColumns) {
+  // Bootstrapping peloton
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, nullptr);
+
+  // Create table
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  auto id_column =
+      catalog::Column(type::Type::INTEGER,
+                      type::Type::GetTypeSize(type::Type::INTEGER), "id", true);
+  auto name_column = catalog::Column(type::Type::VARCHAR, 32, "name", true);
+
+  std::unique_ptr<catalog::Schema> table_schema(
+      new catalog::Schema({id_column, name_column}));
+  catalog::Catalog::GetInstance()->CreateTable(
+      DEFAULT_DB_NAME, "department_table", std::move(table_schema), txn);
+
+  // INSERT INTO department_table VALUES (1, $1)
+  auto insert_statement =
+      new parser::InsertStatement(peloton::InsertType::VALUES);
+
+  auto name = new char[strlen("department_table") + 1]();
+  strcpy(name, "department_table");
+  auto table_info = new parser::TableInfo();
+  table_info->table_name = name;
+  insert_statement->table_info_ = table_info;
+  insert_statement->columns = new std::vector<char *>{strdup("id"), strdup("name")};
+
+  // Value val =
+  //    type::ValueFactory::GetNullValue();  // The value is not important
+  // at  this point
+  auto constant_expr_1 = new expression::ConstantValueExpression(
+    type::ValueFactory::GetIntegerValue(1).Copy());
+  auto parameter_expr_2 = new expression::ParameterValueExpression(1);
+  auto exprs = new std::vector<expression::AbstractExpression *>();
+  exprs->push_back(constant_expr_1);
+  exprs->push_back(parameter_expr_2);
+  insert_statement->insert_values = new std::vector<
+      std::vector<peloton::expression::AbstractExpression *> *>();
+  insert_statement->insert_values->push_back(exprs);
+
+  auto target_table = catalog::Catalog::GetInstance()->GetTableWithName(
+      DEFAULT_DB_NAME, "department_table");
+
+  planner::InsertPlan *insert_plan = new planner::InsertPlan(
+      target_table, insert_statement->columns, insert_statement->insert_values);
+  LOG_INFO("Plan created:\n%s", insert_plan->GetInfo().c_str());
+
+  // VALUES(1, "CS")
+  LOG_INFO("Binding values");
+  auto values = new std::vector<type::Value>();
+  values->push_back(type::ValueFactory::GetVarcharValue(
+      (std::string)"CS", TestingHarness::GetInstance().GetTestingPool()).Copy());
+  LOG_INFO("Value 1: %s", values->at(0).GetInfo().c_str());
+  // bind values to parameters in plan
+  insert_plan->SetParameterValues(values);
+
+  // free the database just created
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+
+  delete values;
+  delete insert_plan;
+  delete insert_statement;
+  //delete constant_expr_1; already deleted by insert_statement's descructor
+  delete parameter_expr_2;
+}
+
+
 }  // End test namespace
 }  // End peloton namespace


### PR DESCRIPTION
Looks like there is a mistake in building parameter_vector_ for insert plan in case insert statement contains column list and value list with constants and parameters. This case wasn't covered by test so I added one.