### PR TITLE
keyword case insensitive issue

### DIFF
--- a/src/common/statement.cpp
+++ b/src/common/statement.cpp
@@ -29,6 +29,10 @@ void Statement::ParseQueryType(const std::string& query_string,
                                std::string& query_type) {
   std::stringstream stream(query_string);
   stream >> query_type;
+	if (query_type.back() == ';') {
+		query_type = query_type.substr(0, query_type.length() - 1);
+	}
+	boost::to_upper(query_type);
 }
 
 std::vector<FieldInfo> Statement::GetTupleDescriptor() const {

--- a/src/common/statement.cpp
+++ b/src/common/statement.cpp
@@ -16,23 +16,40 @@
 #include "planner/abstract_plan.h"
 
 namespace peloton {
+ std::unordered_map<std::string, QueryType> Statement::query_type_map_ {
+    {"BEGIN", QueryType::QUERY_BEGIN}, {"COMMIT", QueryType::QUERY_COMMIT},
+    {"ROLLBACK", QueryType::QUERY_ROLLBACK}, {"SET", QueryType::QUERY_SET},
+    {"SHOW", QueryType::QUERY_SHOW}, {"INSERT", QueryType::QUERY_INSERT},
+    {"PREPARE", QueryType::QUERY_PREPARE}, {"EXECUTE", QueryType::QUERY_EXECUTE}
+  };
 
 Statement::Statement(const std::string& statement_name,
                      const std::string& query_string)
     : statement_name_(statement_name), query_string_(query_string) {
-  ParseQueryType(query_string_, query_type_);
+  ParseQueryTypeString(query_string_, query_type_string_);
+  MapToQueryType(query_type_string_, query_type_);
 }
 
 Statement::~Statement() {}
 
-void Statement::ParseQueryType(const std::string& query_string,
-                               std::string& query_type) {
+void Statement::ParseQueryTypeString(const std::string& query_string,
+                               std::string& query_type_string) {
   std::stringstream stream(query_string);
-  stream >> query_type;
-	if (query_type.back() == ';') {
-		query_type = query_type.substr(0, query_type.length() - 1);
-	}
-	boost::to_upper(query_type);
+  stream >> query_type_string;
+  if (query_type_string.back() == ';') {
+    query_type_string = query_type_string.substr(0, query_type_string.length() - 1);
+  }
+  boost::to_upper(query_type_string);
+}
+
+void Statement::MapToQueryType(const std::string& query_type_string, QueryType& query_type) {
+  std::unordered_map<std::string, QueryType>::iterator it;
+  it  = query_type_map_.find(query_type_string);
+  if (it != query_type_map_.end()) {
+    query_type = it -> second;
+  } else {
+    query_type = QueryType::QUERY_OTHER;
+  }
 }
 
 std::vector<FieldInfo> Statement::GetTupleDescriptor() const {
@@ -51,7 +68,9 @@ void Statement::SetQueryString(const std::string& query_string) {
 
 std::string Statement::GetQueryString() const { return query_string_; }
 
-std::string Statement::GetQueryType() const { return query_type_; }
+std::string Statement::GetQueryTypeString() const { return query_type_string_; }
+
+QueryType Statement::GetQueryType() const { return query_type_; }
 
 void Statement::SetParamTypes(const std::vector<int32_t>& param_types) {
   param_types_ = param_types;
@@ -104,7 +123,7 @@ const std::string Statement::GetInfo() const {
   os << ", ReplanNeeded=" << needs_replan_;
 
   // Query Type
-  os << ", QueryType=" << query_type_;
+  os << ", QueryType=" << query_type_string_;
 
   os << ")";
 

--- a/src/include/common/statement.h
+++ b/src/include/common/statement.h
@@ -44,8 +44,11 @@ class Statement : public Printable {
 
   ~Statement();
 
-  static void ParseQueryType(const std::string& query_string,
-                             std::string& query_type);
+  static void ParseQueryTypeString(const std::string& query_string,
+                             std::string& query_type_string);
+ 
+  static void MapToQueryType(const std::string& query_type_string,
+                             QueryType& query_type);
 
   std::vector<FieldInfo> GetTupleDescriptor() const;
 
@@ -57,7 +60,9 @@ class Statement : public Printable {
 
   std::string GetQueryString() const;
 
-  std::string GetQueryType() const;
+  std::string GetQueryTypeString() const;
+
+  QueryType GetQueryType() const;
 
   void SetParamTypes(const std::vector<int32_t>& param_types);
 
@@ -88,7 +93,12 @@ class Statement : public Printable {
   std::string query_string_;
 
   // first token in query
-  std::string query_type_;
+  // Keep the string token of the query_type because it is returned 
+  // as responses after executing commands.
+  std::string query_type_string_;
+
+  // enum value of query_type
+  QueryType query_type_;
 
   // format codes of the parameters
   std::vector<int32_t> param_types_;
@@ -105,6 +115,10 @@ class Statement : public Printable {
 
   // If this flag is true, then somebody wants us to replan this query
   bool needs_replan_ = false;
-};
 
+  // containing pairs of <query_type_string, query_type>
+  // use map to speed up searching
+  static std::unordered_map<std::string, QueryType> query_type_map_;
+
+};
 }  // namespace peloton

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -665,6 +665,22 @@ StatementType StringToStatementType(const std::string &str);
 std::ostream &operator<<(std::ostream &os, const StatementType &type);
 
 //===--------------------------------------------------------------------===//
+// Query Types
+//===--------------------------------------------------------------------===//
+
+enum class QueryType {
+  QUERY_BEGIN,                // begin query
+  QUERY_COMMIT,               // commit query
+  QUERY_ROLLBACK,             // rollback query
+  QUERY_INSERT,               // insert query
+  QUERY_SET,                  // set query
+  QUERY_SHOW,                 // show query
+  QUERY_PREPARE,	      // prepare query
+  QUERY_EXECUTE, 	      // execute query
+  QUERY_OTHER,                // other queries
+};
+
+//===--------------------------------------------------------------------===//
 // Scan Direction Types
 //===--------------------------------------------------------------------===//
 

--- a/src/include/wire/packet_manager.h
+++ b/src/include/wire/packet_manager.h
@@ -131,7 +131,7 @@ class PacketManager {
 
   // Used to send a packet that indicates the completion of a query. Also has
   // txn state mgmt
-  void CompleteCommand(const std::string& query_type, int rows);
+  void CompleteCommand(const std::string& query_type_string, const QueryType& query_type, int rows);
 
   // Specific response for empty or NULL queries
   void SendEmptyQueryResponse();
@@ -146,7 +146,7 @@ class PacketManager {
    * Also, duplicate BEGINs and COMMITs shouldn't be executed.
    * This function helps filtering out the execution for such cases
    */
-  bool HardcodedExecuteFilter(std::string query_type);
+  bool HardcodedExecuteFilter(QueryType query_type);
 
   /* Execute a Simple query protocol message */
   void ExecQueryMessage(InputPacket* pkt, const size_t thread_id);
@@ -182,7 +182,7 @@ class PacketManager {
   // state to mang skipped queries
   bool skipped_stmt_ = false;
   std::string skipped_query_string_;
-  std::string skipped_query_type_;
+  QueryType skipped_query_type_;
 
   // Statement cache
   // StatementName -> Statement

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -188,19 +188,21 @@ ResultType TrafficCop::ExecuteStatement(
             planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
 
   try {
-    if (statement->GetQueryType() == "BEGIN")
-      return BeginQueryHelper(thread_id);
-    else if (statement->GetQueryType() == "COMMIT")
-      return CommitQueryHelper();
-    else if (statement->GetQueryType() == "ROLLBACK")
-      return AbortQueryHelper();
-    else {
-      auto status = ExecuteStatementPlan(statement->GetPlanTree().get(), params,
-                                         result, result_format, thread_id);
-      LOG_TRACE("Statement executed. Result: %s",
-                ResultTypeToString(status.m_result).c_str());
-      rows_changed = status.m_processed;
-      return status.m_result;
+    switch(statement->GetQueryType()) {
+      case QueryType::QUERY_BEGIN:
+        return BeginQueryHelper(thread_id);
+      case QueryType::QUERY_COMMIT:
+        return CommitQueryHelper();
+      case QueryType::QUERY_ROLLBACK:
+        return AbortQueryHelper();
+      default:
+        auto status = ExecuteStatementPlan(statement->GetPlanTree().get(), params,
+                                           result, result_format,
+                                           thread_id);
+        LOG_TRACE("Statement executed. Result: %s",
+                  ResultTypeToString(status.m_result).c_str());
+        rows_changed = status.m_processed;
+        return status.m_result;
     }
   } catch (Exception &e) {
     error_message = e.what();

--- a/src/wire/packet_manager.cpp
+++ b/src/wire/packet_manager.cpp
@@ -275,31 +275,29 @@ void PacketManager::SendDataRows(std::vector<StatementResult> &results,
   rows_affected = numrows;
 }
 
-void PacketManager::CompleteCommand(const std::string &query_type, int rows) {
+void PacketManager::CompleteCommand(const std::string &query, const QueryType& query_type, int rows) {
   std::unique_ptr<OutputPacket> pkt(new OutputPacket());
   pkt->msg_type = NetworkMessageType::COMMAND_COMPLETE;
-  std::string tag = query_type;
-  /* After Begin, we enter a txn block */
-  if (query_type.compare("BEGIN") == 0) {
-    txn_state_ = NetworkTransactionStateType::BLOCK;
-  }
-  /* After commit, we end the txn block */
-  else if (query_type.compare("COMMIT") == 0) {
-    txn_state_ = NetworkTransactionStateType::IDLE;
-  }
-  /* After rollback, the txn block is ended */
-  else if (!query_type.compare("ROLLBACK")) {
-    txn_state_ = NetworkTransactionStateType::IDLE;
-  }
-  /* the rest are custom status messages for each command */
-  else if (!query_type.compare("INSERT")) {
-    tag += " 0 " + std::to_string(rows);
-  } else {
-    tag += " " + std::to_string(rows);
-  }
-  PacketPutString(pkt.get(), tag);
-
-  responses.push_back(std::move(pkt));
+  std::string tag = query;
+  switch (query_type) {
+    /* After Begin, we enter a txn block */
+    case QueryType::QUERY_BEGIN:
+      txn_state_ = NetworkTransactionStateType::BLOCK;
+      break;
+    /* After commit, we end the txn block */
+    case QueryType::QUERY_COMMIT:
+    /* After rollback, the txn block is ended */
+    case QueryType::QUERY_ROLLBACK:
+      txn_state_ = NetworkTransactionStateType::IDLE;
+      break;
+    case QueryType::QUERY_INSERT:
+      tag += " 0 " + std::to_string(rows);
+      break;
+    default:
+      tag += " " + std::to_string(rows);
+   }     
+   PacketPutString(pkt.get(), tag);
+   responses.push_back(std::move(pkt));
 }
 
 /*
@@ -311,23 +309,27 @@ void PacketManager::SendEmptyQueryResponse() {
   responses.push_back(std::move(response));
 }
 
-bool PacketManager::HardcodedExecuteFilter(std::string query_type) {
-  // Skip SET
-  if (query_type.compare("SET") == 0 || query_type.compare("SHOW") == 0)
-    return false;
-  // skip duplicate BEGIN
-  if (!query_type.compare("BEGIN") &&
-      txn_state_ == NetworkTransactionStateType::BLOCK) {
-    return false;
+bool PacketManager::HardcodedExecuteFilter(QueryType query_type) {
+  switch (query_type) {
+    // Skip SET
+    case QueryType::QUERY_SET:
+    case QueryType::QUERY_SHOW:
+      return false;
+    // Skip duplicate BEGIN
+    case QueryType::QUERY_BEGIN:
+      if (txn_state_ == NetworkTransactionStateType::BLOCK) {
+        return false;  
+      }
+      break;
+    // Skip duuplicate Commits and Rollbacks
+    case QueryType::QUERY_COMMIT:
+    case QueryType::QUERY_ROLLBACK:
+      if (txn_state_ == NetworkTransactionStateType::IDLE) {
+        return false;
+      }
+    default:
+      break;
   }
-  // skip duplicate Commits
-  if (!query_type.compare("COMMIT") &&
-      txn_state_ == NetworkTransactionStateType::IDLE)
-    return false;
-  // skip duplicate Rollbacks
-  if (!query_type.compare("ROLLBACK") &&
-      txn_state_ == NetworkTransactionStateType::IDLE)
-    return false;
   return true;
 }
 
@@ -352,102 +354,111 @@ void PacketManager::ExecQueryMessage(InputPacket *pkt, const size_t thread_id) {
     std::vector<FieldInfo> tuple_descriptor;
     std::string error_message;
     int rows_affected = 0;
-    std::string query_type;
 
-    std::stringstream stream(query);
-    stream >> query_type;
+    QueryType query_type;
+    Statement::MapToQueryType(query, query_type);
+      std::stringstream stream(query);
 
-    if (query_type.compare("PREPARE") == 0) {
-      std::string statement_name;
-      stream >> statement_name;
-      std::size_t pos = query.find("AS");
-      std::string statement_query = query.substr(pos + 3);
-      boost::trim(statement_query);
+    switch (query_type) {
+      case QueryType::QUERY_PREPARE:
+      {
+        std::string statement_name;
+        stream >> statement_name;
+        std::size_t pos = query.find("AS");
+        std::string statement_query = query.substr(pos + 3);
+        boost::trim(statement_query);
 
-      // Prepare statement
-      std::shared_ptr<Statement> statement(nullptr);
+        // Prepare statement
+        std::shared_ptr<Statement> statement(nullptr);
 
-      LOG_DEBUG("PrepareStatement[%s] => %s", statement_name.c_str(),
+        LOG_DEBUG("PrepareStatement[%s] => %s", statement_name.c_str(),
                 statement_query.c_str());
 
-      statement = traffic_cop_->PrepareStatement(statement_name, statement_query,
+        statement = traffic_cop_->PrepareStatement(statement_name, statement_query,
                                                  error_message);
-      if (statement.get() == nullptr) {
-        skipped_stmt_ = true;
-        SendErrorResponse(
-            {{NetworkMessageType::HUMAN_READABLE_ERROR, error_message}});
-        LOG_TRACE("ExecQuery Error");
-        return;
-      }
-
-      auto entry = std::make_pair(statement_name, statement);
-      statement_cache_.insert(entry);
-      for (auto table_id : statement->GetReferencedTables()) {
-        table_statement_cache_[table_id].push_back(statement.get());
-      }
-    } else if (query_type.compare("EXECUTE") == 0) {
-      std::string statement_name;
-      std::shared_ptr<Statement> statement;
-      std::vector<type::Value> param_values;
-      bool unnamed = false;
-      std::vector<std::string> tokens;
-
-      boost::split(tokens, query, boost::is_any_of("(), "));
-
-      statement_name = tokens.at(1);
-      auto statement_cache_itr = statement_cache_.find(statement_name);
-      if (statement_cache_itr != statement_cache_.end()) {
-        statement = *statement_cache_itr;
-      }
-      // Did not find statement with same name
-      else {
-        std::string error_message = "The prepared statement does not exist";
-        LOG_ERROR("%s", error_message.c_str());
-        SendErrorResponse(
-            {{NetworkMessageType::HUMAN_READABLE_ERROR, error_message}});
-        SendReadyForQuery(NetworkTransactionStateType::IDLE);
-        return;
-      }
-
-      std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
-
-      for (std::size_t idx = 2; idx < tokens.size(); idx++) {
-        std::string param_str = tokens.at(idx);
-        boost::trim(param_str);
-        if (param_str.empty()) {
-          continue;
+        if (statement.get() == nullptr) {
+          skipped_stmt_ = true;
+          SendErrorResponse(
+              {{NetworkMessageType::HUMAN_READABLE_ERROR, error_message}});
+          LOG_TRACE("ExecQuery Error");
+          return;
         }
-        param_values.push_back(type::ValueFactory::GetVarcharValue(param_str));
-      }
 
-      if (param_values.size() > 0) {
-        statement->GetPlanTree()->SetParameterValues(&param_values);
+        auto entry = std::make_pair(statement_name, statement);
+        statement_cache_.insert(entry);
+        for (auto table_id : statement->GetReferencedTables()) {
+          table_statement_cache_[table_id].push_back(statement.get());
+        }
+        break;
       }
+      case QueryType::QUERY_EXECUTE:
+      {
+        std::string statement_name;
+        std::shared_ptr<Statement> statement;
+        std::vector<type::Value> param_values;
+        bool unnamed = false;
+        std::vector<std::string> tokens;
 
-      auto status =
-              traffic_cop_->ExecuteStatement(statement, param_values, unnamed, nullptr, result_format,
+        boost::split(tokens, query, boost::is_any_of("(), "));
+
+        statement_name = tokens.at(1);
+        auto statement_cache_itr = statement_cache_.find(statement_name);
+        if (statement_cache_itr != statement_cache_.end()) {
+          statement = *statement_cache_itr;
+        }
+        // Did not find statement with same name
+        else {
+          std::string error_message = "The prepared statement does not exist";
+          LOG_ERROR("%s", error_message.c_str());
+          SendErrorResponse(
+              {{NetworkMessageType::HUMAN_READABLE_ERROR, error_message}});
+          SendReadyForQuery(NetworkTransactionStateType::IDLE);
+          return;
+        }
+
+        std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
+
+        for (std::size_t idx = 2; idx < tokens.size(); idx++) {
+          std::string param_str = tokens.at(idx);
+          boost::trim(param_str);
+          if (param_str.empty()) {
+            continue;
+          }
+          param_values.push_back(type::ValueFactory::GetVarcharValue(param_str));
+        }
+
+        if (param_values.size() > 0) {
+          statement->GetPlanTree()->SetParameterValues(&param_values);
+        }
+
+        auto status =
+                traffic_cop_->ExecuteStatement(statement, param_values, unnamed, nullptr, result_format,
                              result, rows_affected, error_message, thread_id);
 
-      if (status == ResultType::SUCCESS) {
-        tuple_descriptor = std::move(statement->GetTupleDescriptor());
-      } else {
-        SendErrorResponse(
-              {{NetworkMessageType::HUMAN_READABLE_ERROR, error_message}});
-        SendReadyForQuery(NetworkTransactionStateType::IDLE);
-        return;
+        if (status == ResultType::SUCCESS) {
+          tuple_descriptor = std::move(statement->GetTupleDescriptor());
+        } else {
+          SendErrorResponse(
+                {{NetworkMessageType::HUMAN_READABLE_ERROR, error_message}});
+          SendReadyForQuery(NetworkTransactionStateType::IDLE);
+          return;
+        }
+      	break;
       }
-    } else {
-      // execute the query using tcop
-      auto status = traffic_cop_->ExecuteStatement(
-          query, result, tuple_descriptor, rows_affected, error_message,
-          thread_id);
+      default:
+      {
+        // execute the query using tcop
+        auto status = traffic_cop_->ExecuteStatement(
+            query, result, tuple_descriptor, rows_affected, error_message,
+            thread_id);
 
       // check status
-      if (status == ResultType::FAILURE) {
-        SendErrorResponse(
-          {{NetworkMessageType::HUMAN_READABLE_ERROR, error_message}});
-        SendReadyForQuery(NetworkTransactionStateType::IDLE);
-        return;
+        if (status == ResultType::FAILURE) {
+          SendErrorResponse(
+            {{NetworkMessageType::HUMAN_READABLE_ERROR, error_message}});
+          SendReadyForQuery(NetworkTransactionStateType::IDLE);
+          return;
+        }
       }
     }
 
@@ -457,9 +468,8 @@ void PacketManager::ExecQueryMessage(InputPacket *pkt, const size_t thread_id) {
     // send the result rows
     SendDataRows(result, tuple_descriptor.size(), rows_affected);
 
-    CompleteCommand(query_type, rows_affected);
-
-  // handle the case when the string is "  ;"
+    // The response to the SimpleQueryCommand is the query string.
+    CompleteCommand(query, query_type, rows_affected);
   } else {
     SendEmptyQueryResponse();
   }
@@ -477,14 +487,16 @@ void PacketManager::ExecQueryMessage(InputPacket *pkt, const size_t thread_id) {
  * exec_parse_message - handle PARSE message
  */
 void PacketManager::ExecParseMessage(InputPacket *pkt) {
-  std::string error_message, statement_name, query_string, query_type;
+  std::string error_message, statement_name, query_string, query_type_string;
   GetStringToken(pkt, statement_name);
+  QueryType query_type;
 
   // Read prepare statement name
   // Read query string
   GetStringToken(pkt, query_string);
   skipped_stmt_ = false;
-  Statement::ParseQueryType(query_string, query_type);
+  Statement::ParseQueryTypeString(query_string, query_type_string);
+  Statement::MapToQueryType(query_type_string, query_type);
 
   // For an empty query or a query to be filtered, just send parse complete
   // response and don't execute
@@ -901,7 +913,10 @@ void PacketManager::ExecExecuteMessage(InputPacket *pkt,
     if (skipped_query_string_ == "") {
       SendEmptyQueryResponse();
     } else {
-      CompleteCommand(skipped_query_type_, rows_affected);
+      std::string skipped_query_type_string;
+      Statement::ParseQueryTypeString(skipped_query_string_, skipped_query_type_string);
+      // The response to ExecuteCommand is the query_type string token.
+      CompleteCommand(skipped_query_type_string, skipped_query_type_, rows_affected);
     }
     skipped_stmt_ = false;
     return;
@@ -943,7 +958,7 @@ void PacketManager::ExecExecuteMessage(InputPacket *pkt,
           {{NetworkMessageType::HUMAN_READABLE_ERROR, error_message}});
       return;
     case ResultType::ABORTED:
-      if (query_type != "ROLLBACK") {
+      if (query_type != QueryType::QUERY_ROLLBACK) {
         LOG_DEBUG("Failed to execute: Conflicting txn aborted");
         // Send an error response if the abort is not due to ROLLBACK query
         SendErrorResponse({{NetworkMessageType::SQLSTATE_CODE_ERROR,
@@ -954,7 +969,8 @@ void PacketManager::ExecExecuteMessage(InputPacket *pkt,
     default: {
       auto tuple_descriptor = statement->GetTupleDescriptor();
       SendDataRows(results, tuple_descriptor.size(), rows_affected);
-      CompleteCommand(query_type, rows_affected);
+      // The reponse to ExecuteCommand is the query_type string token.
+      CompleteCommand(statement->GetQueryTypeString(), query_type, rows_affected);
       return;
     }
   }
@@ -1095,7 +1111,6 @@ void PacketManager::Reset() {
   txn_state_ = NetworkTransactionStateType::IDLE;
   skipped_stmt_ = false;
   skipped_query_string_.clear();
-  skipped_query_type_.clear();
 
   statement_cache_.clear();
   table_statement_cache_.clear();


### PR DESCRIPTION
1. The query_type is still of string type. Convert it to upper case to match the keywords('BEGIN',  'END', 'ROLLBACK') 
2. Originally the query_type was generated by splitting the query_string using blank characters.(https://github.com/cmu-db/peloton/blob/master/src/common/statement.cpp#L31) A special case is that when the query is 'BEGIN;', it takes query_type as 'BEGIN;' instead of 'BEGIN'. In this case, remove the ending semi-colon.