### PR TITLE
Fixing names

### DIFF
--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -20,7 +20,7 @@
 #include "storage/tuple_iterator.h"
 
 namespace peloton {
-namespace bridge {
+namespace executor {
 
 /*
  * Added for network invoking efficiently
@@ -383,5 +383,5 @@ void CleanExecutorTree(executor::AbstractExecutor *root) {
   }
 }
 
-}  // namespace bridge
+}  // namespace executor
 }  // namespace peloton

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -42,11 +42,11 @@ void CleanExecutorTree(executor::AbstractExecutor *root);
  * value list directly rather than passing Postgres's ParamListInfo
  * @return status of execution.
  */
-peloton_status PlanExecutor::ExecutePlan(
+ExecuteResult PlanExecutor::ExecutePlan(
     const planner::AbstractPlan *plan, concurrency::Transaction *txn,
     const std::vector<type::Value> &params, std::vector<StatementResult> &result,
     const std::vector<int> &result_format) {
-  peloton_status p_status;
+  ExecuteResult p_status;
   if (plan == nullptr) return p_status;
 
   LOG_TRACE("PlanExecutor Start ");

--- a/src/include/executor/plan_executor.h
+++ b/src/include/executor/plan_executor.h
@@ -18,7 +18,7 @@
 #include "concurrency/transaction_manager_factory.h"
 
 namespace peloton {
-namespace bridge {
+namespace executor {
 
 //===--------------------------------------------------------------------===//
 // Plan Executor
@@ -94,5 +94,5 @@ class PlanExecutor {
       std::vector<std::unique_ptr<executor::LogicalTile>> &logical_tile_list);
 };
 
-}  // namespace bridge
+}  // namespace executor
 }  // namespace peloton

--- a/src/include/executor/plan_executor.h
+++ b/src/include/executor/plan_executor.h
@@ -24,14 +24,14 @@ namespace bridge {
 // Plan Executor
 //===--------------------------------------------------------------------===//
 
-typedef struct peloton_status {
+typedef struct ExecuteResult {
   peloton::ResultType m_result;
   int *m_result_slots;
 
   // number of tuples processed
   uint32_t m_processed;
 
-  peloton_status() {
+  ExecuteResult() {
     m_processed = 0;
     m_result = peloton::ResultType::SUCCESS;
     m_result_slots = nullptr;
@@ -43,7 +43,7 @@ typedef struct peloton_status {
   bool SerializeTo(peloton::SerializeOutput &output);
   bool DeserializeFrom(peloton::SerializeInput &input);
 
-} peloton_status;
+} ExecuteResult;
 
 class PlanExecutor {
  public:
@@ -67,7 +67,7 @@ class PlanExecutor {
   }
 
   /* TODO: Delete this mothod
-    static peloton_status ExecutePlan(const planner::AbstractPlan *plan,
+    static ExecuteResult ExecutePlan(const planner::AbstractPlan *plan,
                                       ParamListInfo m_param_list,
                                       TupleDesc m_tuple_desc);
   */
@@ -78,7 +78,7 @@ class PlanExecutor {
    * Before ExecutePlan, a node first receives value list, so we should
    * pass value list directly rather than passing Postgres's ParamListInfo
    */
-  static peloton_status ExecutePlan(const planner::AbstractPlan *plan,
+  static ExecuteResult ExecutePlan(const planner::AbstractPlan *plan,
                                     concurrency::Transaction* txn,
                                     const std::vector<type::Value> &params,
                                     std::vector<StatementResult> &result,

--- a/src/include/storage/database.h
+++ b/src/include/storage/database.h
@@ -19,7 +19,7 @@
 #include "common/printable.h"
 #include "storage/data_table.h"
 
-struct peloton_status;
+struct ExecuteResult;
 struct dirty_table_info;
 struct dirty_index_info;
 

--- a/src/include/tcop/tcop.h
+++ b/src/include/tcop/tcop.h
@@ -65,7 +65,7 @@ class TrafficCop {
 
   // ExecutePrepStmt - Helper to handle txn-specifics for the plan-tree of a
   // statement
-  bridge::ExecuteResult ExecuteStatementPlan(
+  executor::ExecuteResult ExecuteStatementPlan(
       const planner::AbstractPlan *plan, const std::vector<type::Value> &params,
       std::vector<StatementResult> &result, const std::vector<int> &result_format,
       const size_t thread_id = 0);

--- a/src/include/tcop/tcop.h
+++ b/src/include/tcop/tcop.h
@@ -65,7 +65,7 @@ class TrafficCop {
 
   // ExecutePrepStmt - Helper to handle txn-specifics for the plan-tree of a
   // statement
-  bridge::peloton_status ExecuteStatementPlan(
+  bridge::ExecuteResult ExecuteStatementPlan(
       const planner::AbstractPlan *plan, const std::vector<type::Value> &params,
       std::vector<StatementResult> &result, const std::vector<int> &result_format,
       const size_t thread_id = 0);

--- a/src/networking/peloton_service.cpp
+++ b/src/networking/peloton_service.cpp
@@ -365,7 +365,7 @@ void PelotonService::QueryPlan(::google::protobuf::RpcController* controller,
         ss_plan->DeserializeFrom(input);
 
         std::vector<std::unique_ptr<executor::LogicalTile>> logical_tile_list;
-        int tuple_count = peloton::bridge::PlanExecutor::ExecutePlan(
+        int tuple_count = peloton::executor::PlanExecutor::ExecutePlan(
             ss_plan.get(), params, logical_tile_list);
         // Return result
         if (tuple_count < 0) {

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -210,13 +210,13 @@ ResultType TrafficCop::ExecuteStatement(
   }
 }
 
-bridge::ExecuteResult TrafficCop::ExecuteStatementPlan(
+executor::ExecuteResult TrafficCop::ExecuteStatementPlan(
     const planner::AbstractPlan *plan, const std::vector<type::Value> &params,
     std::vector<StatementResult> &result, const std::vector<int> &result_format,
     const size_t thread_id) {
   concurrency::Transaction *txn;
   bool single_statement_txn = false, init_failure = false;
-  bridge::ExecuteResult p_status;
+  executor::ExecuteResult p_status;
 
   auto &curr_state = GetCurrentTxnState();
   if (tcop_txn_state_.empty()) {
@@ -234,7 +234,7 @@ bridge::ExecuteResult TrafficCop::ExecuteStatementPlan(
   // skip if already aborted
   if (curr_state.second != ResultType::ABORTED) {
     PL_ASSERT(txn);
-    p_status = bridge::PlanExecutor::ExecutePlan(plan, txn, params, result,
+    p_status = executor::PlanExecutor::ExecutePlan(plan, txn, params, result,
                                                  result_format);
 
     if (p_status.m_result == ResultType::FAILURE) {

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -210,13 +210,13 @@ ResultType TrafficCop::ExecuteStatement(
   }
 }
 
-bridge::peloton_status TrafficCop::ExecuteStatementPlan(
+bridge::ExecuteResult TrafficCop::ExecuteStatementPlan(
     const planner::AbstractPlan *plan, const std::vector<type::Value> &params,
     std::vector<StatementResult> &result, const std::vector<int> &result_format,
     const size_t thread_id) {
   concurrency::Transaction *txn;
   bool single_statement_txn = false, init_failure = false;
-  bridge::peloton_status p_status;
+  bridge::ExecuteResult p_status;
 
   auto &curr_state = GetCurrentTxnState();
   if (tcop_txn_state_.empty()) {

--- a/test/executor/copy_test.cpp
+++ b/test/executor/copy_test.cpp
@@ -80,7 +80,7 @@ TEST_F(CopyTests, Copying) {
     std::vector<type::Value> params;
     std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
     std::vector<StatementResult> result;
-    bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
+    executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
         statement->GetPlanTree().get(), params, result, result_format);
     EXPECT_EQ(status.m_result, peloton::ResultType::SUCCESS);
     LOG_TRACE("Statement executed. Result: %s",

--- a/test/executor/copy_test.cpp
+++ b/test/executor/copy_test.cpp
@@ -80,7 +80,7 @@ TEST_F(CopyTests, Copying) {
     std::vector<type::Value> params;
     std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
     std::vector<StatementResult> result;
-    bridge::peloton_status status = traffic_cop.ExecuteStatementPlan(
+    bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
         statement->GetPlanTree().get(), params, result, result_format);
     EXPECT_EQ(status.m_result, peloton::ResultType::SUCCESS);
     LOG_TRACE("Statement executed. Result: %s",

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -83,7 +83,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   std::vector<int> result_format;
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
+  executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -83,7 +83,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   std::vector<int> result_format;
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  bridge::peloton_status status = traffic_cop.ExecuteStatementPlan(
+  bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -44,7 +44,7 @@ void ShowTable(std::string database_name, std::string table_name) {
                                                                  table_name);
   std::unique_ptr<Statement> statement;
   auto& peloton_parser = parser::PostgresParser::GetInstance();
-  bridge::peloton_status status;
+  bridge::ExecuteResult status;
   std::vector<type::Value> params;
   std::vector<StatementResult> result;
   optimizer::SimpleOptimizer optimizer;
@@ -125,7 +125,7 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;
   result_format = std::move(std::vector<int>(0, 0));
-  bridge::peloton_status status = traffic_cop.ExecuteStatementPlan(
+  bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -44,7 +44,7 @@ void ShowTable(std::string database_name, std::string table_name) {
                                                                  table_name);
   std::unique_ptr<Statement> statement;
   auto& peloton_parser = parser::PostgresParser::GetInstance();
-  bridge::ExecuteResult status;
+  executor::ExecuteResult status;
   std::vector<type::Value> params;
   std::vector<StatementResult> result;
   optimizer::SimpleOptimizer optimizer;
@@ -125,7 +125,7 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;
   result_format = std::move(std::vector<int>(0, 0));
-  bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
+  executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -129,15 +129,15 @@ TEST_F(UpdateTests, MultiColumnUpdates) {
   //      optimizer::SimpleOptimizer::BuildPelotonPlanTree(select_stmt));
   //  std::vector<type::Value> params;
   //  std::vector<ResultType> result;
-  //  bridge::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
+  //  executor::PlanExecutor::PrintPlan(statement->GetPlanTree().get(), "Plan");
   //
   //  std::vector<int> result_format;
   //  auto tuple_descriptor =
   //      tcop::TrafficCop::GetInstance().GenerateTupleDescriptor(
   //          select_stmt->GetStatement(0));
   //  result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
-  //  UNUSED_ATTRIBUTE bridge::ExecuteResult status =
-  //      bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
+  //  UNUSED_ATTRIBUTE executor::ExecuteResult status =
+  //      executor::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
   //      params,
   //                                        result, result_format);
   //  LOG_INFO("Statement executed. Result: %s",
@@ -214,7 +214,7 @@ TEST_F(UpdateTests, UpdatingOld) {
   std::vector<int> result_format;
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
+  executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -136,7 +136,7 @@ TEST_F(UpdateTests, MultiColumnUpdates) {
   //      tcop::TrafficCop::GetInstance().GenerateTupleDescriptor(
   //          select_stmt->GetStatement(0));
   //  result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
-  //  UNUSED_ATTRIBUTE bridge::peloton_status status =
+  //  UNUSED_ATTRIBUTE bridge::ExecuteResult status =
   //      bridge::PlanExecutor::ExecutePlan(statement->GetPlanTree().get(),
   //      params,
   //                                        result, result_format);
@@ -214,7 +214,7 @@ TEST_F(UpdateTests, UpdatingOld) {
   std::vector<int> result_format;
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  bridge::peloton_status status = traffic_cop.ExecuteStatementPlan(
+  bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -61,7 +61,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
 
-  bridge::peloton_status status = traffic_cop.ExecuteStatementPlan(
+  bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -61,7 +61,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
 
-  bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
+  executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/optimizer/simple_optimizer_test.cpp
+++ b/test/optimizer/simple_optimizer_test.cpp
@@ -68,7 +68,7 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
   std::vector<int> result_format;
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  bridge::peloton_status status = traffic_cop.ExecuteStatementPlan(
+  bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_TRACE("Statement executed. Result: %s",
             ResultTypeToString(status.m_result).c_str());

--- a/test/optimizer/simple_optimizer_test.cpp
+++ b/test/optimizer/simple_optimizer_test.cpp
@@ -68,7 +68,7 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
   std::vector<int> result_format;
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
+  executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_TRACE("Statement executed. Result: %s",
             ResultTypeToString(status.m_result).c_str());

--- a/test/statistics/stats_test.cpp
+++ b/test/statistics/stats_test.cpp
@@ -387,7 +387,7 @@ TEST_F(StatsTests, MultiThreadStatsTest) {
 //  std::vector<type::Value> params;
 //  std::vector<StatementResult> result;
 //  std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
-//  bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
+//  executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
 //      statement->GetPlanTree().get(), params, result, result_format);
 //  LOG_TRACE("Statement executed. Result: %s",
 //            ResultTypeToString(status.m_result).c_str());

--- a/test/statistics/stats_test.cpp
+++ b/test/statistics/stats_test.cpp
@@ -387,7 +387,7 @@ TEST_F(StatsTests, MultiThreadStatsTest) {
 //  std::vector<type::Value> params;
 //  std::vector<StatementResult> result;
 //  std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
-//  bridge::peloton_status status = traffic_cop.ExecuteStatementPlan(
+//  bridge::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
 //      statement->GetPlanTree().get(), params, result, result_format);
 //  LOG_TRACE("Statement executed. Result: %s",
 //            ResultTypeToString(status.m_result).c_str());


### PR DESCRIPTION
1. Renamed `peloton_status` to `ExecuteStatus`
2. Renamed `bridge` namespace to `executor`