### PR TITLE
check the length before inserting data into VARCHAR or VARBINARY columns

### DIFF
--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -238,13 +238,12 @@ class ValueOutOfRangeException : public Exception {
                       " can't be cast as %s because the value is out of range "
                       "for the destination type " +
                       TypeIdToString(newType)) {}
-  ValueOutOfRangeException(const char* str,
-                           const type::TypeId varType,
+  ValueOutOfRangeException(const type::TypeId varType,
                            const size_t length)
       : Exception(EXCEPTION_TYPE_OUT_OF_RANGE,
                   "The value is too long to fit into type " +
                           TypeIdToString(varType) +
-                          "(" + length + ")") {};
+                          "(" + std::to_string(length) + ")") {};
 };
 
 class ConversionException : public Exception {

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -238,6 +238,13 @@ class ValueOutOfRangeException : public Exception {
                       " can't be cast as %s because the value is out of range "
                       "for the destination type " +
                       TypeIdToString(newType)) {}
+  ValueOutOfRangeException(const char* str,
+                           const type::TypeId varType,
+                           const size_t length)
+      : Exception(EXCEPTION_TYPE_OUT_OF_RANGE,
+                  "The value is too long to fit into type " +
+                          TypeIdToString(varType) +
+                          "(" + length + ")") {};
 };
 
 class ConversionException : public Exception {

--- a/src/planner/create_plan.cpp
+++ b/src/planner/create_plan.cpp
@@ -66,6 +66,9 @@ CreatePlan::CreatePlan(parser::CreateStatement *parse_tree) {
 
       auto column = catalog::Column(val, type::Type::GetTypeSize(val),
           std::string(col->name), false);
+      if (!column.IsInlined()) {
+        column.SetLength(col->varlen);
+      }
       for (auto con : column_contraints) {
         column.AddConstraint(con);
       }

--- a/src/storage/tuple.cpp
+++ b/src/storage/tuple.cpp
@@ -62,7 +62,7 @@ void Tuple::SetValue(const oid_t column_offset, const type::Value &value,
     if ((type == type::TypeId::VARCHAR || type == type::TypeId::VARBINARY)
         && (column_length != 0 && value.GetLength() != type::PELOTON_VALUE_NULL)
         && value.GetLength() > column_length) {
-      throw peloton::ValueOutOfRangeException(value.GetData(), type, column_length);
+      throw peloton::ValueOutOfRangeException(type, column_length);
     }
     value.SerializeTo(value_location, is_inlined, data_pool);
   } else {

--- a/src/storage/tuple.cpp
+++ b/src/storage/tuple.cpp
@@ -62,7 +62,7 @@ void Tuple::SetValue(const oid_t column_offset, const type::Value &value,
     if ((type == type::TypeId::VARCHAR || type == type::TypeId::VARBINARY)
         && (column_length != 0 && value.GetLength() != type::PELOTON_VALUE_NULL)
         && value.GetLength() > column_length) {
-      throw peloton::IncompatibleTypeException(type, " value too long");
+      throw peloton::ValueOutOfRangeException(value.GetData(), type, column_length);
     }
     value.SerializeTo(value_location, is_inlined, data_pool);
   } else {

--- a/src/storage/tuple.cpp
+++ b/src/storage/tuple.cpp
@@ -49,7 +49,7 @@ void Tuple::SetValue(const oid_t column_offset, const type::Value &value,
 
   const bool is_inlined = tuple_schema_->IsInlined(column_offset);
   char *value_location = GetDataPtr(column_offset);
-  UNUSED_ATTRIBUTE int32_t column_length =
+  UNUSED_ATTRIBUTE size_t column_length =
       tuple_schema_->GetLength(column_offset);
   if (is_inlined == false)
     column_length = tuple_schema_->GetVariableLength(column_offset);
@@ -59,6 +59,11 @@ void Tuple::SetValue(const oid_t column_offset, const type::Value &value,
 
   // Skip casting if type is same
   if (type == value.GetTypeId()) {
+    if ((type == type::TypeId::VARCHAR || type == type::TypeId::VARBINARY)
+        && (column_length != 0 && value.GetLength() != type::PELOTON_VALUE_NULL)
+        && value.GetLength() > column_length) {
+      throw peloton::IncompatibleTypeException(type, " value too long");
+    }
     value.SerializeTo(value_location, is_inlined, data_pool);
   } else {
     type::Value casted_value = (value.CastAs(type));

--- a/test/statistics/stats_test.cpp
+++ b/test/statistics/stats_test.cpp
@@ -129,9 +129,8 @@ TEST_F(StatsTests, MultiThreadStatsTest) {
                                    "dept_id", true);
   catalog::Constraint constraint(ConstraintType::PRIMARY, "con_primary");
   id_column.AddConstraint(constraint);
-  auto name_column = catalog::Column(
-      type::TypeId::VARCHAR, type::Type::GetTypeSize(type::TypeId::INTEGER),
-      "dept_name", false);
+  auto name_column = catalog::Column(type::TypeId::VARCHAR, 32, "dept_name", false);
+
   std::unique_ptr<catalog::Schema> table_schema(
       new catalog::Schema({id_column, name_column}));
   catalog->CreateDatabase("emp_db", txn);

--- a/test/statistics/testing_stats_util.cpp
+++ b/test/statistics/testing_stats_util.cpp
@@ -111,7 +111,8 @@ void TestingStatsUtil::CreateTable(bool has_primary_key) {
     id_column.AddConstraint(constraint);
   }
   auto name_column =
-      catalog::Column(type::TypeId::VARCHAR, 32, "dept_name", false);
+      catalog::Column(type::TypeId::VARCHAR, 256, "dept_name", false);
+
   std::unique_ptr<catalog::Schema> table_schema(
       new catalog::Schema({id_column, name_column}));
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();

--- a/test/storage/tuple_test.cpp
+++ b/test/storage/tuple_test.cpp
@@ -132,6 +132,20 @@ TEST_F(TupleTests, VarcharTest) {
 
   LOG_TRACE("%s", tuple->GetInfo().c_str());
 
+  // test if VARCHAR length is enforced
+  auto val3 = type::ValueFactory::GetVarcharValue((std::string) "this is a very long string", pool);
+  try {
+    tuple->SetValue(3, val3, pool);
+  }
+  catch (peloton::IncompatibleTypeException e) {}
+  value3 = (tuple->GetValue(3));
+  cmp = type::ValueFactory::GetBooleanValue((value3.CompareNotEquals(val3)));
+  EXPECT_TRUE(cmp.IsTrue());
+  cmp = type::ValueFactory::GetBooleanValue((value3.CompareEquals(val2)));
+  EXPECT_TRUE(cmp.IsTrue());
+
+  LOG_TRACE("%s", tuple->GetInfo().c_str());
+
   // Make sure that our tuple tells us the right estimated size
   size_t expected_size = sizeof(int32_t) + value3.GetLength();
   EXPECT_EQ(expected_size, tuple->GetUninlinedMemorySize());

--- a/test/storage/tuple_test.cpp
+++ b/test/storage/tuple_test.cpp
@@ -137,7 +137,7 @@ TEST_F(TupleTests, VarcharTest) {
   try {
     tuple->SetValue(3, val3, pool);
   }
-  catch (peloton::IncompatibleTypeException e) {}
+  catch (peloton::ValueOutOfRangeException e) {}
   value3 = (tuple->GetValue(3));
   cmp = type::ValueFactory::GetBooleanValue((value3.CompareNotEquals(val3)));
   EXPECT_TRUE(cmp.IsTrue());


### PR DESCRIPTION
fix the bug #636. I add a check in planner phase. When generating a InsertPlan,  one should call tuple->SetValue for each element to be inserted. So I add the check in Tuple::SetValue.