### PR TITLE
Enforcing unique constraint upon table creation

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -259,7 +259,20 @@ ResultType Catalog::CreateTable(const std::string &database_name,
     }
 
     CreatePrimaryIndex(database_oid, table_oid, txn);
-
+    for(auto column : table->GetSchema()->GetColumns()){
+        //Maybe add a is_unique_ in column definition?
+        //Would avoid the double loop for sure.
+        std::vector<std::string> column_name;
+        column_name.push_back(column.GetName());
+        for(auto constraint : column.GetConstraints())
+            if(constraint.GetType() == ConstraintType::UNIQUE)
+                CreateIndex(database_name,
+                            table_name,
+                            column_name,
+                            table_name+"_"+column_name[0]+"_key", true,
+                                                IndexType::BWTREE,
+                                                txn);
+    }
     return ResultType::SUCCESS;
   } catch (CatalogException &e) {
     LOG_TRACE("Can't found database %s. Return RESULT_FAILURE",

--- a/src/planner/create_plan.cpp
+++ b/src/planner/create_plan.cpp
@@ -64,6 +64,11 @@ CreatePlan::CreatePlan(parser::CreateStatement *parse_tree) {
         column_contraints.push_back(constraint);
       }
 
+      if (col->unique) {
+        catalog::Constraint constraint(ConstraintType::UNIQUE, "con_unique");
+        column_contraints.push_back(constraint);
+      }
+
       auto column = catalog::Column(val, type::Type::GetTypeSize(val),
           std::string(col->name), false);
       for (auto con : column_contraints) {


### PR DESCRIPTION
This PR solves issue #714 

The `CreatePlan` wasn't checking for unique constraints and no action was taken even with the constraint defined. Therefore the constraint is added and an index is created alongside the table.