### PR TITLE
Change Plan Executor API into accepting a shared_ptr.

### DIFF
--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -129,11 +129,11 @@ ExecuteResult PlanExecutor::ExecutePlan(
 
     result.clear();
 
-    // Bind: casting const should be removed with later refactoring executor
-    planner::AbstractPlan *planp = plan.get();
+    // Perform binding
     planner::BindingContext context;
-    planp->PerformBinding(context);
+    plan->PerformBinding(context);
 
+    // Prepare output buffer
     std::vector<oid_t> columns;
     plan->GetOutputColumns(columns);
     codegen::BufferingConsumer consumer{columns, context};

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -44,11 +44,12 @@ void CleanExecutorTree(executor::AbstractExecutor *root);
  * value list directly rather than passing Postgres's ParamListInfo
  * @return status of execution.
  */
-ExecuteResult PlanExecutor::ExecutePlan(const planner::AbstractPlan *plan,
-                                        concurrency::Transaction *txn,
-                                        const std::vector<type::Value> &params,
-                                        std::vector<StatementResult> &result,
-                                        const std::vector<int> &result_format) {
+ExecuteResult PlanExecutor::ExecutePlan(
+    std::shared_ptr<planner::AbstractPlan> plan,
+    concurrency::Transaction *txn,
+    const std::vector<type::Value> &params,
+    std::vector<StatementResult> &result,
+    const std::vector<int> &result_format) {
   ExecuteResult p_status;
   if (plan == nullptr) return p_status;
 
@@ -69,7 +70,7 @@ ExecuteResult PlanExecutor::ExecutePlan(const planner::AbstractPlan *plan,
 
     // Build the executor tree
     std::unique_ptr<executor::AbstractExecutor> executor_tree(
-        BuildExecutorTree(nullptr, plan, executor_context.get()));
+        BuildExecutorTree(nullptr, plan.get(), executor_context.get()));
 
     LOG_TRACE("Initializing the executor tree");
 
@@ -129,7 +130,7 @@ ExecuteResult PlanExecutor::ExecutePlan(const planner::AbstractPlan *plan,
     result.clear();
 
     // Bind: casting const should be removed with later refactoring executor
-    planner::AbstractPlan *planp = const_cast<planner::AbstractPlan *>(plan);
+    planner::AbstractPlan *planp = plan.get();
     planner::BindingContext context;
     planp->PerformBinding(context);
 

--- a/src/include/executor/plan_executor.h
+++ b/src/include/executor/plan_executor.h
@@ -67,7 +67,7 @@ class PlanExecutor {
    * Before ExecutePlan, a node first receives value list, so we should
    * pass value list directly rather than passing Postgres's ParamListInfo
    */
-  static ExecuteResult ExecutePlan(const planner::AbstractPlan *plan,
+  static ExecuteResult ExecutePlan(std::shared_ptr<planner::AbstractPlan> plan,
                                     concurrency::Transaction* txn,
                                     const std::vector<type::Value> &params,
                                     std::vector<StatementResult> &result,

--- a/src/include/tcop/tcop.h
+++ b/src/include/tcop/tcop.h
@@ -66,7 +66,8 @@ class TrafficCop {
   // ExecutePrepStmt - Helper to handle txn-specifics for the plan-tree of a
   // statement
   executor::ExecuteResult ExecuteStatementPlan(
-      const planner::AbstractPlan *plan, const std::vector<type::Value> &params,
+      std::shared_ptr<planner::AbstractPlan> plan,
+      const std::vector<type::Value> &params,
       std::vector<StatementResult> &result, const std::vector<int> &result_format,
       const size_t thread_id = 0);
 

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -196,7 +196,7 @@ ResultType TrafficCop::ExecuteStatement(
     else if (statement->GetQueryType() == "ROLLBACK")
       return AbortQueryHelper();
     else {
-      auto status = ExecuteStatementPlan(statement->GetPlanTree().get(), params,
+      auto status = ExecuteStatementPlan(statement->GetPlanTree(), params,
                                          result, result_format,
                                          thread_id);
       LOG_TRACE("Statement executed. Result: %s",
@@ -211,8 +211,10 @@ ResultType TrafficCop::ExecuteStatement(
 }
 
 executor::ExecuteResult TrafficCop::ExecuteStatementPlan(
-    const planner::AbstractPlan *plan, const std::vector<type::Value> &params,
-    std::vector<StatementResult> &result, const std::vector<int> &result_format,
+    std::shared_ptr<planner::AbstractPlan> plan,
+    const std::vector<type::Value> &params,
+    std::vector<StatementResult> &result,
+    const std::vector<int> &result_format,
     const size_t thread_id) {
   concurrency::Transaction *txn;
   bool single_statement_txn = false, init_failure = false;

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -56,7 +56,7 @@ void SetupTables() {
     auto parse_tree = parser.BuildParseTree(sql);
     statement->SetPlanTree(optimizer.BuildPelotonPlanTree(parse_tree));
     auto status = traffic_cop.ExecuteStatementPlan(
-        statement->GetPlanTree().get(), params, result, result_format);
+        statement->GetPlanTree(), params, result, result_format);
     LOG_INFO("Table create result: %s",
              ResultTypeToString(status.m_result).c_str());
   }

--- a/test/executor/copy_test.cpp
+++ b/test/executor/copy_test.cpp
@@ -83,7 +83,7 @@ TEST_F(CopyTests, Copying) {
     std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
     std::vector<StatementResult> result;
     executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
-        statement->GetPlanTree().get(), params, result, result_format);
+        statement->GetPlanTree(), params, result, result_format);
     EXPECT_EQ(status.m_result, peloton::ResultType::SUCCESS);
     LOG_TRACE("Statement executed. Result: %s",
               ResultTypeToString(status.m_result).c_str());

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -85,7 +85,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
   LOG_INFO("Table Created");
@@ -121,7 +121,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   LOG_INFO("Executing plan...");
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -148,7 +148,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   LOG_INFO("Executing plan...");
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -60,7 +60,7 @@ void ShowTable(std::string database_name, std::string table_name) {
   auto tuple_descriptor = tcop::TrafficCop().GenerateTupleDescriptor(
       (parser::SelectStatement*)select_stmt->GetStatement(0));
   result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
 }
 
@@ -125,7 +125,7 @@ TEST_F(DeleteTests, VariousOperations) {
   std::vector<int> result_format;
   result_format = std::move(std::vector<int>(0, 0));
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
   LOG_INFO("Tuple inserted!");
@@ -148,7 +148,7 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -172,7 +172,7 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -198,7 +198,7 @@ TEST_F(DeleteTests, VariousOperations) {
   auto tuple_descriptor =
       tcop::TrafficCop().GenerateTupleDescriptor(select_stmt->GetStatement(0));
   result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -219,7 +219,7 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -242,7 +242,7 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -214,7 +214,7 @@ TEST_F(UpdateTests, UpdatingOld) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
   LOG_INFO("Tuple inserted!");
@@ -241,7 +241,7 @@ TEST_F(UpdateTests, UpdatingOld) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -270,7 +270,7 @@ TEST_F(UpdateTests, UpdatingOld) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -295,7 +295,7 @@ TEST_F(UpdateTests, UpdatingOld) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -321,7 +321,7 @@ TEST_F(UpdateTests, UpdatingOld) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -63,7 +63,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
 
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
   LOG_INFO("Table Created");
@@ -87,7 +87,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
 
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -113,7 +113,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
 
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -134,7 +134,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
 
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -153,7 +153,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(select_stmt));
 
   result_format = std::move(std::vector<int>(4, 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/optimizer/simple_optimizer_test.cpp
+++ b/test/optimizer/simple_optimizer_test.cpp
@@ -71,7 +71,7 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree(), params, result, result_format);
   LOG_TRACE("Statement executed. Result: %s",
             ResultTypeToString(status.m_result).c_str());
   LOG_TRACE("Table Created");
@@ -101,7 +101,7 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
 
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_TRACE("Statement executed. Result: %s",
             ResultTypeToString(status.m_result).c_str());
@@ -122,7 +122,7 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
 
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_TRACE("Statement executed. Result: %s",
             ResultTypeToString(status.m_result).c_str());

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -79,7 +79,7 @@ ResultType TestingSQLUtil::ExecuteSQLQueryWithOptimizer(
 
   try {
     LOG_DEBUG("%s", planner::PlanUtil::GetInfo(plan.get()).c_str());
-    auto status = traffic_cop_.ExecuteStatementPlan(plan.get(), params, result,
+    auto status = traffic_cop_.ExecuteStatementPlan(plan, params, result,
                                                     result_format);
     rows_changed = status.m_processed;
     LOG_INFO("Statement executed. Result: %s",

--- a/test/statistics/testing_stats_util.cpp
+++ b/test/statistics/testing_stats_util.cpp
@@ -47,7 +47,7 @@ void TestingStatsUtil::ShowTable(std::string database_name,
   LOG_DEBUG("%s",
             planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
-  traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(), params,
+  traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(), params,
                                    result, result_format);
 }
 


### PR DESCRIPTION
This PR changes `PlanExecutor::ExecutePlan()` into accepting a `std::shared_ptr<planner::AbstractPlan>` instead of a `const planner::AbstractPlan *`.

This is the minimal change to allow a cache to hold ownership of the plan, which solves https://github.com/cmu-db/peloton/issues/643.