### PR TITLE
Fix hash join and index scan issues in the new optimizer

### DIFF
--- a/src/optimizer/operator_to_plan_transformer.cpp
+++ b/src/optimizer/operator_to_plan_transformer.cpp
@@ -104,12 +104,6 @@ void OperatorToPlanTransformer::Visit(const PhysicalIndexScan *op) {
     key_column_ids.clear();
     expr_types.clear();
     values.clear();
-  } else {
-    // Indes Searchable. Remove predicates that has indexed columns
-    auto original_predicate = predicate;
-    predicate = expression::ExpressionUtil::RemoveTermsWithIndexedColumns(
-        original_predicate, op->table_->GetIndex(index_id));
-    if (predicate != original_predicate) delete original_predicate;
   }
 
   // Generate column ids to pass into scan plan and generate output expr map

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -241,15 +241,6 @@ unique_ptr<planner::AbstractPlan> Optimizer::ChooseBestPlan(
     }
   }
   
-#ifdef LOG_DEBUG_ENABLED
-  LOG_DEBUG("Children map: %ld", children_expr_map.size());
-  for (auto map : children_expr_map) {
-    for (auto iter : map) {
-      LOG_DEBUG("%d", iter.second);
-    }
-  }
-#endif
-  
   
   // Derive root plan
   shared_ptr<OperatorExpression> op =

--- a/src/optimizer/property_set.cpp
+++ b/src/optimizer/property_set.cpp
@@ -58,7 +58,7 @@ const std::shared_ptr<Property> PropertySet::GetPropertyOfType(
 
 bool PropertySet::HasProperty(const Property &r_property) const {
   for (auto property : properties_) {
-    if (*property >= r_property) {
+    if (*property >= r_property && r_property >= *property) {
       return true;
     }
   }

--- a/test/sql/optimizer_sql_test.cpp
+++ b/test/sql/optimizer_sql_test.cpp
@@ -596,6 +596,11 @@ TEST_F(OptimizerSQLTests, JoinTest) {
       },
       false);
 
+  // Test mixing single table predicates with join predicates
+  TestUtil("SELECT test.b FROM TEST, TEST1 "
+               "WHERE test.a = test1.a and test.c > 333 ",
+           {"33", "0"}, false);
+
   /************************* Complex Queries *******************************/
   // Test projection with join
   TestUtil("SELECT test.a, test.b+test2.b FROM TEST, TEST2 WHERE test.a = test2.a",
@@ -623,6 +628,20 @@ TEST_F(OptimizerSQLTests, JoinTest) {
                "ORDER BY test.a",
            {"22", "1", "11", "2", "22", "3", "0", "4"}, true);
 
+
+}
+
+TEST_F(OptimizerSQLTests, IndexTest) {
+  TestingSQLUtil::ExecuteSQLQuery(
+      "create table foo(a int, b varchar(32), primary key(a, b));");
+
+  TestingSQLUtil::ExecuteSQLQuery(
+      "create index sk0 on foo(a);");
+  TestingSQLUtil::ExecuteSQLQuery("INSERT INTO foo VALUES (2, '323');");
+  TestingSQLUtil::ExecuteSQLQuery("INSERT INTO foo VALUES (2, '313');");
+  TestingSQLUtil::ExecuteSQLQuery("INSERT INTO foo VALUES (1, '313');");
+
+  TestUtil("select * from foo where b = '313';", {"2", "313", "1", "313"}, false);
 }
 
 }  // namespace test


### PR DESCRIPTION
This PR fixes two bugs in the new optimizer:

1. #705. When mixing join predicates with single table predicates in hash join plan, the column in the single table predicate is absent during the predicate evaluation. This bug is fixed by ensuring the output column requirement for the hash join operator contains columns in the single table predicates. Note that predicate push-down has not been supported yet.
2.  #600. We enable the new optimizer to use index scan when the columns occurred in the predicates (only consider CompareEqualExpression) forms a subset of the index columns. But the new optimizer excludes the predicates that contain the index columns in the index scan plan, which leads to incorrect results for some queries.