### PR TITLE
Add support for casting VARCHAR to any numeric type

### DIFF
--- a/src/include/type/type_util.h
+++ b/src/include/type/type_util.h
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <string.h>
+
 #include "common/logger.h"
 #include "type/type.h"
 
@@ -25,14 +27,19 @@ namespace type {
 class TypeUtil {
  public:
   /**
-   * Use strncmp to evaluate two strings
+   * Use memcmp to evaluate two strings
    * This does not work with VARBINARY attributes.
    */
   static inline int CompareStrings(const char* str1, int len1, const char* str2,
                                    int len2) {
+    PL_ASSERT(str1 != nullptr);
     PL_ASSERT(len1 >= 0);
+    PL_ASSERT(str2 != nullptr);
     PL_ASSERT(len2 >= 0);
-    int ret = strncmp(str1, str2, std::min(len1, len2));
+    // PAVLO: 2017-04-04
+    // The reason why we use memcmp here is that our inputs are
+    // not null-terminated strings, so we can't use strncmp
+    int ret = memcmp(str1, str2, std::min(len1, len2));
     if (ret == 0 && len1 != len2) {
       ret = len1 - len2;
     }

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -89,14 +89,18 @@ enum class GarbageCollectionType {
 };
 
 //===--------------------------------------------------------------------===//
-// Value types
+// Postgres Value Types
 // This file defines all the types that we will support
 // We do not allow for user-defined types, nor do we try to do anything dynamic.
+//
+// For more information, see 'pg_type.h' in Postgres
+// https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.h#L273
 //===--------------------------------------------------------------------===//
 
 enum class PostgresValueType {
   INVALID = INVALID_TYPE_ID,
   BOOLEAN = 16,
+  TINYINT = 16, // BOOLEAN is an alias for TINYINT
   SMALLINT = 21,
   INTEGER = 23,
   VARBINARY = 17,

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -411,14 +411,25 @@ FieldInfo TrafficCop::GetColumnFieldForValueType(
   PostgresValueType field_type;
   size_t field_size;
   switch (column_type) {
-    case type::Type::BOOLEAN: {
+    case type::Type::BOOLEAN:
+    case type::Type::TINYINT: {
       field_type = PostgresValueType::BOOLEAN;
       field_size = 1;
+      break;
+    }
+    case type::Type::SMALLINT: {
+      field_type = PostgresValueType::SMALLINT;
+      field_size = 2;
       break;
     }
     case type::Type::INTEGER: {
       field_type = PostgresValueType::INTEGER;
       field_size = 4;
+      break;
+    }
+    case type::Type::BIGINT: {
+      field_type = PostgresValueType::BIGINT;
+      field_size = 8;
       break;
     }
     case type::Type::DECIMAL: {
@@ -434,7 +445,7 @@ FieldInfo TrafficCop::GetColumnFieldForValueType(
     }
     case type::Type::TIMESTAMP: {
       field_type = PostgresValueType::TIMESTAMPS;
-      field_size = 64;
+      field_size = 64; // FIXME: Bytes???
       break;
     }
     default: {

--- a/src/type/bigint_type.cpp
+++ b/src/type/bigint_type.cpp
@@ -311,52 +311,44 @@ Value BigintType::Copy(const Value& val) const {
 }
 
 Value BigintType::CastAs(const Value& val, const Type::TypeId type_id) const {
+
   switch (type_id) {
   case Type::TINYINT: {
-    if (val.IsNull())
-      return ValueFactory::GetTinyIntValue(PELOTON_INT8_NULL);
-    if (val.GetAs<int64_t>() > PELOTON_INT8_MAX
-        || val.GetAs<int64_t>() < PELOTON_INT8_MIN)
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
+    if (val.GetAs<int64_t>() > PELOTON_INT8_MAX ||
+        val.GetAs<int64_t>() < PELOTON_INT8_MIN)
       throw Exception(EXCEPTION_TYPE_OUT_OF_RANGE,
           "Numeric value out of range.");
     return ValueFactory::GetTinyIntValue((int8_t) val.GetAs<int64_t>());
   }
   case Type::SMALLINT: {
-    if (val.IsNull())
-      return ValueFactory::GetSmallIntValue(PELOTON_INT16_NULL);
-    if (val.GetAs<int64_t>() > PELOTON_INT16_MAX
-        || val.GetAs<int64_t>() < PELOTON_INT16_MIN)
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
+    if (val.GetAs<int64_t>() > PELOTON_INT16_MAX ||
+        val.GetAs<int64_t>() < PELOTON_INT16_MIN)
       throw Exception(EXCEPTION_TYPE_OUT_OF_RANGE,
           "Numeric value out of range.");
     return ValueFactory::GetSmallIntValue((int16_t) val.GetAs<int64_t>());
   }
   case Type::INTEGER:
   case Type::PARAMETER_OFFSET: {
-    if (val.IsNull())
-      return Value(type_id, PELOTON_INT32_NULL);
-
-    if (val.GetAs<int64_t>() > PELOTON_INT32_MAX
-        || val.GetAs<int64_t>() < PELOTON_INT32_MIN)
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
+    if (val.GetAs<int64_t>() > PELOTON_INT32_MAX ||
+        val.GetAs<int64_t>() < PELOTON_INT32_MIN)
       throw Exception(EXCEPTION_TYPE_OUT_OF_RANGE,
           "Numeric value out of range.");
     return Value(type_id, (int32_t) val.GetAs<int64_t>());
 
   }
   case Type::BIGINT: {
-    if (val.IsNull())
-      return ValueFactory::GetBigIntValue(PELOTON_INT64_NULL);
-
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
     return val.Copy();
   }
   case Type::DECIMAL: {
-    if (val.IsNull())
-      return ValueFactory::GetDecimalValue(PELOTON_DECIMAL_NULL);
-
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
     return ValueFactory::GetDecimalValue((double) val.GetAs<int64_t>());
   }
   case Type::VARCHAR:
-    if (val.IsNull())
-      return ValueFactory::GetVarcharValue(nullptr, 0);
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
     return ValueFactory::GetVarcharValue(val.ToString());
   default:
     break;

--- a/src/type/bigint_type.cpp
+++ b/src/type/bigint_type.cpp
@@ -34,6 +34,10 @@ namespace type {
     return GetCmpBool(left.value_.bigint OP right.GetAs<int64_t>()); \
   case Type::DECIMAL: \
     return GetCmpBool(left.value_.bigint OP right.GetAs<double>()); \
+  case Type::VARCHAR: { \
+    auto r_value = right.CastAs(Type::BIGINT); \
+    return GetCmpBool(left.value_.bigint OP r_value.GetAs<int64_t>()); \
+  } \
   default: \
     break; \
   } // SWITCH
@@ -52,6 +56,10 @@ namespace type {
     case Type::DECIMAL: \
       return ValueFactory::GetDecimalValue( \
                 left.value_.bigint OP right.GetAs<double>()); \
+    case Type::VARCHAR: { \
+      auto r_value = right.CastAs(Type::BIGINT); \
+      return METHOD<int64_t, int64_t>(left, r_value); \
+    } \
     default: \
       break; \
   } // SWITCH
@@ -138,6 +146,10 @@ Value BigintType::Modulo(const Value& left, const Value &right) const {
   case Type::DECIMAL:
     return ValueFactory::GetDecimalValue(
         ValMod(left.value_.bigint, right.GetAs<double>()));
+  case Type::VARCHAR: {
+    auto r_value = right.CastAs(Type::BIGINT);
+    return ModuloValue<int64_t, int64_t>(left, r_value);
+  }
   default:
     break;
   }

--- a/src/type/integer_type.cpp
+++ b/src/type/integer_type.cpp
@@ -21,6 +21,49 @@
 namespace peloton {
 namespace type {
 
+#define INT_COMPARE_FUNC(OP) \
+  switch (right.GetTypeId()) { \
+    case Type::TINYINT: \
+      return GetCmpBool(left.value_.integer OP right.GetAs<int8_t>()); \
+    case Type::SMALLINT: \
+      return GetCmpBool(left.value_.integer OP right.GetAs<int16_t>()); \
+    case Type::INTEGER: \
+    case Type::PARAMETER_OFFSET: \
+      return GetCmpBool(left.value_.integer OP right.GetAs<int32_t>()); \
+  case Type::BIGINT: \
+    return GetCmpBool(left.value_.integer OP right.GetAs<int64_t>()); \
+  case Type::DECIMAL: \
+    return GetCmpBool(left.value_.integer OP right.GetAs<double>()); \
+  case Type::VARCHAR: { \
+    auto r_value = right.CastAs(Type::INTEGER); \
+    return GetCmpBool(left.value_.integer OP r_value.GetAs<int32_t>()); \
+  } \
+  default: \
+    break; \
+  } // SWITCH
+
+#define INT_MODIFY_FUNC(METHOD, OP) \
+  switch (right.GetTypeId()) { \
+    case Type::TINYINT: \
+      return METHOD<int32_t, int8_t>(left, right); \
+    case Type::SMALLINT: \
+      return METHOD<int32_t, int16_t>(left, right); \
+    case Type::INTEGER: \
+    case Type::PARAMETER_OFFSET: \
+      return METHOD<int32_t, int32_t>(left, right); \
+    case Type::BIGINT: \
+      return METHOD<int32_t, int64_t>(left, right); \
+    case Type::DECIMAL: \
+      return ValueFactory::GetDecimalValue( \
+                left.value_.integer OP right.GetAs<double>()); \
+    case Type::VARCHAR: { \
+      auto r_value = right.CastAs(Type::INTEGER); \
+      return METHOD<int32_t, int32_t>(left, r_value); \
+    } \
+    default: \
+      break; \
+  } // SWITCH
+
 IntegerType::IntegerType(TypeId type) :
     IntegerParentType(type) {
 }
@@ -37,21 +80,7 @@ Value IntegerType::Add(const Value& left, const Value &right) const {
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return AddValue<int32_t, int8_t>(left, right);
-  case Type::SMALLINT:
-    return AddValue<int32_t, int16_t>(left, right);
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return AddValue<int32_t, int32_t>(left, right);
-  case Type::BIGINT:
-    return AddValue<int32_t, int64_t>(left, right);
-  case Type::DECIMAL:
-    return ValueFactory::GetDecimalValue(left.value_.integer + right.GetAs<double>());
-  default:
-    break;
-  }
+  INT_MODIFY_FUNC(AddValue, +);
 
   throw Exception("type error");
 }
@@ -62,21 +91,7 @@ Value IntegerType::Subtract(const Value& left, const Value &right) const {
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return SubtractValue<int32_t, int8_t>(left, right);
-  case Type::SMALLINT:
-    return SubtractValue<int32_t, int16_t>(left, right);
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return SubtractValue<int32_t, int32_t>(left, right);
-  case Type::BIGINT:
-    return SubtractValue<int32_t, int64_t>(left, right);
-  case Type::DECIMAL:
-    return ValueFactory::GetDecimalValue(left.value_.integer - right.GetAs<double>());
-  default:
-    break;
-  }
+  INT_MODIFY_FUNC(SubtractValue, -);
 
   throw Exception("type error");
 }
@@ -87,21 +102,7 @@ Value IntegerType::Multiply(const Value& left, const Value &right) const {
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return MultiplyValue<int32_t, int8_t>(left, right);
-  case Type::SMALLINT:
-    return MultiplyValue<int32_t, int16_t>(left, right);
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return MultiplyValue<int32_t, int32_t>(left, right);
-  case Type::BIGINT:
-    return MultiplyValue<int32_t, int64_t>(left, right);
-  case Type::DECIMAL:
-    return ValueFactory::GetDecimalValue(left.value_.integer * right.GetAs<double>());
-  default:
-    break;
-  }
+  INT_MODIFY_FUNC(MultiplyValue, *);
 
   throw Exception("type error");
 }
@@ -113,24 +114,11 @@ Value IntegerType::Divide(const Value& left, const Value &right) const {
     return left.OperateNull(right);
 
   if (right.IsZero()) {
-    throw Exception(EXCEPTION_TYPE_DIVIDE_BY_ZERO, "Division by zerright.");
+    throw Exception(EXCEPTION_TYPE_DIVIDE_BY_ZERO,
+                    "Division by zero on right-hand side");
   }
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return DivideValue<int32_t, int8_t>(left, right);
-  case Type::SMALLINT:
-    return DivideValue<int32_t, int16_t>(left, right);
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return DivideValue<int32_t, int32_t>(left, right);
-  case Type::BIGINT:
-    return DivideValue<int32_t, int64_t>(left, right);
-  case Type::DECIMAL:
-    return ValueFactory::GetDecimalValue(left.value_.integer / right.GetAs<double>());
-  default:
-    break;
-  }
+  INT_MODIFY_FUNC(DivideValue, /);
 
   throw Exception("type error");
 }
@@ -142,7 +130,8 @@ Value IntegerType::Modulo(const Value& left, const Value &right) const {
     return left.OperateNull(right);
 
   if (right.IsZero()) {
-    throw Exception(EXCEPTION_TYPE_DIVIDE_BY_ZERO, "Division by zerright.");
+    throw Exception(EXCEPTION_TYPE_DIVIDE_BY_ZERO,
+                    "Division by zero on right-hand side");
   }
 
   switch (right.GetTypeId()) {
@@ -158,6 +147,10 @@ Value IntegerType::Modulo(const Value& left, const Value &right) const {
   case Type::DECIMAL:
     return ValueFactory::GetDecimalValue(
         ValMod(left.value_.integer, right.GetAs<double>()));
+  case Type::VARCHAR: {
+      auto r_value = right.CastAs(Type::INTEGER);
+      return ModuloValue<int32_t, int32_t>(left, r_value);
+  }
   default:
     break;
   }
@@ -204,26 +197,7 @@ CmpBool IntegerType::CompareEquals(const Value& left, const Value &right) const 
   if (left.IsNull() || right.IsNull())
     return CMP_NULL;
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return GetCmpBool(
-        left.value_.integer == right.GetAs<int8_t>());
-  case Type::SMALLINT:
-    return GetCmpBool(
-        left.value_.integer == right.GetAs<int16_t>());
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return GetCmpBool(
-        left.value_.integer == right.GetAs<int32_t>());
-  case Type::BIGINT:
-    return GetCmpBool(
-        left.value_.integer == right.GetAs<int64_t>());
-  case Type::DECIMAL:
-    return GetCmpBool(
-        left.value_.integer == right.GetAs<double>());
-  default:
-    break;
-  }
+  INT_COMPARE_FUNC(==);
 
   throw Exception("type error");
 }
@@ -235,26 +209,7 @@ CmpBool IntegerType::CompareNotEquals(const Value& left,
   if (left.IsNull() || right.IsNull())
     return CMP_NULL;
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return GetCmpBool(
-        left.value_.integer != right.GetAs<int8_t>());
-  case Type::SMALLINT:
-    return GetCmpBool(
-        left.value_.integer != right.GetAs<int16_t>());
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return GetCmpBool(
-        left.value_.integer != right.GetAs<int32_t>());
-  case Type::BIGINT:
-    return GetCmpBool(
-        left.value_.integer != right.GetAs<int64_t>());
-  case Type::DECIMAL:
-    return GetCmpBool(
-        left.value_.integer != right.GetAs<double>());
-  default:
-    break;
-  }
+  INT_COMPARE_FUNC(!=);
 
   throw Exception("type error");
 }
@@ -266,24 +221,7 @@ CmpBool IntegerType::CompareLessThan(const Value& left,
   if (left.IsNull() || right.IsNull())
     return CMP_NULL;
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return GetCmpBool(left.value_.integer < right.GetAs<int8_t>());
-  case Type::SMALLINT:
-    return GetCmpBool(
-        left.value_.integer < right.GetAs<int16_t>());
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return GetCmpBool(
-        left.value_.integer < right.GetAs<int32_t>());
-  case Type::BIGINT:
-    return GetCmpBool(
-        left.value_.integer < right.GetAs<int64_t>());
-  case Type::DECIMAL:
-    return GetCmpBool(left.value_.integer < right.GetAs<double>());
-  default:
-    break;
-  }
+  INT_COMPARE_FUNC(<);
 
   throw Exception("type error");
 }
@@ -295,26 +233,7 @@ CmpBool IntegerType::CompareLessThanEquals(const Value& left,
   if (left.IsNull() || right.IsNull())
     return CMP_NULL;
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return GetCmpBool(
-        left.value_.integer <= right.GetAs<int8_t>());
-  case Type::SMALLINT:
-    return GetCmpBool(
-        left.value_.integer <= right.GetAs<int16_t>());
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return GetCmpBool(
-        left.value_.integer <= right.GetAs<int32_t>());
-  case Type::BIGINT:
-    return GetCmpBool(
-        left.value_.integer <= right.GetAs<int64_t>());
-  case Type::DECIMAL:
-    return GetCmpBool(
-        left.value_.integer <= right.GetAs<double>());
-  default:
-    break;
-  }
+  INT_COMPARE_FUNC(<=);
 
   throw Exception("type error");
 }
@@ -326,24 +245,7 @@ CmpBool IntegerType::CompareGreaterThan(const Value& left,
   if (left.IsNull() || right.IsNull())
     return CMP_NULL;
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return GetCmpBool(left.value_.integer > right.GetAs<int8_t>());
-  case Type::SMALLINT:
-    return GetCmpBool(
-        left.value_.integer > right.GetAs<int16_t>());
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return GetCmpBool(
-        left.value_.integer >  right.GetAs<int32_t>());
-  case Type::BIGINT:
-    return GetCmpBool(
-        left.value_.integer > right.GetAs<int64_t>());
-  case Type::DECIMAL:
-    return GetCmpBool(left.value_.integer > right.GetAs<double>());
-  default:
-    break;
-  }
+  INT_COMPARE_FUNC(>);
 
   throw Exception("type error");
 }
@@ -355,26 +257,8 @@ CmpBool IntegerType::CompareGreaterThanEquals(const Value& left,
   if (left.IsNull() || right.IsNull())
     return CMP_NULL;
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return GetCmpBool(
-        left.value_.integer >= right.GetAs<int8_t>());
-  case Type::SMALLINT:
-    return GetCmpBool(
-        left.value_.integer >= right.GetAs<int16_t>());
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return GetCmpBool(
-        left.value_.integer >= right.GetAs<int32_t>());
-  case Type::BIGINT:
-    return GetCmpBool(
-        left.value_.integer >= right.GetAs<int64_t>());
-  case Type::DECIMAL:
-    return GetCmpBool(
-        left.value_.integer >= right.GetAs<double>());
-  default:
-    break;
-  }
+  INT_COMPARE_FUNC(>=);
+
   throw Exception("type error");
 }
 

--- a/src/type/integer_type.cpp
+++ b/src/type/integer_type.cpp
@@ -315,46 +315,39 @@ Value IntegerType::Copy(const Value& val) const {
 }
 
 Value IntegerType::CastAs(const Value& val, const Type::TypeId type_id) const {
+
   switch (type_id) {
   case Type::TINYINT: {
-    if (val.IsNull())
-      return ValueFactory::GetTinyIntValue(PELOTON_INT8_NULL);
-    if (val.GetAs<int32_t>() > PELOTON_INT8_MAX
-        || val.GetAs<int32_t>() < PELOTON_INT8_MIN)
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
+    if (val.GetAs<int32_t>() > PELOTON_INT8_MAX ||
+        val.GetAs<int32_t>() < PELOTON_INT8_MIN)
       throw Exception(EXCEPTION_TYPE_OUT_OF_RANGE,
           "Numeric value out of range.");
     return ValueFactory::GetTinyIntValue((int8_t) val.GetAs<int32_t>());
   }
   case Type::SMALLINT: {
-    if (val.IsNull())
-      return ValueFactory::GetSmallIntValue(PELOTON_INT16_NULL);
-
-    if (val.GetAs<int32_t>() > PELOTON_INT16_MAX
-        || val.GetAs<int32_t>() < PELOTON_INT16_MIN)
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
+    if (val.GetAs<int32_t>() > PELOTON_INT16_MAX  ||
+        val.GetAs<int32_t>() < PELOTON_INT16_MIN)
       throw Exception(EXCEPTION_TYPE_OUT_OF_RANGE,
           "Numeric value out of range.");
     return ValueFactory::GetSmallIntValue((int16_t) val.GetAs<int32_t>());
   }
   case Type::INTEGER:
   case Type::PARAMETER_OFFSET: {
-    if (val.IsNull())
-      return Value(type_id, PELOTON_INT32_NULL);
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
     return Value(type_id, (int32_t) val.GetAs<int32_t>());
-
   }
   case Type::BIGINT: {
-    if (val.IsNull())
-      return ValueFactory::GetBigIntValue(PELOTON_INT64_NULL);
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
     return ValueFactory::GetBigIntValue((int64_t) val.GetAs<int32_t>());
   }
   case Type::DECIMAL: {
-    if (val.IsNull())
-      return ValueFactory::GetDecimalValue(PELOTON_DECIMAL_NULL);
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
     return ValueFactory::GetDecimalValue((double) val.GetAs<int32_t>());
   }
   case Type::VARCHAR:
-    if (val.IsNull())
-      return ValueFactory::GetVarcharValue(nullptr, 0);
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
     return ValueFactory::GetVarcharValue(val.ToString());
   default:
     break;

--- a/src/type/smallint_type.cpp
+++ b/src/type/smallint_type.cpp
@@ -342,46 +342,35 @@ Value SmallintType::Copy(const Value& val) const {
 
 Value SmallintType::CastAs(const Value& val,
     const Type::TypeId type_id) const {
+
   switch (type_id) {
   case Type::TINYINT: {
-    if (val.IsNull())
-      return ValueFactory::GetTinyIntValue(PELOTON_INT8_NULL);
-    if (val.GetAs<int16_t>() > PELOTON_INT8_MAX
-        || val.GetAs<int16_t>() < PELOTON_INT8_MIN)
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
+    if (val.GetAs<int16_t>() > PELOTON_INT8_MAX ||
+        val.GetAs<int16_t>() < PELOTON_INT8_MIN)
       throw Exception(EXCEPTION_TYPE_OUT_OF_RANGE,
           "Numeric value out of range.");
     return ValueFactory::GetTinyIntValue((int8_t) val.GetAs<int16_t>());
-
   }
   case Type::SMALLINT: {
-    if (val.IsNull())
-      return ValueFactory::GetSmallIntValue(PELOTON_INT16_NULL);
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
     return val.Copy();
   }
   case Type::INTEGER:
   case Type::PARAMETER_OFFSET: {
-    if (val.IsNull())
-      return Value(type_id, PELOTON_INT32_NULL);
-
-    Value(type_id, (int32_t) val.GetAs<int16_t>());
-
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
+    return Value(type_id, (int32_t) val.GetAs<int16_t>());
   }
   case Type::BIGINT: {
-    if (val.IsNull())
-      return ValueFactory::GetBigIntValue(PELOTON_INT64_NULL);
-
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
     return ValueFactory::GetBigIntValue((int64_t) val.GetAs<int16_t>());
-
   }
   case Type::DECIMAL: {
-    if (val.IsNull())
-      return ValueFactory::GetDecimalValue(PELOTON_DECIMAL_NULL);
-
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
     return ValueFactory::GetDecimalValue((double) val.GetAs<int16_t>());
   }
   case Type::VARCHAR:
-    if (val.IsNull())
-      return ValueFactory::GetVarcharValue(nullptr, 0);
+    if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
     return ValueFactory::GetVarcharValue(val.ToString());
   default:
     break;

--- a/src/type/smallint_type.cpp
+++ b/src/type/smallint_type.cpp
@@ -65,8 +65,6 @@ namespace type {
       break; \
   } // SWITCH
 
-
-
 SmallintType::SmallintType() :
     IntegerParentType(Type::SMALLINT) {
 }

--- a/src/type/tinyint_type.cpp
+++ b/src/type/tinyint_type.cpp
@@ -21,6 +21,50 @@
 namespace peloton {
 namespace type {
 
+#define TINYINT_COMPARE_FUNC(OP) \
+  switch (right.GetTypeId()) { \
+    case Type::TINYINT: \
+      return GetCmpBool(left.value_.tinyint OP right.GetAs<int8_t>()); \
+    case Type::SMALLINT: \
+      return GetCmpBool(left.value_.tinyint OP right.GetAs<int16_t>()); \
+    case Type::INTEGER: \
+    case Type::PARAMETER_OFFSET: \
+      return GetCmpBool(left.value_.tinyint OP right.GetAs<int32_t>()); \
+  case Type::BIGINT: \
+    return GetCmpBool(left.value_.tinyint OP right.GetAs<int64_t>()); \
+  case Type::DECIMAL: \
+    return GetCmpBool(left.value_.tinyint OP right.GetAs<double>()); \
+  case Type::VARCHAR: { \
+    auto r_value = right.CastAs(Type::TINYINT); \
+    return GetCmpBool(left.value_.tinyint OP r_value.GetAs<int8_t>()); \
+  } \
+  default: \
+    break; \
+  } // SWITCH
+
+#define TINYINT_MODIFY_FUNC(METHOD, OP) \
+  switch (right.GetTypeId()) { \
+    case Type::TINYINT: \
+      return METHOD<int8_t, int8_t>(left, right); \
+    case Type::SMALLINT: \
+      return METHOD<int8_t, int16_t>(left, right); \
+    case Type::INTEGER: \
+    case Type::PARAMETER_OFFSET: \
+      return METHOD<int8_t, int32_t>(left, right); \
+    case Type::BIGINT: \
+      return METHOD<int8_t, int64_t>(left, right); \
+    case Type::DECIMAL: \
+      return ValueFactory::GetDecimalValue( \
+                left.value_.tinyint OP right.GetAs<double>()); \
+    case Type::VARCHAR: { \
+      auto r_value = right.CastAs(Type::TINYINT); \
+      return METHOD<int8_t, int8_t>(left, r_value); \
+    } \
+    default: \
+      break; \
+  } // SWITCH
+
+
 TinyintType::TinyintType() :
     IntegerParentType(TINYINT) {
 }
@@ -35,21 +79,8 @@ Value TinyintType::Add(const Value& left, const Value &right) const {
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return AddValue<int8_t, int8_t>(left, right);
-  case Type::SMALLINT:
-    return AddValue<int8_t, int16_t>(left, right);
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return AddValue<int8_t, int32_t>(left, right);
-  case Type::BIGINT:
-    return AddValue<int8_t, int64_t>(left, right);
-  case Type::DECIMAL:
-    return ValueFactory::GetDecimalValue(left.value_.tinyint + right.GetAs<double>());
-  default:
-    break;
-  }
+  TINYINT_MODIFY_FUNC(AddValue, +);
+
   throw Exception("type error");
 }
 
@@ -59,21 +90,7 @@ Value TinyintType::Subtract(const Value& left, const Value &right) const {
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return SubtractValue<int8_t, int8_t>(left, right);
-  case Type::SMALLINT:
-    return SubtractValue<int8_t, int16_t>(left, right);
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return SubtractValue<int8_t, int32_t>(left, right);
-  case Type::BIGINT:
-    return SubtractValue<int8_t, int64_t>(left, right);
-  case Type::DECIMAL:
-    return ValueFactory::GetDecimalValue(left.value_.tinyint - right.GetAs<double>());
-  default:
-    break;
-  }
+  TINYINT_MODIFY_FUNC(SubtractValue, -);
 
   throw Exception("type error");
 }
@@ -83,21 +100,8 @@ Value TinyintType::Multiply(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return MultiplyValue<int8_t, int8_t>(left, right);
-  case Type::SMALLINT:
-    return MultiplyValue<int8_t, int16_t>(left, right);
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return MultiplyValue<int8_t, int32_t>(left, right);
-  case Type::BIGINT:
-    return MultiplyValue<int8_t, int64_t>(left, right);
-  case Type::DECIMAL:
-    return ValueFactory::GetDecimalValue(left.value_.tinyint * right.GetAs<double>());
-  default:
-    break;
-  }
+
+  TINYINT_MODIFY_FUNC(MultiplyValue, *);
 
   throw Exception("type error");
 }
@@ -109,24 +113,12 @@ Value TinyintType::Divide(const Value& left, const Value &right) const {
     return left.OperateNull(right);
 
   if (right.IsZero()) {
-    throw Exception(EXCEPTION_TYPE_DIVIDE_BY_ZERO, "Division by zerright.");
+    throw Exception(EXCEPTION_TYPE_DIVIDE_BY_ZERO,
+                    "Division by zero on right-hand side");
   }
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return DivideValue<int8_t, int8_t>(left, right);
-  case Type::SMALLINT:
-    return DivideValue<int8_t, int16_t>(left, right);
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return DivideValue<int8_t, int32_t>(left, right);
-  case Type::BIGINT:
-    return DivideValue<int8_t, int64_t>(left, right);
-  case Type::DECIMAL:
-    return ValueFactory::GetDecimalValue(left.value_.tinyint / right.GetAs<double>());
-  default:
-    break;
-  }
+  TINYINT_MODIFY_FUNC(DivideValue, /);
+
   throw Exception("type error");
 }
 
@@ -137,7 +129,8 @@ Value TinyintType::Modulo(const Value& left, const Value &right) const {
     return left.OperateNull(right);
 
   if (right.IsZero()) {
-    throw Exception(EXCEPTION_TYPE_DIVIDE_BY_ZERO, "Division by zerright.");
+    throw Exception(EXCEPTION_TYPE_DIVIDE_BY_ZERO,
+                    "Division by zero on right-hand side");
   }
 
   switch (right.GetTypeId()) {
@@ -153,6 +146,10 @@ Value TinyintType::Modulo(const Value& left, const Value &right) const {
   case Type::DECIMAL:
     return ValueFactory::GetDecimalValue(
         ValMod(left.value_.tinyint, right.GetAs<double>()));
+  case Type::VARCHAR: {
+    auto r_value = right.CastAs(Type::TINYINT);
+    return ModuloValue<int8_t, int8_t>(left, r_value);
+  }
   default:
     break;
   }
@@ -200,26 +197,8 @@ CmpBool TinyintType::CompareEquals(const Value& left, const Value &right) const 
   if (left.IsNull() || right.IsNull())
     return CMP_NULL;
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return GetCmpBool(
-        left.value_.tinyint == right.GetAs<int8_t>());
-  case Type::SMALLINT:
-    return GetCmpBool(
-        left.value_.tinyint == right.GetAs<int16_t>());
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return GetCmpBool(
-        left.value_.tinyint == right.GetAs<int32_t>());
-  case Type::BIGINT:
-    return GetCmpBool(
-        left.value_.tinyint == right.GetAs<int64_t>());
-  case Type::DECIMAL:
-    return GetCmpBool(
-        left.value_.tinyint == right.GetAs<double>());
-  default:
-    break;
-  }
+  TINYINT_COMPARE_FUNC(==);
+
   throw Exception("type error");
 }
 
@@ -230,26 +209,7 @@ CmpBool TinyintType::CompareNotEquals(const Value& left,
   if (left.IsNull() || right.IsNull())
     return CMP_NULL;
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return GetCmpBool(
-        left.value_.tinyint != right.GetAs<int8_t>());
-  case Type::SMALLINT:
-    return GetCmpBool(
-        left.value_.tinyint != right.GetAs<int16_t>());
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return GetCmpBool(
-        left.value_.tinyint != right.GetAs<int32_t>());
-  case Type::BIGINT:
-    return GetCmpBool(
-        left.value_.tinyint != right.GetAs<int64_t>());
-  case Type::DECIMAL:
-    return GetCmpBool(
-        left.value_.tinyint != right.GetAs<double>());
-  default:
-    break;
-  }
+  TINYINT_COMPARE_FUNC(!=);
 
   throw Exception("type error");
 }
@@ -261,24 +221,7 @@ CmpBool TinyintType::CompareLessThan(const Value& left,
   if (left.IsNull() || right.IsNull())
     return CMP_NULL;
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return GetCmpBool(left.value_.tinyint < right.GetAs<int8_t>());
-  case Type::SMALLINT:
-    return GetCmpBool(
-        left.value_.tinyint < right.GetAs<int16_t>());
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return GetCmpBool(
-        left.value_.tinyint < right.GetAs<int32_t>());
-  case Type::BIGINT:
-    return GetCmpBool(
-        left.value_.tinyint < right.GetAs<int64_t>());
-  case Type::DECIMAL:
-    return GetCmpBool(left.value_.tinyint < right.GetAs<double>());
-  default:
-    break;
-  }
+  TINYINT_COMPARE_FUNC(<);
 
   throw Exception("type error");
 }
@@ -290,26 +233,7 @@ CmpBool TinyintType::CompareLessThanEquals(const Value& left,
   if (left.IsNull() || right.IsNull())
     return CMP_NULL;
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return GetCmpBool(
-        left.value_.tinyint <= right.GetAs<int8_t>());
-  case Type::SMALLINT:
-    return GetCmpBool(
-        left.value_.tinyint <= right.GetAs<int16_t>());
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return GetCmpBool(
-        left.value_.tinyint <= right.GetAs<int32_t>());
-  case Type::BIGINT:
-    return GetCmpBool(
-        left.value_.tinyint <= right.GetAs<int64_t>());
-  case Type::DECIMAL:
-    return GetCmpBool(
-        left.value_.tinyint <= right.GetAs<double>());
-  default:
-    break;
-  }
+  TINYINT_COMPARE_FUNC(<=);
 
   throw Exception("type error");
 }
@@ -321,24 +245,8 @@ CmpBool TinyintType::CompareGreaterThan(const Value& left,
   if (left.IsNull() || right.IsNull())
     return CMP_NULL;
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return GetCmpBool(left.value_.tinyint > right.GetAs<int8_t>());
-  case Type::SMALLINT:
-    return GetCmpBool(
-        left.value_.tinyint > right.GetAs<int16_t>());
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return GetCmpBool(
-        left.value_.tinyint > right.GetAs<int32_t>());
-  case Type::BIGINT:
-    return GetCmpBool(
-        left.value_.tinyint > right.GetAs<int64_t>());
-  case Type::DECIMAL:
-    return GetCmpBool(left.value_.tinyint > right.GetAs<double>());
-  default:
-    break;
-  }
+  TINYINT_COMPARE_FUNC(>);
+
   throw Exception("type error");
 }
 
@@ -349,26 +257,7 @@ CmpBool TinyintType::CompareGreaterThanEquals(const Value& left,
   if (left.IsNull() || right.IsNull())
     return CMP_NULL;
 
-  switch (right.GetTypeId()) {
-  case Type::TINYINT:
-    return GetCmpBool(
-        left.value_.tinyint >= right.GetAs<int8_t>());
-  case Type::SMALLINT:
-    return GetCmpBool(
-        left.value_.tinyint >= right.GetAs<int16_t>());
-  case Type::INTEGER:
-  case Type::PARAMETER_OFFSET:
-    return GetCmpBool(
-        left.value_.tinyint >= right.GetAs<int32_t>());
-  case Type::BIGINT:
-    return GetCmpBool(
-        left.value_.tinyint >= right.GetAs<int64_t>());
-  case Type::DECIMAL:
-    return GetCmpBool(
-        left.value_.tinyint >= right.GetAs<double>());
-  default:
-    break;
-  }
+  TINYINT_COMPARE_FUNC(>=);
 
   throw Exception("type error");
 }

--- a/src/type/tinyint_type.cpp
+++ b/src/type/tinyint_type.cpp
@@ -309,38 +309,31 @@ Value TinyintType::Copy(const Value& val) const {
 }
 
 Value TinyintType::CastAs(const Value& val, const Type::TypeId type_id) const {
+
   switch (type_id) {
       case Type::TINYINT: {
-        if (val.IsNull())
-          return ValueFactory::GetTinyIntValue(PELOTON_INT8_NULL);
-            return val.Copy();
+        if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
+        return val.Copy();
       }
       case Type::SMALLINT: {
-        if (val.IsNull())
-          return ValueFactory::GetSmallIntValue(PELOTON_INT16_NULL);
-            return ValueFactory::GetSmallIntValue((int16_t)val.GetAs<int8_t>());
-
+        if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
+        return ValueFactory::GetSmallIntValue((int16_t)val.GetAs<int8_t>());
       }
       case Type::INTEGER:
       case Type::PARAMETER_OFFSET: {
-        if (val.IsNull())
-          return Value(type_id, PELOTON_INT32_NULL);
-            Value(type_id, (int32_t)val.GetAs<int8_t>());
+        if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
+        return Value(type_id, (int32_t)val.GetAs<int8_t>());
       }
       case Type::BIGINT: {
-        if (val.IsNull())
-          return ValueFactory::GetBigIntValue(PELOTON_INT64_NULL);
-            return ValueFactory::GetBigIntValue((int64_t)val.GetAs<int8_t>());
+        if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
+        return ValueFactory::GetBigIntValue((int64_t)val.GetAs<int8_t>());
       }
       case Type::DECIMAL: {
-        if (val.IsNull())
-          return ValueFactory::GetDecimalValue(PELOTON_DECIMAL_NULL);
-
-            return ValueFactory::GetDecimalValue((double)val.GetAs<int8_t>());
+        if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
+        return ValueFactory::GetDecimalValue((double)val.GetAs<int8_t>());
       }
       case Type::VARCHAR:
-        if (val.IsNull())
-          return ValueFactory::GetVarcharValue(nullptr, 0);
+        if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
         return ValueFactory::GetVarcharValue(val.ToString());
       default:
         break;

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -393,7 +393,8 @@ bool Value::CheckComparable(const Value &o) const {
       } // SWITCH
       break;
     case Type::VARCHAR:
-      if (o.GetTypeId() == Type::VARCHAR) return true;
+      // Anything can be cast to a string!
+      return true;
       break;
     case Type::VARBINARY:
       if (o.GetTypeId() == Type::VARBINARY) return true;

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -386,6 +386,7 @@ bool Value::CheckComparable(const Value &o) const {
         case Type::INTEGER:
         case Type::BIGINT:
         case Type::DECIMAL:
+        case Type::VARCHAR:
           return true;
         default:
           break;

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -29,13 +29,15 @@ namespace type {
   if (right.GetTypeId() == Type::VARCHAR) { \
     str2 = right.GetData(); \
     len2 = GetLength(right) - 1; \
+    return GetCmpBool(TypeUtil::CompareStrings(str1, len1, \
+                                               str2, len2) OP 0); \
   } else { \
-    std::string to_string = right.ToString(); \
-    str2 = to_string.c_str(); \
-    len2 = static_cast<uint32_t>(to_string.size()); \
+    auto r_value = right.CastAs(Type::VARCHAR); \
+    str2 = r_value.GetData(); \
+    len2 = GetLength(r_value) - 1; \
+    return GetCmpBool(TypeUtil::CompareStrings(str1, len1, \
+                                               str2, len2) OP 0); \
   } \
-  return GetCmpBool(TypeUtil::CompareStrings(str1, len1, \
-                                             str2, len2) OP 0);
 
 VarlenType::VarlenType(TypeId type) : Type(type) {}
 

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -21,6 +21,22 @@
 namespace peloton {
 namespace type {
 
+#define VARLEN_COMPARE_FUNC(OP) \
+  const char *str1 = left.GetData(); \
+  uint32_t len1 = GetLength(left) - 1; \
+  const char *str2; \
+  uint32_t len2; \
+  if (right.GetTypeId() == Type::VARCHAR) { \
+    str2 = right.GetData(); \
+    len2 = GetLength(right) - 1; \
+  } else { \
+    std::string to_string = right.ToString(); \
+    str2 = to_string.c_str(); \
+    len2 = static_cast<uint32_t>(to_string.size()); \
+  } \
+  return GetCmpBool(TypeUtil::CompareStrings(str1, len1, \
+                                             str2, len2) OP 0);
+
 VarlenType::VarlenType(TypeId type) : Type(type) {}
 
 VarlenType::~VarlenType() {}
@@ -30,7 +46,7 @@ const char *VarlenType::GetData(const Value &val) const {
   return val.value_.varlen;
 }
 
-// Get the length of the variable length data
+// Get the length of the variable length data (including the length field)
 uint32_t VarlenType::GetLength(const Value &val) const { return val.size_.len; }
 
 // Access the raw varlen data stored from the tuple storage
@@ -46,11 +62,8 @@ CmpBool VarlenType::CompareEquals(const Value &left, const Value &right) const {
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) == GetLength(right));
   }
-  const char *str1 = left.GetData();
-  const char *str2 = right.GetData();
-  // TODO strcmp does not work on binary values
-  return GetCmpBool(TypeUtil::CompareStrings(str1, GetLength(left), str2,
-                                             GetLength(right)) == 0);
+
+  VARLEN_COMPARE_FUNC(==);
 }
 
 CmpBool VarlenType::CompareNotEquals(const Value &left,
@@ -61,11 +74,8 @@ CmpBool VarlenType::CompareNotEquals(const Value &left,
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) != GetLength(right));
   }
-  const char *str1 = left.GetData();
-  const char *str2 = right.GetData();
-  // TODO strcmp does not work on binary values
-  return GetCmpBool(TypeUtil::CompareStrings(str1, GetLength(left), str2,
-                                             GetLength(right)) != 0);
+
+  VARLEN_COMPARE_FUNC(!=);
 }
 
 CmpBool VarlenType::CompareLessThan(const Value &left,
@@ -76,11 +86,8 @@ CmpBool VarlenType::CompareLessThan(const Value &left,
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) < GetLength(right));
   }
-  const char *str1 = left.GetData();
-  const char *str2 = right.GetData();
-  // TODO strcmp does not work on binary values
-  return GetCmpBool(TypeUtil::CompareStrings(str1, GetLength(left), str2,
-                                             GetLength(right)) < 0);
+
+  VARLEN_COMPARE_FUNC(<);
 }
 
 CmpBool VarlenType::CompareLessThanEquals(const Value &left,
@@ -91,11 +98,8 @@ CmpBool VarlenType::CompareLessThanEquals(const Value &left,
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) <= GetLength(right));
   }
-  const char *str1 = left.GetData();
-  const char *str2 = right.GetData();
-  // TODO strcmp does not work on binary values
-  return GetCmpBool(TypeUtil::CompareStrings(str1, GetLength(left), str2,
-                                             GetLength(right)) <= 0);
+
+  VARLEN_COMPARE_FUNC(<=);
 }
 
 CmpBool VarlenType::CompareGreaterThan(const Value &left,
@@ -106,11 +110,8 @@ CmpBool VarlenType::CompareGreaterThan(const Value &left,
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) > GetLength(right));
   }
-  const char *str1 = left.GetData();
-  const char *str2 = right.GetData();
-  // TODO strcmp does not work on binary values
-  return GetCmpBool(TypeUtil::CompareStrings(str1, GetLength(left), str2,
-                                             GetLength(right)) > 0);
+
+  VARLEN_COMPARE_FUNC(>);
 }
 
 CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
@@ -121,11 +122,8 @@ CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) >= GetLength(right));
   }
-  const char *str1 = left.GetData();
-  const char *str2 = right.GetData();
-  // TODO strcmp does not work on binary values
-  return GetCmpBool(TypeUtil::CompareStrings(str1, GetLength(left), str2,
-                                             GetLength(right)) >= 0);
+
+  VARLEN_COMPARE_FUNC(>=);
 }
 
 Value VarlenType::Min(const Value& left, const Value& right) const {

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -226,6 +226,8 @@ Value VarlenType::CastAs(const Value &val, const Type::TypeId type_id) const {
       return ValueFactory::CastAsSmallInt(val);
     case Type::INTEGER:
       return ValueFactory::CastAsInteger(val);
+    case Type::BIGINT:
+      return ValueFactory::CastAsBigInt(val);
     case Type::TIMESTAMP:
       return ValueFactory::CastAsTimestamp(val);
     case Type::VARCHAR:

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -226,6 +226,8 @@ Value VarlenType::CastAs(const Value &val, const Type::TypeId type_id) const {
       return ValueFactory::CastAsInteger(val);
     case Type::BIGINT:
       return ValueFactory::CastAsBigInt(val);
+    case Type::DECIMAL:
+      return ValueFactory::CastAsDecimal(val);
     case Type::TIMESTAMP:
       return ValueFactory::CastAsTimestamp(val);
     case Type::VARCHAR:

--- a/test/sql/update_sql_test.cpp
+++ b/test/sql/update_sql_test.cpp
@@ -155,7 +155,7 @@ TEST_F(UpdateSQLTests, ComplexUpdateSQLTest) {
   TestingSQLUtil::ExecuteSQLQuery("SELECT salary from employees", result,
                                 tuple_descriptor, rows_affected, error_message);
   // Check the return value
-  EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 0), "10.005000");
+  EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 0), "10.005");
 
   // Another update a tuple into table
   LOG_INFO("Another update a tuple...");
@@ -176,8 +176,8 @@ TEST_F(UpdateSQLTests, ComplexUpdateSQLTest) {
   TestingSQLUtil::ExecuteSQLQuery("SELECT salary, bonus from employees", result,
                                 tuple_descriptor, rows_affected, error_message);
   // Check the return value
-  EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 0), "10.000000");
-  EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 1), "5.500000");
+  EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 0), "10");
+  EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 1), "5.5");
 
   // free the database just created
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();

--- a/test/type/boolean_value_test.cpp
+++ b/test/type/boolean_value_test.cpp
@@ -189,6 +189,10 @@ TEST_F(BooleanValueTests, CastTest) {
   result = type::ValueFactory::CastAsBoolean(valTrue1);
   EXPECT_TRUE(result.IsTrue());
 
+  auto valTrue2 = type::ValueFactory::GetVarcharValue("t");
+  result = type::ValueFactory::CastAsBoolean(valTrue2);
+  EXPECT_TRUE(result.IsTrue());
+
   auto valFalse0 = type::ValueFactory::GetVarcharValue("FaLsE");
   result = type::ValueFactory::CastAsBoolean(valFalse0);
   EXPECT_TRUE(result.IsFalse());
@@ -197,6 +201,10 @@ TEST_F(BooleanValueTests, CastTest) {
 
   auto valFalse1 = type::ValueFactory::GetVarcharValue("0");
   result = type::ValueFactory::CastAsBoolean(valFalse1);
+  EXPECT_TRUE(result.IsFalse());
+
+  auto valFalse2 = type::ValueFactory::GetVarcharValue("f");
+  result = type::ValueFactory::CastAsBoolean(valFalse2);
   EXPECT_TRUE(result.IsFalse());
 
   auto valBustedLike = type::ValueFactory::GetVarcharValue("YourMom");

--- a/test/type/numeric_value_test.cpp
+++ b/test/type/numeric_value_test.cpp
@@ -130,7 +130,7 @@ void CheckCompare2(T x, double y, type::Type::TypeId xtype) {
 
 // Compare decimal and integer
 template<class T>
-void CheckCompare3(double x, T y, type::Type::TypeId ytype ) {
+void CheckCompare3(double x, T y, type::Type::TypeId ytype) {
   type::Value v1 = type::ValueFactory::GetDecimalValue(x);
   type::Value v2 = type::Value(ytype, y);
   if (x == y)
@@ -145,6 +145,19 @@ void CheckCompare3(double x, T y, type::Type::TypeId ytype ) {
 void CheckCompare4(double x, double y) {
   type::Value v1 = type::ValueFactory::GetDecimalValue(x);
   type::Value v2 = type::ValueFactory::GetDecimalValue(y);
+  if (x == y)
+    CheckEqual(v1, v2);
+  else if (x < y)
+    CheckLessThan(v1, v2);
+  else if (x > y)
+    CheckGreaterThan(v1, v2);
+}
+
+// Compare number with varchar
+template<class T>
+void CheckCompare5(T x, T y, type::Type::TypeId xtype) {
+  type::Value v1 = type::Value(xtype, x);
+  type::Value v2 = type::ValueFactory::GetVarcharValue(type::Value(xtype, y).ToString());
   if (x == y)
     CheckEqual(v1, v2);
   else if (x < y)
@@ -380,39 +393,80 @@ void CheckMath4(double x, double y) {
   }
 }
 
-TEST_F(NumericValueTests, ComparisonTest) {
+TEST_F(NumericValueTests, TinyIntComparisonTest) {
   std::srand(SEED);
-
   for (int i = 0; i < TEST_NUM; i++) {
     CheckCompare1<int8_t, int8_t>(RANDOM8(), RANDOM8(), type::Type::TINYINT, type::Type::TINYINT);
     CheckCompare1<int8_t, int16_t>(RANDOM8(), RANDOM16(), type::Type::TINYINT, type::Type::SMALLINT);
     CheckCompare1<int8_t, int32_t>(RANDOM8(), RANDOM32(), type::Type::TINYINT, type::Type::INTEGER);
     CheckCompare1<int8_t, int64_t>(RANDOM8(), RANDOM64(), type::Type::TINYINT, type::Type::BIGINT);
     CheckCompare2<int8_t>(RANDOM8(), RANDOM_DECIMAL(), type::Type::TINYINT);
+    CheckCompare3<int8_t>(RANDOM_DECIMAL(), RANDOM8(), type::Type::TINYINT);
 
+    int8_t v0 = RANDOM8();
+    int8_t v1 = v0 + 1;
+    int8_t v2 = v0 - 1;
+    CheckCompare5<int8_t>(v0, v0, type::Type::TINYINT);
+    CheckCompare5<int8_t>(v0, v1, type::Type::TINYINT);
+    CheckCompare5<int8_t>(v0, v2, type::Type::TINYINT);
+  }
+}
+
+TEST_F(NumericValueTests, SmallIntComparisonTest) {
+  std::srand(SEED);
+  for (int i = 0; i < TEST_NUM; i++) {
     CheckCompare1<int16_t, int8_t>(RANDOM16(), RANDOM8(), type::Type::SMALLINT, type::Type::TINYINT);
     CheckCompare1<int16_t, int16_t>(RANDOM16(), RANDOM16(), type::Type::SMALLINT, type::Type::SMALLINT);
     CheckCompare1<int16_t, int32_t>(RANDOM16(), RANDOM32(), type::Type::SMALLINT, type::Type::INTEGER);
     CheckCompare1<int16_t, int64_t>(RANDOM16(), RANDOM64(), type::Type::SMALLINT, type::Type::BIGINT);
     CheckCompare2<int16_t>(RANDOM16(), RANDOM_DECIMAL(), type::Type::SMALLINT);
+    CheckCompare3<int16_t>(RANDOM_DECIMAL(), RANDOM16(), type::Type::SMALLINT);
 
+    int16_t v0 = RANDOM16();
+    int16_t v1 = v0 + 1;
+    int16_t v2 = v0 - 1;
+    CheckCompare5<int16_t>(v0, v0, type::Type::SMALLINT);
+    CheckCompare5<int16_t>(v0, v1, type::Type::SMALLINT);
+    CheckCompare5<int16_t>(v0, v2, type::Type::SMALLINT);
+  }
+}
+
+TEST_F(NumericValueTests, IntComparisonTest) {
+  std::srand(SEED);
+  for (int i = 0; i < TEST_NUM; i++) {
     CheckCompare1<int32_t, int8_t>(RANDOM32(), RANDOM8(), type::Type::INTEGER, type::Type::TINYINT);
     CheckCompare1<int32_t, int16_t>(RANDOM32(), RANDOM16(), type::Type::INTEGER, type::Type::SMALLINT);
     CheckCompare1<int32_t, int32_t>(RANDOM32(), RANDOM32(), type::Type::INTEGER, type::Type::INTEGER);
     CheckCompare1<int32_t, int64_t>(RANDOM32(), RANDOM64(), type::Type::INTEGER, type::Type::BIGINT);
     CheckCompare2<int32_t>(RANDOM32(), RANDOM_DECIMAL(), type::Type::INTEGER);
+    CheckCompare3<int32_t>(RANDOM_DECIMAL(), RANDOM32(), type::Type::INTEGER);
 
+    int32_t v0 = RANDOM32();
+    int32_t v1 = v0 + 1;
+    int32_t v2 = v0 - 1;
+    CheckCompare5<int32_t>(v0, v0, type::Type::INTEGER);
+    CheckCompare5<int32_t>(v0, v1, type::Type::INTEGER);
+    CheckCompare5<int32_t>(v0, v2, type::Type::INTEGER);
+  }
+}
+
+TEST_F(NumericValueTests, BigIntComparisonTest) {
+  std::srand(SEED);
+  for (int i = 0; i < TEST_NUM; i++) {
     CheckCompare1<int64_t, int8_t>(RANDOM64(), RANDOM8(), type::Type::BIGINT, type::Type::TINYINT);
     CheckCompare1<int64_t, int16_t>(RANDOM64(), RANDOM16(), type::Type::BIGINT, type::Type::SMALLINT);
     CheckCompare1<int64_t, int32_t>(RANDOM64(), RANDOM32(), type::Type::BIGINT, type::Type::INTEGER);
     CheckCompare1<int64_t, int64_t>(RANDOM64(), RANDOM64(), type::Type::BIGINT, type::Type::BIGINT);
     CheckCompare2<int64_t>(RANDOM64(), RANDOM_DECIMAL(), type::Type::BIGINT);
-
-    CheckCompare3<int8_t>(RANDOM_DECIMAL(), RANDOM8(), type::Type::TINYINT);
-    CheckCompare3<int16_t>(RANDOM_DECIMAL(), RANDOM16(), type::Type::SMALLINT);
-    CheckCompare3<int32_t>(RANDOM_DECIMAL(), RANDOM32(), type::Type::INTEGER);
     CheckCompare3<int64_t>(RANDOM_DECIMAL(), RANDOM64(), type::Type::BIGINT);
     CheckCompare4(RANDOM_DECIMAL(), RANDOM_DECIMAL());
+
+    int64_t v0 = RANDOM64();
+    int64_t v1 = v0 + 1;
+    int64_t v2 = v0 - 1;
+    CheckCompare5<int64_t>(v0, v0, type::Type::BIGINT);
+    CheckCompare5<int64_t>(v0, v1, type::Type::BIGINT);
+    CheckCompare5<int64_t>(v0, v2, type::Type::BIGINT);
   }
 }
 

--- a/test/type/numeric_value_test.cpp
+++ b/test/type/numeric_value_test.cpp
@@ -13,12 +13,10 @@
 
 #include <limits.h>
 #include <iostream>
-#include <cstdint>
 #include <cmath>
 
 #include "type/boolean_type.h"
 #include "type/decimal_type.h"
-#include "type/numeric_type.h"
 #include "type/varlen_type.h"
 #include "common/harness.h"
 #include "type/value_factory.h"

--- a/test/type/numeric_value_test.cpp
+++ b/test/type/numeric_value_test.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <cstdint>
 #include <cmath>
+
 #include "type/boolean_type.h"
 #include "type/decimal_type.h"
 #include "type/numeric_type.h"
@@ -560,6 +561,57 @@ TEST_F(NumericValueTests, SqrtTest) {
     v1 = type::ValueFactory::GetBigIntValue(i * i).Sqrt();
     v2 = type::ValueFactory::GetBigIntValue(i);
     CheckEqual(v1, v2);
+  } // FOR
+}
+
+TEST_F(NumericValueTests, CastAsTest) {
+
+  std::vector<type::Type::TypeId> types = {
+      type::Type::TINYINT,
+      type::Type::SMALLINT,
+      type::Type::INTEGER,
+      type::Type::BIGINT,
+//      type::Type::DECIMAL,
+      type::Type::VARCHAR,
+  };
+
+  for (int i = type::PELOTON_INT8_MIN; i <= type::PELOTON_INT8_MAX; i++) {
+    for (auto t1 : types) {
+      type::Value v1;
+
+      switch (t1) {
+        case type::Type::TINYINT:
+          v1 = type::ValueFactory::GetTinyIntValue(i);
+          break;
+        case type::Type::SMALLINT:
+          v1 = type::ValueFactory::GetSmallIntValue(i);
+          break;
+        case type::Type::INTEGER:
+          v1 = type::ValueFactory::GetIntegerValue(i);
+          break;
+        case type::Type::BIGINT:
+          v1 = type::ValueFactory::GetBigIntValue(i);
+          break;
+        case type::Type::DECIMAL:
+          v1 = type::ValueFactory::GetDecimalValue((double)i);
+          break;
+        case type::Type::VARCHAR:
+          v1 = type::ValueFactory::GetVarcharValue(
+                    type::ValueFactory::GetSmallIntValue(i).ToString());
+          break;
+        default:
+          LOG_ERROR("Unexpected type!");
+          ASSERT_FALSE(true);
+      }
+      EXPECT_FALSE(v1.IsNull());
+      for (auto t2 : types) {
+        type::Value v2 = v1.CastAs(t2);
+        LOG_TRACE("[%02d] %s -> %s",
+                  i, TypeIdToString(t1).c_str(),
+                  TypeIdToString(t2).c_str());
+        CheckEqual(v1, v2);
+      } // FOR
+    } // FOR
   } // FOR
 
 }

--- a/test/type/numeric_value_test.cpp
+++ b/test/type/numeric_value_test.cpp
@@ -29,7 +29,7 @@ class NumericValueTests : public PelotonTest {};
 
 #define RANDOM_DECIMAL() ((double)rand() / (double)rand())
 #define SEED 233
-#define TEST_NUM 1
+#define TEST_NUM 100
 
 int8_t RANDOM8() {
   return ((rand() % (SCHAR_MAX * 2 - 1)) - (SCHAR_MAX - 1));
@@ -706,7 +706,7 @@ TEST_F(NumericValueTests, NullValueTest) {
   for (int i = 0; i < 5; i++) {
     EXPECT_TRUE(result[i].IsNull());
   }
-  
+
   result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL).Modulo(
     type::ValueFactory::GetIntegerValue(rand()));
   result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL).Modulo(

--- a/test/type/numeric_value_test.cpp
+++ b/test/type/numeric_value_test.cpp
@@ -571,7 +571,7 @@ TEST_F(NumericValueTests, CastAsTest) {
       type::Type::SMALLINT,
       type::Type::INTEGER,
       type::Type::BIGINT,
-//      type::Type::DECIMAL,
+      type::Type::DECIMAL,
       type::Type::VARCHAR,
   };
 

--- a/test/type/numeric_value_test.cpp
+++ b/test/type/numeric_value_test.cpp
@@ -508,6 +508,62 @@ TEST_F(NumericValueTests, MathTest) {
   }
 }
 
+TEST_F(NumericValueTests, IsZeroTest) {
+  type::Value v1, v2;
+
+  v1 = type::ValueFactory::GetTinyIntValue(0);
+  v2 = type::ValueFactory::GetZeroValueByType(type::Type::TINYINT);
+  EXPECT_TRUE(v1.IsZero());
+  EXPECT_FALSE(v1.IsNull());
+  EXPECT_TRUE(v2.IsZero());
+  CheckEqual(v1, v2);
+
+  v1 = type::ValueFactory::GetSmallIntValue(0);
+  v2 = type::ValueFactory::GetZeroValueByType(type::Type::SMALLINT);
+  EXPECT_TRUE(v1.IsZero());
+  EXPECT_FALSE(v1.IsNull());
+  EXPECT_TRUE(v2.IsZero());
+  CheckEqual(v1, v2);
+
+  v1 = type::ValueFactory::GetIntegerValue(0);
+  v2 = type::ValueFactory::GetZeroValueByType(type::Type::INTEGER);
+  EXPECT_TRUE(v1.IsZero());
+  EXPECT_FALSE(v1.IsNull());
+  EXPECT_TRUE(v2.IsZero());
+  CheckEqual(v1, v2);
+
+  v1 = type::ValueFactory::GetBigIntValue(0);
+  v2 = type::ValueFactory::GetZeroValueByType(type::Type::BIGINT);
+  EXPECT_TRUE(v1.IsZero());
+  EXPECT_FALSE(v1.IsNull());
+  EXPECT_TRUE(v2.IsZero());
+  CheckEqual(v1, v2);
+}
+
+TEST_F(NumericValueTests, SqrtTest) {
+
+  for (int i = 1; i <= 10; i++) {
+    type::Value v1, v2;
+
+    v1 = type::ValueFactory::GetTinyIntValue(i * i).Sqrt();
+    v2 = type::ValueFactory::GetTinyIntValue(i);
+    CheckEqual(v1, v2);
+
+    v1 = type::ValueFactory::GetSmallIntValue(i * i).Sqrt();
+    v2 = type::ValueFactory::GetSmallIntValue(i);
+    CheckEqual(v1, v2);
+
+    v1 = type::ValueFactory::GetIntegerValue(i * i).Sqrt();
+    v2 = type::ValueFactory::GetIntegerValue(i);
+    CheckEqual(v1, v2);
+
+    v1 = type::ValueFactory::GetBigIntValue(i * i).Sqrt();
+    v2 = type::ValueFactory::GetBigIntValue(i);
+    CheckEqual(v1, v2);
+  } // FOR
+
+}
+
 TEST_F(NumericValueTests, DivideByZeroTest) {
   std::srand(SEED);
 


### PR DESCRIPTION
This is the same as #602. It got closed when I did a push force.

http://i.imgur.com/sMOVCZt.gifv

This adds support to cast strings to the appropriate numeric type in any expression. One of the big changes is that I also converted the comparison and modification operations in each of the types into C macros. It's cleaner code now but I think that this will all go away when @pmenon's engine shows up...

```
postgres=# CREATE TABLE foo (val0 TINYINT, val1 SMALLINT, val2 INTEGER, val3 BIGINT);
CREATE TABLE foo (val0 TINYINT, val1 SMALLINT, val2 INTEGER, va
postgres=# INSERT INTO foo VALUES (1, 22, 333, 4444);
INSERT INTO foo VALUES (1, 22, 333, 4444) 1
postgres=# INSERT INTO foo VALUES (2, 33, 444, 5555);
INSERT INTO foo VALUES (2, 33, 444, 5555) 1
postgres=# SELECT * FROM foo WHERE val1 >= '33';
 val0 | val1 | val2 | val3 
------+------+------+------
 2    | 33   |  444 | 5555
(1 row)

postgres=# SELECT 1 + '1' FROM foo;
 expr1 
-------
 2
 2
(2 rows)
```