### PR TITLE
Use `-fsanitize` flags for build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ dist: trusty
 
 matrix:
     include:
-        #- compiler: gcc
-          #addons:
-          #    apt:
-          #      sources:
-          #          - ubuntu-toolchain-r-test
-          #          - boost-latest
-          #      packages:
-          #          - g++-4.9
-          #env: CXX=g++-4.9
+        - compiler: gcc
+          addons:
+              apt:
+                sources:
+                    - ubuntu-toolchain-r-test
+                    - boost-latest
+                packages:
+                    - g++-4.9
+          env: CXX=g++-4.9
         - compiler: gcc
           addons:
               apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ dist: trusty
 
 matrix:
     include:
-        - compiler: gcc
-          addons:
-              apt:
-                sources:
-                    - ubuntu-toolchain-r-test
-                    - boost-latest
-                packages:
-                    - g++-4.9
-          env: CXX=g++-4.9
+        #- compiler: gcc
+          #addons:
+          #    apt:
+          #      sources:
+          #          - ubuntu-toolchain-r-test
+          #          - boost-latest
+          #      packages:
+          #          - g++-4.9
+          #env: CXX=g++-4.9
         - compiler: gcc
           addons:
               apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ dist: trusty
 
 matrix:
     include:
-        - compiler: gcc
-          addons:
-              apt:
-                sources:
-                    - ubuntu-toolchain-r-test
-                    - boost-latest
-                packages:
-                    - g++-4.9
-          env: CXX=g++-4.9
+        #- compiler: gcc
+        #  addons:
+        #      apt:
+        #        sources:
+        #            - ubuntu-toolchain-r-test
+        #            - boost-latest
+        #        packages:
+        #            - g++-4.9
+        #  env: CXX=g++-4.9
         - compiler: gcc
           addons:
               apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
     - mkdir build
     - cd build
     # run cmake
-    - cmake -DCOVERALLS=ON -DCMAKE_BUILD_TYPE=Debug ..
+    - cmake -DCOVERALLS=ON -DCMAKE_BUILD_TYPE=Debug -DUSE_SANITIZER=Address ..
     # build
     - make -j4
     # run tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ include(cmake/Dependencies.cmake)
 
 # ---[ C++11 Flags
 include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++1y" COMPILER_SUPPORTS_CXX1Y)
+check_cxx_compiler_flag("-std=c++1y" COMPILER_SUPPORTS_CXX1Y)
 
 if(COMPILER_SUPPORTS_CXX1Y)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y")
@@ -69,7 +69,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
 endif()
 
 # -- [ Debug Flags
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O1 -ggdb")
 
 # ---[ Flags
 if(UNIX OR APPLE)
@@ -78,6 +78,33 @@ endif()
 
 # ---[ Warnings
 peloton_warnings_disable(CMAKE_CXX_FLAGS -Wno-strict-aliasing)
+
+# Turn on sanitizers if necessary.
+if(USE_SANITIZER)
+    if (USE_SANITIZER STREQUAL "Address")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fsanitize=leak")
+    elseif (USE_SANITIZER STREQUAL "Undefined")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fno-sanitize=vptr,function -fno-sanitize-recover=all")
+        set(BLACKLIST_FILE "${CMAKE_SOURCE_DIR}/utils/sanitizers/ubsan_blacklist.txt")
+        if (EXISTS "${BLACKLIST_FILE}")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize-blacklist=${BLACKLIST_FILE}")
+        endif()
+    elseif (USE_SANITIZER STREQUAL "Thread")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
+    elseif (USE_SANITIZER STREQUAL "Address;Undefined" OR
+            USE_SANITIZER STREQUAL "Undefined;Address")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address,undefined -fno-sanitize=vptr,function -fno-sanitize-recover=all")
+    else()
+        message(FATAL_ERROR "Unsupported value of USE_SANITIZER: ${USE_SANITIZER}")
+    endif()
+    if (USE_SANITIZER MATCHES "(Undefined;)?Address(;Undefined)?")
+        check_cxx_compiler_flag(-fsanitize-address-use-after-scope FSANITIZE_USE_AFTER_SCOPE_FLAG)
+        if (${FSANITIZE_USE_AFTER_SCOPE_FLAG})
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize-address-use-after-scope")
+        endif()
+    endif()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold -fno-omit-frame-pointer -fno-optimize-sibling-calls")
+endif()
 
 # -- [ Coverage
 option(COVERALLS "Generate coveralls data" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
 endif()
 
 # -- [ Debug Flags
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O1 -ggdb")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O1 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 
 # ---[ Flags
 if(UNIX OR APPLE)
@@ -82,13 +82,9 @@ peloton_warnings_disable(CMAKE_CXX_FLAGS -Wno-strict-aliasing)
 # Turn on sanitizers if necessary.
 if(USE_SANITIZER)
     if (USE_SANITIZER STREQUAL "Address")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fsanitize=leak")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
     elseif (USE_SANITIZER STREQUAL "Undefined")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fno-sanitize=vptr,function -fno-sanitize-recover=all")
-        set(BLACKLIST_FILE "${CMAKE_SOURCE_DIR}/utils/sanitizers/ubsan_blacklist.txt")
-        if (EXISTS "${BLACKLIST_FILE}")
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize-blacklist=${BLACKLIST_FILE}")
-        endif()
     elseif (USE_SANITIZER STREQUAL "Thread")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
     elseif (USE_SANITIZER STREQUAL "Address;Undefined" OR
@@ -103,7 +99,9 @@ if(USE_SANITIZER)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize-address-use-after-scope")
         endif()
     endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold -fno-omit-frame-pointer -fno-optimize-sibling-calls")
+    if (CMAKE_COMPILER_IS_GNUCC)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold")
+    endif()
 endif()
 
 # -- [ Coverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
 endif()
 
 # -- [ Debug Flags
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O1 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 
 # ---[ Flags
 if(UNIX OR APPLE)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -39,12 +39,6 @@ endif()
 find_package(JeMalloc)
 include_directories(SYSTEM ${JEMALLOC_INCLUDE_DIR})
 
-
-# --[ Valgrind
-find_program(MEMORYCHECK_COMMAND valgrind)
-set(MEMORYCHECK_COMMAND_OPTIONS "--trace-children=yes --leak-check=full")
-set(MEMORYCHECK_SUPPRESSIONS_FILE "${PROJECT_SOURCE_DIR}/third_party/valgrind/valgrind.supp")
-
 # --[ PQXX
 find_package(PQXX REQUIRED)
 include_directories(SYSTEM ${PQXX_INCLUDE_DIRECTORIES})

--- a/src/include/parser/copy_statement.h
+++ b/src/include/parser/copy_statement.h
@@ -33,15 +33,20 @@ struct CopyStatement : SQLStatement {
         delimiter(','){};
 
   virtual ~CopyStatement() {
-    delete file_path;
-    delete cpy_table;
-  }
+    if (file_path != nullptr) {
+      delete[] file_path;
+    }
 
-  TableRef* cpy_table;
+    if (cpy_table != nullptr) {
+      delete cpy_table;
+    }
+  }
 
   virtual void Accept(SqlNodeVisitor* v) const override {
     v->Visit(this);
   }
+
+  TableRef* cpy_table;
 
   CopyType type;
 

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -195,20 +195,20 @@ struct CreateStatement : TableRefStatement {
         columns(nullptr){};
 
   virtual ~CreateStatement() {
-    if (columns) {
+    if (columns != nullptr) {
       for (auto col : *columns) delete col;
       delete columns;
     }
 
-    if (index_attrs) {
+    if (index_attrs != nullptr) {
       for (auto attr : *index_attrs) delete[] (attr);
       delete index_attrs;
     }
 
-    if (index_name) {
+    if (index_name != nullptr) {
       delete[] (index_name);
     }
-    if (database_name) {
+    if (database_name != nullptr) {
       delete[] (database_name);
     }
   }

--- a/src/include/parser/delete_statement.h
+++ b/src/include/parser/delete_statement.h
@@ -31,9 +31,13 @@ struct DeleteStatement : SQLStatement {
         table_ref(nullptr), expr(nullptr) {};
 
   virtual ~DeleteStatement() {
+    if (table_ref != nullptr) {
+      delete table_ref;
+    }
 
-    delete table_ref;
-    delete expr;
+    if (expr != nullptr) {
+      delete expr;
+    }
   }
 
   std::string GetTableName() const {

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -36,9 +36,17 @@ struct DropStatement : TableRefStatement {
       : TableRefStatement(StatementType::DROP), type(type), missing(false) {}
 
   virtual ~DropStatement() {
-    free(database_name);
-    free(index_name);
-    free(prep_stmt);
+    if (database_name != nullptr) {
+      delete[] database_name;
+    }
+
+    if (index_name != nullptr) {
+      delete[] index_name;
+    }
+
+    if (prep_stmt != nullptr) {
+      delete[] prep_stmt;
+    }
   }
 
   virtual void Accept(SqlNodeVisitor* v) const override {

--- a/src/include/parser/execute_statement.h
+++ b/src/include/parser/execute_statement.h
@@ -27,13 +27,21 @@ struct ExecuteStatement : SQLStatement {
       : SQLStatement(StatementType::EXECUTE), name(NULL), parameters(NULL) {}
 
   virtual ~ExecuteStatement() {
-    free (name);
-
-    if (parameters) {
-      for (auto expr : *parameters) delete expr;
+    if (name != nullptr) {
+      delete[] name;
     }
 
-    delete parameters;
+    if (parameters) {
+      for (auto expr : *parameters) {
+        if (expr != nullptr) {
+          delete expr;
+        }
+      }
+    }
+
+    if (parameters != nullptr) {
+      delete parameters;
+    }
   }
 
   virtual void Accept(SqlNodeVisitor* v) const override {

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -33,26 +33,34 @@ struct InsertStatement : SQLStatement {
         select(NULL) {}
 
   virtual ~InsertStatement() {
-    if (columns) {
-      for (auto col : *columns) delete[] col;
+    if (columns != nullptr) {
+      for (auto col : *columns) {
+        if (col != nullptr) {
+          delete[] col;
+        }
+      }
       delete columns;
     }
 
     if (insert_values) {
-      for (auto tuple : *insert_values) {
-        for (auto expr : *tuple) {
+      for (auto *tuple : *insert_values) {
+        for (auto *expr : *tuple) {
           // Why?
 //          if (expr->GetExpressionType() != ExpressionType::VALUE_PARAMETER)
-            delete expr;
+            if (expr != nullptr) delete expr;
         }
         delete tuple;
       }
       delete insert_values;
     }
 
-    delete select;
+    if (select != nullptr) {
+      delete select;
+    }
 
-    delete table_ref_;
+    if (table_ref_ != nullptr) {
+      delete table_ref_;
+    }
   }
 
   virtual void Accept(SqlNodeVisitor* v) const override { v->Visit(this); }

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -42,12 +42,14 @@ struct InsertStatement : SQLStatement {
       delete columns;
     }
 
-    if (insert_values) {
+    if (insert_values != nullptr) {
       for (auto *tuple : *insert_values) {
         for (auto *expr : *tuple) {
           // Why?
 //          if (expr->GetExpressionType() != ExpressionType::VALUE_PARAMETER)
-            if (expr != nullptr) delete expr;
+            if (expr != nullptr) {
+              delete expr;
+            }
         }
         delete tuple;
       }

--- a/src/include/parser/prepare_statement.h
+++ b/src/include/parser/prepare_statement.h
@@ -32,8 +32,12 @@ struct PrepareStatement : SQLStatement {
       : SQLStatement(StatementType::PREPARE), name(NULL), query(NULL) {}
 
   virtual ~PrepareStatement() {
-    delete query;
-    free(name);
+    if (query != nullptr) {
+      delete query;
+    }
+    if (name != nullptr) {
+      delete[] name;
+    }
   }
 
   /**

--- a/src/include/parser/select_statement.h
+++ b/src/include/parser/select_statement.h
@@ -103,19 +103,36 @@ struct SelectStatement : SQLStatement {
         is_for_update(false){};
 
   virtual ~SelectStatement() {
-    delete from_table;
+    if (from_table != nullptr) {
+      delete from_table;
+    }
 
-    if (select_list) {
-      for (auto expr : *select_list) delete expr;
+    if (select_list != nullptr) {
+      for (auto expr : *select_list) {
+        delete expr;
+      }
       delete select_list;
     }
 
-    delete where_clause;
-    delete group_by;
+    if (where_clause != nullptr) {
+      delete where_clause;
+    }
 
-    delete union_select;
-    delete order;
-    delete limit;
+    if (group_by != nullptr) {
+      delete group_by;
+    }
+
+    if (union_select != nullptr) {
+      delete union_select;
+    }
+
+    if (order != nullptr) {
+      delete order;
+    }
+
+    if (limit != nullptr) {
+      delete limit;
+    }
   }
 
   virtual void Accept(SqlNodeVisitor* v) const override {

--- a/src/include/parser/sql_statement.h
+++ b/src/include/parser/sql_statement.h
@@ -66,7 +66,11 @@ class TableRefStatement : public SQLStatement {
  public:
   TableRefStatement(StatementType type) : SQLStatement(type) {}
 
-  virtual ~TableRefStatement() { delete table_info_; }
+  virtual ~TableRefStatement() {
+    if (table_info_ != nullptr) {
+      delete table_info_;
+    }
+  }
 
   virtual inline std::string GetTableName() const { return table_info_->table_name; }
 

--- a/src/include/parser/update_statement.h
+++ b/src/include/parser/update_statement.h
@@ -62,14 +62,22 @@ struct UpdateStatement : SQLStatement {
         where(NULL) {}
 
   virtual ~UpdateStatement() {
-    delete table;
-
-    if (updates) {
-      for (auto clause : *updates) delete clause;
+    if (table != nullptr) {
+      delete table;
     }
 
-    delete updates;
-    if (where != NULL) delete where;
+    if (updates != nullptr) {
+      for (auto clause : *updates) {
+        if (clause != nullptr) {
+          delete clause;
+        }
+      }
+      delete updates;
+    }
+
+    if (where != nullptr) {
+      delete where;
+    }
   }
 
   virtual void Accept(SqlNodeVisitor* v) const override {

--- a/src/include/type/byte_array.h
+++ b/src/include/type/byte_array.h
@@ -90,7 +90,7 @@ class GenericArray {
   void resetAndExpand(int newLength) {
     PL_ASSERT(newLength >= 0);
     //data_ = boost::shared_array<T>(new T[newLength]);
-    data_ = std::shared_ptr<T>(new T[newLength]);
+    data_ = std::shared_ptr<T>(new T[newLength], std::default_delete<T[]>{});
     PL_MEMSET(data_.get(), 0, newLength * sizeof(T));
     length_ = newLength;
   };
@@ -100,7 +100,7 @@ class GenericArray {
     PL_ASSERT(newLength >= 0);
     PL_ASSERT(newLength > length_);
     //boost::shared_array<T> newData(new T[newLength]);
-    std::shared_ptr<T> newData(new T[newLength]);
+    std::shared_ptr<T> newData(new T[newLength], std::default_delete<T[]>{});
     PL_MEMSET(newData.get(), 0, newLength * sizeof(T)); // makes valgrind happy.
     PL_MEMCPY(newData.get(), data_.get(), length_ * sizeof(T));
     data_ = newData;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,8 +92,8 @@ foreach(test_src ${test_srcs} )
 	)   
 	
 	# add test
-    add_test(${test_name} ${CMAKE_BINARY_DIR}/test/${test_name} --gtest_color=yes
-            --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${test_name}.xml)
+  add_test(${test_name} ${CMAKE_BINARY_DIR}/test/${test_name} --gtest_color=yes
+           --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${test_name}.xml)
 	
 endforeach(test_src ${test_srcs})
 
@@ -130,7 +130,7 @@ foreach(perf_src ${perf_srcs} )
 	)   
 	
 	# add test
-	add_test(${perf_name} ${CMAKE_BINARY_DIR}/test/${perf_name}
-        --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${perf_name}.xml)
+	add_test(${perf_name} ${CMAKE_BINARY_DIR}/test/${perf_name} --gtest_color=yes
+           --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${perf_name}.xml)
 	
 endforeach(perf_src ${perf_srcs})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,23 +65,6 @@ add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_FLAGS} --verbose)
 
 ##################################################################################
 
-# --[ Memcheck
-
-find_program(MEMORYCHECK_COMMAND valgrind REQUIRED)
-
-# Note you can add '--gen-suppressions=all' to MEMORYCHECK_COMMAND_OPTIONS
-# if you want valgrind to print out the syntax to use to suppress a particular
-# memory leak
-set(MEMORYCHECK_COMMAND_OPTIONS
-    --trace-children=yes
-    --leak-check=full
-    --track-origins=yes
-    --soname-synonyms=somalloc=*jemalloc*
-    --error-exitcode=1)
-set(MEMORYCHECK_SUPPRESSIONS_FILE ${PROJECT_SOURCE_DIR}/third_party/valgrind/valgrind.supp)
-
-##################################################################################
-
 # --[ Functionality Tests
 
 foreach(test_src ${test_srcs} )
@@ -109,9 +92,8 @@ foreach(test_src ${test_srcs} )
 	)   
 	
 	# add test
-    add_test(${test_name} ${MEMORYCHECK_COMMAND} ${MEMORYCHECK_COMMAND_OPTIONS}
-        --suppressions=${MEMORYCHECK_SUPPRESSIONS_FILE} ${CMAKE_BINARY_DIR}/test/${test_name}
-        --gtest_output=xml:${CMAKE_BINARY_DIR}/test/unit_${test_name}.xml)
+    add_test(${test_name} ${CMAKE_BINARY_DIR}/test/${test_name} --gtest_color=yes
+            --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${test_name}.xml)
 	
 endforeach(test_src ${test_srcs})
 

--- a/test/gc/transaction_level_gc_manager_test.cpp
+++ b/test/gc/transaction_level_gc_manager_test.cpp
@@ -50,7 +50,7 @@ TEST_F(TransactionLevelGCManagerTests, StartGC) {
   gc_manager.StartGC(gc_threads);
   EXPECT_TRUE(gc_manager.GetStatus() == true);
 
-  std::this_thread::sleep_for(std::chrono::microseconds(100));
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
   gc_manager.StopGC();
   EXPECT_TRUE(gc_manager.GetStatus() == false);

--- a/test/planner/planner_test.cpp
+++ b/test/planner/planner_test.cpp
@@ -290,8 +290,12 @@ TEST_F(PlannerTests, InsertPlanTestParameterColumns) {
   auto table_ref = new parser::TableRef(TableReferenceType::NAME);
   table_ref->table_info_ = new parser::TableInfo();
   table_ref->table_info_->table_name = name;
+
+  auto id_col = new char[strlen("id") + 1], name_col = new char[strlen("name") + 1];
+  strcpy(id_col, "id");
+  strcpy(name_col, "name");
   insert_statement->table_ref_ = table_ref;
-  insert_statement->columns = new std::vector<char *>{strdup("id"), strdup("name")};
+  insert_statement->columns = new std::vector<char *>{id_col, name_col};
 
   // Value val =
   //    type::ValueFactory::GetNullValue();  // The value is not important

--- a/third_party/libcuckoo/cuckoohash_map.hh
+++ b/third_party/libcuckoo/cuckoohash_map.hh
@@ -662,7 +662,7 @@ private:
         const cuckoohash_map* map;
         std::array<size_t, N> i;
 
-        BucketContainer() : map(nullptr), i{} {}
+        BucketContainer() : map(nullptr) {}
 
         template <typename... Args>
         BucketContainer(const cuckoohash_map* _map, Args&&... inds)

--- a/third_party/libcuckoo/cuckoohash_map.hh
+++ b/third_party/libcuckoo/cuckoohash_map.hh
@@ -662,7 +662,7 @@ private:
         const cuckoohash_map* map;
         std::array<size_t, N> i;
 
-        BucketContainer() : map(nullptr) {}
+        BucketContainer() : map(nullptr), i{} {}
 
         template <typename... Args>
         BucketContainer(const cuckoohash_map* _map, Args&&... inds)


### PR DESCRIPTION
This PR replaces Valgrind with `-fsanitize` flags. Valgrind took more than an hour to run all the tests whereas the test suite runs under 10mins with the sanitization flags.

Sanitization flags are enabled through the `USE_SANITIZER` cmake option. We currently support three sanitizers: Address, Thread, and Undefined. Address sanitization ([ASan](https://clang.llvm.org/docs/AddressSanitizer.html)) detects various memory-related problems. Thread sanitization ([TSan](https://clang.llvm.org/docs/ThreadSanitizer.html)) detects data races. Undefined behavior sanitization ([UBSan](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)) detects misaligned pointer usage, overflows etc.

This isn't ready to be merged, but feedback is welcome.