### PR TITLE
Parser Fix

### DIFF
--- a/src/include/expression/expression_util.h
+++ b/src/include/expression/expression_util.h
@@ -419,6 +419,8 @@ class ExpressionUtil {
       auto catalog = catalog::Catalog::GetInstance();
       const catalog::FunctionData &func_data =
           catalog->GetFunction(func_expr->func_name_);
+      LOG_INFO("Function %s found in the catalog", func_data.func_name_.c_str());
+      LOG_INFO("Argument num: %ld", func_data.argument_types_.size());
       func_expr->SetFunctionExpressionParameters(func_data.func_ptr_,
                                                  func_data.return_type_,
                                                  func_data.argument_types_);

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -63,9 +63,17 @@ struct ColumnDefinition {
     FULL
   };
 
-  ColumnDefinition(DataType type) : type(type) {}
+  ColumnDefinition(DataType type) : type(type) {
+    // Set varlen to TEXT_MAX_LENGTH if the data type is TEXT
+    if (type == TEXT)
+      varlen = type::PELOTON_TEXT_MAX_LEN;
+  }
 
-  ColumnDefinition(char* name, DataType type) : name(name), type(type) {}
+  ColumnDefinition(char* name, DataType type) : name(name), type(type) {
+    // Set varlen to TEXT_MAX_LENGTH if the data type is TEXT
+    if (type == TEXT)
+      varlen = type::PELOTON_TEXT_MAX_LEN;
+  }
 
   virtual ~ColumnDefinition() {
     if (primary_key) {

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -48,6 +48,20 @@ struct ColumnDefinition {
     VARBINARY
   };
 
+  enum FKConstrActionType {
+    NOACTION,
+    RESTRICT,
+    CASCADE,
+    SETNULL,
+    SETDEFAULT
+  };
+
+  enum FKConstrMatchType {
+    SIMPLE,
+    PARTIAL,
+    FULL
+  };
+
   ColumnDefinition(DataType type) : type(type) {}
 
   ColumnDefinition(char* name, DataType type) : name(name), type(type) {}
@@ -67,7 +81,8 @@ struct ColumnDefinition {
       delete foreign_key_sink;
     }
     delete[] name;
-    delete table_info_;
+    if (table_info_ != nullptr)
+      delete table_info_;
   }
 
   static type::Type::TypeId GetValueType(DataType type) {
@@ -144,6 +159,11 @@ struct ColumnDefinition {
   std::vector<char*>* primary_key = nullptr;
   std::vector<char*>* foreign_key_source = nullptr;
   std::vector<char*>* foreign_key_sink = nullptr;
+
+  char* foreign_key_table_name = nullptr;
+  FKConstrActionType foreign_key_delete_action;
+  FKConstrActionType foreign_key_update_action;
+  FKConstrMatchType foreign_key_match_type;
 };
 
 /**

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -94,6 +94,8 @@ struct ColumnDefinition {
       delete table_info_;
     if (default_value != nullptr)
       delete default_value;
+    if (check_expression != nullptr)
+      delete check_expression;
   }
 
   static type::Type::TypeId GetValueType(DataType type) {
@@ -166,6 +168,7 @@ struct ColumnDefinition {
   bool primary = false;
   bool unique = false;
   expression::AbstractExpression* default_value = nullptr;
+  expression::AbstractExpression* check_expression = nullptr;
 
   std::vector<char*>* primary_key = nullptr;
   std::vector<char*>* foreign_key_source = nullptr;

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -15,6 +15,7 @@
 #include "type/types.h"
 #include "common/sql_node_visitor.h"
 #include "parser/sql_statement.h"
+#include "expression/abstract_expression.h"
 
 namespace peloton {
 namespace parser {
@@ -83,6 +84,8 @@ struct ColumnDefinition {
     delete[] name;
     if (table_info_ != nullptr)
       delete table_info_;
+    if (default_value != nullptr)
+      delete default_value;
   }
 
   static type::Type::TypeId GetValueType(DataType type) {

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -84,6 +84,14 @@ class PostgresParser {
     }
   }
 
+  static bool IsAggregateFunction(std::string& fun_name) {
+    if (fun_name == "min" || fun_name == "max" ||
+        fun_name == "count" || fun_name == "avg" ||
+        fun_name == "sum")
+      return true;
+    return false;
+  }
+
   //===--------------------------------------------------------------------===//
   // Transform Functions
   //===--------------------------------------------------------------------===//

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -53,6 +53,10 @@ class PostgresParser {
       const std::string& query_string);
 
  private:
+  //===--------------------------------------------------------------------===//
+  // Helper Functions
+  //===--------------------------------------------------------------------===//
+
   // helper for c_str copy
   static char* cstrdup(const char* c_str) {
     char* new_str = new char[strlen(c_str) + 1];
@@ -60,7 +64,31 @@ class PostgresParser {
     return new_str;
   }
 
-  // tansform helper for internal parse tree
+  static ColumnDefinition::FKConstrActionType CharToActionType(char &type) {
+    switch (type) {
+      case 'a':return ColumnDefinition::FKConstrActionType::NOACTION;
+      case 'r':return ColumnDefinition::FKConstrActionType::RESTRICT;
+      case 'c':return ColumnDefinition::FKConstrActionType::CASCADE;
+      case 'n':return ColumnDefinition::FKConstrActionType::SETNULL;
+      case 'd':return ColumnDefinition::FKConstrActionType::SETDEFAULT;
+      default:return ColumnDefinition::FKConstrActionType::NOACTION;
+    }
+  }
+
+  static ColumnDefinition::FKConstrMatchType CharToMatchType(char &type) {
+    switch (type) {
+      case 'f':return ColumnDefinition::FKConstrMatchType::FULL;
+      case 'p':return ColumnDefinition::FKConstrMatchType::PARTIAL;
+      case 's':return ColumnDefinition::FKConstrMatchType::SIMPLE;
+      default:return ColumnDefinition::FKConstrMatchType::SIMPLE;
+    }
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Transform Functions
+  //===--------------------------------------------------------------------===//
+
+  // transform helper for internal parse tree
   static parser::SQLStatementList*
     PgQueryInternalParsetreeTransform(PgQueryInternalParsetreeAndError stmt);
 

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -60,6 +60,9 @@ static const int8_t PELOTON_BOOLEAN_NULL = SCHAR_MIN;
 
 static const uint32_t PELOTON_VARCHAR_MAX_LEN = UINT_MAX;
 
+// Use to make TEXT type as the alias of VARCHAR(TEXT_MAX_LENGTH)
+static const uint32_t PELOTON_TEXT_MAX_LEN= 1000000000;
+
 // Objects (i.e., VARCHAR) with length prefix of -1 are NULL
 #define OBJECTLENGTH_NULL -1
 

--- a/src/include/util/string_util.h
+++ b/src/include/util/string_util.h
@@ -104,6 +104,11 @@ class StringUtil {
   static std::string Upper(const std::string &str);
 
   /**
+ * Convert a string to its uppercase form
+ */
+  static std::string Lower(const std::string &str);
+
+  /**
    * Format a string using printf semantics
    * http://stackoverflow.com/a/8098080
    */

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -973,6 +973,12 @@ PostgresParser::ValueListsTransform(List* root) {
         cur_result->push_back(ParamRefTransform((ParamRef*)expr));
       else if (expr->type == T_A_Const)
         cur_result->push_back(ConstTransform((A_Const*)expr));
+      else if (expr->type == T_SetToDefault){
+        // TODO handle default type
+        // add corresponding expression for
+        // default to cur_result
+        cur_result->push_back(nullptr); 
+      }
     }
     result->push_back(cur_result);
   }

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -460,8 +460,9 @@ expression::AbstractExpression* PostgresParser::FuncCallTransform(
         result = new expression::AggregateExpression(
             agg_fun_type, root->agg_distinct, child);
       } else {
-      throw NotImplementedException(
-        "Aggregation over multiple columns not supported yet...\n");
+        throw NotImplementedException(
+            "Aggregation over multiple columns not supported yet...\n");
+      }
     }
   }
   return result;

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -758,6 +758,10 @@ parser::ColumnDefinition* PostgresParser::ColumnDefTransform(ColumnDef* root) {
         result->default_value =
             AExprTransform(reinterpret_cast<A_Expr*>(constraint->raw_expr));
       }
+      else if (constraint->contype == CONSTR_CHECK) {
+        result->check_expression =
+            AExprTransform(reinterpret_cast<A_Expr*>(constraint->raw_expr));
+      }
     }
   }
 

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -414,6 +414,7 @@ expression::AbstractExpression* PostgresParser::FuncCallTransform(
 
   if (!IsAggregateFunction(fun_name)) {
     // Normal functions (i.e. built-in functions or UDFs)
+    fun_name = (reinterpret_cast<value*>(root->funcname->tail->data.ptr_value))->val.str;
     std::vector<expression::AbstractExpression*> children;
     for (auto cell = root->args->head; cell != nullptr; cell = cell->next) {
       auto expr_node = (Node*) cell->data.ptr_value;

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -428,9 +428,9 @@ expression::AbstractExpression* PostgresParser::FuncCallTransform(
         children.push_back(FuncCallTransform(reinterpret_cast<FuncCall*>(expr_node)));
       }
       else {
-        std::ostringstream oss;
-        oss<<"Type "<<expr_node->type<<"is not supported in function call";
-        throw NotImplementedException(oss.str());
+        throw NotImplementedException(
+            StringUtil::Format("Type %d is not supported in function call.",
+                               expr_node->type));
       }
     }
     result = new expression::FunctionExpression(

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -754,6 +754,10 @@ parser::ColumnDefinition* PostgresParser::ColumnDefTransform(ColumnDef* root) {
         // Match type
         result->foreign_key_match_type = CharToMatchType(constraint->fk_matchtype);
       }
+      else if (constraint->contype == CONSTR_DEFAULT) {
+        result->default_value =
+            AExprTransform(reinterpret_cast<A_Expr*>(constraint->raw_expr));
+      }
     }
   }
 

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <string>
 #include <unordered_set>
+#include <include/parser/pg_list.h>
 
 #include "common/exception.h"
 #include "expression/aggregate_expression.h"
@@ -277,7 +278,6 @@ expression::AbstractExpression* PostgresParser::ParamRefTransform(
 
 // This function takes in groupClause and havingClause of a Postgres SelectStmt
 // transfers into a Peloton GroupByDescription object.
-// TODO: having clause is not handled yet, depends on AExprTransform
 parser::GroupByDescription* PostgresParser::GroupByTransform(List* group,
                                                              Node* having) {
   if (group == nullptr) {
@@ -405,39 +405,61 @@ expression::AbstractExpression* PostgresParser::ConstTransform(A_Const* root) {
   return ValueTransform(root->val);
 }
 
-// This function takes in a Postgres FuncCall parsenode and transfers it into
-// a Peloton FunctionExpression object.
-// TODO: support function calls on a single column.
 expression::AbstractExpression* PostgresParser::FuncCallTransform(
     FuncCall* root) {
   expression::AbstractExpression* result = nullptr;
-  std::string type_string =
-      (reinterpret_cast<value*>(root->funcname->head->data.ptr_value))->val.str;
+  std::string fun_name =
+      StringUtil::Lower(
+          (reinterpret_cast<value*>(root->funcname->head->data.ptr_value))->val.str);
 
-  type_string = "AGGREGATE_" + type_string;
-
-  if (root->agg_star) {
-    expression::AbstractExpression* children = new expression::StarExpression();
-    result = new expression::AggregateExpression(
-        StringToExpressionType(type_string), false, children);
-  } else {
-    if (root->args->length < 2) {
-      // auto children_expr_list = TargetTransform(root->args);
-      expression::AbstractExpression* child;
-      auto expr_node = (Node*)root->args->head->data.ptr_value;
+  if (!IsAggregateFunction(fun_name)) {
+    // Normal functions (i.e. built-in functions or UDFs)
+    std::vector<expression::AbstractExpression*> children;
+    for (auto cell = root->args->head; cell != nullptr; cell = cell->next) {
+      auto expr_node = (Node*) cell->data.ptr_value;
       if (expr_node->type == T_A_Expr) {
-        child = AExprTransform((A_Expr*)expr_node);
+        children.push_back(AExprTransform(reinterpret_cast<A_Expr *>(expr_node)));
       } else if (expr_node->type == T_A_Const) {
-        child = ConstTransform((A_Const*)expr_node);
+        children.push_back(ConstTransform(reinterpret_cast<A_Const *>(expr_node)));
       } else if (expr_node->type == T_ColumnRef) {
-        child = ColumnRefTransform((ColumnRef*)expr_node);
-      } else {
-        throw NotImplementedException(
-          "Function within Aggregate is not supported yet\n");
+        children.push_back(ColumnRefTransform(reinterpret_cast<ColumnRef *>(expr_node)));
+      } else if (expr_node->type == T_FuncCall){
+        children.push_back(FuncCallTransform(reinterpret_cast<FuncCall*>(expr_node)));
       }
+      else {
+        std::ostringstream oss;
+        oss<<"Type "<<expr_node->type<<"is not supported in function call";
+        throw NotImplementedException(oss.str());
+      }
+    }
+    result = new expression::FunctionExpression(
+        fun_name.c_str(), children);
+  }
+  else {
+    // Aggregate function
+    auto agg_fun_type = StringToExpressionType("AGGREGATE_" + fun_name);
+    if (root->agg_star) {
+      expression::AbstractExpression *children = new expression::StarExpression();
       result = new expression::AggregateExpression(
-          StringToExpressionType(type_string), root->agg_distinct, child);
+          agg_fun_type, false, children);
     } else {
+      if (root->args->length < 2) {
+        // auto children_expr_list = TargetTransform(root->args);
+        expression::AbstractExpression *child;
+        auto expr_node = (Node *) root->args->head->data.ptr_value;
+        if (expr_node->type == T_A_Expr) {
+          child = AExprTransform((A_Expr *) expr_node);
+        } else if (expr_node->type == T_A_Const) {
+          child = ConstTransform((A_Const *) expr_node);
+        } else if (expr_node->type == T_ColumnRef) {
+          child = ColumnRefTransform((ColumnRef *) expr_node);
+        } else {
+          LOG_ERROR("Function within Aggregate is not supported yet\n");
+          throw NotImplementedException("");
+        }
+        result = new expression::AggregateExpression(
+            agg_fun_type, root->agg_distinct, child);
+      } else {
       throw NotImplementedException(
         "Aggregation over multiple columns not supported yet...\n");
     }

--- a/src/planner/insert_plan.cpp
+++ b/src/planner/insert_plan.cpp
@@ -62,7 +62,7 @@ InsertPlan::InsertPlan(
       for (uint32_t tuple_idx = 0; tuple_idx < insert_values->size();
            tuple_idx++) {
         auto values = (*insert_values)[tuple_idx];
-        PL_ASSERT(values->size() == table_schema->GetColumnCount());
+        PL_ASSERT(values->size() <= table_schema->GetColumnCount());
         std::unique_ptr<storage::Tuple> tuple(
             new storage::Tuple(table_schema, true));
         int col_cntr = 0;

--- a/src/util/string_util.cpp
+++ b/src/util/string_util.cpp
@@ -106,6 +106,13 @@ std::string StringUtil::Upper(const std::string &str) {
   return (copy);
 }
 
+std::string StringUtil::Lower(const std::string &str) {
+  std::string copy(str);
+  std::transform(copy.begin(), copy.end(), copy.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return (copy);
+}
+
 std::string StringUtil::Format(const std::string fmt_str, ...) {
   // Reserve two times as much as the length of the fmt_str
   int final_n, n = ((int)fmt_str.size()) * 2;


### PR DESCRIPTION
This PR contains several fixes and adds support for several features in the parser according to the open issues:

- Support DEFAULT, REFERENCE and CHECK constraints in CREATE TABLE  (#631, #625 )
- Fix assertion failure in insert executor (#631, #578)
- Make TEXT type an alias to VARCHAR(1000000000) (#626)
Now Peloton can support the following CREATE TABLE statement in the parser:
``` sql
CREATE TABLE TEST (
  a int DEFAULT 1+2,
  b int REFERENCES table2 (bb) ON UPDATE CASCADE,
  c varchar(32) REFERENCES table3 (cc) MATCH FULL ON DELETE SET NULL,
  d int CHECK (d+1 > 0),
  e TEXT
);
```
- Support parsing FunctionExpression `SELECT add(1,a) FROM TEST WHERE FUN(b) > 2`

**_For the constraint team_**  (@vittvolt, @xinzhang1234, +1):
Some members are added in the create_statement.h to store the parsing result for the constraints and you may want to refactor the class if needed. For INSERT with DEFAULT keyword, e.g. `INSERT INTO TEST VALUES (DEFAULT, 1, 2, 3)`, the parser just put nullptr in the value list, you should check it to deal with this case. See https://github.com/hzxa21/peloton/commit/579806548300ca31495b5076845b190b9cf0e8c2#diff-557f49deefef560d7e7b9c3c85259f5fR980

**_For the UDF team_**  (@NasrinJaleel93, @prashasthip, +1):
Now the parser treats UDF and built-in functions as the same and all the information are available in FunctionExpression. https://github.com/cmu-db/peloton/blob/master/src/include/expression/function_expression.h

