### PR TITLE
Codegen cache

### DIFF
--- a/src/codegen/plan_comparator.cpp
+++ b/src/codegen/plan_comparator.cpp
@@ -1,0 +1,554 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// plan_comparator.cpp
+//
+// Identification: src/codegen/plan_comparator.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "codegen/plan_comparator.h"
+#include "expression/constant_value_expression.h"
+#include "expression/parameter_value_expression.h"
+#include "expression/tuple_value_expression.h"
+
+namespace peloton {
+namespace codegen {
+
+//===----------------------------------------------------------------------===//
+// Compare two plans
+//===----------------------------------------------------------------------===//
+int PlanComparator::Compare(const planner::AbstractPlan &A,
+                            const planner::AbstractPlan &B) {
+  PlanNodeType nodeTypeA = A.GetPlanNodeType();
+  PlanNodeType nodeTypeB = B.GetPlanNodeType();
+  if (nodeTypeA != nodeTypeB) {
+    return nodeTypeA < nodeTypeB ? -1 : 1;
+  }
+  switch (nodeTypeA) {
+    case PlanNodeType::SEQSCAN:
+      return CompareSeqScan((planner::SeqScanPlan &)A,
+                            (planner::SeqScanPlan &)B);
+    case PlanNodeType::ORDERBY:
+      return CompareOrderBy((planner::OrderByPlan &)A,
+                            (planner::OrderByPlan &)B);
+    case PlanNodeType::AGGREGATE_V2:
+      return CompareAggregate((planner::AggregatePlan &)A,
+                              (planner::AggregatePlan &)B);
+    case PlanNodeType::HASH:
+      return CompareHash((planner::HashPlan &)A, (planner::HashPlan &)B);
+    case PlanNodeType::HASHJOIN:
+      return CompareHashJoin((planner::HashJoinPlan &)A,
+                             (planner::HashJoinPlan &)B);
+    case PlanNodeType::INSERT:
+      return CompareInsert((planner::InsertPlan &)A, (planner::InsertPlan &)B);
+    case PlanNodeType::DELETE:
+      return CompareDelete((planner::DeletePlan &)A, (planner::DeletePlan &)B);
+    default:
+      throw Exception{"We do not support the plan node type: " +
+          PlanNodeTypeToString(nodeTypeA)};
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Compare function for SeqScanPlan
+// Return: A < B: -1, A = B: 0, A > B: 1
+//===----------------------------------------------------------------------===//
+int PlanComparator::CompareSeqScan(const planner::SeqScanPlan &A,
+                                   const planner::SeqScanPlan &B) {
+  // compare table
+  storage::DataTable *database_ptr_A = A.GetTable();
+  storage::DataTable *database_ptr_B = B.GetTable();
+  if (database_ptr_A != database_ptr_B) {
+    LOG_TRACE("Table equal A=%s, B=%s", database_ptr_A->GetName(),
+              database_ptr_B->GetName());
+    return (database_ptr_A < database_ptr_B) ? -1 : 1;
+  }
+
+  // compare predicate
+  int predicate_comp =
+      ExpressionComparator::Compare(A.GetPredicate(), B.GetPredicate());
+  if (predicate_comp != 0) {
+    LOG_TRACE("Predicates are not equal");
+    return predicate_comp;
+  }
+
+  // compare column_ids
+  size_t column_id_count_A = A.GetColumnIds().size();
+  size_t column_id_count_B = B.GetColumnIds().size();
+  if (column_id_count_A != column_id_count_B)
+    return (column_id_count_A < column_id_count_B) ? -1 : 1;
+  for (size_t it = 0; it < column_id_count_A; it++) {
+    oid_t col_id_A = A.GetColumnIds()[it];
+    oid_t col_id_B = B.GetColumnIds()[it];
+    if (col_id_A != col_id_B) {
+      LOG_TRACE("Column ids are not equal");
+      return (col_id_A < col_id_B) ? -1 : 1;
+    }
+  }
+
+  // compare is_for_update
+  bool is_for_update_A = A.IsForUpdate();
+  bool is_for_update_B = A.IsForUpdate();
+  if (is_for_update_A != is_for_update_B) {
+    LOG_TRACE("Is_for_update flag is not equal");
+    return (is_for_update_A < is_for_update_B) ? -1 : 1;
+  }
+  return CompareChildren(A, B);
+}
+
+//===----------------------------------------------------------------------===//
+// Compare function for OrderByPlan
+// Return: A < B: -1, A = B: 0, A > B: 1
+//===----------------------------------------------------------------------===//
+int PlanComparator::CompareOrderBy(const planner::OrderByPlan &A,
+                                   const planner::OrderByPlan &B) {
+  // compare sort_keys
+  size_t sort_keys_count_A = A.GetSortKeys().size();
+  size_t sort_keys_count_B = B.GetSortKeys().size();
+  if (sort_keys_count_A != sort_keys_count_B)
+    return (sort_keys_count_A < sort_keys_count_B) ? -1 : 1;
+
+  for (size_t it = 0; it < sort_keys_count_A; it++) {
+    oid_t sort_key_A = A.GetSortKeys()[it];
+    oid_t sort_key_B = B.GetSortKeys()[it];
+    if (sort_key_A != sort_key_B) return (sort_key_A < sort_key_B) ? -1 : 1;
+  }
+
+  // compare descend_flags
+  size_t descend_flags_count_A = A.GetDescendFlags().size();
+  size_t descend_flags_count_B = B.GetDescendFlags().size();
+  if (descend_flags_count_A != descend_flags_count_B)
+    return (descend_flags_count_A < descend_flags_count_B) ? -1 : 1;
+
+  for (size_t it = 0; it < descend_flags_count_A; it++) {
+    bool descend_flag_A = A.GetDescendFlags()[it];
+    bool descend_flag_B = B.GetDescendFlags()[it];
+    if (descend_flag_A != descend_flag_B)
+      return (descend_flag_A < descend_flag_B) ? -1 : 1;
+  }
+
+  // compare output_column_ids
+  size_t column_id_count_A = A.GetOutputColumnIds().size();
+  size_t column_id_count_B = B.GetOutputColumnIds().size();
+  if (column_id_count_A != column_id_count_B)
+    return (column_id_count_A < column_id_count_B) ? -1 : 1;
+
+  for (size_t it = 0; it < column_id_count_A; it++) {
+    oid_t col_id_A = A.GetOutputColumnIds()[it];
+    oid_t col_id_B = B.GetOutputColumnIds()[it];
+    if (col_id_A != col_id_B) return (col_id_A < col_id_B) ? -1 : 1;
+  }
+
+  return CompareChildren(A, B);
+}
+
+//===----------------------------------------------------------------------===//
+// Compare function for AggregatePlan
+// Return: A < B: -1, A = B: 0, A > B: 1
+//===----------------------------------------------------------------------===//
+int PlanComparator::CompareAggregate(const planner::AggregatePlan &A,
+                                     const planner::AggregatePlan &B) {
+  // compare project_info
+  int project_info_comp =
+      CompareProjectInfo(A.GetProjectInfo(), B.GetProjectInfo());
+  if (project_info_comp != 0) {
+    return project_info_comp;
+  }
+
+  // compare predicate
+  int predicate_comp =
+      ExpressionComparator::Compare(A.GetPredicate(), B.GetPredicate());
+  if (predicate_comp != 0) {
+    return predicate_comp;
+  }
+
+  // compare unique_agg_term
+  int aggtype_comp =
+      CompareAggType(A.GetUniqueAggTerms(), B.GetUniqueAggTerms());
+  if (aggtype_comp != 0) {
+    return aggtype_comp;
+  }
+
+  // compare groupby_col_ids
+  if (A.GetGroupbyColIds().size() != B.GetGroupbyColIds().size()) {
+    return (A.GetGroupbyColIds().size() < B.GetGroupbyColIds().size()) ? -1 : 1;
+  }
+  for (size_t i = 0; i < A.GetGroupbyColIds().size(); i++) {
+    if (A.GetGroupbyColIds().at(i) != B.GetGroupbyColIds().at(i)) {
+      return (A.GetGroupbyColIds().at(i) < B.GetGroupbyColIds().at(i)) ? -1 : 1;
+    }
+  }
+
+  // compare output_schema
+  int schema_comp = CompareSchema(*A.GetOutputSchema(), *B.GetOutputSchema());
+  if (schema_comp != 0) {
+    return schema_comp;
+  }
+
+  // compare aggregate_strategy
+  if (A.GetAggregateStrategy() != B.GetAggregateStrategy()) {
+    return (A.GetAggregateStrategy() < B.GetAggregateStrategy()) ? -1 : 1;
+  }
+
+  return CompareChildren(A, B);
+}
+
+//===----------------------------------------------------------------------===//
+// Compare function for HashPlan
+// Return: A < B: -1, A = B: 0, A > B: 1
+//===----------------------------------------------------------------------===//
+int PlanComparator::CompareHash(const planner::HashPlan &A,
+                                const planner::HashPlan &B) {
+  if (A.GetHashKeys().size() != B.GetHashKeys().size())
+    return (A.GetHashKeys().size() < B.GetHashKeys().size()) ? -1 : 1;
+  for (size_t i = 0; i < A.GetHashKeys().size(); i++) {
+    int ret = ExpressionComparator::Compare(A.GetHashKeys().at(i).get(),
+                                           B.GetHashKeys().at(i).get());
+    if (ret != 0) return ret;
+  }
+  return CompareChildren(A, B);
+}
+
+//===----------------------------------------------------------------------===//
+// Compare function for HashJoinPlan
+// Return: A < B: -1, A = B: 0, A > B: 1
+//===----------------------------------------------------------------------===//
+int PlanComparator::CompareHashJoin(const planner::HashJoinPlan &A,
+                                    const planner::HashJoinPlan &B) {
+  // compare join_type
+  if (A.GetJoinType() != B.GetJoinType()) {
+    return (A.GetJoinType() < B.GetJoinType()) ? -1 : 1;
+  }
+  // compare predicate
+  int predicate_comp =
+      ExpressionComparator::Compare(A.GetPredicate(), B.GetPredicate());
+  if (predicate_comp != 0) {
+    return predicate_comp;
+  }
+  // compare proj_info
+  int project_info_comp = CompareProjectInfo(A.GetProjInfo(), B.GetProjInfo());
+  if (project_info_comp != 0) {
+    return project_info_comp;
+  }
+
+  // compare proj_schema
+  int schema_comp = CompareSchema(*A.GetSchema(), *B.GetSchema());
+  if (schema_comp != 0) {
+    return schema_comp;
+  }
+
+  std::vector<const expression::AbstractExpression *> keys_A, keys_B;
+  A.GetLeftHashKeys(keys_A);
+  B.GetLeftHashKeys(keys_B);
+  if (keys_A.size() != keys_B.size()) {
+    return keys_A.size() < keys_B.size();
+  }
+  for (size_t i = 0; i < keys_A.size(); i++) {
+    int ret = ExpressionComparator::Compare(keys_A.at(i), keys_B.at(i));
+    if (ret != 0) return ret;
+  }
+
+  keys_A.clear();
+  keys_B.clear();
+  A.GetRightHashKeys(keys_A);
+  A.GetRightHashKeys(keys_B);
+  if (keys_A.size() != keys_B.size()) {
+    return keys_A.size() < keys_B.size();
+  }
+  for (size_t i = 0; i < keys_A.size(); i++) {
+    int ret = ExpressionComparator::Compare(keys_A.at(i), keys_B.at(i));
+    if (ret != 0) return ret;
+  }
+  return CompareChildren(A, B);
+}
+
+//===----------------------------------------------------------------------===//
+// Compare function for InsertPlan
+// Return: A < B: -1, A = B: 0, A > B: 1
+//===----------------------------------------------------------------------===//
+int PlanComparator::CompareInsert(const planner::InsertPlan &A,
+                                  const planner::InsertPlan &B) {
+  if (A.GetTable() != B.GetTable())
+    return (A.GetTable() < B.GetTable()) ? -1 : 1;
+  int ret = PlanComparator::CompareProjectInfo(A.GetProjectInfo(),
+                                               B.GetProjectInfo());
+  if (ret != 0) return ret;
+  if (A.GetBulkInsertCount() != B.GetBulkInsertCount())
+    return (A.GetBulkInsertCount() < B.GetBulkInsertCount()) ? -1 : 1;
+  for (int i = 0; i < (int)A.GetBulkInsertCount(); i++) {
+    int comp = A.GetTuple(i)->Compare(*B.GetTuple(i));
+    if (comp != 0) return comp;
+  }
+  return CompareChildren(A, B);
+}
+
+//===----------------------------------------------------------------------===//
+// Compare function for DeletePlan
+// Return: A < B: -1, A = B: 0, A > B: 1
+//===----------------------------------------------------------------------===//
+int PlanComparator::CompareDelete(const planner::DeletePlan &A,
+                                  const planner::DeletePlan &B) {
+  if (A.GetTable() != B.GetTable())
+    return (A.GetTable() < B.GetTable()) ? -1 : 1;
+  if (A.GetTruncate() != B.GetTruncate())
+    return (A.GetTruncate() < B.GetTruncate()) ? -1 : 1;
+
+  int ret = ExpressionComparator::Compare(
+      const_cast<planner::DeletePlan &>(A).GetPredicate(),
+      const_cast<planner::DeletePlan &>(B).GetPredicate());
+  if (ret != 0) return ret;
+  return CompareChildren(A, B);
+}
+
+//===----------------------------------------------------------------------===//
+// Compare two plans' children
+//===----------------------------------------------------------------------===//
+int PlanComparator::CompareChildren(const planner::AbstractPlan &A,
+                                    const planner::AbstractPlan &B) {
+  if (A.GetChildren().size() != B.GetChildren().size())
+    return (A.GetChildren().size() < B.GetChildren().size()) ? -1 : 1;
+  for (size_t i = 0; i < A.GetChildren().size(); i++) {
+    int ret = Compare(*A.GetChild(i), *B.GetChild(i));
+    if (ret != 0) return ret;
+  }
+  return 0;
+}
+
+//===----------------------------------------------------------------------===//
+// Compare function for catalog::Schema, used in comparing AggregatePlan and
+// HashjoinPlan
+//===----------------------------------------------------------------------===//
+int PlanComparator::CompareSchema(const catalog::Schema &A,
+                                  const catalog::Schema &B) {
+  if (A.GetColumnCount() != B.GetColumnCount())
+    return (A.GetColumnCount() < B.GetColumnCount()) ? -1 : 1;
+  if (A.GetUninlinedColumnCount() != B.GetUninlinedColumnCount())
+    return (A.GetUninlinedColumnCount() < B.GetUninlinedColumnCount()) ? -1 : 1;
+  if (A.IsInlined() != B.IsInlined())
+    return (A.IsInlined() < B.IsInlined()) ? -1 : 1;
+
+  for (oid_t column_itr = 0; column_itr < A.GetColumnCount(); column_itr++) {
+    const catalog::Column &column_info_A = A.GetColumn(column_itr);
+    const catalog::Column &column_info_B = B.GetColumn(column_itr);
+    if (column_info_A.GetType() != column_info_B.GetType())
+      return (column_info_A.GetType() < column_info_B.GetType()) ? -1 : 1;
+    if (column_info_A.is_inlined != column_info_B.is_inlined)
+      return (column_info_A.is_inlined < column_info_B.is_inlined) ? -1 : 1;
+  }
+  return 0;
+}
+
+//===----------------------------------------------------------------------===//
+// Compare function for AggTerm, used in comparing AggregatePlan
+//===----------------------------------------------------------------------===//
+int PlanComparator::CompareAggType(
+    const std::vector<planner::AggregatePlan::AggTerm> &A,
+    const std::vector<planner::AggregatePlan::AggTerm> &B) {
+  if (A.size() != B.size()) return (A.size() < B.size()) ? -1 : 1;
+  for (size_t i = 0; i < A.size(); i++) {
+    if (A.at(i).aggtype != B.at(i).aggtype)
+      return (A.at(i).aggtype < B.at(i).aggtype) ? -1 : 1;
+    int ret =
+        ExpressionComparator::Compare(A.at(i).expression, B.at(i).expression);
+    if (ret != 0) return ret;
+    if (A.at(i).distinct != B.at(i).distinct)
+      return (A.at(i).distinct < B.at(i).distinct) ? -1 : 1;
+  }
+  return 0;
+}
+
+//===----------------------------------------------------------------------===//
+// Compare function for DerivedAttribute, used in comparing ProjectInfo
+//===----------------------------------------------------------------------===//
+int PlanComparator::CompareDerivedAttr(const planner::DerivedAttribute &A,
+                                       const planner::DerivedAttribute &B) {
+  if (A.attribute_info.type != B.attribute_info.type)
+    return (A.attribute_info.type < B.attribute_info.type) ? -1 : 1;
+  if (A.attribute_info.attribute_id != B.attribute_info.attribute_id)
+    return (A.attribute_info.attribute_id < B.attribute_info.attribute_id) ? -1
+                                                                           : 1;
+  return ExpressionComparator::Compare(A.expr, B.expr);
+}
+
+//===----------------------------------------------------------------------===//
+// Compare function for ProjectInfo, used in comparing DerivedAttr
+//===----------------------------------------------------------------------===//
+int PlanComparator::CompareProjectInfo(const planner::ProjectInfo *A,
+                                       const planner::ProjectInfo *B) {
+  if (A == nullptr && B == nullptr) {
+    return 0;
+  }
+  if (A == nullptr || B == nullptr) {
+    return (A == nullptr) ? -1 : 1;
+  }
+  // compare TargetList
+  if (A->GetTargetList().size() != B->GetTargetList().size())
+    return (A->GetTargetList().size() < B->GetTargetList().size()) ? -1 : 1;
+  for (size_t i = 0; i < A->GetTargetList().size(); i++) {
+    if (A->GetTargetList().at(i).first != B->GetTargetList().at(i).first)
+      return (A->GetTargetList().at(i).first < B->GetTargetList().at(i).first)
+                 ? -1
+                 : 1;
+    int derived_comp = CompareDerivedAttr(A->GetTargetList().at(i).second,
+                                          B->GetTargetList().at(i).second);
+    if (derived_comp != 0) return derived_comp;
+  }
+  // compare DirectMapList
+  if (A->GetDirectMapList().size() != B->GetDirectMapList().size())
+    return (A->GetDirectMapList().size() < B->GetDirectMapList().size()) ? -1
+                                                                         : 1;
+  for (size_t i = 0; i < A->GetDirectMapList().size(); i++) {
+    if (A->GetDirectMapList().at(i).first != B->GetDirectMapList().at(i).first)
+      return (A->GetDirectMapList().at(i).first <
+              B->GetDirectMapList().at(i).first)
+                 ? -1
+                 : 1;
+    if (A->GetDirectMapList().at(i).second.first !=
+        B->GetDirectMapList().at(i).second.first)
+      return (A->GetDirectMapList().at(i).second.first <
+              B->GetDirectMapList().at(i).second.first)
+                 ? -1
+                 : 1;
+    if (A->GetDirectMapList().at(i).second.second !=
+        B->GetDirectMapList().at(i).second.second)
+      return (A->GetDirectMapList().at(i).second.second <
+              B->GetDirectMapList().at(i).second.second)
+                 ? -1
+                 : 1;
+  }
+  return 0;
+}
+
+//===----------------------------------------------------------------------===//
+// Compare two expressions' children
+//===----------------------------------------------------------------------===//
+int ExpressionComparator::CompareChildren(
+    const expression::AbstractExpression *A,
+    const expression::AbstractExpression *B) {
+  if (A->GetChildrenSize() != B->GetChildrenSize())
+    return (A->GetChildrenSize() < B->GetChildrenSize()) ? -1 : 1;
+  for (size_t i = 0; i < A->GetChildrenSize(); i++) {
+    int ret = Compare(A->GetChild(i), B->GetChild(i));
+    if (ret != 0) return ret;
+  }
+  return 0;
+}
+
+//===----------------------------------------------------------------------===//
+// Compare two expressions
+//===----------------------------------------------------------------------===//
+int ExpressionComparator::Compare(const expression::AbstractExpression *A,
+                                  const expression::AbstractExpression *B) {
+  if (A == nullptr && B == nullptr)
+    return 0;
+  if (A == nullptr)
+    return 1;
+  if (B == nullptr)
+    return -1;
+
+  ExpressionType nodeTypeA = A->GetExpressionType();
+  ExpressionType nodeTypeB = B->GetExpressionType();
+
+  if (nodeTypeA != nodeTypeB) return (nodeTypeA < nodeTypeB) ? -1 : 1;
+  switch (nodeTypeA) {
+    case ExpressionType::COMPARE_EQUAL:
+    case ExpressionType::COMPARE_NOTEQUAL:
+    case ExpressionType::COMPARE_LESSTHAN:
+    case ExpressionType::COMPARE_GREATERTHAN:
+    case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+    case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+      return CompareChildren(A, B);
+    case ExpressionType::OPERATOR_NOT:
+    case ExpressionType::OPERATOR_PLUS:
+    case ExpressionType::OPERATOR_MINUS:
+    case ExpressionType::OPERATOR_MULTIPLY:
+    case ExpressionType::OPERATOR_DIVIDE:
+    case ExpressionType::OPERATOR_MOD: {
+      if (A->GetValueType() != B->GetValueType())
+        return (A->GetValueType() < B->GetValueType()) ? -1 : 1;
+      return CompareChildren(A, B);
+    }
+    case ExpressionType::VALUE_CONSTANT: {
+      expression::ConstantValueExpression *ptr_A =
+          (expression::ConstantValueExpression *)A;
+      expression::ConstantValueExpression *ptr_B =
+          (expression::ConstantValueExpression *)B;
+      type::Value va = ptr_A->GetValue();
+      type::Value vb = ptr_B->GetValue();
+      if (va.CompareEquals(vb) == type::CmpBool::CMP_FALSE)
+        return va.CompareLessThan(vb) ? -1 : 1;
+      return 0;
+    }
+    case ExpressionType::OPERATOR_UNARY_MINUS:
+      return CompareChildren(A, B);
+    case ExpressionType::AGGREGATE_COUNT:
+    case ExpressionType::AGGREGATE_SUM:
+    case ExpressionType::AGGREGATE_MIN:
+    case ExpressionType::AGGREGATE_MAX:
+    case ExpressionType::AGGREGATE_AVG: {
+      if (A->distinct_ != B->distinct_)
+        return (A->distinct_ < B->distinct_) ? -1 : 1;
+      return CompareChildren(A, B);
+    }
+    case ExpressionType::CONJUNCTION_AND:
+    case ExpressionType::CONJUNCTION_OR:
+      return CompareChildren(A, B);
+    case ExpressionType::VALUE_TUPLE: {
+      expression::TupleValueExpression *ptr_A =
+          (expression::TupleValueExpression *)A;
+      expression::TupleValueExpression *ptr_B =
+          (expression::TupleValueExpression *)B;
+      // compare tuple_idx
+      if (ptr_A->GetTupleId() != ptr_B->GetTupleId())
+        return (ptr_A->GetTupleId() < ptr_B->GetTupleId()) ? -1 : 1;
+      // compare column_idx
+      if (ptr_A->GetColumnId() != ptr_B->GetColumnId())
+        return (ptr_A->GetColumnId() < ptr_B->GetColumnId()) ? -1 : 1;
+      // compare table_name
+      if (ptr_A->GetTableName() != ptr_B->GetTableName())
+        return ptr_A->GetTableName().compare(ptr_B->GetTableName());
+      // compare column_name
+      if (ptr_A->GetColumnName() != ptr_B->GetColumnName())
+        return ptr_A->GetColumnName().compare(ptr_B->GetColumnName());
+      // compare attribute_info
+      if (ptr_A->GetAttributeRef() != nullptr &&
+          ptr_B->GetAttributeRef() != nullptr) {
+        if (ptr_A->GetAttributeRef()->type != ptr_B->GetAttributeRef()->type)
+          return (ptr_A->GetAttributeRef()->type <
+                  ptr_B->GetAttributeRef()->type)
+                     ? -1
+                     : 1;
+        if (ptr_A->GetAttributeRef()->attribute_id !=
+            ptr_B->GetAttributeRef()->attribute_id)
+          return (ptr_A->GetAttributeRef()->attribute_id <
+                  ptr_B->GetAttributeRef()->attribute_id)
+                     ? -1
+                     : 1;
+      } else if (ptr_A->GetAttributeRef() != nullptr ||
+                 ptr_B->GetAttributeRef() != nullptr) {
+        return (ptr_A->GetAttributeRef() == nullptr) ? -1 : 1;
+      }
+
+      break;
+    }
+    case ExpressionType::VALUE_PARAMETER: {
+      expression::ParameterValueExpression *ptr_A =
+          (expression::ParameterValueExpression *)A;
+      expression::ParameterValueExpression *ptr_B =
+          (expression::ParameterValueExpression *)B;
+      if (ptr_A->GetValueIdx() != ptr_B->GetValueIdx())
+        return (ptr_A->GetValueIdx() < ptr_B->GetValueIdx()) ? -1 : 1;
+    }
+    default:
+      throw Exception{"We do not support the expression type: " +
+                      ExpressionTypeToString(nodeTypeA)};
+  }
+  return 0;
+}
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/codegen/plan_comparator.cpp
+++ b/src/codegen/plan_comparator.cpp
@@ -514,25 +514,7 @@ int ExpressionComparator::Compare(const expression::AbstractExpression *A,
       // compare column_name
       if (ptr_A->GetColumnName() != ptr_B->GetColumnName())
         return ptr_A->GetColumnName().compare(ptr_B->GetColumnName());
-      // compare attribute_info
-      if (ptr_A->GetAttributeRef() != nullptr &&
-          ptr_B->GetAttributeRef() != nullptr) {
-        if (ptr_A->GetAttributeRef()->type != ptr_B->GetAttributeRef()->type)
-          return (ptr_A->GetAttributeRef()->type <
-                  ptr_B->GetAttributeRef()->type)
-                     ? -1
-                     : 1;
-        if (ptr_A->GetAttributeRef()->attribute_id !=
-            ptr_B->GetAttributeRef()->attribute_id)
-          return (ptr_A->GetAttributeRef()->attribute_id <
-                  ptr_B->GetAttributeRef()->attribute_id)
-                     ? -1
-                     : 1;
-      } else if (ptr_A->GetAttributeRef() != nullptr ||
-                 ptr_B->GetAttributeRef() != nullptr) {
-        return (ptr_A->GetAttributeRef() == nullptr) ? -1 : 1;
-      }
-
+      // Note that we do not compare Attribute Information
       break;
     }
     case ExpressionType::VALUE_PARAMETER: {

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -47,8 +47,7 @@ void CleanExecutorTree(executor::AbstractExecutor *root);
  */
 ExecuteResult PlanExecutor::ExecutePlan(
     std::shared_ptr<planner::AbstractPlan> plan,
-    concurrency::Transaction *txn,
-    const std::vector<type::Value> &params,
+    concurrency::Transaction *txn, const std::vector<type::Value> &params,
     std::vector<StatementResult> &result,
     const std::vector<int> &result_format) {
   ExecuteResult p_status;

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -128,11 +128,11 @@ ExecuteResult PlanExecutor::ExecutePlan(
 
     result.clear();
 
-    // Bind: casting const should be removed with later refactoring executor
-    planner::AbstractPlan *planp = plan.get();
+    // Perform binding
     planner::BindingContext context;
-    planp->PerformBinding(context);
+    plan->PerformBinding(context);
 
+    // Prepare output buffer
     std::vector<oid_t> columns;
     plan->GetOutputColumns(columns);
     codegen::BufferingConsumer consumer{columns, context};

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -44,11 +44,12 @@ void CleanExecutorTree(executor::AbstractExecutor *root);
  * value list directly rather than passing Postgres's ParamListInfo
  * @return status of execution.
  */
-ExecuteResult PlanExecutor::ExecutePlan(const planner::AbstractPlan *plan,
-                                        concurrency::Transaction *txn,
-                                        const std::vector<type::Value> &params,
-                                        std::vector<StatementResult> &result,
-                                        const std::vector<int> &result_format) {
+ExecuteResult PlanExecutor::ExecutePlan(
+    std::shared_ptr<planner::AbstractPlan> plan,
+    concurrency::Transaction *txn,
+    const std::vector<type::Value> &params,
+    std::vector<StatementResult> &result,
+    const std::vector<int> &result_format) {
   ExecuteResult p_status;
   if (plan == nullptr) return p_status;
 
@@ -69,7 +70,7 @@ ExecuteResult PlanExecutor::ExecutePlan(const planner::AbstractPlan *plan,
     // Build the executor tree
     LOG_TRACE("Building the executor tree");
     std::unique_ptr<executor::AbstractExecutor> executor_tree(
-        BuildExecutorTree(nullptr, plan, executor_context.get()));
+        BuildExecutorTree(nullptr, plan.get(), executor_context.get()));
 
     // Initialize the executor tree
     LOG_TRACE("Initializing the executor tree");
@@ -128,7 +129,7 @@ ExecuteResult PlanExecutor::ExecutePlan(const planner::AbstractPlan *plan,
     result.clear();
 
     // Bind: casting const should be removed with later refactoring executor
-    planner::AbstractPlan *planp = const_cast<planner::AbstractPlan *>(plan);
+    planner::AbstractPlan *planp = plan.get();
     planner::BindingContext context;
     planp->PerformBinding(context);
 

--- a/src/include/codegen/plan_comparator.h
+++ b/src/include/codegen/plan_comparator.h
@@ -1,0 +1,87 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// plan_comparator.h
+//
+// Identification: src/include/codegen/plan_comparator.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "planner/abstract_plan.h"
+#include "planner/abstract_scan_plan.h"
+#include "planner/aggregate_plan.h"
+#include "planner/delete_plan.h"
+#include "planner/hash_join_plan.h"
+#include "planner/hash_plan.h"
+#include "planner/insert_plan.h"
+#include "planner/order_by_plan.h"
+#include "planner/seq_scan_plan.h"
+#include "planner/update_plan.h"
+
+namespace peloton {
+namespace codegen {
+//===----------------------------------------------------------------------===//
+// PlanComparator provides compare function for all plans that are
+// supported by codegen including SeqScanPlan, OrderByPlan, etc.
+//===----------------------------------------------------------------------===//
+class PlanComparator {
+ public:
+  // No constructor
+  PlanComparator() = delete;
+
+  static int Compare(const planner::AbstractPlan &,
+                     const planner::AbstractPlan &);
+ private:
+  // Compare functions
+  static int CompareAggregate(const planner::AggregatePlan &,
+                              const planner::AggregatePlan &);
+  static int CompareDelete(const planner::DeletePlan &,
+                           const planner::DeletePlan &);
+  static int CompareHash(const planner::HashPlan &, const planner::HashPlan &);
+  static int CompareHashJoin(const planner::HashJoinPlan &,
+                             const planner::HashJoinPlan &);
+  static int CompareInsert(const planner::InsertPlan &,
+                           const planner::InsertPlan &);
+  static int CompareOrderBy(const planner::OrderByPlan &,
+                            const planner::OrderByPlan &);
+  static int CompareSeqScan(const planner::SeqScanPlan &,
+                            const planner::SeqScanPlan &);
+  static int CompareUpdate(const planner::UpdatePlan &,
+                           const planner::UpdatePlan &);
+
+  // Helper functions for comparison
+  static int CompareAggType(
+      const std::vector<planner::AggregatePlan::AggTerm> &,
+      const std::vector<planner::AggregatePlan::AggTerm> &);
+  static int CompareChildren(const planner::AbstractPlan &,
+                             const planner::AbstractPlan &);
+  static int CompareDerivedAttr(const planner::DerivedAttribute &,
+                                const planner::DerivedAttribute &);
+  static int CompareProjectInfo(const planner::ProjectInfo *,
+                                const planner::ProjectInfo *);
+  static int CompareSchema(const catalog::Schema &, const catalog::Schema &);
+};
+
+//===----------------------------------------------------------------------===//
+// ExpressionComparator provides compare function for all expressions that are
+// supported by codegen.
+//===----------------------------------------------------------------------===//
+class ExpressionComparator {
+ public:
+  // No constructor
+  ExpressionComparator() = delete;
+
+  static int Compare(const expression::AbstractExpression *,
+                     const expression::AbstractExpression *);
+ private:
+  static int CompareChildren(const expression::AbstractExpression *,
+                             const expression::AbstractExpression *);
+};
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/include/codegen/query_cache.h
+++ b/src/include/codegen/query_cache.h
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// query_cache.h
+//
+// Identification: src/include/codegen/query_cache.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <list>
+#include "codegen/plan_comparator.h"
+#include "codegen/query.h"
+
+namespace peloton {
+namespace codegen {
+// Query cache implementation that maps an AbstractPlan with a CodeGen query
+// using LRU eviction policy. The cache is implemented as a singleton.
+// Potential enhancements:
+//   1) Apply other interesting eviction policies
+//     e.g. Keep some heavy compilation workloads by mixing policies
+//   2) Use some heauristic measure for keeping them in cache
+//   3) Configure the cache size
+//   4) Persistency may increase the performance when rebooted
+class QueryCache {
+ public:
+  static QueryCache& Instance() {
+    static QueryCache query_cache;
+    return query_cache;
+  }
+
+  Query* Find(const std::shared_ptr<planner::AbstractPlan>& key) {
+    auto it = cache_map_.find(key);
+    if (it == cache_map_.end()) return nullptr;
+
+    query_list_.splice(query_list_.begin(), query_list_, it->second);
+    return it->second->second.get();
+  }
+
+  void Add(const std::shared_ptr<planner::AbstractPlan>& key,
+           std::unique_ptr<Query> val) {
+    query_list_.push_front(make_pair(key, std::move(val)));
+    cache_map_.insert(make_pair(key, query_list_.begin()));
+  }
+
+  size_t GetCacheSize() { return max_size_; }
+
+  void SetCacheSize(size_t max_size) {
+    ResizeCache(max_size);
+    max_size_ = max_size;
+  }
+
+  size_t GetSize() { return cache_map_.size(); }
+
+  void ClearCache() { cache_map_.clear(); }
+
+ private:
+  // Can't consturct
+  QueryCache() {}
+
+  // Compartor function of AbstractPlan
+  struct Compare {
+    bool operator()(const std::shared_ptr<planner::AbstractPlan>& a,
+                    const std::shared_ptr<planner::AbstractPlan>& b) const {
+      return (PlanComparator::Compare(*a.get(), *b.get()) < 0);
+    }
+  };
+
+  void ResizeCache(size_t target_size) {
+    while (cache_map_.size() > target_size) {
+      auto last_it = query_list_.end();
+      last_it--;
+      cache_map_.erase(last_it->first);
+      query_list_.pop_back();
+    }
+  }
+
+ private:
+  std::list<std::pair<std::shared_ptr<planner::AbstractPlan>,
+                      std::unique_ptr<Query>>> query_list_;
+
+  std::map<std::shared_ptr<planner::AbstractPlan>,
+           decltype(query_list_.begin()), Compare> cache_map_;
+
+  size_t max_size_ = 0;
+};
+
+}  // namespace codegen
+}  // namespace peloton 

--- a/src/include/codegen/query_cache.h
+++ b/src/include/codegen/query_cache.h
@@ -20,10 +20,10 @@ namespace peloton {
 namespace codegen {
 // Query cache implementation that maps an AbstractPlan with a CodeGen query
 // using LRU eviction policy. The cache is implemented as a singleton.
-// Potential enhancements:
+// Potential future enhancements:
 //   1) Apply other interesting eviction policies
 //     e.g. Keep some heavy compilation workloads by mixing policies
-//   2) Use some heauristic measure for keeping them in cache
+//   2) Manually keep some of the compiled results in the cache
 //   3) Configure the cache size
 //   4) Persistency may increase the performance when rebooted
 class QueryCache {

--- a/src/include/executor/plan_executor.h
+++ b/src/include/executor/plan_executor.h
@@ -67,7 +67,7 @@ class PlanExecutor {
    * Before ExecutePlan, a node first receives value list, so we should
    * pass value list directly rather than passing Postgres's ParamListInfo
    */
-  static ExecuteResult ExecutePlan(const planner::AbstractPlan *plan,
+  static ExecuteResult ExecutePlan(std::shared_ptr<planner::AbstractPlan> plan,
                                     concurrency::Transaction* txn,
                                     const std::vector<type::Value> &params,
                                     std::vector<StatementResult> &result,

--- a/src/include/tcop/tcop.h
+++ b/src/include/tcop/tcop.h
@@ -6,7 +6,7 @@
 //
 // Identification: src/include/tcop/tcop.h
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -55,11 +55,11 @@ class TrafficCop {
                           const size_t thread_id = 0);
 
   // ExecPrepStmt - Execute a statement from a prepared and bound statement
-  ResultType ExecuteStatement(
-      const std::shared_ptr<Statement> &statement,
+  ResultType ExecuteStatement(const std::shared_ptr<Statement> &statement,
       const std::vector<type::Value> &params, const bool unnamed,
       std::shared_ptr<stats::QueryMetric::QueryParams> param_stats,
-      const std::vector<int> &result_format, std::vector<StatementResult> &result,
+      const std::vector<int> &result_format,
+      std::vector<StatementResult> &result,
       int &rows_change, std::string &error_message,
       const size_t thread_id = 0);
 
@@ -68,8 +68,8 @@ class TrafficCop {
   executor::ExecuteResult ExecuteStatementPlan(
       std::shared_ptr<planner::AbstractPlan> plan,
       const std::vector<type::Value> &params,
-      std::vector<StatementResult> &result, const std::vector<int> &result_format,
-      const size_t thread_id = 0);
+      std::vector<StatementResult> &result,
+      const std::vector<int> &result_format, const size_t thread_id = 0);
 
   // InitBindPrepStmt - Prepare and bind a query from a query string
   std::shared_ptr<Statement> PrepareStatement(const std::string &statement_name,
@@ -109,5 +109,5 @@ class TrafficCop {
   ResultType AbortQueryHelper();
 };
 
-}  // End tcop namespace
-}  // End peloton namespace
+}  // namespace tcop
+}  // namespace peloton

--- a/src/include/tcop/tcop.h
+++ b/src/include/tcop/tcop.h
@@ -66,7 +66,8 @@ class TrafficCop {
   // ExecutePrepStmt - Helper to handle txn-specifics for the plan-tree of a
   // statement
   executor::ExecuteResult ExecuteStatementPlan(
-      const planner::AbstractPlan *plan, const std::vector<type::Value> &params,
+      std::shared_ptr<planner::AbstractPlan> plan,
+      const std::vector<type::Value> &params,
       std::vector<StatementResult> &result, const std::vector<int> &result_format,
       const size_t thread_id = 0);
 

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -196,7 +196,7 @@ ResultType TrafficCop::ExecuteStatement(
     else if (statement->GetQueryType() == "ROLLBACK")
       return AbortQueryHelper();
     else {
-      auto status = ExecuteStatementPlan(statement->GetPlanTree().get(), params,
+      auto status = ExecuteStatementPlan(statement->GetPlanTree(), params,
                                          result, result_format,
                                          thread_id);
       LOG_TRACE("Statement executed. Result: %s",
@@ -211,8 +211,10 @@ ResultType TrafficCop::ExecuteStatement(
 }
 
 executor::ExecuteResult TrafficCop::ExecuteStatementPlan(
-    const planner::AbstractPlan *plan, const std::vector<type::Value> &params,
-    std::vector<StatementResult> &result, const std::vector<int> &result_format,
+    std::shared_ptr<planner::AbstractPlan> plan,
+    const std::vector<type::Value> &params,
+    std::vector<StatementResult> &result,
+    const std::vector<int> &result_format,
     const size_t thread_id) {
   concurrency::Transaction *txn;
   bool single_statement_txn = false, init_failure = false;

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -56,7 +56,7 @@ void SetupTables() {
     auto parse_tree = parser.BuildParseTree(sql);
     statement->SetPlanTree(optimizer.BuildPelotonPlanTree(parse_tree));
     auto status = traffic_cop.ExecuteStatementPlan(
-        statement->GetPlanTree().get(), params, result, result_format);
+        statement->GetPlanTree(), params, result, result_format);
     LOG_INFO("Table create result: %s",
              ResultTypeToString(status.m_result).c_str());
   }

--- a/test/codegen/codegen_test_util.cpp
+++ b/test/codegen/codegen_test_util.cpp
@@ -16,6 +16,7 @@
 #include "codegen/runtime_functions_proxy.h"
 #include "codegen/values_runtime_proxy.h"
 #include "codegen/value_proxy.h"
+#include "codegen/query_cache.h"
 
 namespace peloton {
 namespace test {
@@ -122,12 +123,46 @@ codegen::QueryCompiler::CompileStats PelotonCodeGenTest::CompileAndExecute(
   // Run
   compiled_query->Execute(*txn,
                           std::unique_ptr<executor::ExecutorContext> (
-                             new executor::ExecutorContext{txn}).get(),
+                              new executor::ExecutorContext{txn}).get(),
                           consumer_state);
 
   txn_manager.CommitTransaction(txn);
+
   return stats;
 }
+
+codegen::QueryCompiler::CompileStats PelotonCodeGenTest::CompileAndExecuteCache(
+    const std::shared_ptr<planner::AbstractPlan> &plan,
+    codegen::QueryResultConsumer &consumer, char *consumer_state) {
+  // Start a transaction
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto *txn = txn_manager.BeginTransaction();
+
+  // Compile
+  codegen::QueryCompiler::CompileStats stats;
+  codegen::QueryCompiler compiler;
+
+  codegen::Query* query = codegen::QueryCache::Instance().Find(plan);
+  if (query == nullptr) {
+    auto compiled_query = compiler.Compile(*plan, consumer, &stats);
+    compiled_query->Execute(*txn,
+                            std::unique_ptr<executor::ExecutorContext> (
+                                new executor::ExecutorContext{txn}).get(),
+                            consumer_state);
+    codegen::QueryCache::Instance().Add(std::move(plan),
+                                        std::move(compiled_query));
+  }
+  else {
+    query->Execute(*txn,
+                   std::unique_ptr<executor::ExecutorContext> (
+                       new executor::ExecutorContext{txn}).get(),
+                   consumer_state);
+  }
+  txn_manager.CommitTransaction(txn);
+
+  return stats;
+}
+
 
 //===----------------------------------------------------------------------===//
 // PRINTER

--- a/test/codegen/query_cache_test.cpp
+++ b/test/codegen/query_cache_test.cpp
@@ -1,0 +1,459 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// query_cache_test.cpp
+//
+// Identification: test/codegen/query_cache_test.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "codegen/query_cache.h"
+#include "catalog/catalog.h"
+#include "codegen/codegen_test_util.h"
+#include "codegen/plan_comparator.h"
+#include "codegen/query_compiler.h"
+#include "common/harness.h"
+#include "expression/conjunction_expression.h"
+#include "expression/operator_expression.h"
+#include "expression/parameter_value_expression.h"
+#include "planner/order_by_plan.h"
+#include "planner/seq_scan_plan.h"
+
+namespace peloton {
+namespace test {
+
+//===----------------------------------------------------------------------===//
+// This class contains code to test the correctness of plan comparator and query
+// cache by generating pairs of same/different plans of different kinds and
+// testing
+// the comparison result and whether the same plan can successfully find cache.
+// The schema of the table is as follows:
+//
+// +---------+---------+---------+-------------+
+// | A (int) | B (int) | C (int) | D (varchar) |
+// +---------+---------+---------+-------------+
+//
+// The database and tables are created in CreateDatabase() and
+// CreateTestTables(), respectively.
+//
+// By default, the test table is loaded with 64 rows of random values.
+// The right table is loaded with 256 rows of random values.
+//===----------------------------------------------------------------------===//
+typedef std::unique_ptr<const expression::AbstractExpression> AbstractExprPtr;
+
+class QueryCacheTest : public PelotonCodeGenTest {
+ public:
+  QueryCacheTest() : PelotonCodeGenTest(), num_rows_to_insert(64) {
+    // Load test table
+    LoadTestTable(TestTableId(), num_rows_to_insert);
+    LoadTestTable(RightTableId(), 4 * num_rows_to_insert);
+  }
+  uint32_t NumRowsInTestTable() const { return num_rows_to_insert; }
+  uint32_t TestTableId() { return test_table1_id; }
+  uint32_t RightTableId() const { return test_table2_id; }
+
+  // SELECT b FROM table where a >= 40;
+  std::shared_ptr<planner::SeqScanPlan> GetSeqScanPlan() {
+
+    auto* a_col_exp =
+        new expression::TupleValueExpression(type::Type::TypeId::INTEGER, 0, 0);
+    auto* const_40_exp = CodegenTestUtils::ConstIntExpression(40);
+    auto* a_gt_40 = new expression::ComparisonExpression(
+        ExpressionType::COMPARE_GREATERTHANOREQUALTO, a_col_exp, const_40_exp);
+    return std::shared_ptr<planner::SeqScanPlan>(new planner::SeqScanPlan(
+        &GetTestTable(TestTableId()), a_gt_40, {0, 1}));
+  }
+
+  // SELECT a, b, c FROM table where a >= 20 and b = 21;
+  std::shared_ptr<planner::SeqScanPlan> GetSeqScanPlanWithPredicate() {
+    auto* a_col_exp =
+        new expression::TupleValueExpression(type::Type::TypeId::INTEGER, 0, 0);
+    auto* const_20_exp = CodegenTestUtils::ConstIntExpression(20);
+    auto* a_gt_20 = new expression::ComparisonExpression(
+        ExpressionType::COMPARE_GREATERTHANOREQUALTO, a_col_exp, const_20_exp);
+
+    auto* b_col_exp =
+        new expression::TupleValueExpression(type::Type::TypeId::INTEGER, 0, 1);
+    auto* const_21_exp = CodegenTestUtils::ConstIntExpression(21);
+    auto* b_eq_21 = new expression::ComparisonExpression(
+        ExpressionType::COMPARE_EQUAL, b_col_exp, const_21_exp);
+
+    auto* conj_eq = new expression::ConjunctionExpression(
+        ExpressionType::CONJUNCTION_AND, b_eq_21, a_gt_20);
+
+    return std::shared_ptr<planner::SeqScanPlan>(new planner::SeqScanPlan(
+        &GetTestTable(TestTableId()), conj_eq, {0, 1, 2}));
+  }
+
+  // SELECT left_table.a, right_table.a, left_table.b, right_table.c,
+  // FROM left_table
+  // JOIN right_table ON left_table.a = right_table.a
+  std::shared_ptr<planner::HashJoinPlan> GetHashJoinPlan() {
+   DirectMap dm1 = std::make_pair(0, std::make_pair(0, 0));
+    DirectMap dm2 = std::make_pair(1, std::make_pair(1, 0));
+    DirectMap dm3 = std::make_pair(2, std::make_pair(0, 1));
+    DirectMap dm4 = std::make_pair(3, std::make_pair(1, 2));
+    DirectMapList direct_map_list = {dm1, dm2, dm3, dm4};
+    std::unique_ptr<planner::ProjectInfo> projection{
+        new planner::ProjectInfo(TargetList{}, std::move(direct_map_list))};
+
+    // Output schema
+    auto schema = std::shared_ptr<const catalog::Schema>(
+        new catalog::Schema({TestingExecutorUtil::GetColumnInfo(0),
+                             TestingExecutorUtil::GetColumnInfo(0),
+                             TestingExecutorUtil::GetColumnInfo(1),
+                             TestingExecutorUtil::GetColumnInfo(2)}));
+    // Left and right hash keys
+    std::vector<AbstractExprPtr> left_hash_keys;
+    left_hash_keys.emplace_back(new expression::TupleValueExpression(
+        type::Type::TypeId::INTEGER, 0, 0));
+
+    std::vector<AbstractExprPtr> right_hash_keys;
+    right_hash_keys.emplace_back(new expression::TupleValueExpression(
+        type::Type::TypeId::INTEGER, 0, 0));
+
+    std::vector<AbstractExprPtr> hash_keys;
+    hash_keys.emplace_back(new expression::TupleValueExpression(
+        type::Type::TypeId::INTEGER, 0, 0));
+
+    // Finally, the fucking join node
+    std::shared_ptr<planner::HashJoinPlan> hj_plan{new planner::HashJoinPlan(
+        JoinType::INNER, nullptr, std::move(projection), schema, left_hash_keys,
+        right_hash_keys)};
+    std::unique_ptr<planner::HashPlan> hash_plan{
+        new planner::HashPlan(hash_keys)};
+
+    std::unique_ptr<planner::AbstractPlan> left_scan{new planner::SeqScanPlan(
+        &GetTestTable(TestTableId()), nullptr, {0, 1, 2})};
+    std::unique_ptr<planner::AbstractPlan> right_scan{new planner::SeqScanPlan(
+        &GetTestTable(RightTableId()), nullptr, {0, 1, 2})};
+
+    hash_plan->AddChild(std::move(right_scan));
+    hj_plan->AddChild(std::move(left_scan));
+    hj_plan->AddChild(std::move(hash_plan));
+
+    return hj_plan;
+  }
+
+  // SELECT a, avg(b) as x FROM table GROUP BY a WHERE x > 50;
+  std::shared_ptr<planner::AggregatePlan> GetAggregatePlan() {
+    DirectMapList direct_map_list = {{0, {0, 0}}, {1, {1, 0}}};
+    std::unique_ptr<planner::ProjectInfo> proj_info{
+        new planner::ProjectInfo(TargetList(), std::move(direct_map_list))};
+
+    // 2) Setup the average over 'b'
+    auto* tve_expr =
+        new expression::TupleValueExpression(type::Type::TypeId::INTEGER, 0, 1);
+    std::vector<planner::AggregatePlan::AggTerm> agg_terms = {
+        {ExpressionType::AGGREGATE_AVG, tve_expr}};
+    agg_terms[0].agg_ai.type = type::Type::TypeId::DECIMAL;
+
+    // 3) The grouping column
+    std::vector<oid_t> gb_cols = {0};
+
+    // 4) The output schema
+    std::shared_ptr<const catalog::Schema> output_schema{
+        new catalog::Schema({{type::Type::TypeId::INTEGER, 4, "COL_A"},
+                             {type::Type::TypeId::DECIMAL, 8, "AVG(COL_B)"}})};
+
+    // 5) The predicate on the average aggregate
+    auto* x_exp =
+        new expression::TupleValueExpression(type::Type::TypeId::DECIMAL, 1, 0);
+    auto* const_50 = new expression::ConstantValueExpression(
+        type::ValueFactory::GetDecimalValue(50.0));
+    std::unique_ptr<expression::AbstractExpression> x_gt_50{
+        new expression::ComparisonExpression(
+            ExpressionType::COMPARE_GREATERTHAN, x_exp, const_50)};
+
+    // 6) Finally, the aggregation node
+    std::shared_ptr<planner::AggregatePlan> agg_plan{new planner::AggregatePlan(
+        std::move(proj_info), std::move(x_gt_50), std::move(agg_terms),
+        std::move(gb_cols), output_schema, AggregateType::HASH)};
+
+    // 7) The scan that feeds the aggregation
+    std::unique_ptr<planner::AbstractPlan> scan_plan{new planner::SeqScanPlan(
+        &GetTestTable(TestTableId()), nullptr, {0, 1})};
+
+    agg_plan->AddChild(std::move(scan_plan));
+    return agg_plan;
+  }
+
+ private:
+  uint32_t num_rows_to_insert = 64;
+};
+
+TEST_F(QueryCacheTest, SimpleCache) {
+  std::shared_ptr<planner::SeqScanPlan> scan1 = GetSeqScanPlan();
+  std::shared_ptr<planner::SeqScanPlan> scan2 = GetSeqScanPlan();
+
+  planner::BindingContext context1;
+  scan1->PerformBinding(context1);
+  planner::BindingContext context2;
+  scan2->PerformBinding(context2);
+
+  // Check the plan is the same
+  auto ret = codegen::PlanComparator::Compare(*scan1, *scan2);
+  EXPECT_EQ(ret, 0);
+
+  // Execute a new query
+  codegen::BufferingConsumer buffer1{{0}, context1};
+  CompileAndExecuteCache(scan1, buffer1,
+                         reinterpret_cast<char*>(buffer1.GetState()));
+  const auto& results1 = buffer1.GetOutputTuples();
+  EXPECT_EQ(NumRowsInTestTable() - 4, results1.size());
+
+  // Execute a query cached
+  codegen::BufferingConsumer buffer2{{0}, context2};
+  CompileAndExecuteCache(scan2, buffer2,
+                         reinterpret_cast<char*>(buffer2.GetState()));
+  const auto& results2 = buffer2.GetOutputTuples();
+  EXPECT_EQ(NumRowsInTestTable() - 4, results2.size());
+
+  EXPECT_EQ(1, codegen::QueryCache::Instance().GetSize());
+}
+
+TEST_F(QueryCacheTest, CacheSeqScanPlan) {
+
+  // SELECT a, b, c FROM table where a >= 20 and b = 21;
+  auto scan1 = GetSeqScanPlanWithPredicate();
+  auto scan2 = GetSeqScanPlanWithPredicate();
+
+  // Do binding
+  planner::BindingContext context1;
+  scan1->PerformBinding(context1);
+
+  planner::BindingContext context2;
+  scan2->PerformBinding(context2);
+
+  int ret = codegen::PlanComparator::Compare(*scan1, *scan2);
+  EXPECT_EQ(ret, 0);
+
+  codegen::BufferingConsumer buffer1{{0, 1, 2}, context1};
+
+  CompileAndExecuteCache(scan1, buffer1,
+                             reinterpret_cast<char*>(buffer1.GetState()));
+
+  // Check that we got all the results
+  const auto& results1 = buffer1.GetOutputTuples();
+  EXPECT_EQ(1, results1.size());
+  EXPECT_EQ(type::CMP_TRUE, results1[0].GetValue(0).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(20)));
+  EXPECT_EQ(type::CMP_TRUE, results1[0].GetValue(1).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(21)));
+
+  codegen::BufferingConsumer buffer2{{0, 1, 2}, context2};
+  CompileAndExecuteCache(scan2, buffer2,
+                             reinterpret_cast<char*>(buffer2.GetState()));
+
+  const auto& results2 = buffer2.GetOutputTuples();
+  EXPECT_EQ(1, results2.size());
+  EXPECT_EQ(type::CMP_TRUE, results2[0].GetValue(0).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(20)));
+  EXPECT_EQ(type::CMP_TRUE, results2[0].GetValue(1).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(21)));
+
+  EXPECT_EQ(2, codegen::QueryCache::Instance().GetSize());
+}
+
+TEST_F(QueryCacheTest, CacheHashJoinPlan) {
+  auto hj_plan1 = GetHashJoinPlan();
+  auto hj_plan2 = GetHashJoinPlan();
+
+  // Do binding
+  planner::BindingContext context1, context2;
+  hj_plan1->PerformBinding(context1);
+  hj_plan2->PerformBinding(context2);
+
+  int ret = codegen::PlanComparator::Compare(*hj_plan2, *hj_plan1);
+  EXPECT_EQ(ret, 0);
+
+  // We collect the results of the query into an in-memory buffer
+  codegen::BufferingConsumer buffer1{{0, 1, 2, 3}, context1};
+
+  CompileAndExecuteCache(hj_plan1, buffer1,
+                             reinterpret_cast<char*>(buffer1.GetState()));
+
+  // Check results
+  const auto& results1 = buffer1.GetOutputTuples();
+  EXPECT_EQ(64, results1.size());
+
+  // The output has the join columns (that should match) in positions 0 and 1
+  for (const auto& tuple : results1) {
+    type::Value v0 = tuple.GetValue(0);
+    EXPECT_EQ(v0.GetTypeId(), type::Type::TypeId::INTEGER);
+
+    // Check that the joins keys are actually equal
+    EXPECT_EQ(tuple.GetValue(0).CompareEquals(tuple.GetValue(1)),
+              type::CMP_TRUE);
+  }
+
+  // We collect the results of the query into an in-memory buffer
+  codegen::BufferingConsumer buffer2{{0, 1, 2, 3}, context2};
+
+  CompileAndExecuteCache(hj_plan2, buffer2,
+                             reinterpret_cast<char*>(buffer2.GetState()));
+  // Check results
+  const auto& results2 = buffer2.GetOutputTuples();
+  EXPECT_EQ(64, results2.size());
+  for (const auto& tuple : results2) {
+    type::Value v0 = tuple.GetValue(0);
+    EXPECT_EQ(v0.GetTypeId(), type::Type::TypeId::INTEGER);
+
+    // Check that the joins keys are actually equal
+    EXPECT_EQ(tuple.GetValue(0).CompareEquals(tuple.GetValue(1)),
+              type::CMP_TRUE);
+  }
+  EXPECT_EQ(3, codegen::QueryCache::Instance().GetSize());
+}
+
+TEST_F(QueryCacheTest, CacheOrderByPlan) {
+  // plan 1, 2: SELECT * FROM test_table ORDER BY b DESC a ASC;
+  // plan 3: SELECT * FROM test_table ORDER BY b ASC a DESC;
+  std::shared_ptr<planner::OrderByPlan> order_by_plan_1{
+      new planner::OrderByPlan({1, 0}, {true, false}, {0, 1, 2, 3})};
+  std::shared_ptr<planner::OrderByPlan> order_by_plan_2{
+      new planner::OrderByPlan({1, 0}, {true, false}, {0, 1, 2, 3})};
+  std::shared_ptr<planner::OrderByPlan> order_by_plan_3{
+      new planner::OrderByPlan({1, 0}, {false, true}, {0, 1, 2, 3})};
+
+  std::unique_ptr<planner::SeqScanPlan> seq_scan_plan_1{
+      new planner::SeqScanPlan(&GetTestTable(TestTableId()), nullptr,
+                               {0, 1, 2, 3})};
+  std::unique_ptr<planner::SeqScanPlan> seq_scan_plan_2{
+      new planner::SeqScanPlan(&GetTestTable(TestTableId()), nullptr,
+                               {0, 1, 2, 3})};
+  std::unique_ptr<planner::SeqScanPlan> seq_scan_plan_3{
+      new planner::SeqScanPlan(&GetTestTable(TestTableId()), nullptr,
+                               {0, 1, 2, 3})};
+  order_by_plan_1->AddChild(std::move(seq_scan_plan_1));
+  order_by_plan_2->AddChild(std::move(seq_scan_plan_2));
+  order_by_plan_3->AddChild(std::move(seq_scan_plan_3));
+
+  planner::BindingContext context1, context2, context3;
+  order_by_plan_1->PerformBinding(context1);
+  order_by_plan_2->PerformBinding(context2);
+  order_by_plan_3->PerformBinding(context3);
+
+  int ret = codegen::PlanComparator::Compare(*order_by_plan_1.get(),
+                                             *order_by_plan_2.get());
+  EXPECT_EQ(ret, 0);
+
+  ret = (codegen::PlanComparator::Compare(*order_by_plan_1.get(),
+                                          *order_by_plan_3.get()) == 0);
+  EXPECT_EQ(ret, 0);
+
+  codegen::BufferingConsumer buffer1{{0, 1}, context1};
+  codegen::BufferingConsumer buffer2{{0, 1}, context2};
+
+  CompileAndExecuteCache(order_by_plan_1, buffer1,
+                             reinterpret_cast<char*>(buffer1.GetState()));
+
+  auto& results1 = buffer1.GetOutputTuples();
+  EXPECT_EQ(results1.size(), NumRowsInTestTable());
+  EXPECT_TRUE(std::is_sorted(
+      results1.begin(), results1.end(),
+      [](const codegen::WrappedTuple& t1, const codegen::WrappedTuple& t2) {
+        auto is_gte = t1.GetValue(0).CompareGreaterThanEquals(t2.GetValue(0));
+        return is_gte == type::CMP_TRUE;
+      }));
+
+  CompileAndExecuteCache(order_by_plan_2, buffer2,
+                             reinterpret_cast<char*>(buffer2.GetState()));
+  auto& results2 = buffer2.GetOutputTuples();
+  EXPECT_EQ(results2.size(), NumRowsInTestTable());
+  EXPECT_TRUE(std::is_sorted(
+      results2.begin(), results2.end(),
+      [](const codegen::WrappedTuple& t1, const codegen::WrappedTuple& t2) {
+        auto is_gte = t1.GetValue(0).CompareGreaterThanEquals(t2.GetValue(0));
+        return is_gte == type::CMP_TRUE;
+      }));
+
+  ret = (codegen::QueryCache::Instance().Find(std::move(order_by_plan_3)) ==
+         nullptr);
+  EXPECT_EQ(ret, 1);
+
+  EXPECT_EQ(4, codegen::QueryCache::Instance().GetSize());
+}
+
+TEST_F(QueryCacheTest, CacheAggregatePlan) {
+  auto agg_plan1 = GetAggregatePlan();
+  auto agg_plan2 = GetAggregatePlan();
+  planner::BindingContext context1, context2;
+  agg_plan1->PerformBinding(context1);
+  agg_plan2->PerformBinding(context2);
+  int ret = codegen::PlanComparator::Compare(*agg_plan1, *agg_plan2);
+  EXPECT_EQ(ret, 0);
+  EXPECT_EQ(4, codegen::QueryCache::Instance().GetSize());
+
+  codegen::BufferingConsumer buffer1{{0, 1}, context1};
+  codegen::BufferingConsumer buffer2{{0, 1}, context2};
+
+  // Compile and execute
+  CompileAndExecuteCache(agg_plan1, buffer1,
+                             reinterpret_cast<char*>(buffer1.GetState()));
+  // Check results
+  const auto& results1 = buffer1.GetOutputTuples();
+  EXPECT_EQ(results1.size(), 59);
+  EXPECT_EQ(5, codegen::QueryCache::Instance().GetSize());
+
+  // Compile and execute with the cached query
+  CompileAndExecuteCache(agg_plan2, buffer2,
+                             reinterpret_cast<char*>(buffer2.GetState()));
+
+  const auto& results2 = buffer2.GetOutputTuples();
+  EXPECT_EQ(results2.size(), 59);
+
+  // Clean the query cache and leaves only one query
+  codegen::QueryCache::Instance().ClearCache();
+  EXPECT_EQ(0, codegen::QueryCache::Instance().GetSize());
+
+  // Check the correctness of LRU
+  auto agg_plan3 = GetAggregatePlan();
+  planner::BindingContext context3;
+  agg_plan3->PerformBinding(context3);
+  ret = codegen::QueryCache::Instance().Find(agg_plan3) == nullptr ? 0 : 1;
+  EXPECT_EQ(ret, 0);
+}
+
+TEST_F(QueryCacheTest, PerformanceBenchmark) {
+
+  codegen::QueryCache::Instance().ClearCache();
+  Timer<std::ratio<1, 1000>> timer1, timer2;
+
+  timer1.Start();
+  for (int i = 0; i < 10; i++) {
+    auto plan = GetHashJoinPlan();
+    // Do binding
+    planner::BindingContext context;
+    plan->PerformBinding(context);
+    // We collect the results of the query into an in-memory buffer
+    codegen::BufferingConsumer buffer{{0, 1, 2, 3}, context};
+    // COMPILE and run without cache
+    CompileAndExecute(*plan, buffer,
+                      reinterpret_cast<char*>(buffer.GetState()));
+  }
+  timer1.Stop();
+
+  timer2.Start();
+  for (int i = 0; i < 10; i++) {
+    auto plan = GetHashJoinPlan();
+    // Do binding
+    planner::BindingContext context;
+    plan->PerformBinding(context);
+    // We collect the results of the query into an in-memory buffer
+    codegen::BufferingConsumer buffer{{0, 1, 2, 3}, context};
+    // COMPILE and execute with cache
+    CompileAndExecuteCache(plan, buffer,
+                               reinterpret_cast<char*>(buffer.GetState()));
+  }
+  timer2.Stop();
+
+  LOG_INFO("Time spent w/ codegen w/o cache is %f ms", timer1.GetDuration());
+  LOG_INFO("Time spent w/ codegen & cache is %f ms", timer2.GetDuration());
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/codegen/query_cache_test.cpp
+++ b/test/codegen/query_cache_test.cpp
@@ -393,7 +393,7 @@ TEST_F(QueryCacheTest, CacheAggregatePlan) {
 
   // Compile and execute
   CompileAndExecuteCache(agg_plan1, buffer1,
-                             reinterpret_cast<char*>(buffer1.GetState()));
+                         reinterpret_cast<char*>(buffer1.GetState()));
   // Check results
   const auto& results1 = buffer1.GetOutputTuples();
   EXPECT_EQ(results1.size(), 59);
@@ -401,7 +401,7 @@ TEST_F(QueryCacheTest, CacheAggregatePlan) {
 
   // Compile and execute with the cached query
   CompileAndExecuteCache(agg_plan2, buffer2,
-                             reinterpret_cast<char*>(buffer2.GetState()));
+                         reinterpret_cast<char*>(buffer2.GetState()));
 
   const auto& results2 = buffer2.GetOutputTuples();
   EXPECT_EQ(results2.size(), 59);

--- a/test/executor/copy_test.cpp
+++ b/test/executor/copy_test.cpp
@@ -83,7 +83,7 @@ TEST_F(CopyTests, Copying) {
     std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
     std::vector<StatementResult> result;
     executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
-        statement->GetPlanTree().get(), params, result, result_format);
+        statement->GetPlanTree(), params, result, result_format);
     EXPECT_EQ(status.m_result, peloton::ResultType::SUCCESS);
     LOG_TRACE("Statement executed. Result: %s",
               ResultTypeToString(status.m_result).c_str());

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -85,7 +85,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
   LOG_INFO("Table Created");
@@ -121,7 +121,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   LOG_INFO("Executing plan...");
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -148,7 +148,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   LOG_INFO("Executing plan...");
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -60,7 +60,7 @@ void ShowTable(std::string database_name, std::string table_name) {
   auto tuple_descriptor = tcop::TrafficCop().GenerateTupleDescriptor(
       (parser::SelectStatement*)select_stmt->GetStatement(0));
   result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
 }
 
@@ -125,7 +125,7 @@ TEST_F(DeleteTests, VariousOperations) {
   std::vector<int> result_format;
   result_format = std::move(std::vector<int>(0, 0));
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
   LOG_INFO("Tuple inserted!");
@@ -148,7 +148,7 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -172,7 +172,7 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -198,7 +198,7 @@ TEST_F(DeleteTests, VariousOperations) {
   auto tuple_descriptor =
       tcop::TrafficCop().GenerateTupleDescriptor(select_stmt->GetStatement(0));
   result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -219,7 +219,7 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -242,7 +242,7 @@ TEST_F(DeleteTests, VariousOperations) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
   result_format = std::move(std::vector<int>(0, 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -214,7 +214,7 @@ TEST_F(UpdateTests, UpdatingOld) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
   LOG_INFO("Tuple inserted!");
@@ -241,7 +241,7 @@ TEST_F(UpdateTests, UpdatingOld) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -270,7 +270,7 @@ TEST_F(UpdateTests, UpdatingOld) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -295,7 +295,7 @@ TEST_F(UpdateTests, UpdatingOld) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -321,7 +321,7 @@ TEST_F(UpdateTests, UpdatingOld) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/include/codegen/codegen_test_util.h
+++ b/test/include/codegen/codegen_test_util.h
@@ -69,6 +69,10 @@ class PelotonCodeGenTest : public PelotonTest {
       const planner::AbstractPlan &plan, codegen::QueryResultConsumer &consumer,
       char *consumer_state);
 
+  codegen::QueryCompiler::CompileStats CompileAndExecuteCache(
+      const std::shared_ptr<planner::AbstractPlan> &plan,
+      codegen::QueryResultConsumer &consumer, char *consumer_state);
+
  private:
   storage::Database *test_db;
 };

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -63,7 +63,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
 
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
   LOG_INFO("Table Created");
@@ -87,7 +87,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
 
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -113,7 +113,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
 
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -134,7 +134,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
 
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -153,7 +153,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(select_stmt));
 
   result_format = std::move(std::vector<int>(4, 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/optimizer/simple_optimizer_test.cpp
+++ b/test/optimizer/simple_optimizer_test.cpp
@@ -71,7 +71,7 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
-      statement->GetPlanTree().get(), params, result, result_format);
+      statement->GetPlanTree(), params, result, result_format);
   LOG_TRACE("Statement executed. Result: %s",
             ResultTypeToString(status.m_result).c_str());
   LOG_TRACE("Table Created");
@@ -101,7 +101,7 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
 
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_TRACE("Statement executed. Result: %s",
             ResultTypeToString(status.m_result).c_str());
@@ -122,7 +122,7 @@ TEST_F(SimpleOptimizerTests, UpdateDelWithIndexScanTest) {
 
   result_format =
       std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
-  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
+  status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(),
                                             params, result, result_format);
   LOG_TRACE("Statement executed. Result: %s",
             ResultTypeToString(status.m_result).c_str());

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -79,7 +79,7 @@ ResultType TestingSQLUtil::ExecuteSQLQueryWithOptimizer(
 
   try {
     LOG_DEBUG("%s", planner::PlanUtil::GetInfo(plan.get()).c_str());
-    auto status = traffic_cop_.ExecuteStatementPlan(plan.get(), params, result,
+    auto status = traffic_cop_.ExecuteStatementPlan(plan, params, result,
                                                     result_format);
     rows_changed = status.m_processed;
     LOG_INFO("Statement executed. Result: %s",

--- a/test/statistics/testing_stats_util.cpp
+++ b/test/statistics/testing_stats_util.cpp
@@ -47,7 +47,7 @@ void TestingStatsUtil::ShowTable(std::string database_name,
   LOG_DEBUG("%s",
             planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
-  traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(), params,
+  traffic_cop.ExecuteStatementPlan(statement->GetPlanTree(), params,
                                    result, result_format);
 }
 


### PR DESCRIPTION
This is a PR for caching the compiled objects in codegen, so that if the same query is requested, the codegen checks whether or not the plan has already been compiled by comparing each item in the two plans.  This is another PR which is cherry picked from #656, and is based on the PR #675.

This cache could be enhanced further in the future by mixing eviction policies, configuring the cache size, manually pinning some queries in the cache, making them persistent in the cache, etc. In terms of software engineering point of view, the plan comparator could be embedded with plan classes rather than having it separately in codegen.
