### PR TITLE
Minor fix for DEFAULT constraint and refactor postgresparser

### DIFF
--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -118,6 +118,9 @@ class PostgresParser {
   // transform helper for select targets
   static std::vector<expression::AbstractExpression*>* TargetTransform(List* root);
 
+  // transform helper for all expr nodes
+  static expression::AbstractExpression* ExprTransform(Node* root);
+
   // transform helper for A_Expr nodes
   static expression::AbstractExpression* AExprTransform(A_Expr* root);
 

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -292,6 +292,7 @@ parser::GroupByDescription* PostgresParser::GroupByTransform(List* group,
       result->columns->push_back(ExprTransform(temp));
     }
     catch(NotImplementedException e) {
+      delete result;
       throw NotImplementedException(
           StringUtil::Format("Exception thrown in group by expr:\n%s", e.what()));
     }
@@ -303,6 +304,7 @@ parser::GroupByDescription* PostgresParser::GroupByTransform(List* group,
       result->having = ExprTransform(having);
     }
     catch(NotImplementedException e) {
+      delete result;
       throw NotImplementedException(
           StringUtil::Format("Exception thrown in having expr:\n%s", e.what()));
     }
@@ -508,7 +510,7 @@ expression::AbstractExpression* PostgresParser::BoolExprTransform(
   return result;
 }
 
-expression::AbstractExpression* PostgresParser::ExprTransform(Node* node) {
+expression::AbstractExpression* PostgresParser::  ExprTransform(Node* node) {
   expression::AbstractExpression* expr = nullptr;
   switch (node->type) {
     case T_ColumnRef: {
@@ -583,6 +585,7 @@ expression::AbstractExpression* PostgresParser::AExprTransform(A_Expr* root) {
     right_expr = ExprTransform(root->rexpr);
   }
   catch(NotImplementedException e) {
+    delete left_expr;
     throw NotImplementedException(
         StringUtil::Format("Exception thrown in left expr:\n%s", e.what()));
   }
@@ -1194,7 +1197,7 @@ parser::SQLStatementList* PostgresParser::ParseSQLString(
   }
 
   // DEBUG only. Comment this out in release mode
-  print_pg_parse_tree(result.tree);
+//  print_pg_parse_tree(result.tree);
 
   auto transform_result = ListTransform(result.tree);
   pg_query_parse_finish(ctx);

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -738,7 +738,7 @@ TEST_F(PostgresParserTests, DistinctFromTest) {
 TEST_F(PostgresParserTests, ConstraintTest) {
   std::string query = "CREATE TABLE table1 ("
       "a int DEFAULT 1+2,"
-      "b int REFERENCES table2 (bb) ON UPDATE CASCADE,"
+      "b int DEFAULT 1 REFERENCES table2 (bb) ON UPDATE CASCADE,"
       "c varchar(32) REFERENCES table3 (cc) MATCH FULL ON DELETE SET NULL,"
       "d int CHECK (d+1 > 0),"
       "FOREIGN KEY (d) REFERENCES table4 (dd) MATCH SIMPLE ON UPDATE SET DEFAULT"


### PR DESCRIPTION
This PR adds the missing part for parsing constant DEFAULT constraint #644 and refactor postgresparser by adding ExprTransform for all expression nodes for better modularity.