### PR TITLE
fix apt-get install errors on ubuntu when run via vagrant on OSX

### DIFF
--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -66,10 +66,11 @@ if [ "$DISTRO" = "UBUNTU" ]; then
     # Fix for LLVM-3.7 on Ubuntu 14.04
     if [ "$DISTRO_VER" == "14.04" ]; then
         sudo add-apt-repository 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main'
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
         sudo apt-get update
     fi
 
-    sudo apt-get --ignore-missing -y install \
+    sudo apt-get --force-yes --ignore-missing -y install \
         git \
         g++ \
         cmake \


### PR DESCRIPTION
Running packages install via packages.sh seem to fail due to apt-get errors. 
I am running peloton via vagrant setup provided on the installation page. 
Os version: Mac OS X 10.12.5.

This PR fixes it and I am able to build and install peloton successfully after this.

Thanks,
Arun