### PR TITLE
Fix the name-mangling issue on release mode

### DIFF
--- a/src/include/storage/tile_group.h
+++ b/src/include/storage/tile_group.h
@@ -147,7 +147,7 @@ class TileGroup : public Printable {
     return column_map;
   }
 
-  oid_t GetTileGroupId() const { return tile_group_id; }
+  oid_t GetTileGroupId() const;
 
   oid_t GetDatabaseId() const { return database_id; }
 

--- a/src/storage/tile_group.cpp
+++ b/src/storage/tile_group.cpp
@@ -77,6 +77,10 @@ type::AbstractPool *TileGroup::GetTilePool(const oid_t tile_id) const {
   return nullptr;
 }
 
+oid_t TileGroup::GetTileGroupId() const {
+  return tile_group_id;
+}
+
 // TODO: check when this function is called. --Yingjun
 oid_t TileGroup::GetNextTupleSlot() const {
   return tile_group_header->GetCurrentNextTupleSlot();


### PR DESCRIPTION
This fixes the function name mangling in #715, which is also partially also mentioned in #705.  This issue seems to occur on some GCC versions, but it can be reproducible on dev1(5.4.0-6ubuntu1, 16.04.4), dev2(4.8.4-2ubuntu1, 14.04.3) and dev3(4.8.4-2ubuntu1, 14.04.3).  