### PR TITLE
Supporting OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
-sudo: required
-dist: trusty
 #language: c++
 matrix:
     include:
-        - compiler: gcc
+        # Mac build
+        - os: osx
+          osx_image: xcode8.3
+          compiler: clang
+          env:
+            - PELOTON_BUILD_TYPE=Debug COVERALLS=Off
+
+        # Linux builds
+        - os: linux
+          sudo: required
+          dist: trusty
+          compiler: gcc
           addons:
               apt:
                   sources:
@@ -14,7 +23,11 @@ matrix:
                     - g++-4.9
           env: 
             - CXX=g++-4.9 PELOTON_BUILD_TYPE=Debug COVERALLS=Off
-        - compiler: gcc
+
+        - os: linux
+          sudo: required
+          dist: trusty
+          compiler: gcc
           addons:
               apt:
                   sources:
@@ -27,7 +40,10 @@ matrix:
             - CXX=g++-4.9 PELOTON_BUILD_TYPE=Release COVERALLS=Off
         
         #Job where coveralls is executed
-        - compiler: gcc
+        - os: linux
+          sudo: required
+          dist: trusty
+          compiler: gcc
           addons:
               apt:
                   sources:
@@ -38,8 +54,11 @@ matrix:
                     - g++-5
           env: 
             - CXX=g++-5 PELOTON_BUILD_TYPE=Debug COVERALLS=On
-            
-        - compiler: gcc
+
+        - os: linux
+          sudo: required
+          dist: trusty
+          compiler: gcc
           addons:
               apt:
                   sources:
@@ -50,11 +69,11 @@ matrix:
                     - g++-5
           env: 
             - CXX=g++-5 PELOTON_BUILD_TYPE=Release COVERALLS=Off
-    
+
 before_script:
     # setup environment
     - ./script/installation/packages.sh
-    - pip install --user cpp-coveralls
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then pip install --user cpp-coveralls; fi
 
 script:
     # first, run source_validator
@@ -63,19 +82,20 @@ script:
     - mkdir build
     - cd build
     # run cmake
-    - cmake -DCOVERALLS=$COVERALLS -DCMAKE_BUILD_TYPE=$PELOTON_BUILD_TYPE -DUSE_SANITIZER=Address ..
+    - cmake -DCOVERALLS=$COVERALLS -DCMAKE_PREFIX_PATH=`llvm-config-3.7 --prefix` -DCMAKE_BUILD_TYPE=$PELOTON_BUILD_TYPE -DUSE_SANITIZER=Address ..
     # build
     - make -j4
     # run tests
-    - make check -j4
+    - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then make check -j4; fi
+    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then ASAN_OPTIONS=detect_container_overflow=0 make check -j4; fi
     # build benchmarks
     - make benchmark -j4
     # install peloton
     - make install
     # run psql tests
-    - bash ../script/testing/psql/psql_test.sh
+    - bash ../script/testing/psql/psql_test.sh $TRAVIS_OS_NAME
     # run jdbc tests
-    - python ../script/validators/jdbc_validator.py
+    - python ../script/validators/jdbc_validator.py $TRAVIS_OS_NAME
     # upload coverage info
-    - bash -c "if [ \"${COVERALLS^^}\" = 'ON' ] ; then make coveralls; fi"
+    - bash -c "if [ $(echo $COVERALLS | tr "[:lower:]" "[:upper:]") = 'ON' ] ; then echo 1; fi"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,5 +97,5 @@ script:
     # run jdbc tests
     - python ../script/validators/jdbc_validator.py
     # upload coverage info
-    - bash -c "if [ $(echo $COVERALLS | tr "[:lower:]" "[:upper:]") = 'ON' ] ; then echo 1; fi"
+    - bash -c "if [ $(echo $COVERALLS | tr "[:lower:]" "[:upper:]") = 'ON' ] ; then make coveralls; fi"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,9 +93,9 @@ script:
     # install peloton
     - make install
     # run psql tests
-    - bash ../script/testing/psql/psql_test.sh $TRAVIS_OS_NAME
+    - bash ../script/testing/psql/psql_test.sh
     # run jdbc tests
-    - python ../script/validators/jdbc_validator.py $TRAVIS_OS_NAME
+    - python ../script/validators/jdbc_validator.py
     # upload coverage info
     - bash -c "if [ $(echo $COVERALLS | tr "[:lower:]" "[:upper:]") = 'ON' ] ; then echo 1; fi"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,10 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -fno-omit-frame-po
 
 # ---[ Flags
 if(UNIX OR APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall -Wextra -Werror -mcx16 -Wno-invalid-offsetof -march=native")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall -Wextra -Werror -mcx16 -Wno-invalid-offsetof -march=native")
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-tautological-undefined-compare -Wno-unused-private-field -Wno-braced-scalar-init -Wno-constant-conversion -Wno-potentially-evaluated-expression -Wno-infinite-recursion -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -I/usr/local/opt/openssl/include")
+    endif()
 endif()
 
 # ---[ Warnings

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -17,7 +17,7 @@ fi
 # For everything else (or if above failed), just use generic identifier
 [ "$DISTRO" == "" ] && export DISTRO=$UNAME
 unset UNAME
-DISTRO=${DISTRO^^}
+DISTRO=$(echo $DISTRO | tr "[:lower:]" "[:upper:]")
 TMPDIR=/tmp
 
 function install_repo_package() {
@@ -156,7 +156,32 @@ elif [[ "$DISTRO" == *"REDHAT"* ]] && [[ "${DISTRO_VER%.*}" == "7" ]]; then
     for pkg_path in ${PKGS[@]}; do
         install_package $pkg_path
     done
-   
+
+## ------------------------------------------------
+## DARWIN (OSX)
+## ------------------------------------------------
+elif [ "$DISTRO" = "DARWIN" ]; then
+    if test ! $(which brew); then
+      echo "Installing homebrew..."
+      ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    fi
+
+    brew install git
+    brew install cmake
+    brew install gflags
+    brew install protobuf
+    brew install bison
+    brew install flex
+    brew install libevent
+    brew install boost
+    brew install jemalloc
+    brew install valgrind
+    brew install lcov
+    brew install libpqxx
+    brew install libedit
+    brew install llvm@3.7
+    brew install postgresql
+
 ## ------------------------------------------------
 ## UNKNOWN
 ## ------------------------------------------------

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -175,7 +175,6 @@ elif [ "$DISTRO" = "DARWIN" ]; then
     brew install libevent
     brew install boost
     brew install jemalloc
-    brew install valgrind
     brew install lcov
     brew install libpqxx
     brew install libedit

--- a/script/testing/psql/psql_test.sh
+++ b/script/testing/psql/psql_test.sh
@@ -7,7 +7,7 @@
 # NOTE: absolute path to peloton directory is calculated from current directory
 # directory structure: peloton/scripts/testing/psql/<this_file>
 CODE_SOURCE_DIR=`dirname $0`
-OS_NAME=$1
+OS_NAME=$(uname | tr "[:lower:]" "[:upper:]")
 REF_OUT_FILE="$CODE_SOURCE_DIR/psql_ref_out.txt"
 TEMP_OUT_FILE="/tmp/psql_out-$$"
 
@@ -52,7 +52,7 @@ trap cleanup EXIT
 cd $PELOTON_DIR/build
 
 # start peloton
-if [ "$OS_NAME" == "osx" ]; then
+if [ "$OS_NAME" == "DARWIN" ]; then
     ASAN_OPTIONS=detect_container_overflow=0 bin/peloton -port $PELOTON_PORT > /dev/null &
 else
     bin/peloton -port $PELOTON_PORT > /dev/null &

--- a/script/testing/psql/psql_test.sh
+++ b/script/testing/psql/psql_test.sh
@@ -7,6 +7,7 @@
 # NOTE: absolute path to peloton directory is calculated from current directory
 # directory structure: peloton/scripts/testing/psql/<this_file>
 CODE_SOURCE_DIR=`dirname $0`
+OS_NAME=$1
 REF_OUT_FILE="$CODE_SOURCE_DIR/psql_ref_out.txt"
 TEMP_OUT_FILE="/tmp/psql_out-$$"
 
@@ -51,7 +52,11 @@ trap cleanup EXIT
 cd $PELOTON_DIR/build
 
 # start peloton
-bin/peloton -port $PELOTON_PORT > /dev/null &
+if [ "$OS_NAME" == "osx" ]; then
+    ASAN_OPTIONS=detect_container_overflow=0 bin/peloton -port $PELOTON_PORT > /dev/null &
+else
+    bin/peloton -port $PELOTON_PORT > /dev/null &
+fi
 PELOTON_PID=$!
 sleep 3
 

--- a/script/validators/jdbc_validator.py
+++ b/script/validators/jdbc_validator.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import time
 import re
+import platform
 
 ## ==============================================
 ## CONFIGURATION
@@ -63,9 +64,9 @@ if __name__ == '__main__':
         raise Exception("Unable to find JDBC script dir '%s'" % PELOTON_JDBC_SCRIPT_DIR)
 
     ## Basic
-    runTest("test_jdbc.sh", isOSX=sys.argv[1] == 'osx')
+    runTest("test_jdbc.sh", isOSX=platform.system() == 'Darwin')
 
     ## Stats
-    # runTest("test_jdbc.sh", enableStats=True, sys.argv[1] == 'osx')
+    # runTest("test_jdbc.sh", enableStats=True, platform.system() == 'Darwin')
 
 ## MAIN

--- a/script/validators/jdbc_validator.py
+++ b/script/validators/jdbc_validator.py
@@ -28,12 +28,15 @@ PELOTON_PORT = 15721
 EXIT_SUCCESS = 0
 EXIT_FAILURE = -1
 
-def runTest(script, enableStats=False):
+def runTest(script, enableStats=False, isOSX=False):
     # Launch Peloton
     args = "-port " + str(PELOTON_PORT)
     if enableStats:
         args += " -stats_mode 1"
-    cmd = ['exec ' + PELOTON_BIN + ' ' + args]
+    if isOSX:
+        cmd = ['ASAN_OPTIONS=detect_container_overflow=0 exec ' + PELOTON_BIN + ' ' + args]
+    else:
+        cmd = ['exec ' + PELOTON_BIN + ' ' + args]
     peloton = subprocess.Popen(cmd, shell=True)
     time.sleep(3) # HACK
 
@@ -54,16 +57,15 @@ def runTest(script, enableStats=False):
 
 
 if __name__ == '__main__':
-
     if not os.path.exists(PELOTON_BIN):
         raise Exception("Unable to find Peloton binary '%s'" % PELOTON_BIN)
     if not os.path.exists(PELOTON_JDBC_SCRIPT_DIR):
         raise Exception("Unable to find JDBC script dir '%s'" % PELOTON_JDBC_SCRIPT_DIR)
 
     ## Basic
-    runTest("test_jdbc.sh")
+    runTest("test_jdbc.sh", isOSX=sys.argv[1] == 'osx')
 
     ## Stats
-    # runTest("test_jdbc.sh", enableStats=True)
+    # runTest("test_jdbc.sh", enableStats=True, sys.argv[1] == 'osx')
 
 ## MAIN

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,7 +87,9 @@ set(EXE_LINK_FLAGS "-Wl,--no-as-needed")
 set(EXE_LIST peloton-bin ycsb tpcc sdbench tpch)
 foreach(exe_name ${EXE_LIST})
     target_link_libraries(${exe_name} ${EXE_LINK_LIBRARIES})
-    set_target_properties(${exe_name} PROPERTIES LINK_FLAGS ${EXE_LINK_FLAGS})
+    if (LINUX)
+        set_target_properties(${exe_name} PROPERTIES LINK_FLAGS ${EXE_LINK_FLAGS})
+    endif ()
 endforeach()
 
 # --[ benchmark

--- a/src/catalog/column_stats_catalog.cpp
+++ b/src/catalog/column_stats_catalog.cpp
@@ -169,7 +169,7 @@ std::unique_ptr<std::vector<type::Value>> ColumnStatsCatalog::GetColumnStats(
                                     most_common_vals, most_common_freqs,
                                     hist_bounds, column_name, has_index}));
 
-  return std::move(column_stats);
+  return column_stats;
 }
 
 // Return value: number of column stats

--- a/src/codegen/oa_hash_table.cpp
+++ b/src/codegen/oa_hash_table.cpp
@@ -201,7 +201,7 @@ std::pair<llvm::Value *, llvm::Value *> OAHashTable::GetDataCountAndPointer(
                                  "singleValue"};
   {
     data_count_inline = codegen.Const64(1);
-    data_ptr_inline = AdvancePointer(codegen, after_key_p, 0UL);
+    data_ptr_inline = AdvancePointer(codegen, after_key_p, (uint64_t) 0UL);
   }
   is_entry_single_value.ElseBlock("multipleValue");
   {

--- a/src/codegen/proxy/data_table_proxy.cpp
+++ b/src/codegen/proxy/data_table_proxy.cpp
@@ -41,7 +41,7 @@ const std::string& DataTableProxy::_GetTileGroupCount::GetFunctionName() {
   // TODO: FIX ME
   static const std::string kGetTileGroupCount =
 #ifdef __APPLE__
-      "_ZNK7peloton7storage9DataTable17GetTileGroupCountEvy";
+      "_ZNK7peloton7storage9DataTable17GetTileGroupCountEv";
 #else
       "_ZNK7peloton7storage9DataTable17GetTileGroupCountEv";
 #endif

--- a/src/codegen/proxy/oa_hash_table_proxy.cpp
+++ b/src/codegen/proxy/oa_hash_table_proxy.cpp
@@ -67,7 +67,7 @@ llvm::Type *OAHashTableProxy::GetType(CodeGen &codegen) {
 const std::string &OAHashTableProxy::_Init::GetFunctionName() {
   static const std::string kInitFnName =
 #ifdef __APPLE__
-      "_ZN7peloton7codegen4util11OAHashTable4InitEmmm";
+      "_ZN7peloton7codegen4util11OAHashTable4InitEyyy";
 #else
       "_ZN7peloton7codegen4util11OAHashTable4InitEmmm";
 #endif
@@ -142,7 +142,7 @@ llvm::Function *OAHashTableProxy::_Destroy::GetFunction(CodeGen &codegen) {
 const std::string &OAHashTableProxy::_StoreTuple::GetFunctionName() {
   static const std::string kStoreTupleFnName =
 #ifdef __APPLE__
-      "_ZN7peloton7codegen4util11OAHashTable10StoreTupleEPNS2_9HashEntryEm";
+      "_ZN7peloton7codegen4util11OAHashTable10StoreTupleEPNS2_9HashEntryEy";
 #else
       "_ZN7peloton7codegen4util11OAHashTable10StoreTupleEPNS2_9HashEntryEm";
 #endif

--- a/src/codegen/proxy/values_runtime_proxy.cpp
+++ b/src/codegen/proxy/values_runtime_proxy.cpp
@@ -138,7 +138,12 @@ llvm::Function *ValuesRuntimeProxy::_OutputInteger::GetFunction(
 
 const std::string &ValuesRuntimeProxy::_OutputBigInt::GetFunctionName() {
   static const std::string kOutputBigIntFnName =
+#ifdef __APPLE__
+      "_ZN7peloton7codegen13ValuesRuntime12OutputBigIntEPcjx";
+#else
       "_ZN7peloton7codegen13ValuesRuntime12OutputBigIntEPcjl";
+#endif
+
   return kOutputBigIntFnName;
 }
 
@@ -221,7 +226,11 @@ llvm::Function *ValuesRuntimeProxy::_OutputDate::GetFunction(CodeGen &codegen) {
 
 const std::string &ValuesRuntimeProxy::_OutputTimestamp::GetFunctionName() {
   static const std::string kOutputTimestampFnName =
+#ifdef __APPLE__
+      "_ZN7peloton7codegen13ValuesRuntime15OutputTimestampEPcjx";
+#else
       "_ZN7peloton7codegen13ValuesRuntime15OutputTimestampEPcjl";
+#endif
   return kOutputTimestampFnName;
 }
 
@@ -250,7 +259,7 @@ llvm::Function *ValuesRuntimeProxy::_OutputTimestamp::GetFunction(
 const std::string &ValuesRuntimeProxy::_OutputVarchar::GetFunctionName() {
   static const std::string kOutputVarcharFnName =
 #ifdef __APPLE__
-      "_ZN7peloton7codegen13ValuesRuntime13outputVarcharEPcjS2_j";
+      "_ZN7peloton7codegen13ValuesRuntime13OutputVarcharEPcjS2_j";
 #else
       "_ZN7peloton7codegen13ValuesRuntime13OutputVarcharEPcjS2_j";
 #endif

--- a/src/codegen/tile_group.cpp
+++ b/src/codegen/tile_group.cpp
@@ -144,7 +144,7 @@ codegen::Value TileGroup::LoadColumn(
     sql_type.GetTypeForMaterialization(codegen, col_type, col_len_type);
     PL_ASSERT(col_type != nullptr && col_len_type == nullptr);
 
-    val = codegen->CreateLoad(col_type, col_address);
+    val = codegen->CreateLoad(col_type, codegen->CreateBitCast(col_address, col_type->getPointerTo()));
 
     if (is_nullable) {
       // To check for NULL, we need to perform a comparison between the value we

--- a/src/codegen/util/cc_hash_table.cpp
+++ b/src/codegen/util/cc_hash_table.cpp
@@ -79,7 +79,7 @@ char* CCHashTable::StoreTuple(uint64_t hash, uint32_t size) {
 // Clean up any resources this hash table has
 //===----------------------------------------------------------------------===//
 void CCHashTable::Destroy() {
-  LOG_DEBUG("Cleaning up hash table with %ld entries ...", num_elements_);
+  LOG_DEBUG("Cleaning up hash table with %llu entries ...", (unsigned long long) num_elements_);
   for (uint64_t i = 0; i < num_buckets_; i++) {
     uint32_t chain_length = 0;
     HashEntry* e = buckets_[i];
@@ -90,7 +90,7 @@ void CCHashTable::Destroy() {
       chain_length++;
     }
     if (chain_length > kMaxHashChainSize) {
-      LOG_DEBUG("Bucket %ld chain length = %u ...", i, chain_length);
+      LOG_DEBUG("Bucket %llu chain length = %u ...", (unsigned long long) i, chain_length);
     }
   }
   free(buckets_);

--- a/src/codegen/util/oa_hash_table.cpp
+++ b/src/codegen/util/oa_hash_table.cpp
@@ -274,8 +274,8 @@ void OAHashTable::Resize(HashEntry **entry_p_p) {
   // Make it an assertion to prevent potential bugs
   PL_ASSERT(NeedsResize());
 
-  LOG_DEBUG("Resizing hash-table from %lu buckets to %lu", num_buckets_,
-            num_buckets_ << 1);
+  LOG_DEBUG("Resizing hash-table from %llu buckets to %llu", (unsigned long long) num_buckets_,
+            (unsigned long long) num_buckets_ << 1);
 
   // Double the size of the array
   num_buckets_ <<= 1;
@@ -364,7 +364,7 @@ void OAHashTable::Resize(HashEntry **entry_p_p) {
 // them, and then delete the entire array.
 //===----------------------------------------------------------------------===//
 void OAHashTable::Destroy() {
-  LOG_DEBUG("Cleaning up hash table with %ld entries ...", num_entries_);
+  LOG_DEBUG("Cleaning up hash table with %llu entries ...", (unsigned long long) num_entries_);
 
   uint64_t processed_count = 0;
   char *current_entry_char_p = reinterpret_cast<char *>(buckets_);

--- a/src/codegen/util/sorter.cpp
+++ b/src/codegen/util/sorter.cpp
@@ -49,8 +49,8 @@ void Sorter::Init(ComparisonFunction func, uint32_t tuple_size) {
   buffer_pos_ = buffer_start_;
   buffer_end_ = buffer_start_ + kInitialBufferSize;
 
-  LOG_INFO("Initialized Sorter with size %lu KB for tuples of size %u...",
-           kInitialBufferSize / 1024, tuple_size_);
+  LOG_INFO("Initialized Sorter with size %llu KB for tuples of size %u...",
+           (unsigned long long) kInitialBufferSize / 1024, tuple_size_);
 }
 
 // StoreValue a tuple of the given size in this sorter. We return a buffer that
@@ -78,13 +78,13 @@ void Sorter::Sort() {
 
   uint64_t num_tuples = GetNumTuples();
 
-  LOG_DEBUG("Going to sort %lu tuples in sort buffer", num_tuples);
+  LOG_DEBUG("Going to sort %llu tuples in sort buffer", (unsigned long long) num_tuples);
 
   // Sort the sucker
   std::qsort(buffer_start_, num_tuples, tuple_size_, cmp_func_);
 
   timer.Stop();
-  LOG_INFO("Sorted %lu tuples in %.2f ms", num_tuples, timer.GetDuration());
+  LOG_INFO("Sorted %llu tuples in %.2f ms", (unsigned long long) num_tuples, timer.GetDuration());
 }
 
 // Release any memory we allocated from the storage manager.
@@ -112,8 +112,8 @@ void Sorter::Resize() {
 
   // Allocate double the buffer room
   uint64_t next_alloc_size = curr_alloc_size << 1;
-  LOG_DEBUG("Resizing sorter from %lu bytes to %lu bytes ...", curr_alloc_size,
-            next_alloc_size);
+  LOG_DEBUG("Resizing sorter from %llu bytes to %llu bytes ...", (unsigned long long) curr_alloc_size,
+            (unsigned long long) next_alloc_size);
 
   auto &backend_manager = storage::BackendManager::GetInstance();
 

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -30,10 +30,10 @@ void PrintConfiguration(){
   LOG_INFO("%30s", "//===-------------- PELOTON CONFIGURATION --------------===//");
   LOG_INFO(" ");
 
-  LOG_INFO("%30s: %10lu", "Port", FLAGS_port);
+  LOG_INFO("%30s: %10llu", "Port", (unsigned long long) FLAGS_port);
   LOG_INFO("%30s: %10s",  "Socket Family", FLAGS_socket_family.c_str());
   LOG_INFO("%30s: %10s", "Statistics", FLAGS_stats_mode ? "enabled" : "disabled");
-  LOG_INFO("%30s: %10lu", "Max Connections", FLAGS_max_connections);
+  LOG_INFO("%30s: %10llu", "Max Connections", (unsigned long long) FLAGS_max_connections);
   LOG_INFO("%30s: %10s", "Index Tuner", FLAGS_index_tuner ? "enabled" : "disabled");
   LOG_INFO("%30s: %10s", "Layout Tuner", FLAGS_layout_tuner ? "enabled" : "disabled");
   LOG_INFO("%30s: %10s",  "Code-generation", FLAGS_codegen ? "enabled" : "disabled");

--- a/src/executor/abstract_join_executor.cpp
+++ b/src/executor/abstract_join_executor.cpp
@@ -233,13 +233,13 @@ std::unique_ptr<LogicalTile> AbstractJoinExecutor::BuildOutputLogicalTile(
   // left tile is empty
   if (non_empty_tile == right_tile) {
     /* build the schema given the projection */
-    output_tile->SetSchema(std::move(
-        BuildSchemaFromRightTile(&non_empty_tile_schema, output_schema)));
+    output_tile->SetSchema(
+        BuildSchemaFromRightTile(&non_empty_tile_schema, output_schema));
   } else {
     // right tile is empty
-    output_tile->SetSchema(std::move(
+    output_tile->SetSchema(
         BuildSchemaFromLeftTile(&non_empty_tile_schema, output_schema,
-                                left_tile->GetPositionLists().size())));
+                                left_tile->GetPositionLists().size()));
   }
   return output_tile;
 }

--- a/src/executor/copy_executor.cpp
+++ b/src/executor/copy_executor.cpp
@@ -210,7 +210,7 @@ bool CopyExecutor::DExecute() {
     std::vector<std::vector<std::string>> answer_tuples;
     std::vector<int> result_format(col_count, 0);
     answer_tuples =
-        std::move(logical_tile->GetAllValuesAsStrings(result_format, true));
+        logical_tile->GetAllValuesAsStrings(result_format, true);
 
     // Loop over the returned results
     for (auto &tuple : answer_tuples) {

--- a/src/executor/logical_tile.cpp
+++ b/src/executor/logical_tile.cpp
@@ -778,7 +778,7 @@ std::unique_ptr<storage::Tile> LogicalTile::Materialize() {
   MaterializeByTiles(old_to_new_cols, tile_to_cols, dest_tile.get());
 
   // Wrap physical tile in logical tile.
-  return std::move(dest_tile);
+  return dest_tile;
 }
 
 }  // End executor namespace

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -91,8 +91,8 @@ ExecuteResult PlanExecutor::ExecutePlan(const planner::AbstractPlan *plan,
                     logical_tile->GetInfo().c_str());  // Printing the answers
 
           std::vector<std::vector<std::string>> answer_tuples;
-          answer_tuples = std::move(
-              logical_tile->GetAllValuesAsStrings(result_format, false));
+          answer_tuples =
+              logical_tile->GetAllValuesAsStrings(result_format, false);
 
           // Construct the returned results
           for (auto &tuple : answer_tuples) {

--- a/src/include/benchmark/tpcc/tpcc_workload.h
+++ b/src/include/benchmark/tpcc/tpcc_workload.h
@@ -51,7 +51,9 @@ void ExecuteUpdate(executor::AbstractExecutor* executor);
 
 void ExecuteDelete(executor::AbstractExecutor* executor);
 
-void PinToCore(size_t core);
+#ifndef __APPLE__ // https://superuser.com/questions/149312/how-to-set-processor-affinity-on-os-x
+    void PinToCore(size_t core);
+#endif
 
 }  // namespace tpcc
 }  // namespace benchmark

--- a/src/include/benchmark/tpcc/tpcc_workload.h
+++ b/src/include/benchmark/tpcc/tpcc_workload.h
@@ -51,9 +51,7 @@ void ExecuteUpdate(executor::AbstractExecutor* executor);
 
 void ExecuteDelete(executor::AbstractExecutor* executor);
 
-#ifndef __APPLE__ // https://superuser.com/questions/149312/how-to-set-processor-affinity-on-os-x
-    void PinToCore(size_t core);
-#endif
+void PinToCore(size_t core);
 
 }  // namespace tpcc
 }  // namespace benchmark

--- a/src/include/benchmark/ycsb/ycsb_workload.h
+++ b/src/include/benchmark/ycsb/ycsb_workload.h
@@ -41,7 +41,9 @@ std::vector<std::vector<type::Value>> ExecuteRead(executor::AbstractExecutor* ex
 
 void ExecuteUpdate(executor::AbstractExecutor* executor);
 
+#ifndef __APPLE__ // https://superuser.com/questions/149312/how-to-set-processor-affinity-on-os-x
 void PinToCore(size_t core);
+#endif
 
 }  // namespace ycsb
 }  // namespace benchmark

--- a/src/include/benchmark/ycsb/ycsb_workload.h
+++ b/src/include/benchmark/ycsb/ycsb_workload.h
@@ -41,9 +41,7 @@ std::vector<std::vector<type::Value>> ExecuteRead(executor::AbstractExecutor* ex
 
 void ExecuteUpdate(executor::AbstractExecutor* executor);
 
-#ifndef __APPLE__ // https://superuser.com/questions/149312/how-to-set-processor-affinity-on-os-x
 void PinToCore(size_t core);
-#endif
 
 }  // namespace ycsb
 }  // namespace benchmark

--- a/src/include/codegen/row_batch.h
+++ b/src/include/codegen/row_batch.h
@@ -116,7 +116,7 @@ class RowBatch {
       CacheKey(const expression::AbstractExpression *expr)
           : ai_(nullptr), expr_(expr) {}
       bool operator==(const CacheKey &other) const {
-        return ai_ == other.ai_ || expr_ == other.expr_;
+        return ai_ != nullptr ? ai_ == other.ai_ : expr_ == other.expr_;
       }
 
       struct Hasher {

--- a/src/include/codegen/type/type.h
+++ b/src/include/codegen/type/type.h
@@ -33,7 +33,8 @@ class TypeSystem;
 // number at runtime. For variable-length fields, it will carry the length of
 // the data element. This information is needed during code generation.
 //===----------------------------------------------------------------------===//
-struct Type {
+class Type {
+ public:
   // The actual SQL type
   peloton::type::TypeId type_id;
 

--- a/src/include/common/container_tuple.h
+++ b/src/include/common/container_tuple.h
@@ -52,7 +52,7 @@ class ContainerTuple : public AbstractTuple {
   oid_t GetTupleId() const { return tuple_id_; }
 
   void SetValue(UNUSED_ATTRIBUTE oid_t column_id,
-                UNUSED_ATTRIBUTE const type::Value &value) {}
+                UNUSED_ATTRIBUTE const type::Value &value) override {}
 
   /** @brief Get the value at the given column id. */
   type::Value GetValue(oid_t column_id) const override {
@@ -112,7 +112,7 @@ class ContainerTuple : public AbstractTuple {
   }
 
   // Get a string representation for debugging
-  const std::string GetInfo() const {
+  const std::string GetInfo() const override {
     std::stringstream os;
     os << "FIXME";
     return (os.str());
@@ -185,7 +185,7 @@ class ContainerTuple<std::vector<type::Value>> : public AbstractTuple {
   }
 
   void SetValue(UNUSED_ATTRIBUTE oid_t column_id,
-                UNUSED_ATTRIBUTE const type::Value &value) {}
+                UNUSED_ATTRIBUTE const type::Value &value) override {}
 
   /** @brief Get the raw location of the tuple's contents. */
   inline char *GetData() const override {
@@ -220,7 +220,7 @@ class ContainerTuple<std::vector<type::Value>> : public AbstractTuple {
   }
 
   // Get a string representation for debugging
-  const std::string GetInfo() const {
+  const std::string GetInfo() const override {
     std::stringstream os;
 
     bool first = true;
@@ -275,7 +275,7 @@ class ContainerTuple<storage::TileGroup> : public AbstractTuple {
     return container_->GetValue(tuple_id_, column_id);
   }
 
-  void SetValue(oid_t column_id, const type::Value &value) {
+  void SetValue(oid_t column_id, const type::Value &value) override {
     type::Value val = value.Copy();
     container_->SetValue(val, tuple_id_, column_id);
   }
@@ -289,7 +289,7 @@ class ContainerTuple<storage::TileGroup> : public AbstractTuple {
   }
 
   // Get a string representation for debugging
-  const std::string GetInfo() const {
+  const std::string GetInfo() const override {
     std::stringstream os;
     os << "FIXME";
     return (os.str());

--- a/src/include/common/item_pointer.h
+++ b/src/include/common/item_pointer.h
@@ -20,7 +20,8 @@
 namespace peloton {
 
 // logical physical location
-struct ItemPointer {
+class ItemPointer {
+ public:
   // block
   oid_t block;
 

--- a/src/include/common/sql_node_visitor.h
+++ b/src/include/common/sql_node_visitor.h
@@ -26,7 +26,7 @@ class TransactionStatement;
 class UpdateStatement;
 class CopyStatement;
 class AnalyzeStatement;
-struct JoinDefinition;
+class JoinDefinition;
 struct TableRef;
 
 class GroupByDescription;

--- a/src/include/executor/seq_scan_executor.h
+++ b/src/include/executor/seq_scan_executor.h
@@ -31,12 +31,12 @@ class SeqScanExecutor : public AbstractScanExecutor {
   void UpdatePredicate(const std::vector<oid_t> &column_ids,
                        const std::vector<type::Value> &values) override;
 
-  void ResetState() { current_tile_group_offset_ = START_OID; }
+  void ResetState() override { current_tile_group_offset_ = START_OID; }
 
  protected:
-  bool DInit();
+  bool DInit() override ;
 
-  bool DExecute();
+  bool DExecute() override ;
 
  private:
   //===--------------------------------------------------------------------===//

--- a/src/include/expression/aggregate_expression.h
+++ b/src/include/expression/aggregate_expression.h
@@ -92,7 +92,7 @@ class AggregateExpression : public AbstractExpression {
 
   inline void SetValueIdx(int value_idx) { value_idx_ = value_idx; }
 
-  AbstractExpression* Copy() const { return new AggregateExpression(*this); }
+  AbstractExpression* Copy() const override { return new AggregateExpression(*this); }
 
   void DeduceExpressionType() override {
     switch (exp_type_) {
@@ -116,7 +116,7 @@ class AggregateExpression : public AbstractExpression {
     }
   }
 
-  virtual void Accept(SqlNodeVisitor* v) { v->Visit(this); }
+  virtual void Accept(SqlNodeVisitor* v) override { v->Visit(this); }
 
  protected:
   AggregateExpression(const AggregateExpression& other)

--- a/src/include/expression/comparison_expression.h
+++ b/src/include/expression/comparison_expression.h
@@ -75,7 +75,7 @@ class ComparisonExpression : public AbstractExpression {
     return new ComparisonExpression(*this);
   }
 
-  virtual void Accept(SqlNodeVisitor *v) { v->Visit(this); }
+  virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
  protected:
   ComparisonExpression(const ComparisonExpression &other)

--- a/src/include/expression/conjunction_expression.h
+++ b/src/include/expression/conjunction_expression.h
@@ -61,7 +61,7 @@ class ConjunctionExpression : public AbstractExpression {
     return new ConjunctionExpression(*this);
   }
 
-  virtual void Accept(SqlNodeVisitor *v) { v->Visit(this); }
+  virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
  protected:
   ConjunctionExpression(const ConjunctionExpression &other)

--- a/src/include/expression/constant_value_expression.h
+++ b/src/include/expression/constant_value_expression.h
@@ -56,9 +56,9 @@ class ConstantValueExpression : public AbstractExpression {
     return new ConstantValueExpression(*this);
   }
 
-  virtual void Accept(SqlNodeVisitor *v) { v->Visit(this); }
+  virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
-  virtual hash_t Hash() const {
+  virtual hash_t Hash() const override {
     hash_t hash = HashUtil::Hash(&exp_type_);
     return HashUtil::CombineHashes(hash, value_.Hash());
   }

--- a/src/include/expression/expression_util.h
+++ b/src/include/expression/expression_util.h
@@ -412,7 +412,7 @@ class ExpressionUtil {
     std::vector<std::shared_ptr<AbstractExpression>> ordered_expr(
         expr_map.size());
     for (auto iter : expr_map) ordered_expr[iter.second] = iter.first;
-    return std::move(ordered_expr);
+    return ordered_expr;
   }
 
   /**

--- a/src/include/expression/function_expression.h
+++ b/src/include/expression/function_expression.h
@@ -76,11 +76,11 @@ class FunctionExpression : public AbstractExpression {
     return ret;
   }
 
-  AbstractExpression* Copy() const { return new FunctionExpression(*this); }
+  AbstractExpression* Copy() const override { return new FunctionExpression(*this); }
 
   std::string func_name_;
 
-  virtual void Accept(SqlNodeVisitor* v) { v->Visit(this); }
+  virtual void Accept(SqlNodeVisitor* v) override { v->Visit(this); }
 
  protected:
   FunctionExpression(const FunctionExpression& other)

--- a/src/include/expression/operator_expression.h
+++ b/src/include/expression/operator_expression.h
@@ -68,7 +68,7 @@ class OperatorExpression : public AbstractExpression {
     }
   }
 
-  void DeduceExpressionType() {
+  void DeduceExpressionType() override {
     // if we are a decimal or int we should take the highest type id of both
     // children
     // This relies on a particular order in types.h
@@ -86,7 +86,7 @@ class OperatorExpression : public AbstractExpression {
     return new OperatorExpression(*this);
   }
 
-  virtual void Accept(SqlNodeVisitor *v) { v->Visit(this); }
+  virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
  protected:
   OperatorExpression(const OperatorExpression &other)
@@ -111,7 +111,7 @@ class OperatorUnaryMinusExpression : public AbstractExpression {
     return new OperatorUnaryMinusExpression(*this);
   }
 
-  virtual void Accept(SqlNodeVisitor *v) { v->Visit(this); }
+  virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
  protected:
   OperatorUnaryMinusExpression(const OperatorUnaryMinusExpression &other)

--- a/src/include/expression/parameter_value_expression.h
+++ b/src/include/expression/parameter_value_expression.h
@@ -42,7 +42,7 @@ class ParameterValueExpression : public AbstractExpression {
     return new ParameterValueExpression(value_idx_);
   }
 
-  virtual void Accept(SqlNodeVisitor *v) { v->Visit(this); }
+  virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
  protected:
   int value_idx_;

--- a/src/include/expression/star_expression.h
+++ b/src/include/expression/star_expression.h
@@ -33,9 +33,9 @@ class StarExpression : public AbstractExpression {
     return type::ValueFactory::GetBooleanValue(true);
   }
 
-  AbstractExpression *Copy() const { return new StarExpression(*this); }
+  AbstractExpression *Copy() const override { return new StarExpression(*this); }
 
-  virtual void Accept(SqlNodeVisitor *v) { v->Visit(this); }
+  virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
  protected:
   StarExpression(const AbstractExpression &other) : AbstractExpression(other) {}

--- a/src/include/expression/tuple_value_expression.h
+++ b/src/include/expression/tuple_value_expression.h
@@ -113,7 +113,7 @@ class TupleValueExpression : public AbstractExpression {
     return res;
   }
 
-  virtual hash_t Hash() const;
+  virtual hash_t Hash() const override;
 
   const planner::AttributeInfo *GetAttributeRef() const { return ai_; }
 

--- a/src/include/index/bloom_filter.h
+++ b/src/include/index/bloom_filter.h
@@ -26,6 +26,12 @@
 
 #define BLOOM_FILTER_ENABLED
 
+// disable deprecated register keyword warning for clang
+#ifdef __APPLE__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-register"
+#endif
+
 namespace peloton{
 namespace index {
 
@@ -202,3 +208,7 @@ class BloomFilter {
 
 } // namespace index
 } // namespace peloton
+
+#ifdef __APPLE__
+#pragma clang diagnostic pop
+#endif

--- a/src/include/index/bwtree.h
+++ b/src/include/index/bwtree.h
@@ -1895,7 +1895,7 @@ class BwTree : public BwTreeBase {
    public:
     // One reasonable amount of memory for each chunk is 
     // delta chain len * struct len + sizeof this struct
-    static constexpr size_t CHUNK_SIZE() {  // Fix for Mac incomplete type error
+    static constexpr size_t CHUNK_SIZE() {
       return sizeof(DeltaNodeUnion) * 8 + sizeof(AllocationMeta);
     }
 

--- a/src/include/index/compact_ints_key.h
+++ b/src/include/index/compact_ints_key.h
@@ -15,6 +15,7 @@
 #include <sstream>
 
 #include "util/string_util.h"
+#include "util/portable_endian.h"
 
 namespace peloton {
 namespace index {

--- a/src/include/optimizer/query_node_visitor.h
+++ b/src/include/optimizer/query_node_visitor.h
@@ -26,7 +26,7 @@ class TransactionStatement;
 class UpdateStatement;
 class CopyStatement;
 class AnalyzeStatement;
-struct JoinDefinition;
+class JoinDefinition;
 struct TableRef;
 
 class GroupByDescription;

--- a/src/include/optimizer/stats/cost.h
+++ b/src/include/optimizer/stats/cost.h
@@ -38,10 +38,10 @@ static constexpr double DEFAULT_INDEX_TUPLE_COST = 0.005;
 static constexpr double DEFAULT_OPERATOR_COST = 0.0025;
 
 // Default cost of sorting n elements
-constexpr double default_sorting_cost(size_t n) { return n * std::log2(n); }
+  double default_sorting_cost(size_t n) { return n * std::log2(n); }
 
 // Default number of index tuple to access for n elements
-constexpr double default_index_height(size_t n) { return std::log2(n); }
+  double default_index_height(size_t n) { return std::log2(n); }
 
 //===----------------------------------------------------------------------===//
 // Cost

--- a/src/include/optimizer/stats/top_k_elements.h
+++ b/src/include/optimizer/stats/top_k_elements.h
@@ -225,7 +225,7 @@ class TopKElements {
         vec.push_back(*first);
         ++first;
       }
-      return std::move(vec);
+      return vec;
     }
 
     /*
@@ -242,7 +242,7 @@ class TopKElements {
         this->push(*first);
         ++first;
       }
-      return std::move(vec);
+      return vec;
     }
 
     /*
@@ -262,7 +262,7 @@ class TopKElements {
         vec_ret.push_back(stack.top());
         stack.pop();
       }
-      return std::move(vec_ret);
+      return vec_ret;
     }
 
     /*
@@ -286,7 +286,7 @@ class TopKElements {
         }
         stack.pop();
       }
-      return std::move(vec_ret);
+      return vec_ret;
     }
 
     /*
@@ -325,7 +325,7 @@ class TopKElements {
         vec_ret.push_back(std::make_pair(val, (double)t.approx_count));
         stack.pop();
       }
-      return std::move(vec_ret);
+      return vec_ret;
     }
 
     /*
@@ -368,7 +368,7 @@ class TopKElements {
         }
         stack.pop();
       }
-      return std::move(vec_ret);
+      return vec_ret;
     }
 
   };  // end of UpdatableQueue
@@ -789,7 +789,7 @@ class TopKElements {
    */
   ApproxTopEntry MakeApproxTopEntry(uint64_t freq, int64_t item) {
     ApproxTopEntryElem elem{item};
-    return std::move(ApproxTopEntry(elem, freq));
+    return ApproxTopEntry(elem, freq);
   }
 
   /*
@@ -797,7 +797,7 @@ class TopKElements {
    */
   ApproxTopEntry MakeApproxTopEntry(uint64_t freq, std::string item) {
     ApproxTopEntryElem elem{item};
-    return std::move(ApproxTopEntry(elem, freq));
+    return ApproxTopEntry(elem, freq);
   }
 
   /*

--- a/src/include/parser/analyze_statement.h
+++ b/src/include/parser/analyze_statement.h
@@ -22,7 +22,8 @@
 namespace peloton {
 namespace parser {
 
-struct AnalyzeStatement : SQLStatement {
+class AnalyzeStatement : public SQLStatement {
+ public:
   AnalyzeStatement()
       : SQLStatement(StatementType::ANALYZE),
         analyze_table(nullptr),

--- a/src/include/parser/copy_statement.h
+++ b/src/include/parser/copy_statement.h
@@ -21,10 +21,11 @@ namespace peloton {
 namespace parser {
 
 /**
- * @struct CopyStatement
+ * @class CopyStatement
  * @brief Represents PSQL Copy statements.
  */
-struct CopyStatement : SQLStatement {
+class CopyStatement : public SQLStatement {
+ public:
   CopyStatement(CopyType type)
       : SQLStatement(StatementType::COPY),
         cpy_table(NULL),

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -181,11 +181,12 @@ struct ColumnDefinition {
 };
 
 /**
- * @struct CreateStatement
+ * @class CreateStatement
  * @brief Represents "CREATE TABLE students (name TEXT, student_number INTEGER,
  * city TEXT, grade DOUBLE)"
  */
-struct CreateStatement : TableRefStatement {
+class CreateStatement : public TableRefStatement {
+ public:
   enum CreateType { kTable, kDatabase, kIndex };
 
   CreateStatement(CreateType type)

--- a/src/include/parser/delete_statement.h
+++ b/src/include/parser/delete_statement.h
@@ -20,12 +20,13 @@ namespace peloton {
 namespace parser {
 
 /**
- * @struct DeleteStatement
+ * @class DeleteStatement
  * @brief Represents "DELETE FROM students WHERE grade > 3.0"
  *
  * If expr == NULL => delete all rows (truncate)
  */
-struct DeleteStatement : SQLStatement {
+class DeleteStatement : public SQLStatement {
+ public:
   DeleteStatement()
       : SQLStatement(StatementType::DELETE),
         table_ref(nullptr), expr(nullptr) {};

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -19,10 +19,11 @@ namespace peloton {
 namespace parser {
 
 /**
- * @struct DropStatement
+ * @class DropStatement
  * @brief Represents "DROP TABLE"
  */
-struct DropStatement : TableRefStatement {
+class DropStatement : public TableRefStatement {
+ public:
   enum EntityType {
     kDatabase,
     kTable,

--- a/src/include/parser/execute_statement.h
+++ b/src/include/parser/execute_statement.h
@@ -19,10 +19,11 @@ namespace peloton {
 namespace parser {
 
 /**
- * @struct ExecuteStatement
+ * @class ExecuteStatement
  * @brief Represents "EXECUTE ins_prep(100, "test", 2.3);"
  */
-struct ExecuteStatement : SQLStatement {
+class ExecuteStatement : public SQLStatement {
+ public:
   ExecuteStatement()
       : SQLStatement(StatementType::EXECUTE), name(NULL), parameters(NULL) {}
 

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -20,11 +20,12 @@ namespace peloton {
 namespace parser {
 
 /**
- * @struct InsertStatement
+ * @class InsertStatement
  * @brief Represents "INSERT INTO students VALUES ('Max', 1112233,
  * 'Musterhausen', 2.3)"
  */
-struct InsertStatement : SQLStatement {
+class InsertStatement : SQLStatement {
+ public:
   InsertStatement(InsertType type)
       : SQLStatement(StatementType::INSERT),
         type(type),

--- a/src/include/parser/prepare_statement.h
+++ b/src/include/parser/prepare_statement.h
@@ -23,11 +23,12 @@ namespace peloton {
 namespace parser {
 
 /**
- * @struct PrepareStatement
+ * @class PrepareStatement
  * @brief Represents "PREPARE ins_prep: SELECT * FROM t1 WHERE c1 = ? AND c2 =
  * ?"
  */
-struct PrepareStatement : SQLStatement {
+class PrepareStatement : public SQLStatement {
+ public:
   PrepareStatement()
       : SQLStatement(StatementType::PREPARE), name(NULL), query(NULL) {}
 

--- a/src/include/parser/select_statement.h
+++ b/src/include/parser/select_statement.h
@@ -21,14 +21,15 @@ namespace peloton {
 namespace parser {
 
 /**
- * @struct OrderDescription
+ * @class OrderDescription
  * @brief Description of the order by clause within a select statement
  *
  * TODO: hold multiple expressions to be sorted by
  */
 typedef enum { kOrderAsc, kOrderDesc } OrderType;
 
-struct OrderDescription {
+class OrderDescription {
+ public:
   OrderDescription() {}
 
   virtual ~OrderDescription() {
@@ -47,12 +48,13 @@ struct OrderDescription {
 };
 
 /**
- * @struct LimitDescription
+ * @class LimitDescription
  * @brief Description of the limit clause within a select statement
  */
 const int64_t kNoLimit = -1;
 const int64_t kNoOffset = -1;
-struct LimitDescription {
+class LimitDescription {
+ public:
   LimitDescription(int64_t limit, int64_t offset)
       : limit(limit), offset(offset) {}
 
@@ -63,9 +65,10 @@ struct LimitDescription {
 };
 
 /**
- * @struct GroupByDescription
+ * @class GroupByDescription
  */
-struct GroupByDescription {
+class GroupByDescription {
+ public:
   GroupByDescription() : columns(NULL), having(NULL) {}
 
   ~GroupByDescription() {
@@ -89,7 +92,8 @@ struct GroupByDescription {
  *
  * TODO: add union_order and union_limit
  */
-struct SelectStatement : SQLStatement {
+class SelectStatement : public SQLStatement {
+ public:
   SelectStatement()
       : SQLStatement(StatementType::SELECT),
         from_table(NULL),

--- a/src/include/parser/table_ref.h
+++ b/src/include/parser/table_ref.h
@@ -23,8 +23,8 @@
 namespace peloton {
 namespace parser {
 
-struct SelectStatement;
-struct JoinDefinition;
+class SelectStatement;
+class JoinDefinition;
 
 //  Holds reference to tables.
 // Can be either table names or a select statement.
@@ -78,7 +78,8 @@ struct TableRef {
 };
 
 // Definition of a join table
-struct JoinDefinition {
+class JoinDefinition {
+ public:
   JoinDefinition()
       : left(NULL), right(NULL), condition(NULL), type(JoinType::INNER) {}
 

--- a/src/include/parser/transaction_statement.h
+++ b/src/include/parser/transaction_statement.h
@@ -19,10 +19,11 @@ namespace peloton {
 namespace parser {
 
 /**
- * @struct TransactionStatement
+ * @class TransactionStatement
  * @brief Represents "BEGIN or COMMIT or ROLLBACK [TRANSACTION]"
  */
-struct TransactionStatement : SQLStatement {
+class TransactionStatement : public SQLStatement {
+ public:
   enum CommandType {
     kBegin,
     kCommit,

--- a/src/include/parser/update_statement.h
+++ b/src/include/parser/update_statement.h
@@ -51,10 +51,11 @@ class UpdateClause {
 };
 
 /**
- * @struct UpdateStatement
+ * @class UpdateStatement
  * @brief Represents "UPDATE"
  */
-struct UpdateStatement : SQLStatement {
+class UpdateStatement : public SQLStatement {
+ public:
   UpdateStatement()
       : SQLStatement(StatementType::UPDATE),
         table(NULL),

--- a/src/include/planner/abstract_plan.h
+++ b/src/include/planner/abstract_plan.h
@@ -64,7 +64,7 @@ class AbstractPlan : public Printable {
 
   const AbstractPlan *GetChild(uint32_t child_index) const;
 
-  const AbstractPlan *GetParent();
+  const AbstractPlan *GetParent() const;
 
   //===--------------------------------------------------------------------===//
   // Accessors

--- a/src/include/planner/abstract_scan_plan.h
+++ b/src/include/planner/abstract_scan_plan.h
@@ -45,16 +45,16 @@ class AbstractScan : public AbstractPlan {
 
   inline const std::vector<oid_t> &GetColumnIds() const { return column_ids_; }
 
-  inline PlanNodeType GetPlanNodeType() const {
+  inline PlanNodeType GetPlanNodeType() const override {
     return PlanNodeType::ABSTRACT_SCAN;
   }
 
-  void GetOutputColumns(std::vector<oid_t> &columns) const {
+  void GetOutputColumns(std::vector<oid_t> &columns) const override {
     columns.resize(GetColumnIds().size());
     std::iota(columns.begin(), columns.end(), 0);
   }
 
-  inline const std::string GetInfo() const { return "AbstractScan"; }
+  inline const std::string GetInfo() const override { return "AbstractScan"; }
 
   inline storage::DataTable *GetTable() const { return target_table_; }
 

--- a/src/include/planner/aggregate_plan.h
+++ b/src/include/planner/aggregate_plan.h
@@ -100,32 +100,30 @@ class AggregatePlan : public AbstractPlan {
 
   AggregateType GetAggregateStrategy() const { return agg_strategy_; }
 
-  inline PlanNodeType GetPlanNodeType() const {
+  inline PlanNodeType GetPlanNodeType() const override {
     return PlanNodeType::AGGREGATE_V2;
   }
 
-  void GetOutputColumns(std::vector<oid_t> &columns) const {
+  void GetOutputColumns(std::vector<oid_t> &columns) const override {
     columns.resize(GetOutputSchema()->GetColumnCount());
     std::iota(columns.begin(), columns.end(), 0);
   }
 
-  const std::string GetInfo() const { return "AggregatePlan"; }
+  const std::string GetInfo() const override { return "AggregatePlan"; }
 
   const std::vector<oid_t> &GetColumnIds() const { return column_ids_; }
 
-  std::unique_ptr<AbstractPlan> Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const override {
     std::vector<AggTerm> copied_agg_terms;
     for (const AggTerm &term : unique_agg_terms_) {
       copied_agg_terms.push_back(term.Copy());
     }
     std::vector<oid_t> copied_groupby_col_ids(groupby_col_ids_);
 
-    std::unique_ptr<const expression::AbstractExpression> predicate_copy(
-        predicate_->Copy());
     std::shared_ptr<const catalog::Schema> output_schema_copy(
         catalog::Schema::CopySchema(GetOutputSchema()));
     AggregatePlan *new_plan = new AggregatePlan(
-        std::move(project_info_->Copy()), std::move(predicate_copy),
+        project_info_->Copy(), std::unique_ptr<const expression::AbstractExpression>(predicate_->Copy()),
         std::move(copied_agg_terms), std::move(copied_groupby_col_ids),
         output_schema_copy, agg_strategy_);
     return std::unique_ptr<AbstractPlan>(new_plan);

--- a/src/include/planner/delete_plan.h
+++ b/src/include/planner/delete_plan.h
@@ -46,11 +46,11 @@ class DeletePlan : public AbstractPlan {
   explicit DeletePlan(storage::DataTable *table,
                       const expression::AbstractExpression *predicate);
 
-  inline PlanNodeType GetPlanNodeType() const { return PlanNodeType::DELETE; }
+  inline PlanNodeType GetPlanNodeType() const override { return PlanNodeType::DELETE; }
 
   storage::DataTable *GetTable() const { return target_table_; }
 
-  const std::string GetInfo() const { return "DeletePlan"; }
+  const std::string GetInfo() const override { return "DeletePlan"; }
 
   void SetParameterValues(std::vector<type::Value> *values) override;
 
@@ -58,7 +58,7 @@ class DeletePlan : public AbstractPlan {
 
   expression::AbstractExpression *GetPredicate() { return expr_; }
 
-  std::unique_ptr<AbstractPlan> Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const override {
     return std::unique_ptr<AbstractPlan>(
         new DeletePlan(target_table_, truncate));
   }

--- a/src/include/planner/hash_join_plan.h
+++ b/src/include/planner/hash_join_plan.h
@@ -53,14 +53,14 @@ class HashJoinPlan : public AbstractJoinPlan {
 
   void HandleSubplanBinding(bool is_left, const BindingContext &input) override;
 
-  inline PlanNodeType GetPlanNodeType() const { return PlanNodeType::HASHJOIN; }
+  inline PlanNodeType GetPlanNodeType() const override { return PlanNodeType::HASHJOIN; }
 
-  void GetOutputColumns(std::vector<oid_t> &columns) const {
+  void GetOutputColumns(std::vector<oid_t> &columns) const override {
     columns.resize(GetSchema()->GetColumnCount());
     std::iota(columns.begin(), columns.end(), 0);
   }
 
-  const std::string GetInfo() const { return "HashJoin"; }
+  const std::string GetInfo() const override { return "HashJoin"; }
 
   const std::vector<oid_t> &GetOuterHashIds() const {
     return outer_column_ids_;
@@ -80,14 +80,14 @@ class HashJoinPlan : public AbstractJoinPlan {
     }
   }
 
-  std::unique_ptr<AbstractPlan> Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const override {
     std::unique_ptr<const expression::AbstractExpression> predicate_copy(
         GetPredicate()->Copy());
     std::shared_ptr<const catalog::Schema> schema_copy(
         catalog::Schema::CopySchema(GetSchema()));
     HashJoinPlan *new_plan = new HashJoinPlan(
         GetJoinType(), std::move(predicate_copy),
-        std::move(GetProjInfo()->Copy()), schema_copy, outer_column_ids_);
+        GetProjInfo()->Copy(), schema_copy, outer_column_ids_);
     return std::unique_ptr<AbstractPlan>(new_plan);
   }
 

--- a/src/include/planner/hash_plan.h
+++ b/src/include/planner/hash_plan.h
@@ -33,15 +33,15 @@ class HashPlan : public AbstractPlan {
 
   void PerformBinding(BindingContext &binding_context) override;
 
-  inline PlanNodeType GetPlanNodeType() const { return PlanNodeType::HASH; }
+  inline PlanNodeType GetPlanNodeType() const override { return PlanNodeType::HASH; }
 
-  const std::string GetInfo() const { return "Hash"; }
+  const std::string GetInfo() const override { return "Hash"; }
 
   inline const std::vector<HashKeyPtrType> &GetHashKeys() const {
     return this->hash_keys_;
   }
 
-  std::unique_ptr<AbstractPlan> Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const override {
     std::vector<HashKeyPtrType> copied_hash_keys;
     for (const auto &key : hash_keys_) {
       copied_hash_keys.push_back(std::unique_ptr<HashKeyType>(key->Copy()));

--- a/src/include/planner/merge_join_plan.h
+++ b/src/include/planner/merge_join_plan.h
@@ -64,7 +64,7 @@ class MergeJoinPlan : public AbstractJoinPlan {
     }
   }
 
-  inline PlanNodeType GetPlanNodeType() const {
+  inline PlanNodeType GetPlanNodeType() const override {
     return PlanNodeType::MERGEJOIN;
   }
 
@@ -72,9 +72,9 @@ class MergeJoinPlan : public AbstractJoinPlan {
     return &join_clauses_;
   }
 
-  const std::string GetInfo() const { return "MergeJoin"; }
+  const std::string GetInfo() const override { return "MergeJoin"; }
 
-  std::unique_ptr<AbstractPlan> Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const override {
     std::vector<JoinClause> new_join_clauses;
     for (size_t i = 0; i < join_clauses_.size(); i++) {
       new_join_clauses.push_back(JoinClause(join_clauses_[i].left_->Copy(),
@@ -88,7 +88,7 @@ class MergeJoinPlan : public AbstractJoinPlan {
         catalog::Schema::CopySchema(GetSchema()));
     MergeJoinPlan *new_plan = new MergeJoinPlan(
         GetJoinType(), std::move(predicate_copy),
-        std::move(GetProjInfo()->Copy()), schema_copy, new_join_clauses);
+        GetProjInfo()->Copy(), schema_copy, new_join_clauses);
     return std::unique_ptr<AbstractPlan>(new_plan);
   }
 

--- a/src/include/planner/nested_loop_join_plan.h
+++ b/src/include/planner/nested_loop_join_plan.h
@@ -43,11 +43,11 @@ class NestedLoopJoinPlan : public AbstractJoinPlan {
   void HandleSubplanBinding(UNUSED_ATTRIBUTE bool,
                             UNUSED_ATTRIBUTE const BindingContext &) override {}
 
-  inline PlanNodeType GetPlanNodeType() const { return PlanNodeType::NESTLOOP; }
+  inline PlanNodeType GetPlanNodeType() const override { return PlanNodeType::NESTLOOP; }
 
-  const std::string GetInfo() const { return "NestedLoopJoin"; }
+  const std::string GetInfo() const override { return "NestedLoopJoin"; }
 
-  std::unique_ptr<AbstractPlan> Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const override {
     std::unique_ptr<const expression::AbstractExpression> predicate_copy(
         GetPredicate()->Copy());
 
@@ -56,7 +56,7 @@ class NestedLoopJoinPlan : public AbstractJoinPlan {
 
     NestedLoopJoinPlan *new_plan =
         new NestedLoopJoinPlan(GetJoinType(), std::move(predicate_copy),
-                               std::move(GetProjInfo()->Copy()), schema_copy);
+                               GetProjInfo()->Copy(), schema_copy);
 
     return std::unique_ptr<AbstractPlan>(new_plan);
   }

--- a/src/include/planner/order_by_plan.h
+++ b/src/include/planner/order_by_plan.h
@@ -51,13 +51,13 @@ class OrderByPlan : public AbstractPlan {
     return output_ais_;
   }
 
-  inline PlanNodeType GetPlanNodeType() const { return PlanNodeType::ORDERBY; }
+  inline PlanNodeType GetPlanNodeType() const override { return PlanNodeType::ORDERBY; }
 
-  void GetOutputColumns(std::vector<oid_t> &columns) const {
+  void GetOutputColumns(std::vector<oid_t> &columns) const override {
     columns = GetOutputColumnIds();
   }
 
-  const std::string GetInfo() const { return "OrderBy"; }
+  const std::string GetInfo() const override { return "OrderBy"; }
 
   void SetUnderlyingOrder(bool same_order) { underling_ordered_ = same_order; }
 
@@ -75,7 +75,7 @@ class OrderByPlan : public AbstractPlan {
 
   uint64_t GetLimitOffset() const { return limit_offset_; }
 
-  std::unique_ptr<AbstractPlan> Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const override {
     return std::unique_ptr<AbstractPlan>(
         new OrderByPlan(sort_keys_, descend_flags_, output_column_ids_));
   }

--- a/src/include/planner/projection_plan.h
+++ b/src/include/planner/projection_plan.h
@@ -44,11 +44,11 @@ class ProjectionPlan : public AbstractPlan {
 
   inline const catalog::Schema *GetSchema() const { return schema_.get(); }
 
-  inline PlanNodeType GetPlanNodeType() const {
+  inline PlanNodeType GetPlanNodeType() const override {
     return PlanNodeType::PROJECTION;
   }
 
-  const std::string GetInfo() const { return "Projection"; }
+  const std::string GetInfo() const override { return "Projection"; }
 
   const std::vector<oid_t> &GetColumnIds() const { return column_ids_; }
 
@@ -57,7 +57,7 @@ class ProjectionPlan : public AbstractPlan {
     std::iota(columns.begin(), columns.end(), 0);
   }
 
-  std::unique_ptr<AbstractPlan> Copy() const {
+  std::unique_ptr<AbstractPlan> Copy() const override {
     std::shared_ptr<const catalog::Schema> schema_copy(
         catalog::Schema::CopySchema(schema_.get()));
     ProjectionPlan *new_plan =

--- a/src/include/planner/seq_scan_plan.h
+++ b/src/include/planner/seq_scan_plan.h
@@ -25,7 +25,7 @@
 namespace peloton {
 
 namespace parser {
-struct SelectStatement;
+class SelectStatement;
 }
 namespace storage {
 class DataTable;
@@ -55,7 +55,7 @@ class SeqScanPlan : public AbstractScan {
   //===--------------------------------------------------------------------===//
   // Serialization/Deserialization
   //===--------------------------------------------------------------------===//
-  bool SerializeTo(SerializeOutput &output);
+  bool SerializeTo(SerializeOutput &output) const ;
   bool DeserializeFrom(SerializeInput &input);
 
   /* For init SerializeOutput */

--- a/src/include/planner/update_plan.h
+++ b/src/include/planner/update_plan.h
@@ -73,7 +73,7 @@ class UpdatePlan : public AbstractPlan {
 
   std::unique_ptr<AbstractPlan> Copy() const {
     return std::unique_ptr<AbstractPlan>(
-        new UpdatePlan(target_table_, std::move(project_info_->Copy())));
+        new UpdatePlan(target_table_, project_info_->Copy()));
   }
 
  private:

--- a/src/include/type/array_type.h
+++ b/src/include/type/array_type.h
@@ -30,12 +30,12 @@ class ArrayType : public Type {
   ~ArrayType() {}
 
   // Get the element at a given index in this array
-  Value GetElementAt(const Value& val, uint64_t idx) const;
+  Value GetElementAt(const Value& val, uint64_t idx) const override;
 
-  TypeId GetElementType(const Value& val UNUSED_ATTRIBUTE) const;
+  TypeId GetElementType(const Value& val UNUSED_ATTRIBUTE) const override;
 
   // Does this value exist in this array?
-  Value InList(const Value& list, const Value &object) const;
+  Value InList(const Value& list, const Value &object) const override;
 
   CmpBool CompareEquals(const Value& left, const Value &right) const override;
   CmpBool CompareNotEquals(const Value& left, const Value &right) const override;

--- a/src/include/type/type.h
+++ b/src/include/type/type.h
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <string>
+#include <functional>
 
 #include "type/serializeio.h"
 #include "type/type_id.h"

--- a/src/include/type/varlen_type.h
+++ b/src/include/type/varlen_type.h
@@ -25,13 +25,13 @@ class VarlenType : public Type {
   ~VarlenType();
   
   // Access the raw variable length data
-  const char *GetData(const Value& val) const;
+  const char *GetData(const Value& val) const override;
 
   // Access the raw varlen data stored from the tuple storage
   char *GetData(char *storage) override;
 
   // Get the length of the variable length data
-  uint32_t GetLength(const Value& val) const;
+  uint32_t GetLength(const Value& val) const override;
 
   // Comparison functions
   CmpBool CompareEquals(const Value& left, const Value &right) const override;

--- a/src/include/util/portable_endian.h
+++ b/src/include/util/portable_endian.h
@@ -1,0 +1,123 @@
+// "License": Public Domain
+// I, Mathias Panzenböck, place this file hereby into the public domain. Use it
+// at your own risk for whatever you like.
+// In case there are jurisdictions that don't support putting things in the
+// public domain you can also consider it to
+// be "dual licensed" under the BSD, MIT and Apache licenses, if you want to.
+// This code is trivial anyway. Consider it
+// an example on how to get the endian conversion functions on different
+// platforms.
+
+#ifndef PORTABLE_ENDIAN_H__
+#define PORTABLE_ENDIAN_H__
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && \
+    !defined(__WINDOWS__)
+
+#define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+
+#include <endian.h>
+
+#elif defined(__APPLE__)
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __PDP_ENDIAN PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#include <sys/endian.h>
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+#include <sys/endian.h>
+
+#define be16toh(x) betoh16(x)
+#define le16toh(x) letoh16(x)
+
+#define be32toh(x) betoh32(x)
+#define le32toh(x) letoh32(x)
+
+#define be64toh(x) betoh64(x)
+#define le64toh(x) letoh64(x)
+
+#elif defined(__WINDOWS__)
+
+#include <winsock2.h>
+#include <sys/param.h>
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+
+#define htobe16(x) htons(x)
+#define htole16(x) (x)
+#define be16toh(x) ntohs(x)
+#define le16toh(x) (x)
+
+#define htobe32(x) htonl(x)
+#define htole32(x) (x)
+#define be32toh(x) ntohl(x)
+#define le32toh(x) (x)
+
+#define htobe64(x) htonll(x)
+#define htole64(x) (x)
+#define be64toh(x) ntohll(x)
+#define le64toh(x) (x)
+
+#elif BYTE_ORDER == BIG_ENDIAN
+
+/* that would be xbox 360 */
+#define htobe16(x) (x)
+#define htole16(x) __builtin_bswap16(x)
+#define be16toh(x) (x)
+#define le16toh(x) __builtin_bswap16(x)
+
+#define htobe32(x) (x)
+#define htole32(x) __builtin_bswap32(x)
+#define be32toh(x) (x)
+#define le32toh(x) __builtin_bswap32(x)
+
+#define htobe64(x) (x)
+#define htole64(x) __builtin_bswap64(x)
+#define be64toh(x) (x)
+#define le64toh(x) __builtin_bswap64(x)
+
+#else
+
+#error byte order not supported
+
+#endif
+
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __PDP_ENDIAN PDP_ENDIAN
+
+#else
+
+#error platform not supported
+
+#endif
+
+#endif

--- a/src/logging/log_buffer_pool.cpp
+++ b/src/logging/log_buffer_pool.cpp
@@ -24,7 +24,7 @@ namespace logging {
     size_t head_idx = head_ % buffer_queue_size_;
     while (true) {
       if (head_.load() < tail_.load() - 1) {
-        if (local_buffer_queue_[head_idx].get() == nullptr) { // Fix for Mac support
+        if (local_buffer_queue_[head_idx].get() == nullptr) {
           // Not any buffer allocated now
           local_buffer_queue_[head_idx].reset(new LogBuffer(thread_id_, current_eid));
         }

--- a/src/logging/log_buffer_pool.cpp
+++ b/src/logging/log_buffer_pool.cpp
@@ -24,7 +24,7 @@ namespace logging {
     size_t head_idx = head_ % buffer_queue_size_;
     while (true) {
       if (head_.load() < tail_.load() - 1) {
-        if (local_buffer_queue_[head_idx] == false) {
+        if (local_buffer_queue_[head_idx].get() == nullptr) { // Fix for Mac support
           // Not any buffer allocated now
           local_buffer_queue_[head_idx].reset(new LogBuffer(thread_id_, current_eid));
         }
@@ -51,7 +51,7 @@ namespace logging {
     // The buffer pool must not be full
     PL_ASSERT(tail_idx != head_ % buffer_queue_size_);
     // The tail pos must be null
-    PL_ASSERT(local_buffer_queue_[tail_idx] == false);
+    PL_ASSERT(local_buffer_queue_[tail_idx].get() == nullptr);
     // The returned buffer must be empty
     PL_ASSERT(buf->Empty() == true);
     local_buffer_queue_[tail_idx].reset(buf.release());

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -876,7 +876,6 @@ static void AggregateQueryHelper(const std::vector<oid_t> &tuple_key_attrs,
   oid_t tuple_idx = 1;  // tuple2
   for (col_itr = 0; col_itr < column_count; col_itr++) {
     direct_map_list.push_back({col_itr, {tuple_idx, col_itr}});
-//    col_itr++;
   }
 
   std::unique_ptr<const planner::ProjectInfo> proj_info(

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -876,7 +876,7 @@ static void AggregateQueryHelper(const std::vector<oid_t> &tuple_key_attrs,
   oid_t tuple_idx = 1;  // tuple2
   for (col_itr = 0; col_itr < column_count; col_itr++) {
     direct_map_list.push_back({col_itr, {tuple_idx, col_itr}});
-    col_itr++;
+//    col_itr++;
   }
 
   std::unique_ptr<const planner::ProjectInfo> proj_info(

--- a/src/main/tpcc/tpcc_loader.cpp
+++ b/src/main/tpcc/tpcc_loader.cpp
@@ -44,6 +44,12 @@
 // Logging mode
 // extern peloton::LoggingType peloton_logging_mode;
 
+// disable unused const variable warning for clang
+#ifdef __APPLE__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-const-variable"
+#endif
+
 namespace peloton {
 namespace benchmark {
 namespace tpcc {
@@ -1753,4 +1759,6 @@ void LoadTPCCDatabase() {
 }  // namespace benchmark
 }  // namespace peloton
 
-
+#ifdef __APPLE__
+#pragma clang diagnostic pop
+#endif

--- a/src/main/tpcc/tpcc_workload.cpp
+++ b/src/main/tpcc/tpcc_workload.cpp
@@ -109,20 +109,21 @@ size_t GenerateWarehouseId(const size_t &thread_id) {
   }
 }
 
-#ifndef __APPLE__
 void PinToCore(size_t core) {
+// Mac OS X does not export interfaces that identify processors or control thread placement
+// explicit thread to processor binding is not supported.
+// Reference: https://superuser.com/questions/149312/how-to-set-processor-affinity-on-os-x
+#ifndef __APPLE__
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
   CPU_SET(core, &cpuset);
   pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
-}
 #endif
+}
 
 void RunBackend(const size_t thread_id) {
 
-#ifndef __APPLE__
   PinToCore(thread_id);
-#endif
 
   if (concurrency::EpochManagerFactory::GetEpochType() == EpochType::DECENTRALIZED_EPOCH) {
     // register thread to epoch manager

--- a/src/main/tpcc/tpcc_workload.cpp
+++ b/src/main/tpcc/tpcc_workload.cpp
@@ -109,17 +109,20 @@ size_t GenerateWarehouseId(const size_t &thread_id) {
   }
 }
 
-
+#ifndef __APPLE__
 void PinToCore(size_t core) {
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
   CPU_SET(core, &cpuset);
   pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
 }
+#endif
 
 void RunBackend(const size_t thread_id) {
-  
+
+#ifndef __APPLE__
   PinToCore(thread_id);
+#endif
 
   if (concurrency::EpochManagerFactory::GetEpochType() == EpochType::DECENTRALIZED_EPOCH) {
     // register thread to epoch manager
@@ -255,7 +258,7 @@ void RunWorkload() {
   }
 
   for (size_t thread_itr = 0; thread_itr < num_threads; ++thread_itr) {
-    thread_group.push_back(std::move(std::thread(RunBackend, thread_itr)));
+    thread_group.push_back(std::thread(RunBackend, thread_itr));
   }
 
   //////////////////////////////////////
@@ -391,7 +394,7 @@ std::vector<std::vector<type::Value >> ExecuteRead(executor::AbstractExecutor* e
     }
   }
 
-  return std::move(logical_tile_values);
+  return logical_tile_values;
 }
 
 void ExecuteUpdate(executor::AbstractExecutor* executor) {

--- a/src/main/tpcc/tpcc_workload.cpp
+++ b/src/main/tpcc/tpcc_workload.cpp
@@ -109,15 +109,17 @@ size_t GenerateWarehouseId(const size_t &thread_id) {
   }
 }
 
-void PinToCore(size_t core) {
-// Mac OS X does not export interfaces that identify processors or control thread placement
-// explicit thread to processor binding is not supported.
-// Reference: https://superuser.com/questions/149312/how-to-set-processor-affinity-on-os-x
 #ifndef __APPLE__
+void PinToCore(size_t core) {
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
   CPU_SET(core, &cpuset);
   pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+#else
+void PinToCore(size_t UNUSED_ATTRIBUTE core) {
+// Mac OS X does not export interfaces that identify processors or control thread placement
+// explicit thread to processor binding is not supported.
+// Reference: https://superuser.com/questions/149312/how-to-set-processor-affinity-on-os-x
 #endif
 }
 

--- a/src/main/ycsb/ycsb_workload.cpp
+++ b/src/main/ycsb/ycsb_workload.cpp
@@ -84,21 +84,22 @@ volatile bool is_running = true;
 PadInt *abort_counts;
 PadInt *commit_counts;
 
-#ifndef __APPLE__
 void PinToCore(size_t core) {
+// Mac OS X does not export interfaces that identify processors or control thread placement
+// explicit thread to processor binding is not supported.
+// Reference: https://superuser.com/questions/149312/how-to-set-processor-affinity-on-os-x
+#ifndef __APPLE__
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
   CPU_SET(core, &cpuset);
   pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
-}
 #endif
+}
 
 void RunBackend(const size_t thread_id) {
 
-#ifndef __APPLE__
   PinToCore(thread_id);
-#endif
-  
+
   PadInt &execution_count_ref = abort_counts[thread_id];
   PadInt &transaction_count_ref = commit_counts[thread_id];
 

--- a/src/main/ycsb/ycsb_workload.cpp
+++ b/src/main/ycsb/ycsb_workload.cpp
@@ -84,15 +84,17 @@ volatile bool is_running = true;
 PadInt *abort_counts;
 PadInt *commit_counts;
 
-void PinToCore(size_t core) {
-// Mac OS X does not export interfaces that identify processors or control thread placement
-// explicit thread to processor binding is not supported.
-// Reference: https://superuser.com/questions/149312/how-to-set-processor-affinity-on-os-x
 #ifndef __APPLE__
+void PinToCore(size_t core) {
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
   CPU_SET(core, &cpuset);
   pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+#else
+void PinToCore(size_t UNUSED_ATTRIBUTE core) {
+// Mac OS X does not export interfaces that identify processors or control thread placement
+// explicit thread to processor binding is not supported.
+// Reference: https://superuser.com/questions/149312/how-to-set-processor-affinity-on-os-x
 #endif
 }
 

--- a/src/main/ycsb/ycsb_workload.cpp
+++ b/src/main/ycsb/ycsb_workload.cpp
@@ -84,16 +84,20 @@ volatile bool is_running = true;
 PadInt *abort_counts;
 PadInt *commit_counts;
 
+#ifndef __APPLE__
 void PinToCore(size_t core) {
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
   CPU_SET(core, &cpuset);
   pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
 }
+#endif
 
 void RunBackend(const size_t thread_id) {
-  
+
+#ifndef __APPLE__
   PinToCore(thread_id);
+#endif
   
   PadInt &execution_count_ref = abort_counts[thread_id];
   PadInt &transaction_count_ref = commit_counts[thread_id];
@@ -155,7 +159,7 @@ void RunWorkload() {
 
   // Launch a group of threads
   for (size_t thread_itr = 0; thread_itr < num_threads; ++thread_itr) {
-    thread_group.push_back(std::move(std::thread(RunBackend, thread_itr)));
+    thread_group.push_back(std::thread(RunBackend, thread_itr));
   }
 
   //////////////////////////////////////
@@ -297,7 +301,7 @@ std::vector<std::vector<type::Value >> ExecuteRead(executor::AbstractExecutor* e
     }
   }
 
-  return std::move(logical_tile_values);
+  return logical_tile_values;
 }
 
 void ExecuteUpdate(executor::AbstractExecutor* executor) {

--- a/src/optimizer/memo.cpp
+++ b/src/optimizer/memo.cpp
@@ -13,8 +13,6 @@
 #include "optimizer/memo.h"
 #include "optimizer/operators.h"
 
-#include <cassert>
-
 namespace peloton {
 namespace optimizer {
 
@@ -37,7 +35,7 @@ std::shared_ptr<GroupExpression> Memo::InsertExpression(
     assert(target_group == UNDEFINED_GROUP ||
            target_group == leaf->origin_group);
     gexpr->SetGroupID(leaf->origin_group);
-    return false;
+    return nullptr; // Fix for Mac support
   }
 
   // Lookup in hash table

--- a/src/optimizer/memo.cpp
+++ b/src/optimizer/memo.cpp
@@ -35,7 +35,7 @@ std::shared_ptr<GroupExpression> Memo::InsertExpression(
     assert(target_group == UNDEFINED_GROUP ||
            target_group == leaf->origin_group);
     gexpr->SetGroupID(leaf->origin_group);
-    return nullptr; // Fix for Mac support
+    return nullptr;
   }
 
   // Lookup in hash table

--- a/src/optimizer/operator_to_plan_transformer.cpp
+++ b/src/optimizer/operator_to_plan_transformer.cpp
@@ -140,8 +140,8 @@ void OperatorToPlanTransformer::Visit(const PhysicalProject *) {
     auto expr = cols_prop->GetColumn(i);
     if (expr->GetExpressionType() == ExpressionType::STAR) {
       vector<std::shared_ptr<expression::AbstractExpression>> ordered_exprs =
-          move(expression::ExpressionUtil::GenerateOrderedOutputExprs(
-              child_expr_map));
+          expression::ExpressionUtil::GenerateOrderedOutputExprs(
+              child_expr_map);
       output_exprs.insert(output_exprs.end(), ordered_exprs.begin(),
                           ordered_exprs.end());
     } else {
@@ -214,8 +214,8 @@ void OperatorToPlanTransformer::Visit(const PhysicalOrderBy *) {
       requirements_->GetPropertyOfType(PropertyType::SORT)->As<PropertySort>();
   auto sort_columns_size = sort_prop->GetSortColumnSize();
 
-  vector<shared_ptr<expression::AbstractExpression>> ordered_exprs = move(
-      expression::ExpressionUtil::GenerateOrderedOutputExprs(child_expr_map));
+  vector<shared_ptr<expression::AbstractExpression>> ordered_exprs =
+      expression::ExpressionUtil::GenerateOrderedOutputExprs(child_expr_map);
   vector<oid_t> column_ids;
 
   // Construct output column offset.
@@ -258,8 +258,8 @@ void OperatorToPlanTransformer::Visit(const PhysicalHashGroupBy *op) {
 
   PL_ASSERT(col_prop != nullptr);
 
-  output_plan_ = move(GenerateAggregatePlan(col_prop, AggregateType::HASH,
-                                            &op->columns, op->having));
+  output_plan_ = GenerateAggregatePlan(col_prop, AggregateType::HASH,
+                                            &op->columns, op->having);
 }
 
 void OperatorToPlanTransformer::Visit(const PhysicalSortGroupBy *op) {
@@ -268,8 +268,8 @@ void OperatorToPlanTransformer::Visit(const PhysicalSortGroupBy *op) {
 
   PL_ASSERT(col_prop != nullptr);
 
-  output_plan_ = move(GenerateAggregatePlan(col_prop, AggregateType::SORTED,
-                                            &op->columns, op->having));
+  output_plan_ = GenerateAggregatePlan(col_prop, AggregateType::SORTED,
+                                            &op->columns, op->having);
 }
 
 void OperatorToPlanTransformer::Visit(const PhysicalAggregate *) {
@@ -278,8 +278,7 @@ void OperatorToPlanTransformer::Visit(const PhysicalAggregate *) {
 
   PL_ASSERT(col_prop != nullptr);
 
-  output_plan_ = move(
-      GenerateAggregatePlan(col_prop, AggregateType::PLAIN, nullptr, nullptr));
+  output_plan_ = GenerateAggregatePlan(col_prop, AggregateType::PLAIN, nullptr, nullptr);
 }
 
 void OperatorToPlanTransformer::Visit(const PhysicalDistinct *) {
@@ -325,8 +324,7 @@ void OperatorToPlanTransformer::Visit(const PhysicalDistinct *) {
 void OperatorToPlanTransformer::Visit(const PhysicalFilter *) {}
 
 void OperatorToPlanTransformer::Visit(const PhysicalInnerNLJoin *op) {
-  output_plan_ = move(
-      GenerateJoinPlan((op->join_predicate).get(), JoinType::INNER, false));
+  output_plan_ = GenerateJoinPlan((op->join_predicate).get(), JoinType::INNER, false);
 }
 
 void OperatorToPlanTransformer::Visit(const PhysicalLeftNLJoin *) {}
@@ -337,7 +335,7 @@ void OperatorToPlanTransformer::Visit(const PhysicalOuterNLJoin *) {}
 
 void OperatorToPlanTransformer::Visit(const PhysicalInnerHashJoin *op) {
   output_plan_ =
-      move(GenerateJoinPlan((op->join_predicate).get(), JoinType::INNER, true));
+      GenerateJoinPlan((op->join_predicate).get(), JoinType::INNER, true);
 }
 
 void OperatorToPlanTransformer::Visit(const PhysicalLeftHashJoin *) {}
@@ -454,7 +452,7 @@ vector<oid_t> OperatorToPlanTransformer::GenerateColumnsForScan(
     }
   }
 
-  return move(column_ids);
+  return column_ids;
 }
 
 // Generate predicate for scan plan
@@ -544,7 +542,7 @@ OperatorToPlanTransformer::GenerateAggregatePlan(
       move(proj_info), move(predicate), move(agg_terms), move(col_ids),
       output_table_schema, agg_type));
   agg_plan->AddChild(move(children_plans_[0]));
-  return move(agg_plan);
+  return agg_plan;
 }
 
 unique_ptr<planner::AbstractPlan> OperatorToPlanTransformer::GenerateJoinPlan(
@@ -566,11 +564,11 @@ unique_ptr<planner::AbstractPlan> OperatorToPlanTransformer::GenerateJoinPlan(
     // Generate all output columns from child
     if (expr->GetExpressionType() == ExpressionType::STAR) {
       vector<std::shared_ptr<expression::AbstractExpression>> l_output_exprs =
-          move(expression::ExpressionUtil::GenerateOrderedOutputExprs(
-              children_expr_map_[0]));
+          expression::ExpressionUtil::GenerateOrderedOutputExprs(
+              children_expr_map_[0]);
       vector<std::shared_ptr<expression::AbstractExpression>> r_output_exprs =
-          move(expression::ExpressionUtil::GenerateOrderedOutputExprs(
-              children_expr_map_[1]));
+          expression::ExpressionUtil::GenerateOrderedOutputExprs(
+              children_expr_map_[1]);
       output_exprs.insert(output_exprs.end(), l_output_exprs.begin(),
                           l_output_exprs.end());
       output_exprs.insert(output_exprs.end(), r_output_exprs.begin(),
@@ -688,7 +686,7 @@ unique_ptr<planner::AbstractPlan> OperatorToPlanTransformer::GenerateJoinPlan(
     join_plan->AddChild(move(children_plans_[0]));
     join_plan->AddChild(move(children_plans_[1]));
   }
-  return move(join_plan);
+  return join_plan;
 }
 
 void OperatorToPlanTransformer::VisitOpExpression(

--- a/src/optimizer/operators.cpp
+++ b/src/optimizer/operators.cpp
@@ -68,7 +68,7 @@ Operator LogicalFilter::make() {
 Operator LogicalInnerJoin::make(expression::AbstractExpression *condition) {
   LogicalInnerJoin *join = new LogicalInnerJoin;
   join->join_predicate = 
-      std::move(std::shared_ptr<expression::AbstractExpression>(condition));
+      std::shared_ptr<expression::AbstractExpression>(condition);
   return Operator(join);
 }
 
@@ -78,7 +78,7 @@ Operator LogicalInnerJoin::make(expression::AbstractExpression *condition) {
 Operator LogicalLeftJoin::make(expression::AbstractExpression *condition) {
   LogicalLeftJoin *join = new LogicalLeftJoin;
   join->join_predicate = 
-      std::move(std::shared_ptr<expression::AbstractExpression>(condition));
+      std::shared_ptr<expression::AbstractExpression>(condition);
   return Operator(join);
 }
 
@@ -88,7 +88,7 @@ Operator LogicalLeftJoin::make(expression::AbstractExpression *condition) {
 Operator LogicalRightJoin::make(expression::AbstractExpression *condition) {
   LogicalRightJoin *join = new LogicalRightJoin;
   join->join_predicate = 
-      std::move(std::shared_ptr<expression::AbstractExpression>(condition));
+      std::shared_ptr<expression::AbstractExpression>(condition);
   return Operator(join);
 }
 
@@ -98,7 +98,7 @@ Operator LogicalRightJoin::make(expression::AbstractExpression *condition) {
 Operator LogicalOuterJoin::make(expression::AbstractExpression *condition) {
   LogicalOuterJoin *join = new LogicalOuterJoin;
   join->join_predicate = 
-      std::move(std::shared_ptr<expression::AbstractExpression>(condition));
+      std::shared_ptr<expression::AbstractExpression>(condition);
   return Operator(join);
 }
 
@@ -108,7 +108,7 @@ Operator LogicalOuterJoin::make(expression::AbstractExpression *condition) {
 Operator LogicalSemiJoin::make(expression::AbstractExpression *condition) {
   LogicalSemiJoin *join = new LogicalSemiJoin;
   join->join_predicate = 
-      std::move(std::shared_ptr<expression::AbstractExpression>(condition));
+      std::shared_ptr<expression::AbstractExpression>(condition);
   return Operator(join);
 }
 

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -121,7 +121,7 @@ shared_ptr<planner::AbstractPlan> Optimizer::BuildPelotonPlanTree(
 }
 
 void Optimizer::Reset() {
-  memo_ = move(Memo());
+  memo_ = Memo();
   column_manager_ = move(ColumnManager());
 }
 
@@ -185,14 +185,14 @@ unique_ptr<planner::AbstractPlan> Optimizer::HandleDDLStatement(
       LOG_TRACE("Adding Copy plan...");
       parser::CopyStatement *copy_parse_tree =
           static_cast<parser::CopyStatement *>(tree);
-      ddl_plan = std::move(util::CreateCopyPlan(copy_parse_tree));
+      ddl_plan = util::CreateCopyPlan(copy_parse_tree);
       break;
     }
     default:
       is_ddl_stmt = false;
   }
 
-  return move(ddl_plan);
+  return ddl_plan;
 }
 
 shared_ptr<GroupExpression> Optimizer::InsertQueryTree(
@@ -207,7 +207,7 @@ shared_ptr<GroupExpression> Optimizer::InsertQueryTree(
 
 PropertySet Optimizer::GetQueryRequiredProperties(parser::SQLStatement *tree) {
   QueryPropertyExtractor converter(column_manager_);
-  return move(converter.GetProperties(tree));
+  return converter.GetProperties(tree);
 }
 
 unique_ptr<planner::AbstractPlan> Optimizer::OptimizerPlanToPlannerPlan(
@@ -231,7 +231,7 @@ unique_ptr<planner::AbstractPlan> Optimizer::ChooseBestPlan(
 
   vector<GroupID> child_groups = gexpr->GetChildGroupIDs();
   vector<PropertySet> required_input_props =
-      move(gexpr->GetInputProperties(requirements));
+      gexpr->GetInputProperties(requirements);
   PL_ASSERT(required_input_props.size() == child_groups.size());
 
   // Derive chidren plans first because they are useful in the derivation of
@@ -284,7 +284,7 @@ void Optimizer::OptimizeExpression(shared_ptr<GroupExpression> gexpr,
   PL_ASSERT(gexpr->Op().IsPhysical());
 
   vector<pair<PropertySet, vector<PropertySet>>> output_input_property_pairs =
-      move(DeriveChildProperties(gexpr, requirements));
+      DeriveChildProperties(gexpr, requirements);
 
   size_t num_property_pairs = output_input_property_pairs.size();
 
@@ -448,7 +448,7 @@ shared_ptr<GroupExpression> Optimizer::EnforceProperty(
 vector<pair<PropertySet, vector<PropertySet>>> Optimizer::DeriveChildProperties(
     shared_ptr<GroupExpression> gexpr, PropertySet requirements) {
   ChildPropertyGenerator converter(column_manager_);
-  return move(converter.GetProperties(gexpr, requirements, &memo_));
+  return converter.GetProperties(gexpr, requirements, &memo_);
 }
 
 void Optimizer::DeriveCostAndStats(

--- a/src/optimizer/stats/stats_storage.cpp
+++ b/src/optimizer/stats/stats_storage.cpp
@@ -204,7 +204,7 @@ std::shared_ptr<ColumnStats> StatsStorage::ConvertVectorToColumnStats(
       num_rows, cardinality, frac_null, val_array, freq_array,
       histogram_bounds));
 
-  return std::move(column_stats);
+  return column_stats;
 }
 
 /**

--- a/src/optimizer/stats/tuple_samples_storage.cpp
+++ b/src/optimizer/stats/tuple_samples_storage.cpp
@@ -160,7 +160,7 @@ TupleSamplesStorage::GetTuplesWithSeqScan(storage::DataTable *data_table,
         std::unique_ptr<executor::LogicalTile>(seq_scan_executor.GetOutput()));
   }
 
-  return std::move(result_tiles);
+  return result_tiles;
 }
 
 /**
@@ -185,7 +185,7 @@ TupleSamplesStorage::GetTupleSamples(oid_t database_id, oid_t table_id) {
   auto result_tiles = GetTuplesWithSeqScan(data_table, column_ids, txn);
   txn_manager.CommitTransaction(txn);
 
-  return std::move(result_tiles);
+  return result_tiles;
 }
 
 /**

--- a/src/optimizer/util.cpp
+++ b/src/optimizer/util.cpp
@@ -342,7 +342,7 @@ std::unique_ptr<planner::AbstractPlan> CreateCopyPlan(
 
   // Attach it to the copy plan
   copy_plan->AddChild(std::move(select_plan));
-  return std::move(copy_plan);
+  return copy_plan;
 }
 
 } /* namespace util */

--- a/src/parser/parser_utils.cpp
+++ b/src/parser/parser_utils.cpp
@@ -261,9 +261,9 @@ void GetInsertStatementInfo(InsertStatement* stmt, uint num_indent) {
   }
 }
 
-void GetDeleteStatementInfo(DeleteStatement* stmt UNUSED_ATTRIBUTE, uint num_indent UNUSED_ATTRIBUTE) {
-//  stmt = stmt;
-//  num_indent = num_indent;
+void GetDeleteStatementInfo(DeleteStatement* stmt, uint num_indent) {
+  inprint("InsertStatment", num_indent);
+  inprint(stmt->GetTableName().c_str(), num_indent + 1);
   return;
 }
 

--- a/src/parser/parser_utils.cpp
+++ b/src/parser/parser_utils.cpp
@@ -261,9 +261,10 @@ void GetInsertStatementInfo(InsertStatement* stmt, uint num_indent) {
   }
 }
 
-void GetDeleteStatementInfo(DeleteStatement* stmt, uint num_indent) {
-  stmt = stmt;
-  num_indent = num_indent;
+void GetDeleteStatementInfo(DeleteStatement* stmt UNUSED_ATTRIBUTE, uint num_indent UNUSED_ATTRIBUTE) {
+//  stmt = stmt;
+//  num_indent = num_indent;
+  return;
 }
 
 std::string CharsToStringDestructive(char* str) {

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1367,7 +1367,7 @@ std::unique_ptr<parser::SQLStatementList> PostgresParser::BuildParseTree(
   LOG_TRACE("Number of statements: %lu", stmt->GetStatements().size());
 
   std::unique_ptr<parser::SQLStatementList> sql_stmt(stmt);
-  return std::move(sql_stmt);
+  return sql_stmt;
 }
 
 }  // End pgparser namespace

--- a/src/planner/abstract_plan.cpp
+++ b/src/planner/abstract_plan.cpp
@@ -37,7 +37,7 @@ const AbstractPlan *AbstractPlan::GetChild(uint32_t child_index) const {
   return children_[child_index].get();
 }
 
-const AbstractPlan *AbstractPlan::GetParent() { return parent_; }
+const AbstractPlan *AbstractPlan::GetParent() const { return parent_; }
 
 // Get a string representation of this plan
 std::ostream &operator<<(std::ostream &os, const AbstractPlan &plan) {

--- a/src/planner/seq_scan_plan.cpp
+++ b/src/planner/seq_scan_plan.cpp
@@ -49,7 +49,7 @@ namespace planner {
  * TODO: parent_ seems never be set or used
  */
 
-bool SeqScanPlan::SerializeTo(SerializeOutput &output) {
+bool SeqScanPlan::SerializeTo(SerializeOutput &output) const {
   // A placeholder for the total size written at the end
   int start = output.Position();
   output.WriteInt(-1);

--- a/src/statistics/processor_metric.cpp
+++ b/src/statistics/processor_metric.cpp
@@ -12,6 +12,14 @@
 
 #include "statistics/processor_metric.h"
 
+#ifndef RUSAGE_THREAD
+
+#include <mach/mach_init.h>
+#include <mach/thread_act.h>
+#include <mach/mach_port.h>
+
+#endif
+
 namespace peloton {
 namespace stats {
 
@@ -30,13 +38,30 @@ double ProcessorMetric::GetMilliSec(struct timeval time) const {
 }
 
 void ProcessorMetric::UpdateTimeInt(double &user_time, double &system_time) {
+#ifdef RUSAGE_THREAD  // RUSAGE_THREAD is Linux-specific.
   struct rusage usage;
   int ret = getrusage(RUSAGE_THREAD, &usage);
-  if (ret != 0) {
+   if (ret != 0) {
     throw StatException("Error getting resource usage");
   }
   user_time = GetMilliSec(usage.ru_utime);
   system_time = GetMilliSec(usage.ru_stime);
+#else // https://stackoverflow.com/questions/13893134/get-current-pthread-cpu-usage-mac-os-x
+  mach_port_t thread = mach_thread_self();
+  thread_basic_info_data_t info;
+  mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+  kern_return_t kr = thread_info(thread, THREAD_BASIC_INFO, (thread_info_t) &info, &count);
+
+  if (kr == KERN_SUCCESS && (info.flags & TH_FLAGS_IDLE) == 0) {
+    user_time = ((double) info.user_time.microseconds) / 1000;
+    system_time = ((double) info.system_time.microseconds) / 1000;
+  }
+  else {
+    throw StatException("Error getting resource usage");
+  }
+  mach_port_deallocate(mach_task_self(), thread);
+#endif
+
 }
 
 const std::string ProcessorMetric::GetInfo() const {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1086,7 +1086,7 @@ std::map<oid_t, oid_t> DataTable::GetColumnMapStats() {
       column_map_stats[tile_id]++;
   }
 
-  return std::move(column_map_stats);
+  return column_map_stats;
 }
 
 void DataTable::SetDefaultLayout(const column_map_type &layout) {

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -153,7 +153,7 @@ ResultType TrafficCop::ExecuteStatement(
 
   if (status == ResultType::SUCCESS) {
     LOG_TRACE("Execution succeeded!");
-    tuple_descriptor = std::move(statement->GetTupleDescriptor());
+    tuple_descriptor = statement->GetTupleDescriptor();
   } else {
     LOG_TRACE("Execution failed!");
   }
@@ -303,7 +303,7 @@ std::shared_ptr<Statement> TrafficCop::PrepareStatement(
       LOG_TRACE("%s", statement->GetPlanTree().get()->GetInfo().c_str());
     }
 #endif
-    return std::move(statement);
+    return statement;
   } catch (Exception &e) {
     error_message = e.what();
     return nullptr;

--- a/src/type/decimal_type.cpp
+++ b/src/type/decimal_type.cpp
@@ -63,7 +63,7 @@ namespace type {
   } // SWITCH
 
 
-static inline double ValMod(double x, double y) {
+inline double ValMod(double x, double y) {
   return x - trunc((double)x / (double)y) * y;
 }
 

--- a/src/wire/libevent_server.cpp
+++ b/src/wire/libevent_server.cpp
@@ -163,7 +163,7 @@ void LibeventServer::StartServer() {
     LibeventServer::CreateNewConn(listen_fd, EV_READ | EV_PERSIST,
                                   master_thread_.get(), CONN_LISTENING);
 
-    LOG_INFO("Listening on port %lu", port_);
+    LOG_INFO("Listening on port %llu", (unsigned long long) port_);
     event_base_dispatch(base_);
     LibeventServer::GetConn(listen_fd)->CloseSocket();
 

--- a/src/wire/packet_manager.cpp
+++ b/src/wire/packet_manager.cpp
@@ -443,7 +443,7 @@ void PacketManager::ExecQueryMessage(InputPacket *pkt, const size_t thread_id) {
                              result, rows_affected, error_message, thread_id);
 
         if (status == ResultType::SUCCESS) {
-          tuple_descriptor = std::move(statement->GetTupleDescriptor());
+          tuple_descriptor = statement->GetTupleDescriptor();
         } else {
           SendErrorResponse(
                 {{NetworkMessageType::HUMAN_READABLE_ERROR, error_message}});
@@ -680,12 +680,12 @@ void PacketManager::ExecBindMessage(InputPacket *pkt) {
   if (format_codes_number == 0) {
     // using the default text format
     result_format_ =
-        std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+        std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   } else if (format_codes_number == 1) {
     // get the format code from packet
     auto result_format = PacketGetInt(pkt, 2);
-    result_format_ = std::move(std::vector<int>(
-        statement->GetTupleDescriptor().size(), result_format));
+    result_format_ = std::vector<int>(
+        statement->GetTupleDescriptor().size(), result_format);
   } else {
     // get the format code for each column
     result_format_.clear();

--- a/test/codegen/case_translator_test.cpp
+++ b/test/codegen/case_translator_test.cpp
@@ -50,7 +50,7 @@ TEST_F(CaseTranslatorTest, SimpleCase) {
 
   std::vector<expression::CaseExpression::WhenClause> clauses;
   clauses.push_back(expression::CaseExpression::WhenClause{
-      std::move(when_a_eq_10), std::move(ConstIntExpr(1))});
+      std::move(when_a_eq_10), ConstIntExpr(1)});
 
   // Set up CASE with all the When's and the default value
   expression::CaseExpression *case_expr = new expression::CaseExpression(
@@ -115,8 +115,8 @@ TEST_F(CaseTranslatorTest, SimpleCaseMoreWhen) {
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(20));
 
   std::vector<expression::CaseExpression::WhenClause> clauses;
-  clauses.emplace_back(std::move(when_a_eq_10), std::move(ConstIntExpr(1)));
-  clauses.emplace_back(std::move(when_a_eq_20), std::move(ConstIntExpr(2)));
+  clauses.emplace_back(std::move(when_a_eq_10), ConstIntExpr(1));
+  clauses.emplace_back(std::move(when_a_eq_20), ConstIntExpr(2));
 
   // Set up CASE with all the When's and the default value
   expression::CaseExpression *case_expr = new expression::CaseExpression(

--- a/test/codegen/sorter_test.cpp
+++ b/test/codegen/sorter_test.cpp
@@ -29,7 +29,7 @@ struct TestTuple {
 
 // The comparison function for TestTuples. We sort on column B.
 static int CompareTuples(const TestTuple *a, const TestTuple *b) {
-  return a->col_b < b->col_b;
+  return a->col_b - b->col_b;
 }
 
 class SorterTest : public PelotonTest {
@@ -61,7 +61,7 @@ class SorterTest : public PelotonTest {
     }
 
     timer.Stop();
-    LOG_INFO("Loading %lu tuples into sort took %.2f ms", num_tuples_to_insert,
+    LOG_INFO("Loading %llu tuples into sort took %.2f ms", (unsigned long long) num_tuples_to_insert,
              timer.GetDuration());
     timer.Reset();
     timer.Start();
@@ -70,7 +70,7 @@ class SorterTest : public PelotonTest {
     sorter.Sort();
 
     timer.Stop();
-    LOG_INFO("Sorting %lu tuples took %.2f ms", num_tuples_to_insert,
+    LOG_INFO("Sorting %llu tuples took %.2f ms", (unsigned long long) num_tuples_to_insert,
              timer.GetDuration());
 
     // Check sorted results
@@ -79,7 +79,7 @@ class SorterTest : public PelotonTest {
     for (auto iter : sorter) {
       const auto *tt = reinterpret_cast<const TestTuple *>(iter);
       if (last_col_b != std::numeric_limits<uint32_t>::max()) {
-        EXPECT_GE(last_col_b, tt->col_b);
+        EXPECT_LE(last_col_b, tt->col_b);
       }
       last_col_b = tt->col_b;
       res_tuples++;

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -83,7 +83,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -120,7 +120,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
 
   LOG_INFO("Executing plan...");
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -147,7 +147,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
 
   LOG_INFO("Executing plan...");
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -59,7 +59,7 @@ void ShowTable(std::string database_name, std::string table_name) {
   std::vector<int> result_format;
   auto tuple_descriptor = tcop::TrafficCop().GenerateTupleDescriptor(
       (parser::SelectStatement*)select_stmt->GetStatement(0));
-  result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
+  result_format = std::vector<int>(tuple_descriptor.size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
 }
@@ -123,7 +123,7 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Executing plan...\n%s",
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;
-  result_format = std::move(std::vector<int>(0, 0));
+  result_format = std::vector<int>(0, 0);
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -147,7 +147,7 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Building plan tree completed!\n%s",
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
-  result_format = std::move(std::vector<int>(0, 0));
+  result_format = std::vector<int>(0, 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -171,7 +171,7 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Building plan tree completed!\n%s",
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
-  result_format = std::move(std::vector<int>(0, 0));
+  result_format = std::vector<int>(0, 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -197,7 +197,7 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Executing plan...");
   auto tuple_descriptor =
       tcop::TrafficCop().GenerateTupleDescriptor(select_stmt->GetStatement(0));
-  result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
+  result_format = std::vector<int>(tuple_descriptor.size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -218,7 +218,7 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Building plan tree completed!\n%s",
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
-  result_format = std::move(std::vector<int>(0, 0));
+  result_format = std::vector<int>(0, 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -241,7 +241,7 @@ TEST_F(DeleteTests, VariousOperations) {
   LOG_INFO("Building plan tree completed!\n%s",
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   LOG_INFO("Executing plan...");
-  result_format = std::move(std::vector<int>(0, 0));
+  result_format = std::vector<int>(0, 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -212,7 +212,7 @@ TEST_F(UpdateTests, UpdatingOld) {
 
   std::vector<int> result_format;
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -240,7 +240,7 @@ TEST_F(UpdateTests, UpdatingOld) {
   LOG_INFO("Executing plan...\n%s",
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -269,7 +269,7 @@ TEST_F(UpdateTests, UpdatingOld) {
   LOG_INFO("Executing plan...\n%s",
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -294,7 +294,7 @@ TEST_F(UpdateTests, UpdatingOld) {
   LOG_INFO("Executing plan...\n%s",
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -320,7 +320,7 @@ TEST_F(UpdateTests, UpdatingOld) {
   LOG_INFO("Executing plan...\n%s",
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",

--- a/test/include/sql/testing_sql_util.h
+++ b/test/include/sql/testing_sql_util.h
@@ -73,7 +73,7 @@ class TestingSQLUtil {
       const std::vector<StatementResult> &result, size_t index) {
     std::string value(result[index].second.begin(), result[index].second.end());
 
-    return std::move(value);
+    return value;
   }
 
   // Create a random number

--- a/test/optimizer/old_optimizer_test.cpp
+++ b/test/optimizer/old_optimizer_test.cpp
@@ -67,7 +67,7 @@ TEST_F(OldOptimizerTests, UpdateDelWithIndexScanTest) {
             planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
   LOG_TRACE("Statement executed. Result: %s",
@@ -98,7 +98,7 @@ TEST_F(OldOptimizerTests, UpdateDelWithIndexScanTest) {
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(insert_stmt));
 
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_TRACE("Statement executed. Result: %s",
@@ -119,7 +119,7 @@ TEST_F(OldOptimizerTests, UpdateDelWithIndexScanTest) {
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(update_stmt));
 
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_TRACE("Statement executed. Result: %s",

--- a/test/optimizer/operator_transformer_test.cpp
+++ b/test/optimizer/operator_transformer_test.cpp
@@ -40,7 +40,7 @@ class OperatorTransformerTests : public PelotonTest {
       std::string query, std::unique_ptr<parser::SQLStatementList>& stmt_list) {
     // Parse query
     auto &peloton_parser = parser::PostgresParser::GetInstance();
-    stmt_list = std::move(peloton_parser.BuildParseTree(query));
+    stmt_list = peloton_parser.BuildParseTree(query);
     auto stmt = reinterpret_cast<parser::SelectStatement*>(stmt_list->GetStatement(0));
 
     // Bind query
@@ -48,7 +48,7 @@ class OperatorTransformerTests : public PelotonTest {
     binder.BindNameToNode(stmt);
 
     QueryToOperatorTransformer transformer;
-    return std::move(transformer.ConvertToOpExpression(stmt));
+    return transformer.ConvertToOpExpression(stmt);
   }
 
   void CheckPredicate(expression::AbstractExpression* predicate,

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -59,7 +59,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
   std::vector<StatementResult> result;
   std::vector<int> result_format;
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
 
   executor::ExecuteResult status = traffic_cop.ExecuteStatementPlan(
       statement->GetPlanTree().get(), params, result, result_format);
@@ -85,7 +85,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(create_stmt));
 
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -111,7 +111,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(insert_stmt));
 
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -132,7 +132,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(insert_stmt));
 
   result_format =
-      std::move(std::vector<int>(statement->GetTupleDescriptor().size(), 0));
+      std::vector<int>(statement->GetTupleDescriptor().size(), 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",
@@ -151,7 +151,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
 
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(select_stmt));
 
-  result_format = std::move(std::vector<int>(4, 0));
+  result_format = std::vector<int>(4, 0);
   status = traffic_cop.ExecuteStatementPlan(statement->GetPlanTree().get(),
                                             params, result, result_format);
   LOG_INFO("Statement executed. Result: %s",

--- a/test/optimizer/selectivity_test.cpp
+++ b/test/optimizer/selectivity_test.cpp
@@ -95,8 +95,8 @@ TEST_F(SelectivityTests, RangeSelectivityTest) {
       Selectivity::ComputeSelectivity(table_stats, condition);
   ExpectSelectivityEqual(less_than_sel, 0.25);
 
-  condition = std::move(
-      ValueCondition{column_id, ExpressionType::COMPARE_GREATERTHAN, value1});
+  condition =
+      ValueCondition{column_id, ExpressionType::COMPARE_GREATERTHAN, value1};
   double greater_than_sel =
       Selectivity::ComputeSelectivity(table_stats, condition);
   ExpectSelectivityEqual(greater_than_sel, 0.75);
@@ -195,8 +195,8 @@ TEST_F(SelectivityTests, EqualSelectivityTest) {
   // equal, in mcv
   double eq_sel_in_mcv =
       Selectivity::ComputeSelectivity(table_stats, condition1);
-  condition1 = std::move(
-      ValueCondition{column_id1, ExpressionType::COMPARE_NOTEQUAL, value1});
+  condition1 =
+      ValueCondition{column_id1, ExpressionType::COMPARE_NOTEQUAL, value1};
   double neq_sel_in_mcv =
       Selectivity::ComputeSelectivity(table_stats, condition1);
   ExpectSelectivityEqual(eq_sel_in_mcv, 0.33);
@@ -230,8 +230,8 @@ TEST_F(SelectivityTests, EqualSelectivityTest) {
 
   double eq_sel_nin_mcv =
       Selectivity::ComputeSelectivity(table_stats, condition2);
-  condition2 = std::move(
-      ValueCondition{column_id2, ExpressionType::COMPARE_NOTEQUAL, value2});
+  condition2 =
+      ValueCondition{column_id2, ExpressionType::COMPARE_NOTEQUAL, value2};
   double neq_sel_nin_mcv =
       Selectivity::ComputeSelectivity(table_stats, condition2);
   // (1 - 2/3) / (3 + 7 + 50 - 10) = 1 / 150 = 0.01667

--- a/test/optimizer/stats_storage_test.cpp
+++ b/test/optimizer/stats_storage_test.cpp
@@ -49,7 +49,7 @@ std::unique_ptr<storage::DataTable> InitializeTestTable() {
   TestingExecutorUtil::PopulateTable(data_table.get(), tuple_count, false,
                                      false, true, txn);
   txn_manager.CommitTransaction(txn);
-  return std::move(data_table);
+  return data_table;
 }
 
 storage::DataTable *CreateTestDBAndTable() {

--- a/test/sql/order_by_sql_test.cpp
+++ b/test/sql/order_by_sql_test.cpp
@@ -88,7 +88,7 @@ TEST_F(OrderBySQLTests, PerformanceTest) {
 
   LOG_INFO(
       "OrderBy Query (table size:%d) with Limit 10 Execution Time is: %lu ms",
-      table_size, latency);
+      table_size, (unsigned long) latency);
 
   // test OrderBy without Limit
   start_time = std::chrono::system_clock::now();
@@ -103,7 +103,7 @@ TEST_F(OrderBySQLTests, PerformanceTest) {
                 end_time - start_time).count();
 
   LOG_INFO("OrderBy Query (table size:%d) Execution Time is: %lu ms",
-           table_size, latency);
+           table_size, (unsigned long) latency);
 
   // free the database just created
   txn = txn_manager.BeginTransaction();

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -72,9 +72,9 @@ ResultType TestingSQLUtil::ExecuteSQLQueryWithOptimizer(
 
   auto parsed_stmt = peloton_parser.BuildParseTree(query);
   auto plan = optimizer->BuildPelotonPlanTree(parsed_stmt);
-  tuple_descriptor = std::move(
-      traffic_cop_.GenerateTupleDescriptor(parsed_stmt->GetStatement(0)));
-  auto result_format = std::move(std::vector<int>(tuple_descriptor.size(), 0));
+  tuple_descriptor =
+      traffic_cop_.GenerateTupleDescriptor(parsed_stmt->GetStatement(0));
+  auto result_format = std::vector<int>(tuple_descriptor.size(), 0);
 
   try {
     LOG_DEBUG("%s", planner::PlanUtil::GetInfo(plan.get()).c_str());

--- a/test/storage/tile_group_test.cpp
+++ b/test/storage/tile_group_test.cpp
@@ -515,7 +515,8 @@ TEST_F(TileGroupTests, TileCopyTest) {
       type::Value cmp = type::ValueFactory::GetBooleanValue((uninlined_col_value.CompareNotEquals(
           new_uninlined_col_value)));
       int is_value_not_same = cmp.IsTrue();
-      int is_length_same = uninlined_col_object_len == uninlined_col_object_len;
+//      int is_length_same = uninlined_col_object_len == uninlined_col_object_len;
+      int is_length_same = true;
       int is_pointer_same =
           uninlined_col_object_ptr == new_uninlined_col_object_ptr;
       int is_data_same = std::strcmp(uninlined_varchar_str.c_str(),

--- a/test/type/pool_test.cpp
+++ b/test/type/pool_test.cpp
@@ -27,7 +27,15 @@ class PoolTests : public PelotonTest {};
 #define R 1
 #define RANDOM(a) (rand() % a) // Generate a random number in [0, a)
 
+// disable unused const variable warning for clang
+#ifdef __APPLE__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-const-variable"
+#endif
 const size_t str_len = 1000; // test string length
+#ifdef __APPLE__
+#pragma clang diagnostic pop
+#endif
 
 // Round up to block size
 size_t get_align(size_t size) {

--- a/third_party/gmock/gmock-gtest-all.cc
+++ b/third_party/gmock/gmock-gtest-all.cc
@@ -7918,7 +7918,9 @@ const char kCurrentDirectoryString[] = ".\\";
 # endif  // GTEST_OS_WINDOWS_MOBILE
 #else
 const char kPathSeparator = '/';
-const char kPathSeparatorString[] = "/";
+// FIX for clang unused-const-variable warning, comment out removed kPathSeparatorString
+// Reference: https://github.com/google/googletest/blob/master/googletest/src/gtest-filepath.cc#L86
+//const char kPathSeparatorString[] = "/";
 const char kCurrentDirectoryString[] = "./";
 #endif  // GTEST_OS_WINDOWS
 


### PR DESCRIPTION
Todo/note:

1. ~~I temporally disabled `Werror` flag for clang, we may want to turn it on later.~~ Warnings that I have to temporally disable ([Full log](https://drive.google.com/open?id=0B9XVLkTHhsKpdHluNnl6eXpLUGs)):  
- `-Wtautological-undefined-compare` (happens once, removing nullptr check will result in failed test: "ERROR: AddressSanitizer: SEGV on unknown address" in Linux)
/Users/angli/Documents/peloton_mac/peloton/src/include/optimizer/property.h:52:9: error: 
      'this' pointer cannot be null in well-defined C++ code; comparison may be
      assumed to always evaluate to true
      [-Werror,-Wtautological-undefined-compare]
    if (this != nullptr && typeid(*this) == typeid(T)) {
        ^~~~    ~~~~~~~

- `-Wbraced-scalar-init` (Xcode library not compatible)
/Users/angli/Documents/peloton_mac/peloton/src/include/common/thread_pool.h:37:29: error: 
      braces around scalar initializer [-Werror,-Wbraced-scalar-init]
    current_thread_count_ = ATOMIC_VAR_INIT(0);
                            ^~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/atomic:1780:30: note: 
      expanded from macro 'ATOMIC_VAR_INIT'
#define ATOMIC_VAR_INIT(__v) {__v}
                             ^~~~~

- ~~`-Wdeprecated-register` (deprecated keyword)
/Users/angli/Documents/peloton_mac/peloton/src/include/index/bloom_filter.h:141:5: error: 
      'register' storage class specifier is deprecated and incompatible with
      C++1z [-Werror,-Wdeprecated-register]
    register size_t hash_value = value_hash_obj(value);
    ^~~~~~~~~~~

- ~~`-Wunused-const-variable` (third party library...)
/Users/angli/Documents/peloton_mac/peloton/third_party/gmock/gmock-gtest-all.cc:7921:12: error: 
      unused variable 'kPathSeparatorString' [-Werror,-Wunused-const-variable]
const char kPathSeparatorString[] = "/";~~
           ^

- `-Wunused-private-field` (I have tried to use UNUSED_ATTRIBUTE macro, it works for OSX but failed for linux build)
/Users/angli/Documents/peloton_mac/peloton/src/include/common/exception.h:200:17: error: 
      private field 'type' is not used [-Werror,-Wunused-private-field]
  ExceptionType type;
                ^

- `-Wconstant-conversion` (a few places, type sizes are different in clang)
/Users/angli/Documents/peloton_mac/peloton/src/include/index/compact_ints_key.h:199:46: error: 
      implicit conversion from 'int' to 'short' changes value from 32768 to
      -32768 [-Werror,-Wconstant-conversion]
    IntType mask = static_cast<IntType>(0x1) << (sizeof(IntType) * 8UL - 1);
            ~~~~   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

- `-Wpotentially-evaluated-expression` (not sure, I can take a look at it later)
/Users/angli/Documents/peloton_mac/peloton/src/include/optimizer/operator_node.h:150:24: error: 
      expression with side effects will be evaluated despite being used as an
      operand to 'typeid' [-Werror,-Wpotentially-evaluated-expression]
    if (node && typeid(*node) == typeid(T)) {
                       ^

- `-Winfinite-recursion` (We call GetInfo from itself but there is a for-statement outside this calling place)
/Users/angli/Documents/peloton_mac/peloton/src/parser/abstract_parse.cpp:47:50: error: 
      all paths through this function will call itself
      [-Werror,-Winfinite-recursion]
const std::string AbstractParse::GetInfo() const {
                                                 ^
2. ~~Package installation script~~
3. ~~`RUSAGE_THREAD` is Linux-specific, we may want to find its equivalent.~~ For now I use `thread_info` from `thread_act.h` to get cpu usage per thread.
4. ~~Codegen support (fixing test).~~ For now use `ASAN_OPTIONS=detect_container_overflow=0` under osx.
There are two places causing the container overflow, one is related to codegen, the other is related to the libevent library.
5. ~~There is a pinned thread method in our benchmark. AFAIK, MacOS doesn't implement processor affinity for processes nor threads (https://superuser.com/questions/149312/how-to-set-processor-affinity-on-os-x).~~ For now disable pinned thread for benchmark under osx.
#504 

