### PR TITLE
Implement parser edge case

### DIFF
--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -113,7 +113,7 @@ class PostgresParser {
   static parser::JoinDefinition* JoinTransform(JoinExpr* root);
 
   // transform helper for from clauses
-  static parser::TableRef* FromTransform(List* root);
+  static parser::TableRef* FromTransform(SelectStmt* root);
 
   // transform helper for select targets
   static std::vector<expression::AbstractExpression*>* TargetTransform(List* root);

--- a/src/optimizer/stats/cost.cpp
+++ b/src/optimizer/stats/cost.cpp
@@ -74,7 +74,7 @@ void Cost::CombineConjunctionStats(const std::shared_ptr<TableStats> &lhs,
       break;
     default:
       LOG_TRACE("Cost model conjunction on expression type %d not supported",
-                type);
+                (int)type);
   }
   if (output_stats != nullptr) {
     output_stats->num_rows = num_tuples;

--- a/src/optimizer/stats/cost.cpp
+++ b/src/optimizer/stats/cost.cpp
@@ -73,8 +73,8 @@ void Cost::CombineConjunctionStats(const std::shared_ptr<TableStats> &lhs,
       num_tuples = static_cast<size_t>((sel1 + sel2 - sel1 * sel2) * num_rows);
       break;
     default:
-      LOG_TRACE("Cost model conjunction on expression type %d not supported",
-                (int)type);
+      LOG_WARN("Cost model conjunction on expression type %s not supported",
+               ExpressionTypeToString(type).c_str());
   }
   if (output_stats != nullptr) {
     output_stats->num_rows = num_tuples;

--- a/src/optimizer/stats/selectivity.cpp
+++ b/src/optimizer/stats/selectivity.cpp
@@ -43,7 +43,7 @@ double Selectivity::ComputeSelectivity(const std::shared_ptr<TableStats> &stats,
       return DistinctFrom(stats, condition);
     default:
       LOG_TRACE("Expression type %d not supported for computing selectivity",
-                type);
+                (int)(condition.type));
       return DEFAULT_SELECTIVITY;
   }
 }

--- a/src/optimizer/stats/selectivity.cpp
+++ b/src/optimizer/stats/selectivity.cpp
@@ -42,8 +42,8 @@ double Selectivity::ComputeSelectivity(const std::shared_ptr<TableStats> &stats,
     case ExpressionType::COMPARE_DISTINCT_FROM:
       return DistinctFrom(stats, condition);
     default:
-      LOG_TRACE("Expression type %d not supported for computing selectivity",
-                (int)(condition.type));
+      LOG_WARN("Expression type %s not supported for computing selectivity",
+                ExpressionTypeToString(condition.type).c_str());
       return DEFAULT_SELECTIVITY;
   }
 }

--- a/src/optimizer/stats/stats_storage.cpp
+++ b/src/optimizer/stats/stats_storage.cpp
@@ -267,7 +267,7 @@ std::shared_ptr<TableStats> StatsStorage::GetTableStats(
 ResultType StatsStorage::AnalyzeStatsForAllTables(
     concurrency::Transaction *txn) {
   if (txn == nullptr) {
-    LOG_TRACE("Do not have transaction to analyze all tables' stats: %s");
+    LOG_TRACE("Do not have transaction to analyze all tables' stats.");
     return ResultType::FAILURE;
   }
 
@@ -302,7 +302,7 @@ ResultType StatsStorage::AnalyzeStatsForTable(storage::DataTable *table,
                                               concurrency::Transaction *txn) {
   if (txn == nullptr) {
     LOG_TRACE("Do not have transaction to analyze the table stats: %s",
-              table_name.c_str());
+              table->GetName().c_str());
     return ResultType::FAILURE;
   }
   std::unique_ptr<TableStatsCollector> table_stats_collector(

--- a/src/optimizer/stats/tuple_samples_storage.cpp
+++ b/src/optimizer/stats/tuple_samples_storage.cpp
@@ -124,7 +124,7 @@ ResultType TupleSamplesStorage::CollectSamplesForTable(
     storage::DataTable *data_table, concurrency::Transaction *txn) {
   if (txn == nullptr) {
     LOG_TRACE("Do not have transaction to collect samples for table: %s",
-              table_name.c_str());
+              data_table->GetName().c_str());
     return ResultType::FAILURE;
   }
   TupleSampler tuple_sampler(data_table);

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -185,24 +185,24 @@ parser::TableRef* PostgresParser::RangeSubselectTransform(
 }
 
 // Get in a target list and check if is with variables
-bool IsTargetListWithVar(List* target_list) {
+bool IsTargetListWithVariable(List* target_list) {
   // The only valid situation of a null from list is that all targets are constant
-  LOG_DEBUG("size is : %d", target_list->length);
-  print_pg_parse_tree(target_list);
-
   for (auto cell = target_list->head; cell != nullptr; cell = cell->next) {
-
     ResTarget* target = reinterpret_cast<ResTarget*>(cell->data.ptr_value);
-      LOG_DEBUG("Type: %d, expected %d", target->type, T_A_Const);
+    LOG_TRACE("Type: %d", target->type);
 
-      switch (target->val->type) {
-        case T_A_Const:
-        case T_A_Expr:
-        case T_BoolExpr:
-          continue;
-        default:
-          return true;
-      }
+    // Bypass the target nodes with type:
+    // constant("SELECT 1;"), expression ("SELECT 1 + 1"),
+    // and boolean ("SELECT 1!=2;");
+    // TODO: We may want to see if there are more types to check.
+    switch (target->val->type) {
+      case T_A_Const:
+      case T_A_Expr:
+      case T_BoolExpr:
+        continue;
+      default:
+        return true;
+    }
   }
   return false;
 }
@@ -212,20 +212,20 @@ bool IsTargetListWithVar(List* target_list) {
 // TODO: support select from multiple sources, nested queries, various joins
 parser::TableRef* PostgresParser::FromTransform(SelectStmt* select_root) {
   // now support select from only one sources
+
   List* root = select_root->fromClause;
   /* Statement like 'SELECT *;' cannot detect by postgres parser and would lead to
    * a null list of from clause*/
-
   if (root == nullptr) {
-      auto target_list = select_root->targetList;
-      // The only valid situation of a null from list is that all targets are constant
-      LOG_DEBUG("size is : %d", target_list->length);
-      print_pg_parse_tree(target_list);
-      if (IsTargetListWithVar(target_list)) {
-        throw ParserException(
-            StringUtil::Format("Error parsing SQL statement"));
-      }
-      return nullptr;
+    auto target_list = select_root->targetList;
+    // The only valid situation of a null 'from list' is that all targets are constant
+    LOG_TRACE("size is : %d", target_list->length);
+    //print_pg_parse_tree(target_list);
+    if (IsTargetListWithVariable(target_list)) {
+      throw ParserException(
+          StringUtil::Format("Error parsing SQL statement"));
+    }
+    return nullptr;
   }
 
   parser::TableRef* result = nullptr;
@@ -1331,7 +1331,7 @@ parser::SQLStatementList* PostgresParser::ParseSQLString(const char* text) {
   }
 
   // DEBUG only. Comment this out in release mode
-   print_pg_parse_tree(result.tree);
+  // print_pg_parse_tree(result.tree);
 
   parser::SQLStatementList* transform_result = nullptr;
   try {

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -222,8 +222,7 @@ parser::TableRef* PostgresParser::FromTransform(SelectStmt* select_root) {
     LOG_TRACE("size is : %d", target_list->length);
     //print_pg_parse_tree(target_list);
     if (IsTargetListWithVariable(target_list)) {
-      throw ParserException(
-          StringUtil::Format("Error parsing SQL statement"));
+      throw ParserException("Error parsing SQL statement");
     }
     return nullptr;
   }
@@ -542,11 +541,10 @@ expression::AbstractExpression* PostgresParser::FuncCallTransform(
 // It checks the type of each target and call the corresponding helpers.
 std::vector<expression::AbstractExpression*>* PostgresParser::TargetTransform(
     List* root) {
-  /* Statement like 'SELECT;' cannot detect by postgres parser and would lead to
-   * null list*/
+  // Statement like 'SELECT;' cannot detect by postgres parser and would lead to
+  // null list
   if (root == nullptr) {
-      throw ParserException(
-          StringUtil::Format("Error parsing SQL statement"));
+      throw ParserException("Error parsing SQL statement");
   }
 
   std::vector<expression::AbstractExpression*>* result =

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1272,13 +1272,8 @@ parser::SQLStatementList* PostgresParser::ListTransform(List* root) {
     return nullptr;
   }
   LOG_TRACE("%d statements in total\n", (root->length));
-  try {
-    for (auto cell = root->head; cell != nullptr; cell = cell->next) {
-      result->AddStatement(NodeTransform((Node*)cell->data.ptr_value));
-    }
-  } catch (ParserException e) {
-    result->is_valid = false;
-    return result;
+  for (auto cell = root->head; cell != nullptr; cell = cell->next) {
+    result->AddStatement(NodeTransform((Node*)cell->data.ptr_value));
   }
 
   return result;
@@ -1334,7 +1329,7 @@ parser::SQLStatementList* PostgresParser::ParseSQLString(const char* text) {
   parser::SQLStatementList* transform_result = nullptr;
   try {
     transform_result = ListTransform(result.tree);
-  } catch (NotImplementedException e) {
+  } catch (Exception e) {
     if (transform_result != nullptr) {
         delete transform_result;
     }

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1257,9 +1257,15 @@ parser::SQLStatementList* PostgresParser::ListTransform(List* root) {
     return nullptr;
   }
   LOG_TRACE("%d statements in total\n", (root->length));
-  for (auto cell = root->head; cell != nullptr; cell = cell->next) {
-    result->AddStatement(NodeTransform((Node*)cell->data.ptr_value));
+  try {
+    for (auto cell = root->head; cell != nullptr; cell = cell->next) {
+      result->AddStatement(NodeTransform((Node*)cell->data.ptr_value));
+    }
+  } catch (ParserException e) {
+    result->is_valid = false;
+    return result;
   }
+
   return result;
 }
 
@@ -1313,7 +1319,7 @@ parser::SQLStatementList* PostgresParser::ParseSQLString(const char* text) {
   parser::SQLStatementList* transform_result = nullptr;
   try {
     transform_result = ListTransform(result.tree);
-  } catch (Exception e) {
+  } catch (NotImplementedException e) {
     if (transform_result != nullptr) {
         delete transform_result;
     }

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -283,9 +283,7 @@ std::shared_ptr<Statement> TrafficCop::PrepareStatement(
       new Statement(statement_name, query_string));
   try {
     auto &peloton_parser = parser::PostgresParser::GetInstance();
-      LOG_DEBUG("START PARSING");
     auto sql_stmt = peloton_parser.BuildParseTree(query_string);
-      LOG_DEBUG("PARSE_FIN");
     if (sql_stmt->is_valid == false) {
       throw ParserException("Error parsing SQL statement");
     }

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -283,7 +283,9 @@ std::shared_ptr<Statement> TrafficCop::PrepareStatement(
       new Statement(statement_name, query_string));
   try {
     auto &peloton_parser = parser::PostgresParser::GetInstance();
+      LOG_DEBUG("START PARSING");
     auto sql_stmt = peloton_parser.BuildParseTree(query_string);
+      LOG_DEBUG("PARSE_FIN");
     if (sql_stmt->is_valid == false) {
       throw ParserException("Error parsing SQL statement");
     }

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -412,6 +412,17 @@ TEST_F(ParserTests, CopyTest) {
     }
   }
 }
-
+// Test that the wrong queries can be detected.
+TEST_F(ParserTests, WrongQueryTest) {
+  std::vector<std::string> queries;
+  queries.push_back("SELECT;");
+  queries.push_back("SELECT *;");
+  // Parsing
+  for (auto query : queries) {
+    UNUSED_ATTRIBUTE parser::SQLStatementList* result =
+        parser::PostgresParser::ParseSQLString(query.c_str());
+    EXPECT_EQ(result->is_valid, false);
+  }
+}
 }  // End test namespace
 }  // End peloton namespace

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -412,6 +412,7 @@ TEST_F(ParserTests, CopyTest) {
     }
   }
 }
+
 // Test that the wrong queries can be detected.
 TEST_F(ParserTests, WrongQueryTest) {
   std::vector<std::string> queries;
@@ -419,9 +420,7 @@ TEST_F(ParserTests, WrongQueryTest) {
   queries.push_back("SELECT *;");
   // Parsing
   for (auto query : queries) {
-    UNUSED_ATTRIBUTE parser::SQLStatementList* result =
-        parser::PostgresParser::ParseSQLString(query.c_str());
-    EXPECT_EQ(result->is_valid, false);
+    EXPECT_THROW(parser::PostgresParser::ParseSQLString(query.c_str()), Exception);
   }
 }
 }  // End test namespace

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -413,32 +413,5 @@ TEST_F(ParserTests, CopyTest) {
   }
 }
 
-TEST_F(ParserTests, WrongSelectTest) {
-  std::vector<std::string> queries;
-  queries.push_back("SELECT;");
-  queries.push_back("SELECT *;");
-  for (auto query : queries) {
-    parser::SQLStatementList *result =
-        parser::PostgresParser::ParseSQLString(query.c_str());
-
-    if (result->is_valid == true) {
-        LOG_ERROR("Message: %s, line: %d, col: %d", result->parser_msg,
-                  result->error_line, result->error_col);
-    }
-    EXPECT_EQ(result->is_valid, true);
-
-    parser::CopyStatement *copy_stmt =
-            static_cast<parser::CopyStatement *>(result->GetStatement(0));
-
-    EXPECT_EQ(copy_stmt->delimiter, ',');
-    EXPECT_STREQ(copy_stmt->file_path, "/home/user/output.csv");
-
-    if (result != nullptr) {
-        LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());
-        delete result;
-    }
-}
-}
-
 }  // End test namespace
 }  // End peloton namespace

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -413,5 +413,32 @@ TEST_F(ParserTests, CopyTest) {
   }
 }
 
+TEST_F(ParserTests, WrongSelectTest) {
+  std::vector<std::string> queries;
+  queries.push_back("SELECT;");
+  queries.push_back("SELECT *;");
+  for (auto query : queries) {
+    parser::SQLStatementList *result =
+        parser::PostgresParser::ParseSQLString(query.c_str());
+
+    if (result->is_valid == true) {
+        LOG_ERROR("Message: %s, line: %d, col: %d", result->parser_msg,
+                  result->error_line, result->error_col);
+    }
+    EXPECT_EQ(result->is_valid, true);
+
+    parser::CopyStatement *copy_stmt =
+            static_cast<parser::CopyStatement *>(result->GetStatement(0));
+
+    EXPECT_EQ(copy_stmt->delimiter, ',');
+    EXPECT_STREQ(copy_stmt->file_path, "/home/user/output.csv");
+
+    if (result != nullptr) {
+        LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());
+        delete result;
+    }
+}
+}
+
 }  // End test namespace
 }  // End peloton namespace


### PR DESCRIPTION
This PR intents to fix issue #680 that peloton would crash with statements like "SELECT *" and "SELECT;"

The reason is that the Postgres parser does not think the statements mentioned above as wrong statements and the binder and optimizer would continue to execute the wrong parse tree and eventually crash.

The solution is to explicitly check that
1. The target list is not null, which can overcome "SELECT;" 
2. The from clause list is not null **when the target contains any variables 'like * or item column'**, this would overcome "SELECT *;"

A unit test case is added in parser_test to check "SELECT *" and "SELECT;".

There may still be other edge cases in 2 since right now only constant, bool expression and expression type are checked.