### PR TITLE
switch to use smart pointer in parser

### DIFF
--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -84,7 +84,7 @@ void BindNodeVisitor::Visit(const parser::UpdateStatement *node) {
 
   node->table->Accept(this);
   if (node->where != nullptr) node->where->Accept(this);
-  for (auto& update : *(node->updates)) {
+  for (auto& update : node->updates) {
     update->value->Accept(this);
   }
 

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -36,7 +36,7 @@ void BindNodeVisitor::Visit(const parser::SelectStatement *node) {
   if (node->order != nullptr) node->order->Accept(this);
   if (node->limit != nullptr) node->limit->Accept(this);
   if (node->group_by != nullptr) node->group_by->Accept(this);
-  for (auto& select_element : *(node->select_list)) {
+  for (auto& select_element : node->select_list) {
     select_element->Accept(this);
   }
 
@@ -59,8 +59,8 @@ void BindNodeVisitor::Visit(const parser::TableRef *node) {
   else if (node->join != nullptr)
     node->join->Accept(this);
   // Multiple tables
-  else if (node->list != nullptr) {
-    for (auto& table : *(node->list)) table->Accept(this);
+  else if (!node->list.empty()) {
+    for (auto& table : node->list) table->Accept(this);
   }
   // Single table
   else {
@@ -69,13 +69,13 @@ void BindNodeVisitor::Visit(const parser::TableRef *node) {
 }
 
 void BindNodeVisitor::Visit(const parser::GroupByDescription *node) {
-  for (auto& col : *(node->columns)) {
+  for (auto& col : node->columns) {
     col->Accept(this);
   }
   if (node->having != nullptr) node->having->Accept(this);
 }
 void BindNodeVisitor::Visit(const parser::OrderDescription *node) {
-  for (auto expr : *(node->exprs))
+  for (auto& expr : node->exprs)
     if (expr != nullptr) expr->Accept(this);
 }
 

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -36,7 +36,7 @@ void BindNodeVisitor::Visit(const parser::SelectStatement *node) {
   if (node->order != nullptr) node->order->Accept(this);
   if (node->limit != nullptr) node->limit->Accept(this);
   if (node->group_by != nullptr) node->group_by->Accept(this);
-  for (auto select_element : *(node->select_list)) {
+  for (auto& select_element : *(node->select_list)) {
     select_element->Accept(this);
   }
 
@@ -60,7 +60,7 @@ void BindNodeVisitor::Visit(const parser::TableRef *node) {
     node->join->Accept(this);
   // Multiple tables
   else if (node->list != nullptr) {
-    for (parser::TableRef *table : *(node->list)) table->Accept(this);
+    for (auto& table : *(node->list)) table->Accept(this);
   }
   // Single table
   else {
@@ -69,7 +69,7 @@ void BindNodeVisitor::Visit(const parser::TableRef *node) {
 }
 
 void BindNodeVisitor::Visit(const parser::GroupByDescription *node) {
-  for (auto col : *(node->columns)) {
+  for (auto& col : *(node->columns)) {
     col->Accept(this);
   }
   if (node->having != nullptr) node->having->Accept(this);
@@ -84,7 +84,7 @@ void BindNodeVisitor::Visit(const parser::UpdateStatement *node) {
 
   node->table->Accept(this);
   if (node->where != nullptr) node->where->Accept(this);
-  for (auto update : *node->updates) {
+  for (auto& update : *(node->updates)) {
     update->value->Accept(this);
   }
 

--- a/src/include/index/scan_optimizer.h
+++ b/src/include/index/scan_optimizer.h
@@ -233,10 +233,8 @@ class ConjunctionScanPredicate {
       PL_ASSERT(high_key_p_ != nullptr);
     }
 
-    if (high_key_p_ != nullptr) {
-      delete high_key_p_;
-    }
-
+    delete high_key_p_;
+  
     return;
   }
 

--- a/src/include/optimizer/operators.h
+++ b/src/include/optimizer/operators.h
@@ -147,13 +147,13 @@ class LogicalGroupBy : public OperatorNode<LogicalGroupBy> {
 class LogicalInsert : public OperatorNode<LogicalInsert> {
  public:
   static Operator make(
-      storage::DataTable *target_table, std::vector<std::unique_ptr<char[]>> *columns,
-      std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *
+      storage::DataTable *target_table, const std::vector<std::string> *columns,
+      const std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>> *
           values);
 
   storage::DataTable *target_table;
-  std::vector<std::unique_ptr<char[]>> *columns;
-  std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *values;
+  const std::vector<std::string> *columns;
+  const std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>> *values;
 };
 
 class LogicalInsertSelect : public OperatorNode<LogicalInsertSelect> {
@@ -179,10 +179,10 @@ class LogicalDelete : public OperatorNode<LogicalDelete> {
 class LogicalUpdate : public OperatorNode<LogicalUpdate> {
  public:
   static Operator make(storage::DataTable *target_table,
-                       std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates);
+                       const std::vector<std::unique_ptr<parser::UpdateClause>>* updates);
 
   storage::DataTable *target_table;
-  std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates;
+  const std::vector<std::unique_ptr<parser::UpdateClause>>* updates;
 };
 
 //===--------------------------------------------------------------------===//
@@ -335,13 +335,13 @@ class PhysicalOuterHashJoin : public OperatorNode<PhysicalOuterHashJoin> {
 class PhysicalInsert : public OperatorNode<PhysicalInsert> {
  public:
   static Operator make(
-      storage::DataTable *target_table, std::vector<std::unique_ptr<char[]>> *columns,
-      std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *
+      storage::DataTable *target_table, const std::vector<std::string> *columns,
+      const std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>> *
           values);
 
   storage::DataTable *target_table;
-  std::vector<std::unique_ptr<char[]>> *columns;
-  std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *values;
+  const std::vector<std::string> *columns;
+  const std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>> *values;
 };
 
 class PhysicalInsertSelect : public OperatorNode<PhysicalInsertSelect> {
@@ -366,10 +366,10 @@ class PhysicalDelete : public OperatorNode<PhysicalDelete> {
 class PhysicalUpdate : public OperatorNode<PhysicalUpdate> {
  public:
   static Operator make(storage::DataTable *target_table,
-  std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates);
+  const std::vector<std::unique_ptr<parser::UpdateClause>>* updates);
 
   storage::DataTable *target_table;
-  std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates;
+  const std::vector<std::unique_ptr<parser::UpdateClause>>* updates;
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/include/optimizer/operators.h
+++ b/src/include/optimizer/operators.h
@@ -147,13 +147,13 @@ class LogicalGroupBy : public OperatorNode<LogicalGroupBy> {
 class LogicalInsert : public OperatorNode<LogicalInsert> {
  public:
   static Operator make(
-      storage::DataTable *target_table, std::vector<char *> *columns,
-      std::vector<std::vector<peloton::expression::AbstractExpression *> *> *
+      storage::DataTable *target_table, std::vector<std::unique_ptr<char[]>> *columns,
+      std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *
           values);
 
   storage::DataTable *target_table;
-  std::vector<char *> *columns;
-  std::vector<std::vector<peloton::expression::AbstractExpression *> *> *values;
+  std::vector<std::unique_ptr<char[]>> *columns;
+  std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *values;
 };
 
 class LogicalInsertSelect : public OperatorNode<LogicalInsertSelect> {
@@ -179,10 +179,10 @@ class LogicalDelete : public OperatorNode<LogicalDelete> {
 class LogicalUpdate : public OperatorNode<LogicalUpdate> {
  public:
   static Operator make(storage::DataTable *target_table,
-                       std::vector<peloton::parser::UpdateClause*> updates);
+                       std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates);
 
   storage::DataTable *target_table;
-  std::vector<peloton::parser::UpdateClause*> updates;
+  std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates;
 };
 
 //===--------------------------------------------------------------------===//
@@ -335,13 +335,13 @@ class PhysicalOuterHashJoin : public OperatorNode<PhysicalOuterHashJoin> {
 class PhysicalInsert : public OperatorNode<PhysicalInsert> {
  public:
   static Operator make(
-      storage::DataTable *target_table, std::vector<char *> *columns,
-      std::vector<std::vector<peloton::expression::AbstractExpression *> *> *
+      storage::DataTable *target_table, std::vector<std::unique_ptr<char[]>> *columns,
+      std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *
           values);
 
   storage::DataTable *target_table;
-  std::vector<char *> *columns;
-  std::vector<std::vector<peloton::expression::AbstractExpression *> *> *values;
+  std::vector<std::unique_ptr<char[]>> *columns;
+  std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *values;
 };
 
 class PhysicalInsertSelect : public OperatorNode<PhysicalInsertSelect> {
@@ -366,10 +366,10 @@ class PhysicalDelete : public OperatorNode<PhysicalDelete> {
 class PhysicalUpdate : public OperatorNode<PhysicalUpdate> {
  public:
   static Operator make(storage::DataTable *target_table,
-      std::vector<peloton::parser::UpdateClause*> updates);
+  std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates);
 
   storage::DataTable *target_table;
-  std::vector<peloton::parser::UpdateClause*> updates;
+  std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates;
 };
 
 //===--------------------------------------------------------------------===//

--- a/src/include/parser/analyze_statement.h
+++ b/src/include/parser/analyze_statement.h
@@ -26,8 +26,7 @@ class AnalyzeStatement : public SQLStatement {
  public:
   AnalyzeStatement()
       : SQLStatement(StatementType::ANALYZE),
-        analyze_table(nullptr),
-        analyze_columns(nullptr) {};
+        analyze_table(nullptr) {};
 
   virtual ~AnalyzeStatement() {}
 
@@ -38,11 +37,8 @@ class AnalyzeStatement : public SQLStatement {
     return analyze_table->GetTableName();
   }
 
-  const std::vector<std::unique_ptr<char[]>>& GetColumnNames() const {
-    if (analyze_columns == nullptr) {
-      return NULL_COLUMN;
-    }
-    return (*analyze_columns);
+  const std::vector<std::string>& GetColumnNames() const {
+    return analyze_columns;
   }
 
   std::string GetDatabaseName() const {
@@ -57,10 +53,9 @@ class AnalyzeStatement : public SQLStatement {
   }
 
   std::unique_ptr<parser::TableRef> analyze_table;
-  std::unique_ptr<std::vector<std::unique_ptr<char[]>>> analyze_columns;
+  std::vector<std::string> analyze_columns;
 
   const std::string INVALID_NAME = "";
-  const std::vector<std::unique_ptr<char[]>> NULL_COLUMN = {};
 };
 
 }  // namespace parser

--- a/src/include/parser/analyze_statement.h
+++ b/src/include/parser/analyze_statement.h
@@ -29,16 +29,7 @@ class AnalyzeStatement : public SQLStatement {
         analyze_table(nullptr),
         analyze_columns(nullptr) {};
 
-  // TODO: use smart pointer to avoid raw delete.
-  virtual ~AnalyzeStatement() {
-    if (analyze_columns != nullptr) {
-      for (auto col : *analyze_columns) delete[] col;
-      delete analyze_columns;
-    }
-    if (analyze_table != nullptr) {
-      delete analyze_table;
-    }
-  }
+  virtual ~AnalyzeStatement() {}
 
   std::string GetTableName() const {
     if (analyze_table == nullptr) {
@@ -47,9 +38,9 @@ class AnalyzeStatement : public SQLStatement {
     return analyze_table->GetTableName();
   }
 
-  std::vector<char*> GetColumnNames() const {
+  const std::vector<std::unique_ptr<char[]>>& GetColumnNames() const {
     if (analyze_columns == nullptr) {
-      return {};
+      return NULL_COLUMN;
     }
     return (*analyze_columns);
   }
@@ -65,10 +56,11 @@ class AnalyzeStatement : public SQLStatement {
     v->Visit(this);
   }
 
-  parser::TableRef* analyze_table;
-  std::vector<char*>* analyze_columns;
+  std::unique_ptr<parser::TableRef> analyze_table;
+  std::unique_ptr<std::vector<std::unique_ptr<char[]>>> analyze_columns;
 
   const std::string INVALID_NAME = "";
+  const std::vector<std::unique_ptr<char[]>> NULL_COLUMN = {};
 };
 
 }  // namespace parser

--- a/src/include/parser/copy_statement.h
+++ b/src/include/parser/copy_statement.h
@@ -28,30 +28,22 @@ class CopyStatement : public SQLStatement {
  public:
   CopyStatement(CopyType type)
       : SQLStatement(StatementType::COPY),
-        cpy_table(NULL),
+        cpy_table(nullptr),
         type(type),
-        file_path(NULL),
+        file_path(nullptr),
         delimiter(','){};
 
-  virtual ~CopyStatement() {
-    if (file_path != nullptr) {
-      delete[] file_path;
-    }
-
-    if (cpy_table != nullptr) {
-      delete cpy_table;
-    }
-  }
+  virtual ~CopyStatement() {}
 
   virtual void Accept(SqlNodeVisitor* v) const override {
     v->Visit(this);
   }
 
-  TableRef* cpy_table;
+  std::unique_ptr<TableRef> cpy_table;
 
   CopyType type;
 
-  char* file_path;
+  std::unique_ptr<char[]> file_path;
   char delimiter;
 };
 

--- a/src/include/parser/copy_statement.h
+++ b/src/include/parser/copy_statement.h
@@ -30,8 +30,7 @@ class CopyStatement : public SQLStatement {
       : SQLStatement(StatementType::COPY),
         cpy_table(nullptr),
         type(type),
-        file_path(nullptr),
-        delimiter(','){};
+        delimiter(',') {};
 
   virtual ~CopyStatement() {}
 
@@ -43,7 +42,7 @@ class CopyStatement : public SQLStatement {
 
   CopyType type;
 
-  std::unique_ptr<char[]> file_path;
+  std::string file_path;
   char delimiter;
 };
 

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -108,7 +108,7 @@ struct ColumnDefinition {
     }
   }
 
-  std::string name = nullptr;
+  std::string name;
 
   // The name of the table and its database
   std::unique_ptr<TableInfo> table_info_ = nullptr;
@@ -145,8 +145,7 @@ class CreateStatement : public TableRefStatement {
   CreateStatement(CreateType type)
       : TableRefStatement(StatementType::CREATE),
         type(type),
-        if_not_exists(false),
-        columns(nullptr){};
+        if_not_exists(false) {};
 
   virtual ~CreateStatement() {}
 

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -151,11 +151,6 @@ class CreateStatement : public TableRefStatement {
 
   virtual ~CreateStatement() {}
 
-    if (trigger_when) {
-      delete trigger_when;
-    }
-  }
-
   virtual void Accept(SqlNodeVisitor* v) const override { v->Visit(this); }
 
   CreateType type;

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -168,7 +168,7 @@ class CreateStatement : public TableRefStatement {
   std::vector<std::string> trigger_funcname;
   std::vector<std::string> trigger_args;
   std::vector<std::string> trigger_columns;
-  expression::AbstractExpression* trigger_when;
+  std::unique_ptr<expression::AbstractExpression> trigger_when;
   int16_t trigger_type;  // information about row, timing, events, access by
                          // pg_trigger
 };

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -87,7 +87,6 @@ struct ColumnDefinition {
 
       // case ADDRESS:
       //  return type::Type::ADDRESS;
-      //  break;
 
       case DataType::TIMESTAMP:
         return type::TypeId::TIMESTAMP;
@@ -109,7 +108,7 @@ struct ColumnDefinition {
     }
   }
 
-  std::unique_ptr<char[]> name = nullptr;
+  std::string name = nullptr;
 
   // The name of the table and its database
   std::unique_ptr<TableInfo> table_info_ = nullptr;
@@ -122,13 +121,13 @@ struct ColumnDefinition {
   std::unique_ptr<expression::AbstractExpression> default_value = nullptr;
   std::unique_ptr<expression::AbstractExpression> check_expression = nullptr;
 
-  std::unique_ptr<std::vector<std::unique_ptr<char[]>>> primary_key = nullptr;
-  std::unique_ptr<std::vector<std::unique_ptr<char[]>>> foreign_key_source = nullptr;
-  std::unique_ptr<std::vector<std::unique_ptr<char[]>>> foreign_key_sink = nullptr;
+  std::vector<std::string> primary_key;
+  std::vector<std::string> foreign_key_source;
+  std::vector<std::string> foreign_key_sink;
 
-  std::vector<char *>* multi_unique_cols = nullptr;
+  std::vector<std::string> multi_unique_cols;
 
-  char* foreign_key_table_name = nullptr;
+  std::string foreign_key_table_name;
   FKConstrActionType foreign_key_delete_action;
   FKConstrActionType foreign_key_update_action;
   FKConstrMatchType foreign_key_match_type;
@@ -156,21 +155,21 @@ class CreateStatement : public TableRefStatement {
   CreateType type;
   bool if_not_exists;
 
-  std::unique_ptr<std::vector<std::unique_ptr<ColumnDefinition>>> columns;
-  std::unique_ptr<std::vector<std::unique_ptr<char[]>>> index_attrs = nullptr;
+  std::vector<std::unique_ptr<ColumnDefinition>> columns;
+  std::vector<std::string> index_attrs;
 
   IndexType index_type;
 
-  std::unique_ptr<char[]> index_name = nullptr;
-  std::unique_ptr<char[]> trigger_name = nullptr;
-  std::unique_ptr<char[]> database_name = nullptr;
+  std::string index_name;
+  std::string trigger_name;
+  std::string database_name;
 
   bool unique = false;
 
-  std::vector<char*>* trigger_funcname = nullptr;
-  std::vector<char*>* trigger_args = nullptr;
-  std::vector<char*>* trigger_columns = nullptr;
-  expression::AbstractExpression* trigger_when = nullptr;
+  std::vector<std::string> trigger_funcname;
+  std::vector<std::string> trigger_args;
+  std::vector<std::string> trigger_columns;
+  expression::AbstractExpression* trigger_when;
   int16_t trigger_type;  // information about row, timing, events, access by
                          // pg_trigger
 };

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -63,33 +63,7 @@ struct ColumnDefinition {
       varlen = type::PELOTON_TEXT_MAX_LEN;
   }
 
-  virtual ~ColumnDefinition() {
-    if (primary_key) {
-      for (auto key : *primary_key) delete[](key);
-      delete primary_key;
-    }
-
-    if (foreign_key_source) {
-      for (auto key : *foreign_key_source) delete[](key);
-      delete foreign_key_source;
-    }
-    if (foreign_key_sink) {
-      for (auto key : *foreign_key_sink) delete[](key);
-      delete foreign_key_sink;
-    }
-    if (multi_unique_cols) {
-      for (auto key : *multi_unique_cols) delete[] (key);
-      delete multi_unique_cols;
-    }
-
-    delete[] name;
-    if (table_info_ != nullptr)
-      delete table_info_;
-    if (default_value != nullptr)
-      delete default_value;
-    if (check_expression != nullptr)
-      delete check_expression;
-  }
+  virtual ~ColumnDefinition() {}
 
   static type::TypeId GetValueType(DataType type) {
     switch (type) {
@@ -135,22 +109,22 @@ struct ColumnDefinition {
     }
   }
 
-  char* name = nullptr;
+  std::unique_ptr<char[]> name = nullptr;
 
   // The name of the table and its database
-  TableInfo* table_info_ = nullptr;
+  std::unique_ptr<TableInfo> table_info_ = nullptr;
 
   DataType type;
   size_t varlen = 0;
   bool not_null = false;
   bool primary = false;
   bool unique = false;
-  expression::AbstractExpression* default_value = nullptr;
-  expression::AbstractExpression* check_expression = nullptr;
+  std::unique_ptr<expression::AbstractExpression> default_value = nullptr;
+  std::unique_ptr<expression::AbstractExpression> check_expression = nullptr;
 
-  std::vector<char*>* primary_key = nullptr;
-  std::vector<char*>* foreign_key_source = nullptr;
-  std::vector<char*>* foreign_key_sink = nullptr;
+  std::unique_ptr<std::vector<std::unique_ptr<char[]>>> primary_key = nullptr;
+  std::unique_ptr<std::vector<std::unique_ptr<char[]>>> foreign_key_source = nullptr;
+  std::unique_ptr<std::vector<std::unique_ptr<char[]>>> foreign_key_sink = nullptr;
 
   std::vector<char *>* multi_unique_cols = nullptr;
 
@@ -175,38 +149,7 @@ class CreateStatement : public TableRefStatement {
         if_not_exists(false),
         columns(nullptr){};
 
-  virtual ~CreateStatement() {
-    if (columns != nullptr) {
-      for (auto col : *columns) delete col;
-      delete columns;
-    }
-
-    if (index_attrs != nullptr) {
-      for (auto attr : *index_attrs) delete[] (attr);
-      delete index_attrs;
-    }
-    if (trigger_funcname) {
-      for (auto t : *trigger_funcname) delete[](t);
-      delete trigger_funcname;
-    }
-    if (trigger_args) {
-      for (auto t : *trigger_args) delete[](t);
-      delete trigger_args;
-    }
-    if (trigger_columns) {
-      for (auto t : *trigger_columns) delete[](t);
-      delete trigger_columns;
-    }
-
-    if (index_name != nullptr) {
-      delete[] (index_name);
-    }
-    if (trigger_name) {
-      delete[](trigger_name);
-    }
-    if (database_name) {
-      delete[](database_name);
-    }
+  virtual ~CreateStatement() {}
 
     if (trigger_when) {
       delete trigger_when;
@@ -218,14 +161,14 @@ class CreateStatement : public TableRefStatement {
   CreateType type;
   bool if_not_exists;
 
-  std::vector<ColumnDefinition*>* columns;
-  std::vector<char*>* index_attrs = nullptr;
+  std::unique_ptr<std::vector<std::unique_ptr<ColumnDefinition>>> columns;
+  std::unique_ptr<std::vector<std::unique_ptr<char[]>>> index_attrs = nullptr;
 
   IndexType index_type;
 
-  char* index_name = nullptr;
-  char* trigger_name = nullptr;
-  char* database_name = nullptr;
+  std::unique_ptr<char[]> index_name = nullptr;
+  std::unique_ptr<char[]> trigger_name = nullptr;
+  std::unique_ptr<char[]> database_name = nullptr;
 
   bool unique = false;
 

--- a/src/include/parser/delete_statement.h
+++ b/src/include/parser/delete_statement.h
@@ -31,15 +31,7 @@ class DeleteStatement : public SQLStatement {
       : SQLStatement(StatementType::DELETE),
         table_ref(nullptr), expr(nullptr) {};
 
-  virtual ~DeleteStatement() {
-    if (table_ref != nullptr) {
-      delete table_ref;
-    }
-
-    if (expr != nullptr) {
-      delete expr;
-    }
-  }
+  virtual ~DeleteStatement() {}
 
   std::string GetTableName() const {
     return table_ref->GetTableName();
@@ -53,8 +45,8 @@ class DeleteStatement : public SQLStatement {
     v->Visit(this);
   }
 
-  parser::TableRef* table_ref;
-  expression::AbstractExpression* expr;
+  std::unique_ptr<parser::TableRef> table_ref;
+  std::unique_ptr<expression::AbstractExpression> expr;
 };
 
 }  // namespace parser

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -63,8 +63,8 @@ class DropStatement : public TableRefStatement {
   bool missing;
 
   // drop trigger
-  std::string table_name_of_trigger = nullptr;
-  std::string trigger_name = nullptr;
+  std::string table_name_of_trigger;
+  std::string trigger_name;
 };
 
 }  // namespace parser

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -50,37 +50,16 @@ class DropStatement : public TableRefStatement {
         table_name_of_trigger(cstrdup(table_name_of_trigger.c_str())),
         trigger_name(cstrdup(trigger_name.c_str())) {}
 
-
-  virtual ~DropStatement() {
-    if (database_name != nullptr) {
-      delete[] database_name;
-    }
-
-    if (index_name != nullptr) {
-      delete[] index_name;
-    }
-
-    if (prep_stmt != nullptr) {
-      delete[] prep_stmt;
-    }
-
-    if (table_name_of_trigger != nullptr) {
-      delete[] table_name_of_trigger;
-    }
-
-    if (trigger_name != nullptr) {
-      delete[] trigger_name;
-    }
-  }
+  virtual ~DropStatement() {}
 
   virtual void Accept(SqlNodeVisitor* v) const override {
     v->Visit(this);
   }
 
   EntityType type;
-  char* database_name = nullptr;
-  char* index_name = nullptr;
-  char* prep_stmt = nullptr;
+  std::unique_ptr<char[]> database_name = nullptr;
+  std::unique_ptr<char[]> index_name = nullptr;
+  std::unique_ptr<char[]> prep_stmt = nullptr;
   bool missing;
 
   // drop trigger

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -48,7 +48,7 @@ class DropStatement : public TableRefStatement {
       : TableRefStatement(StatementType::DROP),
         type(type),
         table_name_of_trigger(cstrdup(table_name_of_trigger.c_str())),
-        trigger_name(cstrdup(trigger_name.c_str())) {}
+        trigger_name(trigger_name) {}
 
   virtual ~DropStatement() {}
 
@@ -57,14 +57,14 @@ class DropStatement : public TableRefStatement {
   }
 
   EntityType type;
-  std::unique_ptr<char[]> database_name = nullptr;
-  std::unique_ptr<char[]> index_name = nullptr;
-  std::unique_ptr<char[]> prep_stmt = nullptr;
+  std::string database_name;
+  std::string index_name;
+  std::string prep_stmt;
   bool missing;
 
   // drop trigger
-  char* table_name_of_trigger = nullptr;
-  char* trigger_name = nullptr;
+  std::string table_name_of_trigger = nullptr;
+  std::string trigger_name = nullptr;
 };
 
 }  // namespace parser

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -34,20 +34,13 @@ class DropStatement : public TableRefStatement {
     kTrigger
   };
 
-  // helper for c_str copy
-  static char* cstrdup(const char* c_str) {
-    char* new_str = new char[strlen(c_str) + 1];
-    strcpy(new_str, c_str);
-    return new_str;
-  }
-
   DropStatement(EntityType type)
       : TableRefStatement(StatementType::DROP), type(type), missing(false) {}
 
   DropStatement(EntityType type, std::string table_name_of_trigger, std::string trigger_name)
       : TableRefStatement(StatementType::DROP),
         type(type),
-        table_name_of_trigger(cstrdup(table_name_of_trigger.c_str())),
+        table_name_of_trigger(table_name_of_trigger),
         trigger_name(trigger_name) {}
 
   virtual ~DropStatement() {}

--- a/src/include/parser/execute_statement.h
+++ b/src/include/parser/execute_statement.h
@@ -25,7 +25,7 @@ namespace parser {
 class ExecuteStatement : public SQLStatement {
  public:
   ExecuteStatement()
-      : SQLStatement(StatementType::EXECUTE), name(nullptr), parameters(nullptr) {}
+      : SQLStatement(StatementType::EXECUTE) {}
 
   virtual ~ExecuteStatement() {}
 

--- a/src/include/parser/execute_statement.h
+++ b/src/include/parser/execute_statement.h
@@ -33,8 +33,8 @@ class ExecuteStatement : public SQLStatement {
     v->Visit(this);
   }
 
-  std::unique_ptr<char[]> name;
-  std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>> parameters;
+  std::string name;
+  std::vector<std::unique_ptr<expression::AbstractExpression>> parameters;
 };
 
 }  // namespace parser

--- a/src/include/parser/execute_statement.h
+++ b/src/include/parser/execute_statement.h
@@ -25,32 +25,16 @@ namespace parser {
 class ExecuteStatement : public SQLStatement {
  public:
   ExecuteStatement()
-      : SQLStatement(StatementType::EXECUTE), name(NULL), parameters(NULL) {}
+      : SQLStatement(StatementType::EXECUTE), name(nullptr), parameters(nullptr) {}
 
-  virtual ~ExecuteStatement() {
-    if (name != nullptr) {
-      delete[] name;
-    }
-
-    if (parameters) {
-      for (auto expr : *parameters) {
-        if (expr != nullptr) {
-          delete expr;
-        }
-      }
-    }
-
-    if (parameters != nullptr) {
-      delete parameters;
-    }
-  }
+  virtual ~ExecuteStatement() {}
 
   virtual void Accept(SqlNodeVisitor* v) const override {
     v->Visit(this);
   }
 
-  char* name;
-  std::vector<expression::AbstractExpression*>* parameters;
+  std::unique_ptr<char[]> name;
+  std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>> parameters;
 };
 
 }  // namespace parser

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -29,8 +29,6 @@ class InsertStatement : SQLStatement {
   InsertStatement(InsertType type)
       : SQLStatement(StatementType::INSERT),
         type(type),
-        columns(nullptr),
-        insert_values(nullptr),
         select(nullptr) {}
 
   virtual ~InsertStatement() {}
@@ -46,7 +44,7 @@ class InsertStatement : SQLStatement {
 
   InsertType type;
   std::vector<std::string> columns;
-  std::vector<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>
+  std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>>
       insert_values;
   std::unique_ptr<SelectStatement> select;
 

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -29,42 +29,11 @@ class InsertStatement : SQLStatement {
   InsertStatement(InsertType type)
       : SQLStatement(StatementType::INSERT),
         type(type),
-        columns(NULL),
-        insert_values(NULL),
-        select(NULL) {}
+        columns(nullptr),
+        insert_values(nullptr),
+        select(nullptr) {}
 
-  virtual ~InsertStatement() {
-    if (columns != nullptr) {
-      for (auto col : *columns) {
-        if (col != nullptr) {
-          delete[] col;
-        }
-      }
-      delete columns;
-    }
-
-    if (insert_values != nullptr) {
-      for (auto *tuple : *insert_values) {
-        for (auto *expr : *tuple) {
-          // Why?
-//          if (expr->GetExpressionType() != ExpressionType::VALUE_PARAMETER)
-            if (expr != nullptr) {
-              delete expr;
-            }
-        }
-        delete tuple;
-      }
-      delete insert_values;
-    }
-
-    if (select != nullptr) {
-      delete select;
-    }
-
-    if (table_ref_ != nullptr) {
-      delete table_ref_;
-    }
-  }
+  virtual ~InsertStatement() {}
 
   virtual void Accept(SqlNodeVisitor* v) const override { v->Visit(this); }
 
@@ -76,13 +45,13 @@ class InsertStatement : SQLStatement {
   }
 
   InsertType type;
-  std::vector<char*>* columns;
-  std::vector<std::vector<peloton::expression::AbstractExpression*>*>*
+  std::unique_ptr<std::vector<std::unique_ptr<char[]>>> columns;
+  std::unique_ptr<std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>>>
       insert_values;
-  SelectStatement* select;
+  std::unique_ptr<SelectStatement> select;
 
   // Which table are we inserting into
-  TableRef* table_ref_;
+  std::unique_ptr<TableRef> table_ref_;
 };
 
 }  // namespace parser

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -45,8 +45,8 @@ class InsertStatement : SQLStatement {
   }
 
   InsertType type;
-  std::unique_ptr<std::vector<std::unique_ptr<char[]>>> columns;
-  std::unique_ptr<std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>>>
+  std::vector<std::string> columns;
+  std::vector<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>
       insert_values;
   std::unique_ptr<SelectStatement> select;
 

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -109,7 +109,7 @@ class PostgresParser {
   static parser::TableRef* FromTransform(SelectStmt* root);
 
   // transform helper for select targets
-  static std::vector<std::unique_ptr<expression::AbstractExpression>>&& TargetTransform(List* root);
+  static std::vector<std::unique_ptr<expression::AbstractExpression>>* TargetTransform(List* root);
 
   // transform helper for all expr nodes
   static expression::AbstractExpression* ExprTransform(Node* root);
@@ -166,10 +166,10 @@ class PostgresParser {
   static parser::SQLStatement* CreateDbTransform(CreatedbStmt* root);
 
   // transform helper for column name (for insert statement)
-  static std::vector<std::string>&& ColumnNameTransform(List* root);
+  static std::vector<std::string>* ColumnNameTransform(List* root);
 
   // transform helper for ListsTransform (insert multiple rows)
-  static std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>>&&
+  static std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>>*
   ValueListsTransform(List* root);
 
   // transform helper for insert statements
@@ -191,7 +191,7 @@ class PostgresParser {
   static parser::UpdateStatement* UpdateTransform(UpdateStmt* update_stmt);
 
   // transform helper for update statement
-  static std::vector<std::unique_ptr<parser::UpdateClause>>&& UpdateTargetTransform(List* root);
+  static std::vector<std::unique_ptr<parser::UpdateClause>>* UpdateTargetTransform(List* root);
 
   // transform helper for drop statement
   static parser::DropStatement* DropTransform(DropStmt* root);

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -109,8 +109,12 @@ class PostgresParser {
   static parser::TableRef* FromTransform(SelectStmt* root);
 
   // transform helper for select targets
+<<<<<<< 7be6c98f362bf21ebf5a8d651c96d4d05a2e1032
   static std::vector<expression::AbstractExpression*>* TargetTransform(
       List* root);
+=======
+  static std::vector<std::unique_ptr<expression::AbstractExpression>>* TargetTransform(List* root);
+>>>>>>> merge the latest code
 
   // transform helper for all expr nodes
   static expression::AbstractExpression* ExprTransform(Node* root);
@@ -167,11 +171,16 @@ class PostgresParser {
   static parser::SQLStatement* CreateDbTransform(CreatedbStmt* root);
 
   // transform helper for column name (for insert statement)
-  static std::vector<char*>* ColumnNameTransform(List* root);
+  static std::vector<std::unique_ptr<char[]>>* ColumnNameTransform(List* root);
 
   // transform helper for ListsTransform (insert multiple rows)
+<<<<<<< 7be6c98f362bf21ebf5a8d651c96d4d05a2e1032
   static std::vector<std::vector<expression::AbstractExpression*>*>*
   ValueListsTransform(List* root);
+=======
+  static std::vector<std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>>>*
+      ValueListsTransform(List* root);
+>>>>>>> merge the latest code
 
   // transform helper for insert statements
   static parser::SQLStatement* InsertTransform(InsertStmt* root);
@@ -192,7 +201,7 @@ class PostgresParser {
   static parser::UpdateStatement* UpdateTransform(UpdateStmt* update_stmt);
 
   // transform helper for update statement
-  static std::vector<parser::UpdateClause*>* UpdateTargetTransform(List* root);
+  static std::vector<std::unique_ptr<parser::UpdateClause>>* UpdateTargetTransform(List* root);
 
   // transform helper for drop statement
   static parser::DropStatement* DropTransform(DropStmt* root);
@@ -216,8 +225,12 @@ class PostgresParser {
   // transform helper for constant values
   static expression::AbstractExpression* ValueTransform(value val);
 
+<<<<<<< 7be6c98f362bf21ebf5a8d651c96d4d05a2e1032
   static std::vector<expression::AbstractExpression*>* ParamListTransform(
       List* root);
+=======
+  static std::vector<std::unique_ptr<expression::AbstractExpression>>* ParamListTransform(List* root);
+>>>>>>> merge the latest code
 
   // transform helper for execute statement
   static parser::PrepareStatement* PrepareTransform(PrepareStmt* root);

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -109,7 +109,7 @@ class PostgresParser {
   static parser::TableRef* FromTransform(SelectStmt* root);
 
   // transform helper for select targets
-  static std::vector<std::unique_ptr<expression::AbstractExpression>> TargetTransform(List* root);
+  static std::vector<std::unique_ptr<expression::AbstractExpression>>&& TargetTransform(List* root);
 
   // transform helper for all expr nodes
   static expression::AbstractExpression* ExprTransform(Node* root);
@@ -166,10 +166,10 @@ class PostgresParser {
   static parser::SQLStatement* CreateDbTransform(CreatedbStmt* root);
 
   // transform helper for column name (for insert statement)
-  static std::vector<std::string> ColumnNameTransform(List* root);
+  static std::vector<std::string>&& ColumnNameTransform(List* root);
 
   // transform helper for ListsTransform (insert multiple rows)
-  static std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>>
+  static std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>>&&
   ValueListsTransform(List* root);
 
   // transform helper for insert statements
@@ -191,7 +191,7 @@ class PostgresParser {
   static parser::UpdateStatement* UpdateTransform(UpdateStmt* update_stmt);
 
   // transform helper for update statement
-  static std::vector<std::unique_ptr<parser::UpdateClause>>* UpdateTargetTransform(List* root);
+  static std::vector<std::unique_ptr<parser::UpdateClause>>&& UpdateTargetTransform(List* root);
 
   // transform helper for drop statement
   static parser::DropStatement* DropTransform(DropStmt* root);

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -109,12 +109,7 @@ class PostgresParser {
   static parser::TableRef* FromTransform(SelectStmt* root);
 
   // transform helper for select targets
-<<<<<<< 7be6c98f362bf21ebf5a8d651c96d4d05a2e1032
-  static std::vector<expression::AbstractExpression*>* TargetTransform(
-      List* root);
-=======
   static std::vector<std::unique_ptr<expression::AbstractExpression>>* TargetTransform(List* root);
->>>>>>> merge the latest code
 
   // transform helper for all expr nodes
   static expression::AbstractExpression* ExprTransform(Node* root);
@@ -174,13 +169,8 @@ class PostgresParser {
   static std::vector<std::unique_ptr<char[]>>* ColumnNameTransform(List* root);
 
   // transform helper for ListsTransform (insert multiple rows)
-<<<<<<< 7be6c98f362bf21ebf5a8d651c96d4d05a2e1032
-  static std::vector<std::vector<expression::AbstractExpression*>*>*
-  ValueListsTransform(List* root);
-=======
   static std::vector<std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>>>*
-      ValueListsTransform(List* root);
->>>>>>> merge the latest code
+  ValueListsTransform(List* root);
 
   // transform helper for insert statements
   static parser::SQLStatement* InsertTransform(InsertStmt* root);
@@ -225,12 +215,7 @@ class PostgresParser {
   // transform helper for constant values
   static expression::AbstractExpression* ValueTransform(value val);
 
-<<<<<<< 7be6c98f362bf21ebf5a8d651c96d4d05a2e1032
-  static std::vector<expression::AbstractExpression*>* ParamListTransform(
-      List* root);
-=======
   static std::vector<std::unique_ptr<expression::AbstractExpression>>* ParamListTransform(List* root);
->>>>>>> merge the latest code
 
   // transform helper for execute statement
   static parser::PrepareStatement* PrepareTransform(PrepareStmt* root);

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -94,7 +94,7 @@ class PostgresParser {
     PgQueryInternalParsetreeTransform(PgQueryInternalParsetreeAndError stmt);
 
   // transform helper for Alias parsenodes
-  static char* AliasTransform(Alias* root);
+  static std::string AliasTransform(Alias* root);
 
   // transform helper for RangeVar parsenodes
   static parser::TableRef* RangeVarTransform(RangeVar* root);
@@ -109,7 +109,7 @@ class PostgresParser {
   static parser::TableRef* FromTransform(SelectStmt* root);
 
   // transform helper for select targets
-  static std::vector<std::unique_ptr<expression::AbstractExpression>>* TargetTransform(List* root);
+  static std::vector<std::unique_ptr<expression::AbstractExpression>> TargetTransform(List* root);
 
   // transform helper for all expr nodes
   static expression::AbstractExpression* ExprTransform(Node* root);
@@ -166,10 +166,10 @@ class PostgresParser {
   static parser::SQLStatement* CreateDbTransform(CreatedbStmt* root);
 
   // transform helper for column name (for insert statement)
-  static std::vector<std::unique_ptr<char[]>>* ColumnNameTransform(List* root);
+  static std::vector<std::string> ColumnNameTransform(List* root);
 
   // transform helper for ListsTransform (insert multiple rows)
-  static std::vector<std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>>>*
+  static std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>>
   ValueListsTransform(List* root);
 
   // transform helper for insert statements
@@ -215,7 +215,7 @@ class PostgresParser {
   // transform helper for constant values
   static expression::AbstractExpression* ValueTransform(value val);
 
-  static std::vector<std::unique_ptr<expression::AbstractExpression>>* ParamListTransform(List* root);
+  static std::vector<std::unique_ptr<expression::AbstractExpression>> ParamListTransform(List* root);
 
   // transform helper for execute statement
   static parser::PrepareStatement* PrepareTransform(PrepareStmt* root);

--- a/src/include/parser/prepare_statement.h
+++ b/src/include/parser/prepare_statement.h
@@ -30,16 +30,9 @@ namespace parser {
 class PrepareStatement : public SQLStatement {
  public:
   PrepareStatement()
-      : SQLStatement(StatementType::PREPARE), name(NULL), query(NULL) {}
+      : SQLStatement(StatementType::PREPARE), name(nullptr), query(nullptr) {}
 
-  virtual ~PrepareStatement() {
-    if (query != nullptr) {
-      delete query;
-    }
-    if (name != nullptr) {
-      delete[] name;
-    }
-  }
+  virtual ~PrepareStatement() {}
 
   /**
    * @param vector of placeholders that the parser found
@@ -71,8 +64,8 @@ class PrepareStatement : public SQLStatement {
     v->Visit(this);
   }
 
-  char* name;
-  SQLStatementList* query;
+  std::unique_ptr<char[]> name;
+  std::unique_ptr<SQLStatementList> query;
   std::vector<std::unique_ptr<expression::ParameterValueExpression>>
       placeholders;
 };

--- a/src/include/parser/prepare_statement.h
+++ b/src/include/parser/prepare_statement.h
@@ -30,7 +30,7 @@ namespace parser {
 class PrepareStatement : public SQLStatement {
  public:
   PrepareStatement()
-      : SQLStatement(StatementType::PREPARE), name(nullptr), query(nullptr) {}
+      : SQLStatement(StatementType::PREPARE), query(nullptr) {}
 
   virtual ~PrepareStatement() {}
 

--- a/src/include/parser/prepare_statement.h
+++ b/src/include/parser/prepare_statement.h
@@ -64,7 +64,7 @@ class PrepareStatement : public SQLStatement {
     v->Visit(this);
   }
 
-  std::unique_ptr<char[]> name;
+  std::string name;
   std::unique_ptr<SQLStatementList> query;
   std::vector<std::unique_ptr<expression::ParameterValueExpression>>
       placeholders;

--- a/src/include/parser/select_statement.h
+++ b/src/include/parser/select_statement.h
@@ -62,7 +62,7 @@ class LimitDescription {
  */
 class GroupByDescription {
  public:
-  GroupByDescription() : columns(nullptr), having(nullptr) {}
+  GroupByDescription() : having(nullptr) {}
 
   ~GroupByDescription() {}
 
@@ -84,7 +84,6 @@ class SelectStatement : public SQLStatement {
       : SQLStatement(StatementType::SELECT),
         from_table(nullptr),
         select_distinct(false),
-        select_list(nullptr),
         where_clause(nullptr),
         group_by(nullptr),
         union_select(nullptr),
@@ -110,8 +109,8 @@ class SelectStatement : public SQLStatement {
   bool is_for_update;
 
  public:
-  const std::vector<std::unique_ptr<expression::AbstractExpression>>* getSelectList() const {
-    return select_list.get();
+  const std::vector<std::unique_ptr<expression::AbstractExpression>>& getSelectList() const {
+    return select_list;
   }
 
   void UpdateWhereClause(expression::AbstractExpression* expr) {

--- a/src/include/parser/select_statement.h
+++ b/src/include/parser/select_statement.h
@@ -69,21 +69,14 @@ class LimitDescription {
  */
 class GroupByDescription {
  public:
-  GroupByDescription() : columns(NULL), having(NULL) {}
+  GroupByDescription() : columns(nullptr), having(nullptr) {}
 
-  ~GroupByDescription() {
-    if (columns != nullptr) {
-      for (auto col : *columns) delete col;
-      delete columns;
-    }
-    if (having != nullptr)
-      delete having;
-  }
+  ~GroupByDescription() {}
 
   void Accept(SqlNodeVisitor* v) const { v->Visit(this); }
 
-  std::vector<expression::AbstractExpression*>* columns;
-  expression::AbstractExpression* having;
+  std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>> columns;
+  std::unique_ptr<expression::AbstractExpression> having;
 };
 
 /**
@@ -96,72 +89,40 @@ class SelectStatement : public SQLStatement {
  public:
   SelectStatement()
       : SQLStatement(StatementType::SELECT),
-        from_table(NULL),
+        from_table(nullptr),
         select_distinct(false),
-        select_list(NULL),
-        where_clause(NULL),
-        group_by(NULL),
-        union_select(NULL),
-        order(NULL),
-        limit(NULL),
+        select_list(nullptr),
+        where_clause(nullptr),
+        group_by(nullptr),
+        union_select(nullptr),
+        order(nullptr),
+        limit(nullptr),
         is_for_update(false){};
 
-  virtual ~SelectStatement() {
-    if (from_table != nullptr) {
-      delete from_table;
-    }
-
-    if (select_list != nullptr) {
-      for (auto expr : *select_list) {
-        delete expr;
-      }
-      delete select_list;
-    }
-
-    if (where_clause != nullptr) {
-      delete where_clause;
-    }
-
-    if (group_by != nullptr) {
-      delete group_by;
-    }
-
-    if (union_select != nullptr) {
-      delete union_select;
-    }
-
-    if (order != nullptr) {
-      delete order;
-    }
-
-    if (limit != nullptr) {
-      delete limit;
-    }
-  }
+  virtual ~SelectStatement() {}
 
   virtual void Accept(SqlNodeVisitor* v) const override {
     v->Visit(this);
   }
 
-  TableRef* from_table;
+  std::unique_ptr<TableRef> from_table;
   bool select_distinct;
-  std::vector<expression::AbstractExpression*>* select_list;
-  expression::AbstractExpression* where_clause;
-  GroupByDescription* group_by;
+  std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>> select_list;
+  std::unique_ptr<expression::AbstractExpression> where_clause;
+  std::unique_ptr<GroupByDescription> group_by;
 
-  SelectStatement* union_select;
-  OrderDescription* order;
-  LimitDescription* limit;
+  std::unique_ptr<SelectStatement> union_select;
+  std::unique_ptr<OrderDescription> order;
+  std::unique_ptr<LimitDescription> limit;
   bool is_for_update;
 
  public:
-  const std::vector<expression::AbstractExpression*>* getSelectList() const {
-    return select_list;
+  const std::vector<std::unique_ptr<expression::AbstractExpression>>* getSelectList() const {
+    return select_list.get();
   }
 
   void UpdateWhereClause(expression::AbstractExpression* expr) {
-    delete where_clause;
-    where_clause = expr;
+    where_clause.reset(expr);
   }
 };
 

--- a/src/include/parser/select_statement.h
+++ b/src/include/parser/select_statement.h
@@ -32,19 +32,12 @@ class OrderDescription {
  public:
   OrderDescription() {}
 
-  virtual ~OrderDescription() {
-    delete types;
-
-    for (auto expr : *exprs)
-      delete expr;
-
-    delete exprs;
-  }
+  virtual ~OrderDescription() {}
 
   void Accept(SqlNodeVisitor* v) const { v->Visit(this); }
 
-  std::vector<OrderType>* types;
-  std::vector<expression::AbstractExpression*>* exprs;
+  std::vector<OrderType> types;
+  std::vector<std::unique_ptr<expression::AbstractExpression>> exprs;
 };
 
 /**
@@ -75,7 +68,7 @@ class GroupByDescription {
 
   void Accept(SqlNodeVisitor* v) const { v->Visit(this); }
 
-  std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>> columns;
+  std::vector<std::unique_ptr<expression::AbstractExpression>> columns;
   std::unique_ptr<expression::AbstractExpression> having;
 };
 
@@ -107,7 +100,7 @@ class SelectStatement : public SQLStatement {
 
   std::unique_ptr<TableRef> from_table;
   bool select_distinct;
-  std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>> select_list;
+  std::vector<std::unique_ptr<expression::AbstractExpression>> select_list;
   std::unique_ptr<expression::AbstractExpression> where_clause;
   std::unique_ptr<GroupByDescription> group_by;
 

--- a/src/include/parser/sql_statement.h
+++ b/src/include/parser/sql_statement.h
@@ -31,9 +31,9 @@ namespace parser {
 struct TableInfo {
   ~TableInfo() {}
 
-  std::unique_ptr<char[]> table_name = nullptr;
+  std::string table_name;
 
-  std::unique_ptr<char[]> database_name = nullptr;
+  std::string database_name;
 };
 
 // Base class for every SQLStatement
@@ -63,14 +63,16 @@ class TableRefStatement : public SQLStatement {
 
   virtual ~TableRefStatement() {}
 
-  virtual inline std::string GetTableName() const { return table_info_->table_name.get(); }
+  virtual inline std::string GetTableName() const {
+    return table_info_->table_name;
+  }
 
   // Get the name of the database of this table
   virtual inline std::string GetDatabaseName() const {
-    if (table_info_->database_name == nullptr) {
+    if (table_info_->database_name.empty()) {
       return DEFAULT_DB_NAME;
     }
-    return table_info_->database_name.get();
+    return table_info_->database_name;
   }
 
   std::unique_ptr<TableInfo> table_info_ = nullptr;

--- a/src/include/parser/sql_statement.h
+++ b/src/include/parser/sql_statement.h
@@ -29,15 +29,11 @@ namespace peloton {
 namespace parser {
 
 struct TableInfo {
-  ~TableInfo() {
-    if (table_name != nullptr)
-      delete[] table_name;
-    if (database_name != nullptr)
-      delete[] database_name;
-  }
-  char* table_name = nullptr;
-  ;
-  char* database_name = nullptr;
+  ~TableInfo() {}
+
+  std::unique_ptr<char[]> table_name = nullptr;
+
+  std::unique_ptr<char[]> database_name = nullptr;
 };
 
 // Base class for every SQLStatement
@@ -65,23 +61,19 @@ class TableRefStatement : public SQLStatement {
  public:
   TableRefStatement(StatementType type) : SQLStatement(type) {}
 
-  virtual ~TableRefStatement() {
-    if (table_info_ != nullptr) {
-      delete table_info_;
-    }
-  }
+  virtual ~TableRefStatement() {}
 
-  virtual inline std::string GetTableName() const { return table_info_->table_name; }
+  virtual inline std::string GetTableName() const { return table_info_->table_name.get(); }
 
   // Get the name of the database of this table
   virtual inline std::string GetDatabaseName() const {
     if (table_info_->database_name == nullptr) {
       return DEFAULT_DB_NAME;
     }
-    return table_info_->database_name;
+    return table_info_->database_name.get();
   }
 
-  TableInfo* table_info_ = nullptr;
+  std::unique_ptr<TableInfo> table_info_ = nullptr;
 };
 
 // Represents the result of the SQLParser.
@@ -89,31 +81,28 @@ class TableRefStatement : public SQLStatement {
 class SQLStatementList : public Printable {
  public:
   SQLStatementList()
-      : is_valid(true), parser_msg(NULL), error_line(0), error_col(0){};
+      : is_valid(true), parser_msg(nullptr), error_line(0), error_col(0){};
 
-  SQLStatementList(SQLStatement* stmt) : is_valid(true), parser_msg(NULL) {
+  SQLStatementList(SQLStatement* stmt) : is_valid(true), parser_msg(nullptr) {
     AddStatement(stmt);
   };
 
   virtual ~SQLStatementList() {
-    // clean up statements
-    for (auto stmt : statements) delete stmt;
-
     delete (char*)parser_msg;
   }
 
-  void AddStatement(SQLStatement* stmt) { statements.push_back(stmt); }
+  void AddStatement(SQLStatement* stmt) { statements.push_back(std::unique_ptr<SQLStatement>(stmt)); }
 
-  SQLStatement* GetStatement(int id) const { return statements[id]; }
+  SQLStatement* GetStatement(int id) const { return statements[id].get(); }
 
-  const std::vector<SQLStatement*>& GetStatements() const { return statements; }
+  const std::vector<std::unique_ptr<SQLStatement>>& GetStatements() const { return statements; }
 
   size_t GetNumStatements() const { return statements.size(); }
 
   // Get a string representation for debugging
   const std::string GetInfo() const;
 
-  std::vector<SQLStatement*> statements;
+  std::vector<std::unique_ptr<SQLStatement>> statements;
   bool is_valid;
   const char* parser_msg;
   int error_line;

--- a/src/include/parser/table_ref.h
+++ b/src/include/parser/table_ref.h
@@ -31,11 +31,8 @@ class JoinDefinition;
 struct TableRef {
   TableRef(TableReferenceType type)
       : type(type),
-        schema(nullptr),
         table_info_(nullptr),
-        alias(nullptr),
         select(nullptr),
-        list(nullptr),
         join(nullptr) {}
 
   virtual ~TableRef();
@@ -54,25 +51,27 @@ struct TableRef {
   std::unique_ptr<JoinDefinition> join;
 
   // Convenience accessor methods
-  inline bool HasSchema() { return schema != nullptr; }
+  inline bool HasSchema() { return !schema.empty(); }
 
   // Get the name of the database of this table
-  inline const char* GetDatabaseName() const {
-    if (table_info_ == nullptr || table_info_->database_name == nullptr) {
+  inline std::string GetDatabaseName() const {
+    if (table_info_ == nullptr || table_info_->database_name.empty()) {
       return DEFAULT_DB_NAME;
     }
-    return table_info_->database_name.get();
+    return table_info_->database_name;
   }
 
   // Get the name of the table
-  inline const char* GetTableAlias() const {
-    if (alias != nullptr)
-      return alias.get();
+  inline std::string GetTableAlias() const {
+    if (!alias.empty())
+      return alias;
     else
-      return table_info_->table_name.get();
+      return table_info_->table_name;
   }
 
-  inline const char* GetTableName() const { return table_info_->table_name.get(); }
+  inline std::string GetTableName() const {
+    return table_info_->table_name;
+  }
 
   void Accept(SqlNodeVisitor* v) const { v->Visit(this); }
 };

--- a/src/include/parser/table_ref.h
+++ b/src/include/parser/table_ref.h
@@ -31,48 +31,48 @@ class JoinDefinition;
 struct TableRef {
   TableRef(TableReferenceType type)
       : type(type),
-        schema(NULL),
-        table_info_(NULL),
-        alias(NULL),
-        select(NULL),
-        list(NULL),
-        join(NULL) {}
+        schema(nullptr),
+        table_info_(nullptr),
+        alias(nullptr),
+        select(nullptr),
+        list(nullptr),
+        join(nullptr) {}
 
   virtual ~TableRef();
 
   TableReferenceType type;
 
-  char* schema;
+  std::unique_ptr<char[]> schema;
 
   // Expression of database name and table name
-  TableInfo* table_info_ = nullptr;
+  std::unique_ptr<TableInfo> table_info_ = nullptr;
 
-  char* alias;
+  std::unique_ptr<char[]> alias;
 
   SelectStatement* select;
-  std::vector<TableRef*>* list;
-  JoinDefinition* join;
+  std::unique_ptr<std::vector<std::unique_ptr<TableRef>>> list;
+  std::unique_ptr<JoinDefinition> join;
 
   // Convenience accessor methods
-  inline bool HasSchema() { return schema != NULL; }
+  inline bool HasSchema() { return schema != nullptr; }
 
   // Get the name of the database of this table
   inline const char* GetDatabaseName() const {
     if (table_info_ == nullptr || table_info_->database_name == nullptr) {
       return DEFAULT_DB_NAME;
     }
-    return table_info_->database_name;
+    return table_info_->database_name.get();
   }
 
   // Get the name of the table
   inline const char* GetTableAlias() const {
-    if (alias != NULL)
-      return alias;
+    if (alias != nullptr)
+      return alias.get();
     else
-      return table_info_->table_name;
+      return table_info_->table_name.get();
   }
 
-  inline const char* GetTableName() const { return table_info_->table_name; }
+  inline const char* GetTableName() const { return table_info_->table_name.get(); }
 
   void Accept(SqlNodeVisitor* v) const { v->Visit(this); }
 };
@@ -81,17 +81,13 @@ struct TableRef {
 class JoinDefinition {
  public:
   JoinDefinition()
-      : left(NULL), right(NULL), condition(NULL), type(JoinType::INNER) {}
+      : left(nullptr), right(nullptr), condition(nullptr), type(JoinType::INNER) {}
 
-  virtual ~JoinDefinition() {
-    delete left;
-    delete right;
-    delete condition;
-  }
+  virtual ~JoinDefinition() {}
 
-  TableRef* left;
-  TableRef* right;
-  expression::AbstractExpression* condition;
+  std::unique_ptr<TableRef> left;
+  std::unique_ptr<TableRef> right;
+  std::unique_ptr<expression::AbstractExpression> condition;
 
   JoinType type;
 

--- a/src/include/parser/table_ref.h
+++ b/src/include/parser/table_ref.h
@@ -42,15 +42,15 @@ struct TableRef {
 
   TableReferenceType type;
 
-  std::unique_ptr<char[]> schema;
+  std::string schema;
 
   // Expression of database name and table name
   std::unique_ptr<TableInfo> table_info_ = nullptr;
 
-  std::unique_ptr<char[]> alias;
+  std::string alias;
 
   SelectStatement* select;
-  std::unique_ptr<std::vector<std::unique_ptr<TableRef>>> list;
+  std::vector<std::unique_ptr<TableRef>> list;
   std::unique_ptr<JoinDefinition> join;
 
   // Convenience accessor methods

--- a/src/include/parser/update_statement.h
+++ b/src/include/parser/update_statement.h
@@ -28,26 +28,19 @@ namespace parser {
  */
 class UpdateClause {
  public:
-  char* column;
-  expression::AbstractExpression* value;
+  std::unique_ptr<char[]> column;
+  std::unique_ptr<expression::AbstractExpression> value;
 
-  ~UpdateClause() {
-    if (column != nullptr) {
-      delete[] column;
-    }
-    if (value != nullptr) {
-      delete value;
-    }
-  }
+  ~UpdateClause() {}
 
   UpdateClause* Copy() {
     UpdateClause* new_clause = new UpdateClause();
-    std::string str(column);
+    std::string str(column.get());
     char* new_cstr = new char[str.length() + 1];
     std::strcpy(new_cstr, str.c_str());
     expression::AbstractExpression* new_expr = value->Copy();
-    new_clause->column = new_cstr;
-    new_clause->value = new_expr;
+    new_clause->column.reset(new_cstr);
+    new_clause->value.reset(new_expr);
     return new_clause;
   }
 };
@@ -60,27 +53,12 @@ class UpdateStatement : public SQLStatement {
  public:
   UpdateStatement()
       : SQLStatement(StatementType::UPDATE),
-        table(NULL),
-        updates(NULL),
-        where(NULL) {}
+        table(nullptr),
+        updates(nullptr),
+        where(nullptr) {}
 
   virtual ~UpdateStatement() {
-    if (table != nullptr) {
-      delete table;
-    }
-
-    if (updates != nullptr) {
-      for (auto clause : *updates) {
-        if (clause != nullptr) {
-          delete clause;
-        }
-      }
-      delete updates;
-    }
-
-    if (where != nullptr) {
-      delete where;
-    }
+    printf("Destory UpdateStatement\n");
   }
 
   virtual void Accept(SqlNodeVisitor* v) const override {
@@ -88,9 +66,9 @@ class UpdateStatement : public SQLStatement {
   }
 
   // TODO: switch to char* instead of TableRef
-  TableRef* table;
-  std::vector<UpdateClause*>* updates;
-  expression::AbstractExpression* where = nullptr;
+  std::unique_ptr<TableRef> table;
+  std::unique_ptr<std::vector<std::unique_ptr<UpdateClause>>> updates;
+  std::unique_ptr<expression::AbstractExpression> where = nullptr;
 };
 
 }  // namespace parser

--- a/src/include/parser/update_statement.h
+++ b/src/include/parser/update_statement.h
@@ -57,9 +57,7 @@ class UpdateStatement : public SQLStatement {
         updates(nullptr),
         where(nullptr) {}
 
-  virtual ~UpdateStatement() {
-    printf("Destory UpdateStatement\n");
-  }
+  virtual ~UpdateStatement() {}
 
   virtual void Accept(SqlNodeVisitor* v) const override {
     v->Visit(this);

--- a/src/include/parser/update_statement.h
+++ b/src/include/parser/update_statement.h
@@ -28,7 +28,7 @@ namespace parser {
  */
 class UpdateClause {
  public:
-  std::unique_ptr<char[]> column;
+  std::string column;
   std::unique_ptr<expression::AbstractExpression> value;
 
   ~UpdateClause() {}

--- a/src/include/parser/update_statement.h
+++ b/src/include/parser/update_statement.h
@@ -35,11 +35,9 @@ class UpdateClause {
 
   UpdateClause* Copy() {
     UpdateClause* new_clause = new UpdateClause();
-    std::string str(column.get());
-    char* new_cstr = new char[str.length() + 1];
-    std::strcpy(new_cstr, str.c_str());
+    std::string str(column);
+    new_clause->column = column;
     expression::AbstractExpression* new_expr = value->Copy();
-    new_clause->column.reset(new_cstr);
     new_clause->value.reset(new_expr);
     return new_clause;
   }

--- a/src/include/parser/update_statement.h
+++ b/src/include/parser/update_statement.h
@@ -52,7 +52,6 @@ class UpdateStatement : public SQLStatement {
   UpdateStatement()
       : SQLStatement(StatementType::UPDATE),
         table(nullptr),
-        updates(nullptr),
         where(nullptr) {}
 
   virtual ~UpdateStatement() {}
@@ -63,7 +62,7 @@ class UpdateStatement : public SQLStatement {
 
   // TODO: switch to char* instead of TableRef
   std::unique_ptr<TableRef> table;
-  std::unique_ptr<std::vector<std::unique_ptr<UpdateClause>>> updates;
+  std::vector<std::unique_ptr<UpdateClause>> updates;
   std::unique_ptr<expression::AbstractExpression> where = nullptr;
 };
 

--- a/src/include/planner/copy_plan.h
+++ b/src/include/planner/copy_plan.h
@@ -32,7 +32,7 @@ class CopyPlan : public AbstractPlan {
  public:
   CopyPlan() = delete;
 
-  explicit CopyPlan(char *file_path, bool deserialize_parameters)
+  explicit CopyPlan(std::string file_path, bool deserialize_parameters)
       : file_path(file_path), deserialize_parameters(deserialize_parameters) {
     LOG_DEBUG("Creating a Copy Plan");
   }

--- a/src/include/planner/insert_plan.h
+++ b/src/include/planner/insert_plan.h
@@ -48,8 +48,8 @@ class InsertPlan : public AbstractPlan {
                       oid_t bulk_insert_count = 1);
 
   explicit InsertPlan(
-      storage::DataTable *table, std::vector<std::unique_ptr<char[]>> *columns,
-      std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *
+      storage::DataTable *table, const std::vector<std::string> *columns,
+      const std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>> *
           insert_values);
 
   // Get a varlen pool (will construct the pool only if needed)

--- a/src/include/planner/insert_plan.h
+++ b/src/include/planner/insert_plan.h
@@ -48,8 +48,8 @@ class InsertPlan : public AbstractPlan {
                       oid_t bulk_insert_count = 1);
 
   explicit InsertPlan(
-      storage::DataTable *table, std::vector<char *> *columns,
-      std::vector<std::vector<peloton::expression::AbstractExpression *> *> *
+      storage::DataTable *table, std::vector<std::unique_ptr<char[]>> *columns,
+      std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *
           insert_values);
 
   // Get a varlen pool (will construct the pool only if needed)

--- a/src/optimizer/operator_to_plan_transformer.cpp
+++ b/src/optimizer/operator_to_plan_transformer.cpp
@@ -259,7 +259,7 @@ void OperatorToPlanTransformer::Visit(const PhysicalHashGroupBy *op) {
   PL_ASSERT(col_prop != nullptr);
 
   output_plan_ = GenerateAggregatePlan(col_prop, AggregateType::HASH,
-                                            &op->columns, op->having);
+                                       &op->columns, op->having);
 }
 
 void OperatorToPlanTransformer::Visit(const PhysicalSortGroupBy *op) {
@@ -269,7 +269,7 @@ void OperatorToPlanTransformer::Visit(const PhysicalSortGroupBy *op) {
   PL_ASSERT(col_prop != nullptr);
 
   output_plan_ = GenerateAggregatePlan(col_prop, AggregateType::SORTED,
-                                            &op->columns, op->having);
+                                       &op->columns, op->having);
 }
 
 void OperatorToPlanTransformer::Visit(const PhysicalAggregate *) {
@@ -379,7 +379,7 @@ void OperatorToPlanTransformer::Visit(const PhysicalUpdate *op) {
 
   // Evaluate update expression and add to target list
   for (auto& update : *(op->updates)) {
-    auto column = std::string(update->column.get());
+    auto column = update->column;
     auto col_id = schema->GetColumnID(column);
     if (update_col_ids.find(col_id) != update_col_ids.end())
       throw SyntaxException("Multiple assignments to same column " + column);

--- a/src/optimizer/operator_to_plan_transformer.cpp
+++ b/src/optimizer/operator_to_plan_transformer.cpp
@@ -378,14 +378,14 @@ void OperatorToPlanTransformer::Visit(const PhysicalUpdate *op) {
   GenerateTableExprMap(table_expr_map, table_alias, op->target_table);
 
   // Evaluate update expression and add to target list
-  for (auto update : op->updates) {
-    auto column = std::string(update->column);
+  for (auto& update : *(op->updates)) {
+    auto column = std::string(update->column.get());
     auto col_id = schema->GetColumnID(column);
     if (update_col_ids.find(col_id) != update_col_ids.end())
       throw SyntaxException("Multiple assignments to same column " + column);
     update_col_ids.insert(col_id);
     expression::ExpressionUtil::EvaluateExpression({table_expr_map},
-                                                   update->value);
+                                                   update->value.get());
     planner::DerivedAttribute attribute{update->value->Copy()};
     tl.emplace_back(col_id, attribute);
   }

--- a/src/optimizer/operators.cpp
+++ b/src/optimizer/operators.cpp
@@ -136,8 +136,8 @@ Operator LogicalGroupBy::make(
 // Insert
 //===--------------------------------------------------------------------===//
 Operator LogicalInsert::make(
-    storage::DataTable *target_table, std::vector<char *> *columns,
-    std::vector<std::vector<peloton::expression::AbstractExpression *> *> *
+    storage::DataTable *target_table, std::vector<std::unique_ptr<char[]>> *columns,
+    std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *
         values) {
   LogicalInsert *insert_op = new LogicalInsert;
   insert_op->target_table = target_table;
@@ -166,7 +166,7 @@ Operator LogicalDelete::make(storage::DataTable *target_table) {
 //===--------------------------------------------------------------------===//
 Operator LogicalUpdate::make(
     storage::DataTable *target_table,
-    std::vector<peloton::parser::UpdateClause *> updates) {
+    std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates) {
   LogicalUpdate *update_op = new LogicalUpdate;
   update_op->target_table = target_table;
   update_op->updates = updates;
@@ -339,8 +339,8 @@ Operator PhysicalOuterHashJoin::make(std::shared_ptr<expression::AbstractExpress
 // PhysicalInsert
 //===--------------------------------------------------------------------===//
 Operator PhysicalInsert::make(
-    storage::DataTable *target_table, std::vector<char *> *columns,
-    std::vector<std::vector<peloton::expression::AbstractExpression *> *> *
+    storage::DataTable *target_table, std::vector<std::unique_ptr<char[]>> *columns,
+    std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *
         values) {
   PhysicalInsert *insert_op = new PhysicalInsert;
   insert_op->target_table = target_table;
@@ -372,7 +372,7 @@ Operator PhysicalDelete::make(storage::DataTable *target_table) {
 //===--------------------------------------------------------------------===//
 Operator PhysicalUpdate::make(
     storage::DataTable *target_table,
-    std::vector<peloton::parser::UpdateClause *> updates) {
+    std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates) {
   PhysicalUpdate *update = new PhysicalUpdate;
   update->target_table = target_table;
   update->updates = updates;

--- a/src/optimizer/operators.cpp
+++ b/src/optimizer/operators.cpp
@@ -136,8 +136,8 @@ Operator LogicalGroupBy::make(
 // Insert
 //===--------------------------------------------------------------------===//
 Operator LogicalInsert::make(
-    storage::DataTable *target_table, std::vector<std::unique_ptr<char[]>> *columns,
-    std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *
+    storage::DataTable *target_table, const std::vector<std::string> *columns,
+    const std::vector<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>> *
         values) {
   LogicalInsert *insert_op = new LogicalInsert;
   insert_op->target_table = target_table;
@@ -166,7 +166,7 @@ Operator LogicalDelete::make(storage::DataTable *target_table) {
 //===--------------------------------------------------------------------===//
 Operator LogicalUpdate::make(
     storage::DataTable *target_table,
-    std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates) {
+    const std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates) {
   LogicalUpdate *update_op = new LogicalUpdate;
   update_op->target_table = target_table;
   update_op->updates = updates;
@@ -339,8 +339,8 @@ Operator PhysicalOuterHashJoin::make(std::shared_ptr<expression::AbstractExpress
 // PhysicalInsert
 //===--------------------------------------------------------------------===//
 Operator PhysicalInsert::make(
-    storage::DataTable *target_table, std::vector<std::unique_ptr<char[]>> *columns,
-    std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *
+    storage::DataTable *target_table, const std::vector<std::string> *columns,
+    const std::vector<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>> *
         values) {
   PhysicalInsert *insert_op = new PhysicalInsert;
   insert_op->target_table = target_table;
@@ -372,7 +372,7 @@ Operator PhysicalDelete::make(storage::DataTable *target_table) {
 //===--------------------------------------------------------------------===//
 Operator PhysicalUpdate::make(
     storage::DataTable *target_table,
-    std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates) {
+    const std::vector<std::unique_ptr<peloton::parser::UpdateClause>>* updates) {
   PhysicalUpdate *update = new PhysicalUpdate;
   update->target_table = target_table;
   update->updates = updates;

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -86,7 +86,8 @@ shared_ptr<planner::AbstractPlan> Optimizer::BuildPelotonPlanTree(
 
   unique_ptr<planner::AbstractPlan> child_plan = nullptr;
 
-  auto parse_tree = parse_tree_list->GetStatements().at(0);
+  auto parse_tree = parse_tree_list->GetStatements().at(0).get();
+
   // Handle ddl statement
   bool is_ddl_stmt;
   auto ddl_plan = HandleDDLStatement(parse_tree, is_ddl_stmt, txn);

--- a/src/optimizer/query_property_extractor.cpp
+++ b/src/optimizer/query_property_extractor.cpp
@@ -35,7 +35,7 @@ PropertySet QueryPropertyExtractor::GetProperties(parser::SQLStatement *stmt) {
 
 void QueryPropertyExtractor::Visit(const parser::SelectStatement *select_stmt) {
   // Generate PropertyPredicate
-  auto predicate = select_stmt->where_clause;
+  auto predicate = select_stmt->where_clause.get();
   if (predicate != nullptr) {
     property_set_.AddProperty(shared_ptr<PropertyPredicate>(
         new PropertyPredicate(predicate->Copy())));
@@ -43,9 +43,9 @@ void QueryPropertyExtractor::Visit(const parser::SelectStatement *select_stmt) {
 
   // Generate PropertyColumns
   vector<shared_ptr<expression::AbstractExpression>> output_expressions;
-  for (auto col : *select_stmt->select_list) {
+  for (auto& col : *select_stmt->select_list) {
     // Recursively deduce expression value type
-    expression::ExpressionUtil::EvaluateExpression({ExprMap()}, col);
+    expression::ExpressionUtil::EvaluateExpression({ExprMap()}, col.get());
     // Recursively deduce expression name
     col->DeduceExpressionName();
     output_expressions.emplace_back(col->Copy());

--- a/src/optimizer/query_property_extractor.cpp
+++ b/src/optimizer/query_property_extractor.cpp
@@ -43,7 +43,7 @@ void QueryPropertyExtractor::Visit(const parser::SelectStatement *select_stmt) {
 
   // Generate PropertyColumns
   vector<shared_ptr<expression::AbstractExpression>> output_expressions;
-  for (auto& col : *select_stmt->select_list) {
+  for (auto& col : select_stmt->select_list) {
     // Recursively deduce expression value type
     expression::ExpressionUtil::EvaluateExpression({ExprMap()}, col.get());
     // Recursively deduce expression name
@@ -74,11 +74,11 @@ void QueryPropertyExtractor::Visit(const parser::GroupByDescription *) {}
 void QueryPropertyExtractor::Visit(const parser::OrderDescription *node) {
   vector<bool> sort_ascendings;
   vector<shared_ptr<expression::AbstractExpression>> sort_cols;
-  auto len = node->exprs->size();
+  auto len = node->exprs.size();
   for (size_t idx = 0; idx < len; idx++) {
-    auto &expr = node->exprs->at(idx);
+    auto &expr = node->exprs.at(idx);
     sort_cols.emplace_back(expr->Copy());
-    sort_ascendings.push_back(node->types->at(idx) == parser::kOrderAsc);
+    sort_ascendings.push_back(node->types.at(idx) == parser::kOrderAsc);
   }
 
   property_set_.AddProperty(shared_ptr<PropertySort>(

--- a/src/optimizer/query_to_operator_transformer.cpp
+++ b/src/optimizer/query_to_operator_transformer.cpp
@@ -19,13 +19,10 @@
 #include "optimizer/query_node_visitor.h"
 #include "optimizer/query_to_operator_transformer.h"
 
-#include "planner/order_by_plan.h"
-#include "planner/projection_plan.h"
 #include "planner/seq_scan_plan.h"
 
 #include "parser/statements.h"
 
-#include "catalog/catalog.h"
 #include "catalog/manager.h"
 
 using std::vector;
@@ -68,7 +65,7 @@ void QueryToOperatorTransformer::Visit(const parser::SelectStatement *op) {
     if (op->group_by != nullptr) {
       // Make copies of groupby columns
       vector<shared_ptr<expression::AbstractExpression>> group_by_cols;
-      for (auto& col : *op->group_by->columns)
+      for (auto& col : op->group_by->columns)
         group_by_cols.emplace_back(col->Copy());
       auto group_by = std::make_shared<OperatorExpression>(
           LogicalGroupBy::make(move(group_by_cols), op->group_by->having.get()));
@@ -78,7 +75,7 @@ void QueryToOperatorTransformer::Visit(const parser::SelectStatement *op) {
       // Check plain aggregation
       bool has_aggregation = false;
       bool has_other_exprs = false;
-      for (auto& expr : *op->getSelectList()) {
+      for (auto& expr : op->getSelectList()) {
         vector<shared_ptr<expression::AggregateExpression>> aggr_exprs;
         expression::ExpressionUtil::GetAggregateExprs(aggr_exprs, expr.get());
         if (aggr_exprs.size() > 0)
@@ -180,13 +177,13 @@ void QueryToOperatorTransformer::Visit(const parser::TableRef *node) {
     node->join->Accept(this);
   }
     // Multiple tables
-  else if (node->list != nullptr && node->list->size() > 1) {
-    node->list->at(0)->Accept(this);
+  else if (node->list.size() > 1) {
+    node->list.at(0)->Accept(this);
     auto left_expr = output_expr;
     auto left_table_alias_set = table_alias_set_;
     table_alias_set_.clear();
 
-    node->list->at(1)->Accept(this);
+    node->list.at(1)->Accept(this);
     auto right_expr = output_expr;
 
     util::SetUnion(table_alias_set_, left_table_alias_set);
@@ -197,8 +194,8 @@ void QueryToOperatorTransformer::Visit(const parser::TableRef *node) {
     join_expr->PushChild(left_expr);
     join_expr->PushChild(right_expr);
 
-    for (size_t i=2; i<node->list->size(); i++) {
-      node->list->at(i)->Accept(this);
+    for (size_t i = 2; i < node->list.size(); i++) {
+      node->list.at(i)->Accept(this);
       auto old_join_expr = join_expr;
       join_expr = std::make_shared<OperatorExpression>(
           LogicalInnerJoin::make(
@@ -210,8 +207,8 @@ void QueryToOperatorTransformer::Visit(const parser::TableRef *node) {
   }
     // Single table
   else {
-    if (node->list != nullptr && node->list->size() == 1)
-      node = node->list->at(0).get();
+    if (node->list.size() == 1)
+      node = node->list.at(0).get();
     storage::DataTable *target_table =
         catalog::Catalog::GetInstance()->GetTableWithName(
             node->GetDatabaseName(), node->GetTableName(), txn_);
@@ -244,7 +241,7 @@ void QueryToOperatorTransformer::Visit(const parser::InsertStatement *op) {
   }
   else {
     auto insert_expr = std::make_shared<OperatorExpression>(
-        LogicalInsert::make(target_table, op->columns.get(), op->insert_values.get()));
+        LogicalInsert::make(target_table, &op->columns, &op->insert_values));
     output_expr = insert_expr;
   }
 }

--- a/src/optimizer/query_to_operator_transformer.cpp
+++ b/src/optimizer/query_to_operator_transformer.cpp
@@ -270,7 +270,7 @@ void QueryToOperatorTransformer::Visit(const parser::UpdateStatement *op) {
       op->table->GetDatabaseName(), op->table->GetTableName(), txn_);
 
   auto update_expr = std::make_shared<OperatorExpression>(
-      LogicalUpdate::make(target_table, op->updates.get()));
+      LogicalUpdate::make(target_table, &op->updates));
 
   auto table_scan = std::make_shared<OperatorExpression>(
       LogicalGet::make(target_table, op->table->GetTableName(), true));

--- a/src/optimizer/util.cpp
+++ b/src/optimizer/util.cpp
@@ -326,7 +326,7 @@ std::unique_ptr<planner::AbstractPlan> CreateCopyPlan(
   }
 
   std::unique_ptr<planner::AbstractPlan> copy_plan(
-      new planner::CopyPlan(copy_stmt->file_path, deserialize_parameters));
+      new planner::CopyPlan(copy_stmt->file_path.get(), deserialize_parameters));
 
   auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();

--- a/src/optimizer/util.cpp
+++ b/src/optimizer/util.cpp
@@ -326,7 +326,7 @@ std::unique_ptr<planner::AbstractPlan> CreateCopyPlan(
   }
 
   std::unique_ptr<planner::AbstractPlan> copy_plan(
-      new planner::CopyPlan(copy_stmt->file_path.get(), deserialize_parameters));
+      new planner::CopyPlan(copy_stmt->file_path, deserialize_parameters));
 
   auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -900,9 +900,7 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
         }
       } else if (constraint->contype == CONSTR_FOREIGN) {
         auto col = new ColumnDefinition(ColumnDefinition::DataType::FOREIGN);
-        col->table_info_ = new TableInfo();
-        col->foreign_key_source = new std::vector<char*>();
-        col->foreign_key_sink = new std::vector<char*>();
+        col->table_info_.reset(new TableInfo());
         // Transform foreign key attributes
         for (auto attr_cell = constraint->fk_attrs->head; attr_cell != nullptr;
              attr_cell = attr_cell->next) {

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1007,7 +1007,7 @@ parser::SQLStatement* PostgresParser::CreateTriggerTransform(
     }
   }
   // when
-  result->trigger_when = WhenTransform(root->whenClause);
+  result->trigger_when.reset(WhenTransform(root->whenClause));
 
   int16_t& tgtype = result->trigger_type;
   TRIGGER_CLEAR_TYPE(tgtype);

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1026,10 +1026,10 @@ parser::SQLStatement* PostgresParser::CreateTriggerTransform(
   tgtype |= root->timing;
   tgtype |= root->events;
 
-  result->table_info_ = new TableInfo();
-  result->table_info_->table_name = cstrdup(root->relation->relname);
+  result->table_info_.reset(new TableInfo());
+  result->table_info_->table_name.reset(cstrdup(root->relation->relname));
 
-  result->trigger_name = cstrdup(root->trigname);
+  result->trigger_name.reset(cstrdup(root->trigname));
 
   return result;
 }
@@ -1067,7 +1067,7 @@ parser::DropStatement* PostgresParser::DropTableTransform(DropStmt* root) {
     LOG_INFO("%d", ((Node*)(table_list->head->data.ptr_value))->type);
     table_info->table_name.reset(cstrdup(
       reinterpret_cast<value*>(table_list->head->data.ptr_value)->val.str));
-    res->table_info_ = table_info;
+    res->table_info_.reset(table_info);
     break;
   }
   return res;

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1397,7 +1397,9 @@ parser::UpdateStatement* PostgresParser::UpdateTransform(
   auto result = new parser::UpdateStatement();
   result->table.reset(RangeVarTransform(update_stmt->relation));
   result->where.reset(WhereTransform(update_stmt->whereClause));
-  result->updates.reset(UpdateTargetTransform(update_stmt->targetList));
+  for (auto &clause : *UpdateTargetTransform(update_stmt->targetList)) {
+    result->updates.emplace_back(std::move(clause));
+  }
   return result;
 }
 

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -902,7 +902,7 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
       // Transform Regular Column
       ColumnDefinition* temp =
           ColumnDefTransform(reinterpret_cast<ColumnDef*>(node));
-      result->columns->push_back(std::move(std::unique_ptr<ColumnDefinition>(temp)));
+      result->columns->push_back(std::unique_ptr<ColumnDefinition>(temp));
     } else if (node->type == T_Constraint) {
       // Transform Constraints
       auto constraint = reinterpret_cast<Constraint*>(node);
@@ -921,7 +921,7 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
         for (auto attr_cell = constraint->fk_attrs->head; attr_cell != nullptr;
              attr_cell = attr_cell->next) {
           value* attr_val = reinterpret_cast<value*>(attr_cell->data.ptr_value);
-          col->foreign_key_source->push_back(std::move(std::unique_ptr<char[]>(cstrdup(attr_val->val.str))));
+          col->foreign_key_source->push_back(std::unique_ptr<char[]>(cstrdup(attr_val->val.str)));
         }
         // Transform Primary key attributes
         for (auto attr_cell = constraint->pk_attrs->head; attr_cell != nullptr;
@@ -939,7 +939,7 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
         // Match type
         col->foreign_key_match_type = CharToMatchType(constraint->fk_matchtype);
 
-        result->columns->push_back(std::move(std::unique_ptr<ColumnDefinition>(col)));
+        result->columns->push_back(std::unique_ptr<ColumnDefinition>(col));
       } else {
         throw NotImplementedException(StringUtil::Format(
             "Constraint of type %d not supported yet", node->type));
@@ -975,7 +975,7 @@ parser::SQLStatement* PostgresParser::CreateIndexTransform(IndexStmt* root) {
   for (auto cell = root->indexParams->head; cell != nullptr;
        cell = cell->next) {
     char* index_attr = reinterpret_cast<IndexElem*>(cell->data.ptr_value)->name;
-    result->index_attrs->push_back(std::move(std::unique_ptr<char[]>(cstrdup(index_attr))));
+    result->index_attrs->push_back(std::unique_ptr<char[]>(cstrdup(index_attr)));
   }
   result->index_type = IndexType::BWTREE;
   result->table_info_.reset(new TableInfo());
@@ -1191,7 +1191,7 @@ PostgresParser::ParamListTransform(List* root) {
         new std::vector<std::unique_ptr<expression::AbstractExpression>>();
 
   for (auto cell = root->head; cell != NULL; cell = cell->next) {
-    result->push_back(std::move(std::unique_ptr<expression::AbstractExpression>(ConstTransform((A_Const*)(cell->data.ptr_value)))));
+    result->push_back(std::unique_ptr<expression::AbstractExpression>(ConstTransform((A_Const*)(cell->data.ptr_value))));
   }
 
   return result;

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -36,13 +36,6 @@
 namespace peloton {
 namespace parser {
 
-// helper for c_str copy
-static char* cstrdup(const char* c_str) {
-  char* new_str = new char[strlen(c_str) + 1];
-  strcpy(new_str, c_str);
-  return new_str;
-}
-
 PostgresParser::PostgresParser() {}
 
 PostgresParser::~PostgresParser() {}
@@ -1066,8 +1059,8 @@ parser::DropStatement* PostgresParser::DropTriggerTransform(DropStmt* root) {
   auto res = new DropStatement(DropStatement::EntityType::kTrigger);
   auto cell = root->objects->head;
   auto list = reinterpret_cast<List*>(cell->data.ptr_value);
-  res->table_name_of_trigger = cstrdup(reinterpret_cast<value*>(list->head->data.ptr_value)->val.str);
-  res->trigger_name = cstrdup(reinterpret_cast<value*>(list->head->next->data.ptr_value)->val.str);
+  res->table_name_of_trigger = reinterpret_cast<value*>(list->head->data.ptr_value)->val.str;
+  res->trigger_name = reinterpret_cast<value*>(list->head->next->data.ptr_value)->val.str;
   return res;
 }
 

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -99,31 +99,27 @@ parser::JoinDefinition* PostgresParser::JoinTransform(JoinExpr* root) {
 
   // Check the type of left arg and right arg before transform
   if (root->larg->type == T_RangeVar) {
-    result->left = RangeVarTransform(reinterpret_cast<RangeVar*>(root->larg));
+    result->left.reset(RangeVarTransform(reinterpret_cast<RangeVar*>(root->larg)));
   } else if (root->larg->type == T_RangeSubselect) {
-    result->left =
-        RangeSubselectTransform(reinterpret_cast<RangeSubselect*>(root->larg));
+    result->left.reset(RangeSubselectTransform(reinterpret_cast<RangeSubselect*>(root->larg)));
   } else if (root->larg->type == T_JoinExpr) {
     TableRef *l_table_ref = new TableRef(TableReferenceType::JOIN);
-    l_table_ref->join =
-        JoinTransform(reinterpret_cast<JoinExpr*>(root->larg));
-    result->left = l_table_ref;
+    l_table_ref->join.reset(JoinTransform(reinterpret_cast<JoinExpr*>(root->larg)));
+    result->left.reset(l_table_ref);
   } else {
     delete result;
     throw NotImplementedException(StringUtil::Format(
         "Join arg type %d not supported yet...\n", root->larg->type));
   }
   if (root->rarg->type == T_RangeVar) {
-    result->right = RangeVarTransform(reinterpret_cast<RangeVar*>(root->rarg));
+    result->right.reset(RangeVarTransform(reinterpret_cast<RangeVar*>(root->rarg)));
   } else if (root->rarg->type == T_RangeSubselect) {
-    result->right = 
-        RangeSubselectTransform(reinterpret_cast<RangeSubselect*>(root->rarg));
+    result->right.reset(RangeSubselectTransform(reinterpret_cast<RangeSubselect*>(root->rarg)));
   } else if (root->rarg->type == T_JoinExpr) {
 
     TableRef *r_table_ref = new TableRef(TableReferenceType::JOIN);
-    r_table_ref->join =
-        JoinTransform(reinterpret_cast<JoinExpr*>(root->rarg));
-    result->right = r_table_ref;
+    r_table_ref->join.reset(JoinTransform(reinterpret_cast<JoinExpr*>(root->rarg)));
+    result->right.reset(r_table_ref);
   } else {
     delete result;
     throw NotImplementedException(StringUtil::Format(
@@ -134,13 +130,11 @@ parser::JoinDefinition* PostgresParser::JoinTransform(JoinExpr* root) {
   // transform the quals, depends on AExprTranform and BoolExprTransform
   switch (root->quals->type) {
     case T_A_Expr: {
-      result->condition =
-          AExprTransform(reinterpret_cast<A_Expr*>(root->quals));
+      result->condition.reset(AExprTransform(reinterpret_cast<A_Expr*>(root->quals)));
       break;
     }
     case T_BoolExpr: {
-      result->condition =
-          BoolExprTransform(reinterpret_cast<BoolExpr*>(root->quals));
+      result->condition.reset(BoolExprTransform(reinterpret_cast<BoolExpr*>(root->quals)));
       break;
     }
     default: {
@@ -157,22 +151,22 @@ parser::JoinDefinition* PostgresParser::JoinTransform(JoinExpr* root) {
 parser::TableRef* PostgresParser::RangeVarTransform(RangeVar* root) {
   parser::TableRef* result =
       new parser::TableRef(StringToTableReferenceType("name"));
-  result->table_info_ = new parser::TableInfo();
+  result->table_info_.reset(new parser::TableInfo());
 
   if (root->schemaname) {
-    result->schema = cstrdup(root->schemaname);
-    result->table_info_->database_name = cstrdup(root->schemaname);
+    result->schema.reset(cstrdup(root->schemaname));
+    result->table_info_->database_name.reset(cstrdup(root->schemaname));
   }
 
   // parse alias
-  result->alias = AliasTransform(root->alias);
+  result->alias.reset(AliasTransform(root->alias));
 
   if (root->relname) {
-    result->table_info_->table_name = cstrdup(root->relname);
+    result->table_info_->table_name.reset(cstrdup(root->relname));
   }
 
   if (root->catalogname) {
-    result->table_info_->database_name = cstrdup(root->catalogname);
+    result->table_info_->database_name.reset(cstrdup(root->catalogname));
   }
   return result;
 }
@@ -184,7 +178,7 @@ parser::TableRef* PostgresParser::RangeSubselectTransform(
   auto result = new parser::TableRef(StringToTableReferenceType("select"));
   result->select = reinterpret_cast<parser::SelectStatement*>(
       SelectTransform(reinterpret_cast<SelectStmt*>(root->subquery)));
-  result->alias = AliasTransform(root->alias);
+  result->alias.reset(AliasTransform(root->alias));
   if (result->select == nullptr) {
     delete result;
     result = nullptr;
@@ -240,18 +234,16 @@ parser::TableRef* PostgresParser::FromTransform(SelectStmt* select_root) {
   Node* node;
   if (root->length > 1) {
     result = new TableRef(StringToTableReferenceType("CROSS_PRODUCT"));
-    result->list = new std::vector<TableRef*>();
+    result->list.reset(new std::vector<std::unique_ptr<TableRef>>());
     for (auto cell = root->head; cell != nullptr; cell = cell->next) {
       node = reinterpret_cast<Node*>(cell->data.ptr_value);
       switch (node->type) {
         case T_RangeVar: {
-          result->list->push_back(
-              RangeVarTransform(reinterpret_cast<RangeVar*>(node)));
+          result->list->push_back(std::unique_ptr<TableRef>(RangeVarTransform(reinterpret_cast<RangeVar*>(node))));
           break;
         }
         case T_RangeSubselect: {
-          result->list->push_back(
-              RangeSubselectTransform(reinterpret_cast<RangeSubselect*>(node)));
+          result->list->push_back(std::unique_ptr<TableRef>(RangeSubselectTransform(reinterpret_cast<RangeSubselect*>(node))));
           break;
         }
         default: {
@@ -272,7 +264,7 @@ parser::TableRef* PostgresParser::FromTransform(SelectStmt* select_root) {
     }
     case T_JoinExpr: {
       result = new parser::TableRef(StringToTableReferenceType("join"));
-      result->join = JoinTransform(reinterpret_cast<JoinExpr*>(node));
+      result->join.reset(JoinTransform(reinterpret_cast<JoinExpr*>(node)));
       if (result->join == nullptr) {
         delete result;
         result = nullptr;
@@ -387,11 +379,11 @@ parser::GroupByDescription* PostgresParser::GroupByTransform(List* group,
   }
 
   parser::GroupByDescription* result = new parser::GroupByDescription();
-  result->columns = new std::vector<expression::AbstractExpression*>();
+  result->columns.reset(new std::vector<std::unique_ptr<expression::AbstractExpression>>());
   for (auto cell = group->head; cell != nullptr; cell = cell->next) {
     Node* temp = reinterpret_cast<Node*>(cell->data.ptr_value);
     try {
-      result->columns->push_back(ExprTransform(temp));
+      result->columns->push_back(std::unique_ptr<expression::AbstractExpression>(ExprTransform(temp)));
     }
     catch(NotImplementedException e) {
       delete result;
@@ -403,7 +395,7 @@ parser::GroupByDescription* PostgresParser::GroupByTransform(List* group,
   // having clauses not implemented yet, depends on AExprTransform
   if (having != nullptr) {
     try {
-      result->having = ExprTransform(having);
+      result->having.reset(ExprTransform(having));
     }
     catch(NotImplementedException e) {
       delete result;
@@ -548,7 +540,7 @@ expression::AbstractExpression* PostgresParser::FuncCallTransform(
 // This function takes in the whereClause part of a Postgres SelectStmt
 // parsenode and transfers it into the select_list of a Peloton SelectStatement.
 // It checks the type of each target and call the corresponding helpers.
-std::vector<expression::AbstractExpression*>* PostgresParser::TargetTransform(
+std::vector<std::unique_ptr<expression::AbstractExpression>>* PostgresParser::TargetTransform(
     List* root) {
   // Statement like 'SELECT;' cannot detect by postgres parser and would lead to
   // null list
@@ -556,8 +548,8 @@ std::vector<expression::AbstractExpression*>* PostgresParser::TargetTransform(
       throw ParserException("Error parsing SQL statement");
   }
 
-  std::vector<expression::AbstractExpression*>* result =
-      new std::vector<expression::AbstractExpression*>();
+  auto result =
+      new std::vector<std::unique_ptr<expression::AbstractExpression>>();
   for (auto cell = root->head; cell != nullptr; cell = cell->next) {
     ResTarget* target = reinterpret_cast<ResTarget*>(cell->data.ptr_value);
     expression::AbstractExpression* expr = nullptr;
@@ -569,7 +561,7 @@ std::vector<expression::AbstractExpression*>* PostgresParser::TargetTransform(
           StringUtil::Format("Exception thrown in target val:\n%s", e.what()));
     }
     if (target->name != nullptr) expr->alias = target->name;
-    result->push_back(expr);
+    result->push_back(std::unique_ptr<expression::AbstractExpression>(expr));
   }
   return result;
 }
@@ -835,18 +827,19 @@ parser::ColumnDefinition* PostgresParser::ColumnDefTransform(ColumnDef* root) {
       else if (constraint->contype == CONSTR_UNIQUE)
         result->unique = true;
       else if (constraint->contype == CONSTR_FOREIGN) {
-        result->foreign_key_sink = new std::vector<char*>();
-        result->table_info_ = new TableInfo();
+        result->foreign_key_sink.reset(new std::vector<std::unique_ptr<char[]>>());
+        result->table_info_.reset(new TableInfo());
         // Transform foreign key attributes
         // Reference table
-        result->table_info_->table_name = cstrdup(constraint->pktable->relname);
+        result->table_info_->table_name.reset(cstrdup(constraint->pktable->relname));
         // Reference column
         if (constraint->pk_attrs != nullptr)
           for (auto attr_cell = constraint->pk_attrs->head;
                attr_cell != nullptr; attr_cell = attr_cell->next) {
             value* attr_val =
                 reinterpret_cast<value*>(attr_cell->data.ptr_value);
-            result->foreign_key_sink->push_back(cstrdup(attr_val->val.str));
+            result->foreign_key_sink->push_back(std::unique_ptr<char[]>(
+                    cstrdup(attr_val->val.str)));
           }
         // Action type
         result->foreign_key_delete_action =
@@ -858,7 +851,7 @@ parser::ColumnDefinition* PostgresParser::ColumnDefTransform(ColumnDef* root) {
       }
       else if (constraint->contype == CONSTR_DEFAULT) {
         try {
-          result->default_value = ExprTransform(constraint->raw_expr);
+          result->default_value.reset(ExprTransform(constraint->raw_expr));
         }
         catch (NotImplementedException e) {
           throw NotImplementedException(
@@ -867,7 +860,7 @@ parser::ColumnDefinition* PostgresParser::ColumnDefTransform(ColumnDef* root) {
       }
       else if (constraint->contype == CONSTR_CHECK) {
         try {
-          result->check_expression = ExprTransform(constraint->raw_expr);
+          result->check_expression.reset(ExprTransform(constraint->raw_expr));
         }
         catch(NotImplementedException e) {
           throw NotImplementedException(
@@ -889,17 +882,17 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
   parser::CreateStatement* result =
       new CreateStatement(CreateStatement::CreateType::kTable);
   RangeVar* relation = root->relation;
-  result->table_info_ = new parser::TableInfo();
+  result->table_info_.reset(new parser::TableInfo());
 
   if (relation->relname) {
-    result->table_info_->table_name = cstrdup(relation->relname);
+    result->table_info_->table_name.reset(cstrdup(relation->relname));
   }
   if (relation->catalogname) {
-    result->table_info_->database_name = cstrdup(relation->catalogname);
+    result->table_info_->database_name.reset(cstrdup(relation->catalogname));
   };
 
   if (root->tableElts->length > 0) {
-    result->columns = new std::vector<ColumnDefinition*>();
+    result->columns.reset(new std::vector<std::unique_ptr<ColumnDefinition>>());
   }
 
   std::unordered_set<std::string> primary_keys;
@@ -909,7 +902,7 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
       // Transform Regular Column
       ColumnDefinition* temp =
           ColumnDefTransform(reinterpret_cast<ColumnDef*>(node));
-      result->columns->push_back(temp);
+      result->columns->push_back(std::move(std::unique_ptr<ColumnDefinition>(temp)));
     } else if (node->type == T_Constraint) {
       // Transform Constraints
       auto constraint = reinterpret_cast<Constraint*>(node);
@@ -928,16 +921,16 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
         for (auto attr_cell = constraint->fk_attrs->head; attr_cell != nullptr;
              attr_cell = attr_cell->next) {
           value* attr_val = reinterpret_cast<value*>(attr_cell->data.ptr_value);
-          col->foreign_key_source->push_back(cstrdup(attr_val->val.str));
+          col->foreign_key_source->push_back(std::move(std::unique_ptr<char[]>(cstrdup(attr_val->val.str))));
         }
         // Transform Primary key attributes
         for (auto attr_cell = constraint->pk_attrs->head; attr_cell != nullptr;
              attr_cell = attr_cell->next) {
           value* attr_val = reinterpret_cast<value*>(attr_cell->data.ptr_value);
-          col->foreign_key_sink->push_back(cstrdup(attr_val->val.str));
+          col->foreign_key_sink->push_back(std::unique_ptr<char[]>(cstrdup(attr_val->val.str)));
         }
         // Update Reference Table
-        col->table_info_->table_name = cstrdup(constraint->pktable->relname);
+        col->table_info_->table_name.reset(cstrdup(constraint->pktable->relname));
         // Action type
         col->foreign_key_delete_action =
             CharToActionType(constraint->fk_del_action);
@@ -946,13 +939,12 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
         // Match type
         col->foreign_key_match_type = CharToMatchType(constraint->fk_matchtype);
 
-        result->columns->push_back(col);
+        result->columns->push_back(std::move(std::unique_ptr<ColumnDefinition>(col)));
       } else {
         throw NotImplementedException(StringUtil::Format(
             "Constraint of type %d not supported yet", node->type));
       }
     } else {
-      delete result->table_info_;
       delete result;
       throw NotImplementedException(StringUtil::Format(
           "tableElt of type %d not supported yet...", node->type));
@@ -960,10 +952,10 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
   }
 
   // Enforce Primary Keys
-  for (auto column : *result->columns) {
+  for (auto& column : *(result->columns)) {
     // Skip Foreign Key Constraint
     if (column->name == nullptr) continue;
-    if (primary_keys.find(std::string(column->name)) != primary_keys.end()) {
+    if (primary_keys.find(std::string(column->name.get())) != primary_keys.end()) {
       column->primary = true;
     }
   }
@@ -979,16 +971,16 @@ parser::SQLStatement* PostgresParser::CreateIndexTransform(IndexStmt* root) {
   parser::CreateStatement* result =
       new parser::CreateStatement(CreateStatement::kIndex);
   result->unique = root->unique;
-  result->index_attrs = new std::vector<char*>;
+  result->index_attrs.reset(new std::vector<std::unique_ptr<char[]>>());
   for (auto cell = root->indexParams->head; cell != nullptr;
        cell = cell->next) {
     char* index_attr = reinterpret_cast<IndexElem*>(cell->data.ptr_value)->name;
-    result->index_attrs->push_back(cstrdup(index_attr));
+    result->index_attrs->push_back(std::move(std::unique_ptr<char[]>(cstrdup(index_attr))));
   }
   result->index_type = IndexType::BWTREE;
-  result->table_info_ = new TableInfo();
-  result->table_info_->table_name = cstrdup(root->relation->relname);
-  result->index_name = cstrdup(root->idxname);
+  result->table_info_.reset(new TableInfo());
+  result->table_info_->table_name.reset(cstrdup(root->relation->relname));
+  result->index_name.reset(cstrdup(root->idxname));
   return result;
 }
 
@@ -1049,7 +1041,7 @@ parser::SQLStatement* PostgresParser::CreateTriggerTransform(
 parser::SQLStatement* PostgresParser::CreateDbTransform(CreatedbStmt* root) {
   parser::CreateStatement* result =
       new parser::CreateStatement(CreateStatement::kDatabase);
-  result->database_name = cstrdup(root->dbname);
+  result->database_name.reset(cstrdup(root->dbname));
   return result;
 }
 
@@ -1073,8 +1065,8 @@ parser::DropStatement* PostgresParser::DropTableTransform(DropStmt* root) {
     auto table_info = new TableInfo{};
     auto table_list = reinterpret_cast<List*>(cell->data.ptr_value);
     LOG_INFO("%d", ((Node*)(table_list->head->data.ptr_value))->type);
-    table_info->table_name = cstrdup(
-      reinterpret_cast<value*>(table_list->head->data.ptr_value)->val.str);
+    table_info->table_name.reset(cstrdup(
+      reinterpret_cast<value*>(table_list->head->data.ptr_value)->val.str));
     res->table_info_ = table_info;
     break;
   }
@@ -1093,8 +1085,7 @@ parser::DropStatement* PostgresParser::DropTriggerTransform(DropStmt* root) {
 parser::DeleteStatement* PostgresParser::TruncateTransform(TruncateStmt* root) {
   auto result = new DeleteStatement();
   for (auto cell = root->relations->head; cell != nullptr; cell = cell->next) {
-    result->table_ref =
-        RangeVarTransform(reinterpret_cast<RangeVar*>(cell->data.ptr_value));
+    result->table_ref.reset(RangeVarTransform(reinterpret_cast<RangeVar*>(cell->data.ptr_value)));
     break;
   }
   return result;
@@ -1102,26 +1093,26 @@ parser::DeleteStatement* PostgresParser::TruncateTransform(TruncateStmt* root) {
 
 parser::ExecuteStatement* PostgresParser::ExecuteTransform(ExecuteStmt* root) {
   auto result = new ExecuteStatement();
-  result->name = cstrdup(root->name);
+  result->name.reset(cstrdup(root->name));
   if (root->params != nullptr)
-    result->parameters = ParamListTransform(root->params);
+    result->parameters.reset(ParamListTransform(root->params));
   return result;
 }
 
 parser::PrepareStatement* PostgresParser::PrepareTransform(PrepareStmt* root) {
   auto res = new PrepareStatement();
-  res->name = cstrdup(root->name);
+  res->name.reset(cstrdup(root->name));
   auto stmt_list = new SQLStatementList();
-  stmt_list->statements.push_back(NodeTransform(root->query));
-  res->query = stmt_list;
+  stmt_list->statements.push_back(std::unique_ptr<SQLStatement>(NodeTransform(root->query)));
+  res->query.reset(stmt_list);
   return res;
 }
 
 // TODO: Only support COPY TABLE TO FILE and DELIMITER option
 parser::CopyStatement* PostgresParser::CopyTransform(CopyStmt* root) {
   auto res = new CopyStatement(peloton::CopyType::EXPORT_OTHER);
-  res->cpy_table = RangeVarTransform(root->relation);
-  res->file_path = cstrdup(root->filename);
+  res->cpy_table.reset(RangeVarTransform(root->relation));
+  res->file_path.reset(cstrdup(root->filename));
   for (auto cell = root->options->head; cell != NULL; cell = cell->next) {
     auto def_elem = reinterpret_cast<DefElem*>(cell->data.ptr_value);
     if (strcmp(def_elem->defname, "delimiter") == 0) {
@@ -1141,20 +1132,20 @@ parser::AnalyzeStatement* PostgresParser::VacuumTransform(VacuumStmt* root) {
   }
   auto res = new AnalyzeStatement();
   if (root->relation != NULL) { //TOOD: check NULL vs nullptr
-    res->analyze_table = RangeVarTransform(root->relation);
+    res->analyze_table.reset(RangeVarTransform(root->relation));
   }
-  res->analyze_columns = ColumnNameTransform(root->va_cols);
+  res->analyze_columns.reset(ColumnNameTransform(root->va_cols));
   return res;
 }
 
-std::vector<char*>* PostgresParser::ColumnNameTransform(List* root) {
+std::vector<std::unique_ptr<char[]>>* PostgresParser::ColumnNameTransform(List* root) {
   if (root == nullptr) return nullptr;
 
-  std::vector<char*>* result = new std::vector<char*>();
+  auto result = new std::vector<std::unique_ptr<char[]>>();
 
   for (auto cell = root->head; cell != NULL; cell = cell->next) {
     ResTarget* target = (ResTarget*)(cell->data.ptr_value);
-    result->push_back(cstrdup(target->name));
+    result->push_back(std::unique_ptr<char[]>(cstrdup(target->name)));
   }
 
   return result;
@@ -1164,45 +1155,43 @@ std::vector<char*>* PostgresParser::ColumnNameTransform(List* root) {
 // parsenode and transfers it into Peloton AbstractExpression.
 // This is a vector pointer of vector pointers because one InsertStmt can insert
 // multiple tuples.
-std::vector<std::vector<expression::AbstractExpression*>*>*
+std::vector<std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>>>*
 PostgresParser::ValueListsTransform(List* root) {
-  std::vector<std::vector<expression::AbstractExpression*>*>* result =
-      new std::vector<std::vector<expression::AbstractExpression*>*>();
+  auto result = new std::vector<std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>>>();
 
   for (auto value_list = root->head; value_list != NULL;
        value_list = value_list->next) {
-    std::vector<expression::AbstractExpression*>* cur_result =
-        new std::vector<expression::AbstractExpression*>();
+    auto cur_result = new std::vector<std::unique_ptr<expression::AbstractExpression>>();
 
     List* target = (List*)(value_list->data.ptr_value);
     for (auto cell = target->head; cell != NULL; cell = cell->next) {
       auto expr = reinterpret_cast<Expr*>(cell->data.ptr_value);
       if (expr->type == T_ParamRef)
-        cur_result->push_back(ParamRefTransform((ParamRef*)expr));
+        cur_result->push_back(std::unique_ptr<expression::AbstractExpression>(ParamRefTransform((ParamRef*)expr)));
       else if (expr->type == T_A_Const)
-        cur_result->push_back(ConstTransform((A_Const*)expr));
-      else if (expr->type == T_SetToDefault) {
+        cur_result->push_back(std::unique_ptr<expression::AbstractExpression>(ConstTransform((A_Const*)expr)));
+      else if (expr->type == T_SetToDefault){
         // TODO handle default type
         // add corresponding expression for
         // default to cur_result
         cur_result->push_back(nullptr);
       }
     }
-    result->push_back(cur_result);
+    result->push_back(std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>>(cur_result));
   }
 
   return result;
 }
 
 // This function takes in the paramlist of a Postgres ExecuteStmt
-// parsenode and transfers it into Peloton AbstractExpression.
-std::vector<expression::AbstractExpression*>*
+// parsenode and transfers it into Peloton AbstractExpressio
+std::vector<std::unique_ptr<expression::AbstractExpression>>*
 PostgresParser::ParamListTransform(List* root) {
-  std::vector<expression::AbstractExpression*>* result =
-      new std::vector<expression::AbstractExpression*>();
+  std::vector<std::unique_ptr<expression::AbstractExpression>>* result =
+        new std::vector<std::unique_ptr<expression::AbstractExpression>>();
 
   for (auto cell = root->head; cell != NULL; cell = cell->next) {
-    result->push_back(ConstTransform((A_Const*)(cell->data.ptr_value)));
+    result->push_back(std::move(std::unique_ptr<expression::AbstractExpression>(ConstTransform((A_Const*)(cell->data.ptr_value)))));
   }
 
   return result;
@@ -1224,22 +1213,22 @@ parser::SQLStatement* PostgresParser::InsertTransform(InsertStmt* root) {
     // if select from a table to insert
     result = new parser::InsertStatement(InsertType::SELECT);
 
-    result->select = reinterpret_cast<parser::SelectStatement*>(
-        SelectTransform(select_stmt));
+    result->select.reset(reinterpret_cast<parser::SelectStatement*>(
+        SelectTransform(select_stmt)));
 
   } else {
     // Directly insert some values
     result = new parser::InsertStatement(InsertType::VALUES);
 
     PL_ASSERT(select_stmt->valuesLists != NULL);
-    result->insert_values = ValueListsTransform(select_stmt->valuesLists);
+    result->insert_values.reset(ValueListsTransform(select_stmt->valuesLists));
   }
 
   // The table to insert into
-  result->table_ref_ = RangeVarTransform((RangeVar*)(root->relation));
+  result->table_ref_.reset(RangeVarTransform((RangeVar*)(root->relation)));
 
   // The columns to insert into
-  result->columns = ColumnNameTransform(root->cols);
+  result->columns.reset(ColumnNameTransform(root->cols));
   return (parser::SQLStatement*)result;
 }
 
@@ -1260,24 +1249,23 @@ parser::SQLStatement* PostgresParser::SelectTransform(SelectStmt* root) {
         throw e;
       }
       result->select_distinct = root->distinctClause != NULL ? true : false;
-      result->group_by =
-          GroupByTransform(root->groupClause, root->havingClause);
-      result->order = OrderByTransform(root->sortClause);
-      result->where_clause = WhereTransform(root->whereClause);
+      result->group_by.reset(GroupByTransform(root->groupClause, root->havingClause));
+      result->order.reset(OrderByTransform(root->sortClause));
+      result->where_clause.reset(WhereTransform(root->whereClause));
       if (root->limitCount != nullptr) {
         int64_t limit =
             reinterpret_cast<A_Const*>(root->limitCount)->val.val.ival;
         int64_t offset = 0;
         if (root->limitOffset != nullptr)
           offset = reinterpret_cast<A_Const*>(root->limitOffset)->val.val.ival;
-        result->limit = new LimitDescription(limit, offset);
+        result->limit.reset(new LimitDescription(limit, offset));
       }
       break;
     case SETOP_UNION:
       result = reinterpret_cast<parser::SelectStatement*>(
           SelectTransform(root->larg));
-      result->union_select = reinterpret_cast<parser::SelectStatement*>(
-          SelectTransform(root->rarg));
+      result->union_select.reset(reinterpret_cast<parser::SelectStatement*>(
+          SelectTransform(root->rarg)));
       break;
     default:
       throw NotImplementedException(StringUtil::Format(
@@ -1293,8 +1281,8 @@ parser::SQLStatement* PostgresParser::SelectTransform(SelectStmt* root) {
 // DeleteStmt parsenodes.
 parser::SQLStatement* PostgresParser::DeleteTransform(DeleteStmt* root) {
   parser::DeleteStatement* result = new parser::DeleteStatement();
-  result->table_ref = RangeVarTransform(root->relation);
-  result->expr = WhereTransform(root->whereClause);
+  result->table_ref.reset(RangeVarTransform(root->relation));
+  result->expr.reset(WhereTransform(root->whereClause));
   return (parser::SQLStatement*)result;
 }
 
@@ -1394,21 +1382,21 @@ parser::SQLStatementList* PostgresParser::ListTransform(List* root) {
   return result;
 }
 
-std::vector<parser::UpdateClause*>* PostgresParser::UpdateTargetTransform(
+std::vector<std::unique_ptr<parser::UpdateClause>>* PostgresParser::UpdateTargetTransform(
     List* root) {
-  auto result = new std::vector<parser::UpdateClause*>();
+  auto result = new std::vector<std::unique_ptr<parser::UpdateClause>>();
   for (auto cell = root->head; cell != NULL; cell = cell->next) {
     auto update_clause = new UpdateClause();
     ResTarget* target = (ResTarget*)(cell->data.ptr_value);
-    update_clause->column = cstrdup(target->name);
+    update_clause->column.reset(cstrdup(target->name));
     try {
-      update_clause->value = ExprTransform(target->val);
+      update_clause->value.reset(ExprTransform(target->val));
     }
     catch(NotImplementedException e) {
       throw NotImplementedException(
           StringUtil::Format("Exception thrown in update expr:\n%s", e.what()));
     }
-    result->push_back(update_clause);
+    result->push_back(std::unique_ptr<UpdateClause>(update_clause));
   }
   return result;
 }
@@ -1418,9 +1406,9 @@ std::vector<parser::UpdateClause*>* PostgresParser::UpdateTargetTransform(
 parser::UpdateStatement* PostgresParser::UpdateTransform(
     UpdateStmt* update_stmt) {
   auto result = new parser::UpdateStatement();
-  result->table = RangeVarTransform(update_stmt->relation);
-  result->where = WhereTransform(update_stmt->whereClause);
-  result->updates = UpdateTargetTransform(update_stmt->targetList);
+  result->table.reset(RangeVarTransform(update_stmt->relation));
+  result->where.reset(WhereTransform(update_stmt->whereClause));
+  result->updates.reset(UpdateTargetTransform(update_stmt->targetList));
   return result;
 }
 

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1242,8 +1242,8 @@ parser::SQLStatement* PostgresParser::SelectTransform(SelectStmt* root) {
     case SETOP_NONE:
       result = new parser::SelectStatement();
       try {
-        result->select_list = TargetTransform(root->targetList);
-        result->from_table = FromTransform(root);
+        result->select_list.reset(TargetTransform(root->targetList));
+        result->from_table.reset(FromTransform(root));
       } catch (ParserException &e) {
         delete (result);
         throw e;

--- a/src/parser/sql_statement.cpp
+++ b/src/parser/sql_statement.cpp
@@ -70,7 +70,7 @@ const std::string SQLStatementList::GetInfo() const {
   std::ostringstream os;
 
   if (is_valid) {
-    for (auto stmt : statements) {
+    for (auto& stmt : statements) {
       os << stmt->GetInfo();
     }
   } else {

--- a/src/parser/table_ref.cpp
+++ b/src/parser/table_ref.cpp
@@ -17,17 +17,7 @@ namespace peloton {
 namespace parser {
 
 TableRef::~TableRef() {
-  delete table_info_;
-  delete[] alias;
-  delete[] schema;
-
   delete select;
-  delete join;
-
-  if (list) {
-    for (auto ref : (*list)) delete ref;
-    delete list;
-  }
 }
 
 }  // namespace parser

--- a/src/planner/analyze_plan.cpp
+++ b/src/planner/analyze_plan.cpp
@@ -41,7 +41,7 @@ AnalyzePlan::AnalyzePlan(parser::AnalyzeStatement *analyze_stmt,
   table_name_ = analyze_stmt->GetTableName();
   column_names_ = std::vector<char*>();
   for (auto& name : analyze_stmt->GetColumnNames())
-    column_names_.push_back(name.get());
+    column_names_.push_back((char*)name.c_str());
   if (!table_name_.empty()) {
     target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
         analyze_stmt->GetDatabaseName(), table_name_, txn);

--- a/src/planner/analyze_plan.cpp
+++ b/src/planner/analyze_plan.cpp
@@ -39,7 +39,9 @@ AnalyzePlan::AnalyzePlan(std::string table_name,
 AnalyzePlan::AnalyzePlan(parser::AnalyzeStatement *analyze_stmt,
                          concurrency::Transaction *txn) {
   table_name_ = analyze_stmt->GetTableName();
-  column_names_ = analyze_stmt->GetColumnNames();
+  column_names_ = std::vector<char*>();
+  for (auto& name : analyze_stmt->GetColumnNames())
+    column_names_.push_back(name.get());
   if (!table_name_.empty()) {
     target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
         analyze_stmt->GetDatabaseName(), table_name_, txn);

--- a/src/planner/create_plan.cpp
+++ b/src/planner/create_plan.cpp
@@ -203,15 +203,15 @@ void CreatePlan::ProcessForeignKeyConstraint(const std::string &table_name,
   ForeignKeyInfo fkey_info;
 
   // Extract source and sink column names
-  for (auto key : *(col->foreign_key_source)) {
+  for (auto& key : col->foreign_key_source) {
     fkey_info.foreign_key_sources.push_back(key);
   }
-  for (auto key : *(col->foreign_key_sink)) {
+  for (auto& key : col->foreign_key_sink) {
     fkey_info.foreign_key_sinks.push_back(key);
   }
 
   // Extract table names
-  fkey_info.sink_table_name = strdup(col->table_info_->table_name);
+  fkey_info.sink_table_name = col->table_info_->table_name;
 
   // Extract delete and update actions
   fkey_info.upd_action = col->foreign_key_update_action;

--- a/src/planner/insert_plan.cpp
+++ b/src/planner/insert_plan.cpp
@@ -43,8 +43,8 @@ InsertPlan::InsertPlan(storage::DataTable *table,
 }
 
 InsertPlan::InsertPlan(
-    storage::DataTable *table, std::vector<std::unique_ptr<char[]>> *columns,
-    std::vector<std::unique_ptr<std::vector<std::unique_ptr<peloton::expression::AbstractExpression>>>> *
+    storage::DataTable *table, const std::vector<std::string> *columns,
+    const std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>> *
         insert_values)
     : bulk_insert_count(insert_values->size()) {
 
@@ -56,11 +56,11 @@ InsertPlan::InsertPlan(
   if (target_table_) {
     const catalog::Schema *table_schema = target_table_->GetSchema();
     // INSERT INTO table_name VALUES (val2, val2, ...)
-    if (columns == NULL) {
+    if (columns->empty()) {
       for (uint32_t tuple_idx = 0; tuple_idx < insert_values->size();
            tuple_idx++) {
-        auto values = (*insert_values)[tuple_idx].get();
-        PL_ASSERT(values->size() <= table_schema->GetColumnCount());
+        auto& values = (*insert_values)[tuple_idx];
+        PL_ASSERT(values.size() <= table_schema->GetColumnCount());
         std::unique_ptr<storage::Tuple> tuple(
             new storage::Tuple(table_schema, true));
         int col_cntr = 0;
@@ -105,7 +105,7 @@ InsertPlan::InsertPlan(
       // columns has to be less than or equal that of schema
       for (uint32_t tuple_idx = 0; tuple_idx < insert_values->size();
            tuple_idx++) {
-        auto values = (*insert_values)[tuple_idx].get();
+        auto& values = (*insert_values)[tuple_idx];
         PL_ASSERT(columns->size() <= table_schema->GetColumnCount());
         std::unique_ptr<storage::Tuple> tuple(
             new storage::Tuple(table_schema, true));
@@ -116,7 +116,7 @@ InsertPlan::InsertPlan(
 
         // Update parameter info in the specified columns order
         for (size_t pos = 0; pos < query_columns_cnt; pos++) {
-          auto col_name = query_columns->at(pos).get();
+          auto col_name = query_columns->at(pos);
           auto col_cntr = table_schema->GetColumnID(col_name);
 
           PL_ASSERT(col_cntr != INVALID_OID);
@@ -135,7 +135,7 @@ InsertPlan::InsertPlan(
               ExpressionTypeToString(values->at(pos)->GetExpressionType())
                   .c_str());
 
-          if (values->at(pos)->GetExpressionType() ==
+          if (values.at(pos)->GetExpressionType() ==
               ExpressionType::VALUE_PARAMETER) {
             std::tuple<oid_t, oid_t, oid_t> pair =
                 std::make_tuple(tuple_idx, col_cntr, param_index);
@@ -146,7 +146,7 @@ InsertPlan::InsertPlan(
           } else {
             expression::ConstantValueExpression *const_expr_elem =
                 dynamic_cast<expression::ConstantValueExpression *>(
-                    values->at(pos).get());
+                    values.at(pos).get());
             type::Value val = (const_expr_elem->GetValue());
             tuple->SetValue(col_cntr, val, data_pool);
           }
@@ -156,7 +156,7 @@ InsertPlan::InsertPlan(
         if (query_columns_cnt < table_columns_cnt) {
           for (size_t col_cntr = 0; col_cntr < table_columns_cnt; col_cntr++) {
             auto col = table_columns[col_cntr];
-            if (std::find_if(query_columns->begin(), query_columns->end(), [&col](std::unique_ptr<char[]>& x){return col.GetName() == x.get();})
+            if (std::find_if(query_columns->begin(), query_columns->end(), [&col](const std::string& x){return col.GetName() == x;})
                 == query_columns->end()) {
               tuple->SetValue(col_cntr, type::ValueFactory::GetNullValueByType(
                   col.GetType()),

--- a/src/planner/insert_plan.cpp
+++ b/src/planner/insert_plan.cpp
@@ -65,7 +65,7 @@ InsertPlan::InsertPlan(
             new storage::Tuple(table_schema, true));
         int col_cntr = 0;
         int param_index = 0;
-        for (expression::AbstractExpression *elem : *values) {
+        for (auto& elem : values) {
           // Default value to be inserted
           if (elem == nullptr) {
             // No default value

--- a/src/storage/database.cpp
+++ b/src/storage/database.cpp
@@ -29,7 +29,7 @@ Database::~Database() {
   // Clean up all the tables
   LOG_TRACE("Deleting tables from database");
   for (auto table : tables) {
-    if (table != nullptr) delete table;
+    delete table;
   }
 
   LOG_TRACE("Finish deleting tables from database");

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -378,12 +378,11 @@ void TrafficCop::GetDataTables(
     std::vector<storage::DataTable *> &target_tables) {
   if (from_table == nullptr) return;
 
-  if (from_table->list == NULL) {
+  if (from_table->list.empty()) {
     if (from_table->join == NULL) {
-      auto *target_table = static_cast<storage::DataTable *>(
-          catalog::Catalog::GetInstance()->GetTableWithName(
-              from_table->GetDatabaseName(), from_table->GetTableName(),
-              GetCurrentTxnState().first));
+      auto *target_table = catalog::Catalog::GetInstance()->GetTableWithName(
+          from_table->GetDatabaseName(), from_table->GetTableName(),
+          GetCurrentTxnState().first);
       target_tables.push_back(target_table);
     } else {
       GetDataTables(from_table->join->left.get(), target_tables);
@@ -393,7 +392,7 @@ void TrafficCop::GetDataTables(
 
   // Query has multiple tables. Recursively add all tables
   else {
-    for (auto& table : *(from_table->list)) {
+    for (auto& table : from_table->list) {
       GetDataTables(table.get(), target_tables);
     }
   }
@@ -421,7 +420,7 @@ std::vector<FieldInfo> TrafficCop::GenerateTupleDescriptor(
   GetDataTables(select_stmt->from_table.get(), target_tables);
 
   int count = 0;
-  for (auto& expr : *(select_stmt->select_list)) {
+  for (auto& expr : select_stmt->select_list) {
     count++;
     if (expr->GetExpressionType() == ExpressionType::STAR) {
       for (auto target_table : target_tables) {

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -343,10 +343,10 @@ std::shared_ptr<Statement> TrafficCop::PrepareStatement(
         planner::PlanUtil::GetTablesReferenced(plan.get());
     statement->SetReferencedTables(table_oids);
 
-    for (auto stmt : sql_stmt->GetStatements()) {
+    for (auto& stmt : sql_stmt->GetStatements()) {
       LOG_TRACE("SQLStatement: %s", stmt->GetInfo().c_str());
       if (stmt->GetType() == StatementType::SELECT) {
-        auto tuple_descriptor = GenerateTupleDescriptor(stmt);
+        auto tuple_descriptor = GenerateTupleDescriptor(stmt.get());
         statement->SetTupleDescriptor(tuple_descriptor);
       }
       break;
@@ -386,15 +386,15 @@ void TrafficCop::GetDataTables(
               GetCurrentTxnState().first));
       target_tables.push_back(target_table);
     } else {
-      GetDataTables(from_table->join->left, target_tables);
-      GetDataTables(from_table->join->right, target_tables);
+      GetDataTables(from_table->join->left.get(), target_tables);
+      GetDataTables(from_table->join->right.get(), target_tables);
     }
   }
 
   // Query has multiple tables. Recursively add all tables
   else {
-    for (auto table : *(from_table->list)) {
-      GetDataTables(table, target_tables);
+    for (auto& table : *(from_table->list)) {
+      GetDataTables(table.get(), target_tables);
     }
   }
 }
@@ -418,10 +418,10 @@ std::vector<FieldInfo> TrafficCop::GenerateTupleDescriptor(
 
   // Check if query only has one Table
   // Example : SELECT * FROM A;
-  GetDataTables(select_stmt->from_table, target_tables);
+  GetDataTables(select_stmt->from_table.get(), target_tables);
 
   int count = 0;
-  for (auto expr : *select_stmt->select_list) {
+  for (auto& expr : *(select_stmt->select_list)) {
     count++;
     if (expr->GetExpressionType() == ExpressionType::STAR) {
       for (auto target_table : target_tables) {

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -93,7 +93,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementTest) {
 
   auto parse_tree = parser.BuildParseTree(selectSQL);
   auto selectStmt =
-      dynamic_cast<parser::SelectStatement*>(parse_tree->GetStatements().at(0));
+      dynamic_cast<parser::SelectStatement*>(parse_tree->GetStatements().at(0).get());
   binder->BindNameToNode(selectStmt);
 
   oid_t db_oid =
@@ -107,11 +107,11 @@ TEST_F(BinderCorrectnessTest, SelectStatementTest) {
   // Check select_list
   LOG_INFO("Checking select list");
   auto tupleExpr =
-      (expression::TupleValueExpression*)(*selectStmt->select_list)[0];
+      (expression::TupleValueExpression*)(*selectStmt->select_list)[0].get();
   EXPECT_EQ(tupleExpr->GetBoundOid(),
             make_tuple(db_oid, tableA_oid, 0));  // A.a1
   EXPECT_EQ(type::TypeId::INTEGER, tupleExpr->GetValueType());
-  tupleExpr = (expression::TupleValueExpression*)(*selectStmt->select_list)[1];
+  tupleExpr = (expression::TupleValueExpression*)(*selectStmt->select_list)[1].get();
   EXPECT_EQ(tupleExpr->GetBoundOid(),
             make_tuple(db_oid, tableB_oid, 1));  // B.b2
   EXPECT_EQ(type::TypeId::VARCHAR, tupleExpr->GetValueType());
@@ -136,11 +136,11 @@ TEST_F(BinderCorrectnessTest, SelectStatementTest) {
   // Check Group By and Having
   LOG_INFO("Checking group by");
   tupleExpr =
-      (expression::TupleValueExpression*)selectStmt->group_by->columns->at(0);
+      (expression::TupleValueExpression*)selectStmt->group_by->columns->at(0).get();
   EXPECT_EQ(tupleExpr->GetBoundOid(),
             make_tuple(db_oid, tableA_oid, 0));  // A.a1
   tupleExpr =
-      (expression::TupleValueExpression*)selectStmt->group_by->columns->at(1);
+      (expression::TupleValueExpression*)selectStmt->group_by->columns->at(1).get();
   EXPECT_EQ(tupleExpr->GetBoundOid(),
             make_tuple(db_oid, tableB_oid, 1));  // B.b2
   tupleExpr =
@@ -161,7 +161,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementTest) {
   binder.reset(new binder::BindNodeVisitor(txn));
   selectSQL = "SELECT * FROM A, B as A";
   parse_tree = parser.BuildParseTree(selectSQL);
-  selectStmt = (parser::SelectStatement*)(parse_tree->GetStatements().at(0));
+  selectStmt = (parser::SelectStatement*)(parse_tree->GetStatements().at(0).get());
   try {
     binder->BindNameToNode(selectStmt);
     EXPECT_TRUE(false);
@@ -176,7 +176,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementTest) {
   binder.reset(new binder::BindNodeVisitor(txn));
   selectSQL = "SELECT * FROM A, A as AA where A.a1 = AA.a2";
   parse_tree = parser.BuildParseTree(selectSQL);
-  selectStmt = (parser::SelectStatement*)(parse_tree->GetStatements().at(0));
+  selectStmt = (parser::SelectStatement*)(parse_tree->GetStatements().at(0).get());
   binder->BindNameToNode(selectStmt);
   LOG_INFO("Checking where clause");
   tupleExpr =
@@ -194,13 +194,13 @@ TEST_F(BinderCorrectnessTest, SelectStatementTest) {
   binder.reset(new binder::BindNodeVisitor(txn));
   selectSQL = "SELECT AA.a1, b2 FROM A as AA, B WHERE AA.a1 = B.b1";
   parse_tree = parser.BuildParseTree(selectSQL);
-  selectStmt = (parser::SelectStatement*)(parse_tree->GetStatements().at(0));
+  selectStmt = (parser::SelectStatement*)(parse_tree->GetStatements().at(0).get());
   binder->BindNameToNode(selectStmt);
   tupleExpr =
-      (expression::TupleValueExpression*)(selectStmt->select_list->at(0));
+      (expression::TupleValueExpression*)(selectStmt->select_list->at(0).get());
   EXPECT_EQ(tupleExpr->GetBoundOid(), make_tuple(db_oid, tableA_oid, 0));
   tupleExpr =
-      (expression::TupleValueExpression*)(selectStmt->select_list->at(1));
+      (expression::TupleValueExpression*)(selectStmt->select_list->at(1).get());
   EXPECT_EQ(tupleExpr->GetBoundOid(), make_tuple(db_oid, tableB_oid, 1));
   txn_manager.CommitTransaction(txn);
   // Delete the test database
@@ -230,7 +230,7 @@ TEST_F(BinderCorrectnessTest, DeleteStatementTest) {
 
   auto parse_tree = parser.BuildParseTree(deleteSQL);
   auto deleteStmt =
-      dynamic_cast<parser::DeleteStatement*>(parse_tree->GetStatements().at(0));
+      dynamic_cast<parser::DeleteStatement*>(parse_tree->GetStatements().at(0).get());
   binder->BindNameToNode(deleteStmt);
 
   txn_manager.CommitTransaction(txn);

--- a/test/executor/insert_test.cpp
+++ b/test/executor/insert_test.cpp
@@ -21,7 +21,6 @@
 #include "executor/insert_executor.h"
 #include "executor/executor_context.h"
 #include "expression/constant_value_expression.h"
-#include "expression/tuple_value_expression.h"
 #include "parser/insert_statement.h"
 #include "planner/insert_plan.h"
 
@@ -68,71 +67,64 @@ TEST_F(InsertTests, InsertRecord) {
   std::unique_ptr<parser::InsertStatement> insert_node(
       new parser::InsertStatement(InsertType::VALUES));
 
-  char *name = new char[11]();
-  strcpy(name, "TEST_TABLE");
+  std::string name = "TEST_TABLE";
   auto table_ref = new parser::TableRef(TableReferenceType::NAME);
   parser::TableInfo *table_info = new parser::TableInfo();
-  table_info->table_name.reset(name);
+  table_info->table_name = name;
 
-  char *col_1 = new char[8]();
-  strcpy(col_1, "dept_id");
-
-  char *col_2 = new char[10]();
-  strcpy(col_2, "dept_name");
+  std::string col_1 = "dept_id";
+  std::string col_2 = "dept_name";
 
   table_ref->table_info_.reset(table_info);
   insert_node->table_ref_.reset(table_ref);
 
-  insert_node->columns.reset(new std::vector<std::unique_ptr<char[]>>);
-  insert_node->columns->push_back(std::unique_ptr<char[]>(col_1));
-  insert_node->columns->push_back(std::unique_ptr<char[]>(col_2));
+  insert_node->columns.push_back(col_1);
+  insert_node->columns.push_back(col_2);
 
-  insert_node->insert_values.reset(
-      new std::vector<std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>>>);
-  auto values_ptr = new std::vector<std::unique_ptr<expression::AbstractExpression>>;
-  insert_node->insert_values->push_back(
-      std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>>(values_ptr));
+  insert_node->insert_values.push_back(
+      std::vector<std::unique_ptr<expression::AbstractExpression>>());
+  auto& values_ptr = insert_node->insert_values[0];
 
-  values_ptr->push_back(std::unique_ptr<expression::AbstractExpression>(
+  values_ptr.push_back(std::unique_ptr<expression::AbstractExpression>(
       new expression::ConstantValueExpression(type::ValueFactory::GetIntegerValue(70))));
 
-  values_ptr->push_back(std::unique_ptr<expression::AbstractExpression>(
+  values_ptr.push_back(std::unique_ptr<expression::AbstractExpression>(
       new expression::ConstantValueExpression(type::ValueFactory::GetVarcharValue("Hello"))));
 
   insert_node->select.reset(new parser::SelectStatement());
 
-  planner::InsertPlan node(table, insert_node->columns.get(),
-                           insert_node->insert_values.get());
+  planner::InsertPlan node(table, &insert_node->columns,
+                           &insert_node->insert_values);
   executor::InsertExecutor executor(&node, context.get());
 
   EXPECT_TRUE(executor.Init());
   EXPECT_TRUE(executor.Execute());
   EXPECT_EQ(1, table->GetTupleCount());
 
-  values_ptr->at(0).reset(new expression::ConstantValueExpression(
+  values_ptr.at(0).reset(new expression::ConstantValueExpression(
       type::ValueFactory::GetIntegerValue(80)));
-  planner::InsertPlan node2(table, insert_node->columns.get(),
-                            insert_node->insert_values.get());
+  planner::InsertPlan node2(table, &insert_node->columns,
+                            &insert_node->insert_values);
   executor::InsertExecutor executor2(&node2, context.get());
 
   EXPECT_TRUE(executor2.Init());
   EXPECT_TRUE(executor2.Execute());
   EXPECT_EQ(2, table->GetTupleCount());
 
-  auto values_ptr2 = new std::vector<std::unique_ptr<expression::AbstractExpression>>;
-  insert_node->insert_values->push_back(
-      std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>>(values_ptr2));
+  insert_node->insert_values.push_back(
+      std::vector<std::unique_ptr<expression::AbstractExpression>>());
+  auto& values_ptr2 = insert_node->insert_values[1];
 
-  values_ptr2->push_back(std::unique_ptr<expression::AbstractExpression>(
+  values_ptr2.push_back(std::unique_ptr<expression::AbstractExpression>(
       new expression::ConstantValueExpression(type::ValueFactory::GetIntegerValue(100))));
 
-  values_ptr2->push_back(std::unique_ptr<expression::AbstractExpression>(
+  values_ptr2.push_back(std::unique_ptr<expression::AbstractExpression>(
       new expression::ConstantValueExpression(type::ValueFactory::GetVarcharValue("Hello"))));
 
-  values_ptr->at(0).reset(new expression::ConstantValueExpression(
+  values_ptr.at(0).reset(new expression::ConstantValueExpression(
       type::ValueFactory::GetIntegerValue(90)));
-  planner::InsertPlan node3(table, insert_node->columns.get(),
-                            insert_node->insert_values.get());
+  planner::InsertPlan node3(table, &insert_node->columns,
+                            &insert_node->insert_values);
   executor::InsertExecutor executor3(&node3, context.get());
 
   EXPECT_TRUE(executor3.Init());

--- a/test/executor/insert_test.cpp
+++ b/test/executor/insert_test.cpp
@@ -72,7 +72,7 @@ TEST_F(InsertTests, InsertRecord) {
   strcpy(name, "TEST_TABLE");
   auto table_ref = new parser::TableRef(TableReferenceType::NAME);
   parser::TableInfo *table_info = new parser::TableInfo();
-  table_info->table_name = name;
+  table_info->table_name.reset(name);
 
   char *col_1 = new char[8]();
   strcpy(col_1, "dept_id");
@@ -80,59 +80,59 @@ TEST_F(InsertTests, InsertRecord) {
   char *col_2 = new char[10]();
   strcpy(col_2, "dept_name");
 
-  table_ref->table_info_ = table_info;
-  insert_node->table_ref_ = table_ref;
+  table_ref->table_info_.reset(table_info);
+  insert_node->table_ref_.reset(table_ref);
 
-  insert_node->columns = new std::vector<char *>;
-  insert_node->columns->push_back(const_cast<char *>(col_1));
-  insert_node->columns->push_back(const_cast<char *>(col_2));
+  insert_node->columns.reset(new std::vector<std::unique_ptr<char[]>>);
+  insert_node->columns->push_back(std::unique_ptr<char[]>(col_1));
+  insert_node->columns->push_back(std::unique_ptr<char[]>(col_2));
 
-  insert_node->insert_values =
-      new std::vector<std::vector<expression::AbstractExpression *> *>;
-  auto values_ptr = new std::vector<expression::AbstractExpression *>;
-  insert_node->insert_values->push_back(values_ptr);
+  insert_node->insert_values.reset(
+      new std::vector<std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>>>);
+  auto values_ptr = new std::vector<std::unique_ptr<expression::AbstractExpression>>;
+  insert_node->insert_values->push_back(
+      std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>>(values_ptr));
 
-  values_ptr->push_back(new expression::ConstantValueExpression(
-      type::ValueFactory::GetIntegerValue(70)));
+  values_ptr->push_back(std::unique_ptr<expression::AbstractExpression>(
+      new expression::ConstantValueExpression(type::ValueFactory::GetIntegerValue(70))));
 
-  values_ptr->push_back(new expression::ConstantValueExpression(
-      type::ValueFactory::GetVarcharValue("Hello")));
+  values_ptr->push_back(std::unique_ptr<expression::AbstractExpression>(
+      new expression::ConstantValueExpression(type::ValueFactory::GetVarcharValue("Hello"))));
 
-  insert_node->select = new parser::SelectStatement();
+  insert_node->select.reset(new parser::SelectStatement());
 
-  planner::InsertPlan node(table, insert_node->columns,
-                           insert_node->insert_values);
+  planner::InsertPlan node(table, insert_node->columns.get(),
+                           insert_node->insert_values.get());
   executor::InsertExecutor executor(&node, context.get());
 
   EXPECT_TRUE(executor.Init());
   EXPECT_TRUE(executor.Execute());
   EXPECT_EQ(1, table->GetTupleCount());
 
-  delete values_ptr->at(0);
-  values_ptr->at(0) = new expression::ConstantValueExpression(
-      type::ValueFactory::GetIntegerValue(80));
-  planner::InsertPlan node2(table, insert_node->columns,
-                            insert_node->insert_values);
+  values_ptr->at(0).reset(new expression::ConstantValueExpression(
+      type::ValueFactory::GetIntegerValue(80)));
+  planner::InsertPlan node2(table, insert_node->columns.get(),
+                            insert_node->insert_values.get());
   executor::InsertExecutor executor2(&node2, context.get());
 
   EXPECT_TRUE(executor2.Init());
   EXPECT_TRUE(executor2.Execute());
   EXPECT_EQ(2, table->GetTupleCount());
 
-  auto values_ptr2 = new std::vector<expression::AbstractExpression *>;
-  insert_node->insert_values->push_back(values_ptr2);
+  auto values_ptr2 = new std::vector<std::unique_ptr<expression::AbstractExpression>>;
+  insert_node->insert_values->push_back(
+      std::unique_ptr<std::vector<std::unique_ptr<expression::AbstractExpression>>>(values_ptr2));
 
-  values_ptr2->push_back(new expression::ConstantValueExpression(
-      type::ValueFactory::GetIntegerValue(100)));
+  values_ptr2->push_back(std::unique_ptr<expression::AbstractExpression>(
+      new expression::ConstantValueExpression(type::ValueFactory::GetIntegerValue(100))));
 
-  values_ptr2->push_back(new expression::ConstantValueExpression(
-      type::ValueFactory::GetVarcharValue("Hello")));
+  values_ptr2->push_back(std::unique_ptr<expression::AbstractExpression>(
+      new expression::ConstantValueExpression(type::ValueFactory::GetVarcharValue("Hello"))));
 
-  delete values_ptr->at(0);
-  values_ptr->at(0) = new expression::ConstantValueExpression(
-      type::ValueFactory::GetIntegerValue(90));
-  planner::InsertPlan node3(table, insert_node->columns,
-                            insert_node->insert_values);
+  values_ptr->at(0).reset(new expression::ConstantValueExpression(
+      type::ValueFactory::GetIntegerValue(90)));
+  planner::InsertPlan node3(table, insert_node->columns.get(),
+                            insert_node->insert_values.get());
   executor::InsertExecutor executor3(&node3, context.get());
 
   EXPECT_TRUE(executor3.Init());

--- a/test/executor/insert_test.cpp
+++ b/test/executor/insert_test.cpp
@@ -121,7 +121,7 @@ TEST_F(InsertTests, InsertRecord) {
   values_ptr2.push_back(std::unique_ptr<expression::AbstractExpression>(
       new expression::ConstantValueExpression(type::ValueFactory::GetVarcharValue("Hello"))));
 
-  values_ptr.at(0).reset(new expression::ConstantValueExpression(
+  insert_node->insert_values[0].at(0).reset(new expression::ConstantValueExpression(
       type::ValueFactory::GetIntegerValue(90)));
   planner::InsertPlan node3(table, &insert_node->columns,
                             &insert_node->insert_values);

--- a/test/optimizer/operator_transformer_test.cpp
+++ b/test/optimizer/operator_transformer_test.cpp
@@ -69,7 +69,7 @@ class OperatorTransformerTests : public PelotonTest {
     auto ref_stmt = parsed_stmt->GetStatement(0);
     binder::BindNodeVisitor binder(txn);
     binder.BindNameToNode(ref_stmt);
-    auto ref_expr = ((parser::SelectStatement*)ref_stmt)->select_list->at(0).get();
+    auto ref_expr = ((parser::SelectStatement*)ref_stmt)->select_list.at(0).get();
     txn_manager.CommitTransaction(txn);
     LOG_INFO("Expected: %s", true_predicates.c_str());
     LOG_INFO("Actual: %s", predicate->GetInfo().c_str());

--- a/test/optimizer/operator_transformer_test.cpp
+++ b/test/optimizer/operator_transformer_test.cpp
@@ -69,7 +69,7 @@ class OperatorTransformerTests : public PelotonTest {
     auto ref_stmt = parsed_stmt->GetStatement(0);
     binder::BindNodeVisitor binder(txn);
     binder.BindNameToNode(ref_stmt);
-    auto ref_expr = ((parser::SelectStatement*)ref_stmt)->select_list->at(0);
+    auto ref_expr = ((parser::SelectStatement*)ref_stmt)->select_list->at(0).get();
     txn_manager.CommitTransaction(txn);
     LOG_INFO("Expected: %s", true_predicates.c_str());
     LOG_INFO("Actual: %s", predicate->GetInfo().c_str());
@@ -121,7 +121,7 @@ TEST_F(OperatorTransformerTests, JoinTransformationTest) {
   // Check Where
   stmt = reinterpret_cast<parser::SelectStatement*>(stmt_list->GetStatement(0));
   EXPECT_NE(stmt->where_clause, nullptr);
-  CheckPredicate(stmt->where_clause,
+  CheckPredicate(stmt->where_clause.get(),
                  "test as A, test as B, test as C", "A.b = 1 AND B.c + 1 = 10");
   EXPECT_TRUE(op != nullptr);
   // Check Join Predicates

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -170,7 +170,6 @@ TEST_F(ParserTests, SelectParserTest) {
   parser::SelectStatement* stmt =
       (parser::SelectStatement*)list->GetStatement(0);
 
-  EXPECT_NOTNULL(stmt->select_list);
   EXPECT_NOTNULL(stmt->from_table);
   EXPECT_NOTNULL(stmt->group_by);
   EXPECT_NOTNULL(stmt->order);
@@ -180,26 +179,26 @@ TEST_F(ParserTests, SelectParserTest) {
   EXPECT_NULL(stmt->union_select);
 
   // Select List
-  EXPECT_EQ(stmt->select_list->size(), 2);
-  EXPECT_EQ(stmt->select_list->at(0)->GetExpressionType(),
+  EXPECT_EQ(stmt->select_list.size(), 2);
+  EXPECT_EQ(stmt->select_list.at(0)->GetExpressionType(),
             ExpressionType::VALUE_TUPLE);
-  EXPECT_EQ(stmt->select_list->at(1)->GetExpressionType(),
+  EXPECT_EQ(stmt->select_list.at(1)->GetExpressionType(),
             ExpressionType::AGGREGATE_SUM);
 
   // Join Table
   parser::JoinDefinition* join = stmt->from_table->join.get();
   EXPECT_EQ(stmt->from_table->type, TableReferenceType::JOIN);
   EXPECT_NOTNULL(join);
-  EXPECT_STREQ(join->left->GetTableName(), "customers");
-  EXPECT_STREQ(join->right->GetTableName(), "orders");
-  EXPECT_STREQ(join->left->GetDatabaseName(), "order_db");
+  EXPECT_STREQ(join->left->GetTableName().c_str(), "customers");
+  EXPECT_STREQ(join->right->GetTableName().c_str(), "orders");
+  EXPECT_STREQ(join->left->GetDatabaseName().c_str(), "order_db");
 
   // Group By
-  EXPECT_EQ(stmt->group_by->columns->size(), 1);
+  EXPECT_EQ(stmt->group_by->columns.size(), 1);
 
   // Order By
-  EXPECT_EQ(stmt->order->types->at(0), parser::kOrderDesc);
-  EXPECT_EQ(stmt->order->exprs->at(0)->GetExpressionType(),
+  EXPECT_EQ(stmt->order->types.at(0), parser::kOrderDesc);
+  EXPECT_EQ(stmt->order->exprs.at(0)->GetExpressionType(),
             ExpressionType::AGGREGATE_SUM);
 
   // Limit
@@ -404,7 +403,7 @@ TEST_F(ParserTests, CopyTest) {
         static_cast<parser::CopyStatement*>(result->GetStatement(0));
 
     EXPECT_EQ(copy_stmt->delimiter, ',');
-    EXPECT_STREQ(copy_stmt->file_path.get(), "/home/user/output.csv");
+    EXPECT_STREQ(copy_stmt->file_path.c_str(), "/home/user/output.csv");
 
     if (result != nullptr) {
       LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -187,7 +187,7 @@ TEST_F(ParserTests, SelectParserTest) {
             ExpressionType::AGGREGATE_SUM);
 
   // Join Table
-  parser::JoinDefinition* join = stmt->from_table->join;
+  parser::JoinDefinition* join = stmt->from_table->join.get();
   EXPECT_EQ(stmt->from_table->type, TableReferenceType::JOIN);
   EXPECT_NOTNULL(join);
   EXPECT_STREQ(join->left->GetTableName(), "customers");
@@ -404,7 +404,7 @@ TEST_F(ParserTests, CopyTest) {
         static_cast<parser::CopyStatement*>(result->GetStatement(0));
 
     EXPECT_EQ(copy_stmt->delimiter, ',');
-    EXPECT_STREQ(copy_stmt->file_path, "/home/user/output.csv");
+    EXPECT_STREQ(copy_stmt->file_path.get(), "/home/user/output.csv");
 
     if (result != nullptr) {
       LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());

--- a/test/parser/parser_utils_test.cpp
+++ b/test/parser/parser_utils_test.cpp
@@ -122,31 +122,31 @@ TEST_F(ParserUtilTests, BasicTest) {
       LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
                 stmt_list->error_line, stmt_list->error_col);
     }
-    for (parser::SQLStatement* stmt : stmt_list->statements) {
+    for (auto &stmt : stmt_list->statements) {
       switch (stmt->GetType()) {
         case StatementType::SELECT:
           EXPECT_TRUE(parser::ParserUtils::GetSelectStatementInfo(
-                          (parser::SelectStatement*)stmt, 0).size() > 0);
+                          (parser::SelectStatement*)stmt.get(), 0).size() > 0);
           break;
         case StatementType::INSERT:
           EXPECT_TRUE(parser::ParserUtils::GetInsertStatementInfo(
-                          (parser::InsertStatement*)stmt, 0).size() > 0);
+                          (parser::InsertStatement*)stmt.get(), 0).size() > 0);
           break;
         case StatementType::CREATE:
           EXPECT_TRUE(parser::ParserUtils::GetCreateStatementInfo(
-                          (parser::CreateStatement*)stmt, 0).size() > 0);
+                          (parser::CreateStatement*)stmt.get(), 0).size() > 0);
           break;
         case StatementType::DELETE:
           EXPECT_TRUE(parser::ParserUtils::GetDeleteStatementInfo(
-                          (parser::DeleteStatement*)stmt, 0).size() > 0);
+                          (parser::DeleteStatement*)stmt.get(), 0).size() > 0);
           break;
         case StatementType::COPY:
           EXPECT_TRUE(parser::ParserUtils::GetCopyStatementInfo(
-                          (parser::CopyStatement*)stmt, 0).size() > 0);
+                          (parser::CopyStatement*)stmt.get(), 0).size() > 0);
           break;
         case StatementType::UPDATE:
           EXPECT_TRUE(parser::ParserUtils::GetUpdateStatementInfo(
-                          (parser::UpdateStatement*)stmt, 0).size() > 0);
+                          (parser::UpdateStatement*)stmt.get(), 0).size() > 0);
           break;
         default:
           break;

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -632,11 +632,11 @@ TEST_F(PostgresParserTests, CreateTest) {
   EXPECT_EQ(column->varlen, 255);
 
   // Check Foreign Key Constraint
-  column = create_stmt->columns->at(4);
+  column = create_stmt->columns.at(4).get();
   EXPECT_EQ(parser::ColumnDefinition::DataType::FOREIGN, column->type);
-  EXPECT_EQ("c_id", std::string(column->foreign_key_source->at(0)));
-  EXPECT_EQ("cid", std::string(column->foreign_key_sink->at(0)));
-  EXPECT_EQ("country", std::string(column->table_info_->table_name));
+  EXPECT_EQ("c_id", column->foreign_key_source.at(0));
+  EXPECT_EQ("cid", column->foreign_key_sink.at(0));
+  EXPECT_EQ("country", column->table_info_->table_name);
 
   delete stmt_list;
 }
@@ -781,10 +781,9 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   column = create_stmt->columns.at(1).get();
   EXPECT_EQ("b", column->name);
   EXPECT_EQ(parser::ColumnDefinition::DataType::INT, column->type);
-  EXPECT_TRUE(column->foreign_key_sink != nullptr);
-  EXPECT_TRUE(column->foreign_key_sink->size() == 1);
-  EXPECT_EQ("bb", std::string(column->foreign_key_sink->at(0)));
-  EXPECT_EQ("table2", std::string(column->table_info_->table_name));
+  EXPECT_TRUE(column->foreign_key_sink.size() == 1);
+  EXPECT_EQ("bb", column->foreign_key_sink.at(0));
+  EXPECT_EQ("table2", column->table_info_->table_name);
   EXPECT_EQ(FKConstrActionType::CASCADE, column->foreign_key_update_action);
   EXPECT_EQ(FKConstrActionType::NOACTION, column->foreign_key_delete_action);
   EXPECT_EQ(FKConstrMatchType::SIMPLE, column->foreign_key_match_type);
@@ -793,10 +792,9 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   column = create_stmt->columns.at(2).get();
   EXPECT_EQ("c", column->name);
   EXPECT_EQ(parser::ColumnDefinition::DataType::VARCHAR, column->type);
-  EXPECT_TRUE(column->foreign_key_sink != nullptr);
-  EXPECT_TRUE(column->foreign_key_sink->size() == 1);
-  EXPECT_EQ("cc", std::string(column->foreign_key_sink->at(0)));
-  EXPECT_EQ("table3", std::string(column->table_info_->table_name));
+  EXPECT_TRUE(column->foreign_key_sink.size() == 1);
+  EXPECT_EQ("cc", column->foreign_key_sink.at(0));
+  EXPECT_EQ("table3", column->table_info_->table_name);
   EXPECT_EQ(FKConstrActionType::NOACTION, column->foreign_key_update_action);
   EXPECT_EQ(FKConstrActionType::SETNULL, column->foreign_key_delete_action);
   EXPECT_EQ(FKConstrMatchType::FULL, column->foreign_key_match_type);
@@ -825,12 +823,10 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   // Check Fifth column
   column = create_stmt->columns.at(4).get();
   EXPECT_EQ(parser::ColumnDefinition::DataType::FOREIGN, column->type);
-  EXPECT_TRUE(column->foreign_key_source != nullptr);
-  EXPECT_TRUE(column->foreign_key_source->size() == 1);
-  EXPECT_EQ("d", std::string(column->foreign_key_source->at(0).get()));
-  EXPECT_TRUE(column->foreign_key_sink != nullptr);
-  EXPECT_TRUE(column->foreign_key_sink->size() == 1);
-  EXPECT_EQ("dd", std::string(column->foreign_key_sink->at(0)));
+  EXPECT_TRUE(column->foreign_key_source.size() == 1);
+  EXPECT_EQ("d", column->foreign_key_source.at(0));
+  EXPECT_TRUE(column->foreign_key_sink.size() == 1);
+  EXPECT_EQ("dd", column->foreign_key_sink.at(0));
   EXPECT_EQ("table4", std::string(column->table_info_->table_name));
   EXPECT_EQ(FKConstrActionType::SETDEFAULT, column->foreign_key_update_action);
   EXPECT_EQ(FKConstrActionType::NOACTION, column->foreign_key_delete_action);

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -338,27 +338,26 @@ TEST_F(PostgresParserTests, ColumnUpdateTest) {
     EXPECT_EQ(sql_stmt->GetType(), StatementType::UPDATE);
     auto update_stmt = (parser::UpdateStatement *)(sql_stmt);
     auto table = update_stmt->table.get();
-    auto updates = update_stmt->updates.get();
+    auto &updates = update_stmt->updates;
     auto where_clause = update_stmt->where.get();
 
     EXPECT_NE(table, nullptr);
     EXPECT_NE(table->table_info_, nullptr);
     EXPECT_EQ(table->table_info_->table_name, "customer");
 
-    EXPECT_NE(updates, nullptr);
-    EXPECT_EQ(updates->size(), 2);
-    EXPECT_EQ((*updates)[0]->column, "c_balance");
-    EXPECT_EQ((*updates)[0]->value->GetExpressionType(),
+    EXPECT_EQ(updates.size(), 2);
+    EXPECT_EQ(updates[0]->column, "c_balance");
+    EXPECT_EQ(updates[0]->value->GetExpressionType(),
               ExpressionType::VALUE_TUPLE);
     expression::TupleValueExpression *column_value_0 =
-        (expression::TupleValueExpression *)((*updates)[0]->value.get());
+        (expression::TupleValueExpression *)(updates[0]->value.get());
     EXPECT_EQ(column_value_0->GetColumnName(), "c_balance");
 
-    EXPECT_EQ((*updates)[1]->column, "c_delivery_cnt");
-    EXPECT_EQ((*updates)[1]->value->GetExpressionType(),
+    EXPECT_EQ(updates[1]->column, "c_delivery_cnt");
+    EXPECT_EQ(updates[1]->value->GetExpressionType(),
               ExpressionType::VALUE_TUPLE);
     expression::TupleValueExpression *column_value_1 =
-        (expression::TupleValueExpression *)((*updates)[1]->value.get());
+        (expression::TupleValueExpression *)(updates[1]->value.get());
     EXPECT_EQ(column_value_1->GetColumnName(), "c_delivery_cnt");
 
     EXPECT_NE(where_clause, nullptr);
@@ -392,16 +391,16 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
 
   // TODO: Uncomment when the AExpressionTransfrom supports operator expression
   // Test First Set Condition
-  EXPECT_EQ(update_stmt->updates->at(0)->column, "s_quantity");
+  EXPECT_EQ(update_stmt->updates.at(0)->column, "s_quantity");
   auto constant =
-      (expression::ConstantValueExpression *)update_stmt->updates->at(0)->value.get();
+      (expression::ConstantValueExpression *)update_stmt->updates.at(0)->value.get();
   EXPECT_TRUE(constant->GetValue().CompareEquals(
       type::ValueFactory::GetDecimalValue(48)));
 
   // Test Second Set Condition
-  EXPECT_EQ(update_stmt->updates->at(1)->column, "s_ytd");
+  EXPECT_EQ(update_stmt->updates.at(1)->column, "s_ytd");
   auto op_expr =
-      (expression::OperatorExpression *)update_stmt->updates->at(1)->value.get();
+      (expression::OperatorExpression *)update_stmt->updates.at(1)->value.get();
   auto child1 = (expression::TupleValueExpression *)op_expr->GetChild(0);
   EXPECT_EQ(child1->GetColumnName(), "s_ytd");
   auto child2 = (expression::ConstantValueExpression *)op_expr->GetChild(1);
@@ -488,7 +487,7 @@ TEST_F(PostgresParserTests, StringUpdateTest) {
       "2");
 
   // Check update clause
-  auto update_clause = update->updates->at(0).get();
+  auto update_clause = update->updates.at(0).get();
   EXPECT_EQ(update_clause->column, "ol_delivery_d");
   auto value = update_clause->value.get();
   EXPECT_EQ(value->GetExpressionType(), ExpressionType::VALUE_CONSTANT);

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -923,7 +923,7 @@ TEST_F(PostgresParserTests, CreateTriggerTest) {
   // when
   // Check the expression tree of trigger_when is identical to the query
   // Need to check type and value of each node.
-  auto when = create_trigger_stmt->trigger_when;
+  auto &when = create_trigger_stmt->trigger_when;
   EXPECT_NE(nullptr, when);
   EXPECT_EQ(ExpressionType::COMPARE_NOTEQUAL, when->GetExpressionType());
   EXPECT_EQ(2, when->GetChildrenSize());

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -109,10 +109,10 @@ TEST_F(PostgresParserTests, OrderByTest) {
   // SELECT * FROM foo ORDER BY id;
   std::string query = "SELECT * FROM foo ORDER BY id;";
   auto stmt_list = parser.BuildParseTree(query).release();
-  auto sql_stmt = stmt_list->statements[0];
+  auto sql_stmt = stmt_list->statements[0].get();
   EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
   auto select_stmt = (parser::SelectStatement *)(sql_stmt);
-  auto order_by = select_stmt->order;
+  auto order_by = select_stmt->order.get();
   EXPECT_NE(order_by, nullptr);
   EXPECT_NE(order_by->types, nullptr);
   EXPECT_NE(order_by->exprs, nullptr);
@@ -128,10 +128,10 @@ TEST_F(PostgresParserTests, OrderByTest) {
   // SELECT * FROM foo ORDER BY id ASC;
   query = "SELECT * FROM foo ORDER BY id ASC;";
   stmt_list = parser.BuildParseTree(query).release();
-  sql_stmt = stmt_list->statements[0];
+  sql_stmt = stmt_list->statements[0].get();
   EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
   select_stmt = (parser::SelectStatement *)(sql_stmt);
-  order_by = select_stmt->order;
+  order_by = select_stmt->order.get();
   EXPECT_NE(order_by, nullptr);
   EXPECT_NE(order_by->types, nullptr);
   EXPECT_NE(order_by->exprs, nullptr);
@@ -147,10 +147,10 @@ TEST_F(PostgresParserTests, OrderByTest) {
   // SELECT * FROM foo ORDER BY id DESC;
   query = "SELECT * FROM foo ORDER BY id DESC;";
   stmt_list = parser.BuildParseTree(query).release();
-  sql_stmt = stmt_list->statements[0];
+  sql_stmt = stmt_list->statements[0].get();
   EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
   select_stmt = (parser::SelectStatement *)(sql_stmt);
-  order_by = select_stmt->order;
+  order_by = select_stmt->order.get();
   EXPECT_NE(order_by, nullptr);
   EXPECT_NE(order_by->types, nullptr);
   EXPECT_NE(order_by->exprs, nullptr);
@@ -166,10 +166,10 @@ TEST_F(PostgresParserTests, OrderByTest) {
   // SELECT * FROM foo ORDER BY id, name;
   query = "SELECT * FROM foo ORDER BY id, name;";
   stmt_list = parser.BuildParseTree(query).release();
-  sql_stmt = stmt_list->statements[0];
+  sql_stmt = stmt_list->statements[0].get();
   EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
   select_stmt = (parser::SelectStatement *)(sql_stmt);
-  order_by = select_stmt->order;
+  order_by = select_stmt->order.get();
   EXPECT_NE(order_by, nullptr);
   EXPECT_NE(order_by->types, nullptr);
   EXPECT_NE(order_by->exprs, nullptr);
@@ -189,10 +189,10 @@ TEST_F(PostgresParserTests, OrderByTest) {
   // SELECT * FROM foo ORDER BY id, name;
   query = "SELECT * FROM foo ORDER BY id, name DESC;";
   stmt_list = parser.BuildParseTree(query).release();
-  sql_stmt = stmt_list->statements[0];
+  sql_stmt = stmt_list->statements[0].get();
   EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
   select_stmt = (parser::SelectStatement *)(sql_stmt);
-  order_by = select_stmt->order;
+  order_by = select_stmt->order.get();
   EXPECT_NE(order_by, nullptr);
   EXPECT_NE(order_by->types, nullptr);
   EXPECT_NE(order_by->exprs, nullptr);
@@ -266,11 +266,11 @@ TEST_F(PostgresParserTests, JoinTest) {
     // Test for multiple table join
     if (ii == 5) {
       auto select_stmt =
-          reinterpret_cast<parser::SelectStatement *>(stmt_list->statements[0]);
-      auto join_table = select_stmt->from_table;
+          reinterpret_cast<parser::SelectStatement *>(stmt_list->statements[0].get());
+      auto join_table = select_stmt->from_table.get();
       EXPECT_TRUE(join_table->type == TableReferenceType::JOIN);
-      auto l_join = join_table->join->left;
-      auto r_table = join_table->join->right;
+      auto l_join = join_table->join->left.get();
+      auto r_table = join_table->join->right.get();
       EXPECT_TRUE(l_join->type == TableReferenceType::JOIN);
       EXPECT_TRUE(r_table->type == TableReferenceType::NAME);
       LOG_INFO("condition 0 : %s", join_table->join->condition->GetInfo().c_str());
@@ -343,35 +343,35 @@ TEST_F(PostgresParserTests, ColumnUpdateTest) {
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
 
     EXPECT_EQ(stmt_list->statements.size(), 1);
-    auto sql_stmt = stmt_list->statements[0];
+    auto sql_stmt = stmt_list->statements[0].get();
 
     EXPECT_EQ(sql_stmt->GetType(), StatementType::UPDATE);
     auto update_stmt = (parser::UpdateStatement *)(sql_stmt);
-    auto table = update_stmt->table;
-    auto updates = update_stmt->updates;
-    auto where_clause = update_stmt->where;
+    auto table = update_stmt->table.get();
+    auto updates = update_stmt->updates.get();
+    auto where_clause = update_stmt->where.get();
 
     EXPECT_NE(table, nullptr);
     EXPECT_NE(table->table_info_, nullptr);
     EXPECT_NE(table->table_info_->table_name, nullptr);
-    EXPECT_EQ(std::string(table->table_info_->table_name),
+    EXPECT_EQ(std::string(table->table_info_->table_name.get()),
               std::string("customer"));
 
     EXPECT_NE(updates, nullptr);
     EXPECT_EQ(updates->size(), 2);
-    EXPECT_EQ(std::string((*updates)[0]->column), std::string("c_balance"));
+    EXPECT_EQ(std::string((*updates)[0]->column.get()), std::string("c_balance"));
     EXPECT_EQ((*updates)[0]->value->GetExpressionType(),
               ExpressionType::VALUE_TUPLE);
     expression::TupleValueExpression *column_value_0 =
-        (expression::TupleValueExpression *)((*updates)[0]->value);
+        (expression::TupleValueExpression *)((*updates)[0]->value.get());
     EXPECT_EQ(column_value_0->GetColumnName(), std::string("c_balance"));
 
-    EXPECT_EQ(std::string((*updates)[1]->column),
+    EXPECT_EQ(std::string((*updates)[1]->column.get()),
               std::string("c_delivery_cnt"));
     EXPECT_EQ((*updates)[1]->value->GetExpressionType(),
               ExpressionType::VALUE_TUPLE);
     expression::TupleValueExpression *column_value_1 =
-        (expression::TupleValueExpression *)((*updates)[1]->value);
+        (expression::TupleValueExpression *)((*updates)[1]->value.get());
     EXPECT_EQ(column_value_1->GetColumnName(), std::string("c_delivery_cnt"));
 
     EXPECT_NE(where_clause, nullptr);
@@ -400,21 +400,21 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   parser::SQLStatementList *stmt_list = parser.BuildParseTree(query).release();
   EXPECT_TRUE(stmt_list->is_valid);
 
-  auto update_stmt = (parser::UpdateStatement *)stmt_list->GetStatements()[0];
-  EXPECT_EQ(std::string(update_stmt->table->table_info_->table_name), "stock");
+  auto update_stmt = (parser::UpdateStatement *)stmt_list->GetStatements()[0].get();
+  EXPECT_EQ(std::string(update_stmt->table->table_info_->table_name.get()), "stock");
 
   // TODO: Uncomment when the AExpressionTransfrom supports operator expression
   // Test First Set Condition
-  EXPECT_EQ(std::string(update_stmt->updates->at(0)->column), "s_quantity");
+  EXPECT_EQ(std::string(update_stmt->updates->at(0)->column.get()), "s_quantity");
   auto constant =
-      (expression::ConstantValueExpression *)update_stmt->updates->at(0)->value;
+      (expression::ConstantValueExpression *)update_stmt->updates->at(0)->value.get();
   EXPECT_TRUE(constant->GetValue().CompareEquals(
       type::ValueFactory::GetDecimalValue(48)));
 
   // Test Second Set Condition
-  EXPECT_EQ(std::string(update_stmt->updates->at(1)->column), "s_ytd");
+  EXPECT_EQ(std::string(update_stmt->updates->at(1)->column.get()), "s_ytd");
   auto op_expr =
-      (expression::OperatorExpression *)update_stmt->updates->at(1)->value;
+      (expression::OperatorExpression *)update_stmt->updates->at(1)->value.get();
   auto child1 = (expression::TupleValueExpression *)op_expr->GetChild(0);
   EXPECT_EQ(child1->GetColumnName(), "s_ytd");
   auto child2 = (expression::ConstantValueExpression *)op_expr->GetChild(1);
@@ -422,7 +422,7 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
       child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
 
   // Test Where clause
-  auto where = (expression::OperatorExpression *)update_stmt->where;
+  auto where = (expression::OperatorExpression *)update_stmt->where.get();
   EXPECT_EQ(where->GetExpressionType(), ExpressionType::CONJUNCTION_AND);
   auto cond1 = (expression::OperatorExpression *)where->GetChild(0);
   EXPECT_EQ(cond1->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
@@ -460,11 +460,11 @@ TEST_F(PostgresParserTests, StringUpdateTest) {
   auto update = (parser::UpdateStatement *)stmt;
 
   // Check table name
-  auto table_ref = update->table;
-  EXPECT_EQ(std::string(table_ref->table_info_->table_name), "order_line");
+  auto table_ref = update->table.get();
+  EXPECT_EQ(std::string(table_ref->table_info_->table_name.get()), "order_line");
 
   // Check where expression
-  auto where = update->where;
+  auto where = update->where.get();
   EXPECT_EQ(where->GetExpressionType(), ExpressionType::CONJUNCTION_AND);
   EXPECT_EQ(where->GetChildrenSize(), 2);
   EXPECT_EQ(where->GetChild(0)->GetExpressionType(),
@@ -501,9 +501,9 @@ TEST_F(PostgresParserTests, StringUpdateTest) {
       "2");
 
   // Check update clause
-  auto update_clause = update->updates->at(0);
-  EXPECT_EQ(std::string(update_clause->column), "ol_delivery_d");
-  auto value = update_clause->value;
+  auto update_clause = update->updates->at(0).get();
+  EXPECT_EQ(std::string(update_clause->column.get()), "ol_delivery_d");
+  auto value = update_clause->value.get();
   EXPECT_EQ(value->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
   EXPECT_EQ(
       ((expression::ConstantValueExpression *)value)->GetValue().ToString(),
@@ -597,14 +597,14 @@ TEST_F(PostgresParserTests, InsertTest) {
 
     // Test NULL Value parsing
     EXPECT_TRUE(((expression::ConstantValueExpression *)
-                     insert_stmt->insert_values->at(0)->at(0))
+                     insert_stmt->insert_values->at(0)->at(0).get())
                     ->GetValue()
                     .IsNull());
     // Test normal value
     type::Value five = type::ValueFactory::GetIntegerValue(5);
     type::CmpBool res = five.CompareEquals(
         ((expression::ConstantValueExpression *)
-             insert_stmt->insert_values->at(1)->at(1))->GetValue());
+             insert_stmt->insert_values->at(1)->at(1).get())->GetValue());
     EXPECT_EQ(1, res);
 
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
@@ -631,18 +631,18 @@ TEST_F(PostgresParserTests, CreateTest) {
   // Check column definition
   EXPECT_EQ(create_stmt->columns->size(), 5);
   // Check First column
-  auto column = create_stmt->columns->at(0);
+  auto column = create_stmt->columns->at(0).get();
   EXPECT_TRUE(column->not_null);
   EXPECT_TRUE(column->unique);
   EXPECT_TRUE(column->primary);
   EXPECT_EQ(std::string(column->name), "id");
   EXPECT_EQ(parser::ColumnDefinition::DataType::INT, column->type);
   // Check Second column
-  column = create_stmt->columns->at(1);
+  column = create_stmt->columns->at(1).get();
   EXPECT_FALSE(column->not_null);
   EXPECT_TRUE(column->primary);
   // Check Third column
-  column = create_stmt->columns->at(2);
+  column = create_stmt->columns->at(2).get();
   EXPECT_FALSE(column->primary);
   EXPECT_EQ(column->varlen, 255);
 
@@ -696,11 +696,11 @@ TEST_F(PostgresParserTests, CreateIndexTest) {
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
   // Check attributes
   EXPECT_EQ(parser::CreateStatement::kIndex, create_stmt->type);
-  EXPECT_EQ("idx_order", std::string(create_stmt->index_name));
-  EXPECT_EQ("oorder", std::string(create_stmt->table_info_->table_name));
+  EXPECT_EQ("idx_order", std::string(create_stmt->index_name.get()));
+  EXPECT_EQ("oorder", std::string(create_stmt->table_info_->table_name.get()));
   EXPECT_TRUE(create_stmt->unique);
-  EXPECT_EQ("o_w_id", std::string(create_stmt->index_attrs->at(0)));
-  EXPECT_EQ("o_d_id", std::string(create_stmt->index_attrs->at(1)));
+  EXPECT_EQ("o_w_id", std::string(create_stmt->index_attrs->at(0).get()));
+  EXPECT_EQ("o_d_id", std::string(create_stmt->index_attrs->at(1).get()));
 
   delete stmt_list;
 }
@@ -777,11 +777,11 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_EQ(create_stmt->columns->size(), 5);
 
   // Check First column
-  auto column = create_stmt->columns->at(0);
-  EXPECT_EQ("a", std::string(column->name));
+  auto column = create_stmt->columns->at(0).get();
+  EXPECT_EQ("a", std::string(column->name.get()));
   EXPECT_EQ(parser::ColumnDefinition::DataType::INT, column->type);
   EXPECT_TRUE(column->default_value != nullptr);
-  auto default_expr = (expression::OperatorExpression*) column->default_value;
+  auto default_expr = (expression::OperatorExpression*) column->default_value.get();
   EXPECT_TRUE(default_expr != nullptr);
   EXPECT_EQ(ExpressionType::OPERATOR_PLUS, default_expr->GetExpressionType());
   EXPECT_EQ(2, default_expr->GetChildrenSize());
@@ -793,8 +793,8 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_TRUE(child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
 
   // Check Second column
-  column = create_stmt->columns->at(1);
-  EXPECT_EQ("b", std::string(column->name));
+  column = create_stmt->columns->at(1).get();
+  EXPECT_EQ("b", std::string(column->name.get()));
   EXPECT_EQ(parser::ColumnDefinition::DataType::INT, column->type);
   EXPECT_TRUE(column->foreign_key_sink != nullptr);
   EXPECT_TRUE(column->foreign_key_sink->size() == 1);
@@ -805,8 +805,8 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_EQ(FKConstrMatchType::SIMPLE, column->foreign_key_match_type);
 
   // Check Third column
-  column = create_stmt->columns->at(2);
-  EXPECT_EQ("c", std::string(column->name));
+  column = create_stmt->columns->at(2).get();
+  EXPECT_EQ("c", std::string(column->name.get()));
   EXPECT_EQ(parser::ColumnDefinition::DataType::VARCHAR, column->type);
   EXPECT_TRUE(column->foreign_key_sink != nullptr);
   EXPECT_TRUE(column->foreign_key_sink->size() == 1);
@@ -817,8 +817,8 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_EQ(FKConstrMatchType::FULL, column->foreign_key_match_type);
 
   // Check Fourth column
-  column = create_stmt->columns->at(3);
-  EXPECT_EQ("d", std::string(column->name));
+  column = create_stmt->columns->at(3).get();
+  EXPECT_EQ("d", std::string(column->name.get()));
   EXPECT_EQ(parser::ColumnDefinition::DataType::INT, column->type);
   EXPECT_TRUE(column->check_expression != nullptr);
   EXPECT_EQ(ExpressionType::COMPARE_GREATERTHAN, column->check_expression->GetExpressionType());
@@ -838,11 +838,11 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_TRUE(check_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(0)));
 
   // Check Fifth column
-  column = create_stmt->columns->at(4);
+  column = create_stmt->columns->at(4).get();
   EXPECT_EQ(parser::ColumnDefinition::DataType::FOREIGN, column->type);
   EXPECT_TRUE(column->foreign_key_source != nullptr);
   EXPECT_TRUE(column->foreign_key_source->size() == 1);
-  EXPECT_EQ("d", std::string(column->foreign_key_source->at(0)));
+  EXPECT_EQ("d", std::string(column->foreign_key_source->at(0).get()));
   EXPECT_TRUE(column->foreign_key_sink != nullptr);
   EXPECT_TRUE(column->foreign_key_sink->size() == 1);
   EXPECT_EQ("dd", std::string(column->foreign_key_sink->at(0)));
@@ -875,21 +875,21 @@ TEST_F(PostgresParserTests, DataTypeTest) {
   EXPECT_EQ(create_stmt->columns->size(), 3);
 
   // Check First column
-  auto column = create_stmt->columns->at(0);
-  EXPECT_EQ("a", std::string(column->name));
+  auto column = create_stmt->columns->at(0).get();
+  EXPECT_EQ("a", std::string(column->name.get()));
   EXPECT_EQ(type::TypeId::VARCHAR, column->GetValueType(column->type));
   EXPECT_EQ(peloton::type::PELOTON_TEXT_MAX_LEN, column->varlen);
 
 
   // Check Second column
-  column = create_stmt->columns->at(1);
-  EXPECT_EQ("b", std::string(column->name));
+  column = create_stmt->columns->at(1).get();
+  EXPECT_EQ("b", std::string(column->name.get()));
   EXPECT_EQ(type::TypeId::VARCHAR, column->GetValueType(column->type));
   EXPECT_EQ(1024, column->varlen);
 
   // Check Third column
-  column = create_stmt->columns->at(2);
-  EXPECT_EQ("c", std::string(column->name));
+  column = create_stmt->columns->at(2).get();
+  EXPECT_EQ("c", std::string(column->name.get()));
   EXPECT_EQ(type::TypeId::VARBINARY, column->GetValueType(column->type));
   EXPECT_EQ(32, column->varlen);
 
@@ -1008,7 +1008,7 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
 
   // Check ADD(1,a)
-  auto fun_expr = (expression::FunctionExpression*) (select_stmt->select_list->at(0));
+  auto fun_expr = (expression::FunctionExpression*) (select_stmt->select_list->at(0).get());
   EXPECT_TRUE(fun_expr != nullptr);
   EXPECT_EQ("add", fun_expr->func_name_);
   EXPECT_EQ(2, fun_expr->GetChildrenSize());
@@ -1020,7 +1020,7 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ("a", tv_expr->GetColumnName());
 
   // Check chr(2)
-  fun_expr = (expression::FunctionExpression*) (select_stmt->select_list->at(1));
+  fun_expr = (expression::FunctionExpression*) (select_stmt->select_list->at(1).get());
   EXPECT_TRUE(fun_expr != nullptr);
   EXPECT_EQ("chr", fun_expr->func_name_);
   EXPECT_EQ(1, fun_expr->GetChildrenSize());
@@ -1029,7 +1029,7 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_TRUE(const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(99)));
 
   // Check FUN(b) > 2
-  auto op_expr = (expression::OperatorExpression*)select_stmt->where_clause;
+  auto op_expr = (expression::OperatorExpression*)select_stmt->where_clause.get();
   EXPECT_TRUE(op_expr != nullptr);
   EXPECT_EQ(ExpressionType::COMPARE_GREATERTHAN, op_expr->GetExpressionType());
   fun_expr = (expression::FunctionExpression*) op_expr->GetChild(0);

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -921,7 +921,7 @@ TEST_F(PostgresParserTests, CreateTriggerTest) {
   // create type
   EXPECT_EQ(parser::CreateStatement::CreateType::kTrigger, create_trigger_stmt->type);
   // trigger name
-  EXPECT_EQ("check_update", std::string(create_trigger_stmt->trigger_name));
+  EXPECT_EQ("check_update", std::string(create_trigger_stmt->trigger_name.get()));
   // table name
   EXPECT_EQ("accounts", create_trigger_stmt->GetTableName());
 

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -114,13 +114,11 @@ TEST_F(PostgresParserTests, OrderByTest) {
   auto select_stmt = (parser::SelectStatement *)(sql_stmt);
   auto order_by = select_stmt->order.get();
   EXPECT_NE(order_by, nullptr);
-  EXPECT_NE(order_by->types, nullptr);
-  EXPECT_NE(order_by->exprs, nullptr);
 
-  EXPECT_EQ(order_by->types->size(), 1);
-  EXPECT_EQ(order_by->exprs->size(), 1);
-  EXPECT_EQ(order_by->types->at(0), parser::OrderType::kOrderAsc);
-  auto expr = order_by->exprs->at(0);
+  EXPECT_EQ(order_by->types.size(), 1);
+  EXPECT_EQ(order_by->exprs.size(), 1);
+  EXPECT_EQ(order_by->types.at(0), parser::OrderType::kOrderAsc);
+  auto expr = order_by->exprs.at(0).get();
   EXPECT_EQ(expr->GetExpressionType(), ExpressionType::VALUE_TUPLE);
   EXPECT_EQ(((expression::TupleValueExpression *)expr)->GetColumnName(), "id");
   delete stmt_list;
@@ -133,13 +131,11 @@ TEST_F(PostgresParserTests, OrderByTest) {
   select_stmt = (parser::SelectStatement *)(sql_stmt);
   order_by = select_stmt->order.get();
   EXPECT_NE(order_by, nullptr);
-  EXPECT_NE(order_by->types, nullptr);
-  EXPECT_NE(order_by->exprs, nullptr);
 
-  EXPECT_EQ(order_by->types->size(), 1);
-  EXPECT_EQ(order_by->exprs->size(), 1);
-  EXPECT_EQ(order_by->types->at(0), parser::OrderType::kOrderAsc);
-  expr = order_by->exprs->at(0);
+  EXPECT_EQ(order_by->types.size(), 1);
+  EXPECT_EQ(order_by->exprs.size(), 1);
+  EXPECT_EQ(order_by->types.at(0), parser::OrderType::kOrderAsc);
+  expr = order_by->exprs.at(0).get();
   EXPECT_EQ(expr->GetExpressionType(), ExpressionType::VALUE_TUPLE);
   EXPECT_EQ(((expression::TupleValueExpression *)expr)->GetColumnName(), "id");
   delete stmt_list;
@@ -152,13 +148,11 @@ TEST_F(PostgresParserTests, OrderByTest) {
   select_stmt = (parser::SelectStatement *)(sql_stmt);
   order_by = select_stmt->order.get();
   EXPECT_NE(order_by, nullptr);
-  EXPECT_NE(order_by->types, nullptr);
-  EXPECT_NE(order_by->exprs, nullptr);
 
-  EXPECT_EQ(order_by->types->size(), 1);
-  EXPECT_EQ(order_by->exprs->size(), 1);
-  EXPECT_EQ(order_by->types->at(0), parser::OrderType::kOrderDesc);
-  expr = order_by->exprs->at(0);
+  EXPECT_EQ(order_by->types.size(), 1);
+  EXPECT_EQ(order_by->exprs.size(), 1);
+  EXPECT_EQ(order_by->types.at(0), parser::OrderType::kOrderDesc);
+  expr = order_by->exprs.at(0).get();
   EXPECT_EQ(expr->GetExpressionType(), ExpressionType::VALUE_TUPLE);
   EXPECT_EQ(((expression::TupleValueExpression *)expr)->GetColumnName(), "id");
   delete stmt_list;
@@ -171,16 +165,14 @@ TEST_F(PostgresParserTests, OrderByTest) {
   select_stmt = (parser::SelectStatement *)(sql_stmt);
   order_by = select_stmt->order.get();
   EXPECT_NE(order_by, nullptr);
-  EXPECT_NE(order_by->types, nullptr);
-  EXPECT_NE(order_by->exprs, nullptr);
 
-  EXPECT_EQ(order_by->types->size(), 2);
-  EXPECT_EQ(order_by->exprs->size(), 2);
-  EXPECT_EQ(order_by->types->at(0), parser::OrderType::kOrderAsc);
-  expr = order_by->exprs->at(0);
+  EXPECT_EQ(order_by->types.size(), 2);
+  EXPECT_EQ(order_by->exprs.size(), 2);
+  EXPECT_EQ(order_by->types.at(0), parser::OrderType::kOrderAsc);
+  expr = order_by->exprs.at(0).get();
   EXPECT_EQ(expr->GetExpressionType(), ExpressionType::VALUE_TUPLE);
   EXPECT_EQ(((expression::TupleValueExpression *)expr)->GetColumnName(), "id");
-  expr = order_by->exprs->at(1);
+  expr = order_by->exprs.at(1).get();
   EXPECT_EQ(expr->GetExpressionType(), ExpressionType::VALUE_TUPLE);
   EXPECT_EQ(((expression::TupleValueExpression *)expr)->GetColumnName(),
             "name");
@@ -194,17 +186,15 @@ TEST_F(PostgresParserTests, OrderByTest) {
   select_stmt = (parser::SelectStatement *)(sql_stmt);
   order_by = select_stmt->order.get();
   EXPECT_NE(order_by, nullptr);
-  EXPECT_NE(order_by->types, nullptr);
-  EXPECT_NE(order_by->exprs, nullptr);
 
-  EXPECT_EQ(order_by->types->size(), 2);
-  EXPECT_EQ(order_by->exprs->size(), 2);
-  EXPECT_EQ(order_by->types->at(0), parser::OrderType::kOrderAsc);
-  expr = order_by->exprs->at(0);
+  EXPECT_EQ(order_by->types.size(), 2);
+  EXPECT_EQ(order_by->exprs.size(), 2);
+  EXPECT_EQ(order_by->types.at(0), parser::OrderType::kOrderAsc);
+  expr = order_by->exprs.at(0).get();
   EXPECT_EQ(expr->GetExpressionType(), ExpressionType::VALUE_TUPLE);
   EXPECT_EQ(((expression::TupleValueExpression *)expr)->GetColumnName(), "id");
-  EXPECT_EQ(order_by->types->at(1), parser::OrderType::kOrderDesc);
-  expr = order_by->exprs->at(1);
+  EXPECT_EQ(order_by->types.at(1), parser::OrderType::kOrderDesc);
+  expr = order_by->exprs.at(1).get();
   EXPECT_EQ(expr->GetExpressionType(), ExpressionType::VALUE_TUPLE);
   EXPECT_EQ(((expression::TupleValueExpression *)expr)->GetColumnName(),
             "name");
@@ -353,26 +343,23 @@ TEST_F(PostgresParserTests, ColumnUpdateTest) {
 
     EXPECT_NE(table, nullptr);
     EXPECT_NE(table->table_info_, nullptr);
-    EXPECT_NE(table->table_info_->table_name, nullptr);
-    EXPECT_EQ(std::string(table->table_info_->table_name.get()),
-              std::string("customer"));
+    EXPECT_EQ(table->table_info_->table_name, "customer");
 
     EXPECT_NE(updates, nullptr);
     EXPECT_EQ(updates->size(), 2);
-    EXPECT_EQ(std::string((*updates)[0]->column.get()), std::string("c_balance"));
+    EXPECT_EQ((*updates)[0]->column, "c_balance");
     EXPECT_EQ((*updates)[0]->value->GetExpressionType(),
               ExpressionType::VALUE_TUPLE);
     expression::TupleValueExpression *column_value_0 =
         (expression::TupleValueExpression *)((*updates)[0]->value.get());
-    EXPECT_EQ(column_value_0->GetColumnName(), std::string("c_balance"));
+    EXPECT_EQ(column_value_0->GetColumnName(), "c_balance");
 
-    EXPECT_EQ(std::string((*updates)[1]->column.get()),
-              std::string("c_delivery_cnt"));
+    EXPECT_EQ((*updates)[1]->column, "c_delivery_cnt");
     EXPECT_EQ((*updates)[1]->value->GetExpressionType(),
               ExpressionType::VALUE_TUPLE);
     expression::TupleValueExpression *column_value_1 =
         (expression::TupleValueExpression *)((*updates)[1]->value.get());
-    EXPECT_EQ(column_value_1->GetColumnName(), std::string("c_delivery_cnt"));
+    EXPECT_EQ(column_value_1->GetColumnName(), "c_delivery_cnt");
 
     EXPECT_NE(where_clause, nullptr);
     EXPECT_EQ(where_clause->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
@@ -381,12 +368,12 @@ TEST_F(PostgresParserTests, ColumnUpdateTest) {
     auto right_child = where_clause->GetChild(1);
     EXPECT_EQ(left_child->GetExpressionType(), ExpressionType::VALUE_TUPLE);
     auto left_tuple = (expression::TupleValueExpression *)(left_child);
-    EXPECT_EQ(left_tuple->GetColumnName(), std::string("c_w_id"));
+    EXPECT_EQ(left_tuple->GetColumnName(), "c_w_id");
 
     EXPECT_EQ(right_child->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
     auto right_const = (expression::ConstantValueExpression *)(right_child);
 
-    EXPECT_EQ(right_const->GetValue().ToString(), std::string("2"));
+    EXPECT_EQ(right_const->GetValue().ToString(), "2");
 
     delete stmt_list;
   }
@@ -401,18 +388,18 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   EXPECT_TRUE(stmt_list->is_valid);
 
   auto update_stmt = (parser::UpdateStatement *)stmt_list->GetStatements()[0].get();
-  EXPECT_EQ(std::string(update_stmt->table->table_info_->table_name.get()), "stock");
+  EXPECT_EQ(update_stmt->table->table_info_->table_name, "stock");
 
   // TODO: Uncomment when the AExpressionTransfrom supports operator expression
   // Test First Set Condition
-  EXPECT_EQ(std::string(update_stmt->updates->at(0)->column.get()), "s_quantity");
+  EXPECT_EQ(update_stmt->updates->at(0)->column, "s_quantity");
   auto constant =
       (expression::ConstantValueExpression *)update_stmt->updates->at(0)->value.get();
   EXPECT_TRUE(constant->GetValue().CompareEquals(
       type::ValueFactory::GetDecimalValue(48)));
 
   // Test Second Set Condition
-  EXPECT_EQ(std::string(update_stmt->updates->at(1)->column.get()), "s_ytd");
+  EXPECT_EQ(update_stmt->updates->at(1)->column, "s_ytd");
   auto op_expr =
       (expression::OperatorExpression *)update_stmt->updates->at(1)->value.get();
   auto child1 = (expression::TupleValueExpression *)op_expr->GetChild(0);
@@ -461,7 +448,7 @@ TEST_F(PostgresParserTests, StringUpdateTest) {
 
   // Check table name
   auto table_ref = update->table.get();
-  EXPECT_EQ(std::string(table_ref->table_info_->table_name.get()), "order_line");
+  EXPECT_EQ(table_ref->table_info_->table_name, "order_line");
 
   // Check where expression
   auto where = update->where.get();
@@ -502,7 +489,7 @@ TEST_F(PostgresParserTests, StringUpdateTest) {
 
   // Check update clause
   auto update_clause = update->updates->at(0).get();
-  EXPECT_EQ(std::string(update_clause->column.get()), "ol_delivery_d");
+  EXPECT_EQ(update_clause->column, "ol_delivery_d");
   auto value = update_clause->value.get();
   EXPECT_EQ(value->GetExpressionType(), ExpressionType::VALUE_CONSTANT);
   EXPECT_EQ(
@@ -592,19 +579,18 @@ TEST_F(PostgresParserTests, InsertTest) {
     EXPECT_TRUE(stmt_list->GetStatement(0)->GetType() == StatementType::INSERT);
     auto insert_stmt = (parser::InsertStatement *)stmt_list->GetStatement(0);
     EXPECT_EQ("foo", insert_stmt->GetTableName());
-    EXPECT_TRUE(insert_stmt->insert_values != nullptr);
-    EXPECT_EQ(2, insert_stmt->insert_values->size());
+    EXPECT_EQ(2, insert_stmt->insert_values.size());
 
     // Test NULL Value parsing
     EXPECT_TRUE(((expression::ConstantValueExpression *)
-                     insert_stmt->insert_values->at(0)->at(0).get())
+                     insert_stmt->insert_values.at(0).at(0).get())
                     ->GetValue()
                     .IsNull());
     // Test normal value
     type::Value five = type::ValueFactory::GetIntegerValue(5);
     type::CmpBool res = five.CompareEquals(
         ((expression::ConstantValueExpression *)
-             insert_stmt->insert_values->at(1)->at(1).get())->GetValue());
+             insert_stmt->insert_values.at(1).at(1).get())->GetValue());
     EXPECT_EQ(1, res);
 
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
@@ -629,20 +615,20 @@ TEST_F(PostgresParserTests, CreateTest) {
   auto create_stmt = (parser::CreateStatement *)stmt_list->GetStatement(0);
   LOG_INFO("Statement List Info:\n%s", stmt_list->GetInfo().c_str());
   // Check column definition
-  EXPECT_EQ(create_stmt->columns->size(), 5);
+  EXPECT_EQ(create_stmt->columns.size(), 5);
   // Check First column
-  auto column = create_stmt->columns->at(0).get();
+  auto column = create_stmt->columns.at(0).get();
   EXPECT_TRUE(column->not_null);
   EXPECT_TRUE(column->unique);
   EXPECT_TRUE(column->primary);
-  EXPECT_EQ(std::string(column->name), "id");
+  EXPECT_EQ(column->name, "id");
   EXPECT_EQ(parser::ColumnDefinition::DataType::INT, column->type);
   // Check Second column
-  column = create_stmt->columns->at(1).get();
+  column = create_stmt->columns.at(1).get();
   EXPECT_FALSE(column->not_null);
   EXPECT_TRUE(column->primary);
   // Check Third column
-  column = create_stmt->columns->at(2).get();
+  column = create_stmt->columns.at(2).get();
   EXPECT_FALSE(column->primary);
   EXPECT_EQ(column->varlen, 255);
 
@@ -696,11 +682,11 @@ TEST_F(PostgresParserTests, CreateIndexTest) {
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
   // Check attributes
   EXPECT_EQ(parser::CreateStatement::kIndex, create_stmt->type);
-  EXPECT_EQ("idx_order", std::string(create_stmt->index_name.get()));
-  EXPECT_EQ("oorder", std::string(create_stmt->table_info_->table_name.get()));
+  EXPECT_EQ("idx_order", create_stmt->index_name);
+  EXPECT_EQ("oorder", create_stmt->table_info_->table_name);
   EXPECT_TRUE(create_stmt->unique);
-  EXPECT_EQ("o_w_id", std::string(create_stmt->index_attrs->at(0).get()));
-  EXPECT_EQ("o_d_id", std::string(create_stmt->index_attrs->at(1).get()));
+  EXPECT_EQ("o_w_id", create_stmt->index_attrs.at(0));
+  EXPECT_EQ("o_d_id", create_stmt->index_attrs.at(1));
 
   delete stmt_list;
 }
@@ -726,7 +712,7 @@ TEST_F(PostgresParserTests, InsertIntoSelectTest) {
     EXPECT_TRUE(stmt_list->GetStatement(0)->GetType() == StatementType::INSERT);
     auto insert_stmt = (parser::InsertStatement *)stmt_list->GetStatement(0);
     EXPECT_EQ("foo", insert_stmt->GetTableName());
-    EXPECT_TRUE(insert_stmt->insert_values == nullptr);
+    EXPECT_TRUE(insert_stmt->insert_values.empty());
     EXPECT_TRUE(insert_stmt->select->GetType() == StatementType::SELECT);
     EXPECT_EQ("bar",
               std::string(insert_stmt->select->from_table->GetTableName()));
@@ -774,11 +760,11 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   auto create_stmt = (parser::CreateStatement *)stmt_list->GetStatement(0);
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
   // Check column definition
-  EXPECT_EQ(create_stmt->columns->size(), 5);
+  EXPECT_EQ(create_stmt->columns.size(), 5);
 
   // Check First column
-  auto column = create_stmt->columns->at(0).get();
-  EXPECT_EQ("a", std::string(column->name.get()));
+  auto column = create_stmt->columns.at(0).get();
+  EXPECT_EQ("a", column->name);
   EXPECT_EQ(parser::ColumnDefinition::DataType::INT, column->type);
   EXPECT_TRUE(column->default_value != nullptr);
   auto default_expr = (expression::OperatorExpression*) column->default_value.get();
@@ -793,8 +779,8 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_TRUE(child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
 
   // Check Second column
-  column = create_stmt->columns->at(1).get();
-  EXPECT_EQ("b", std::string(column->name.get()));
+  column = create_stmt->columns.at(1).get();
+  EXPECT_EQ("b", column->name);
   EXPECT_EQ(parser::ColumnDefinition::DataType::INT, column->type);
   EXPECT_TRUE(column->foreign_key_sink != nullptr);
   EXPECT_TRUE(column->foreign_key_sink->size() == 1);
@@ -805,8 +791,8 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_EQ(FKConstrMatchType::SIMPLE, column->foreign_key_match_type);
 
   // Check Third column
-  column = create_stmt->columns->at(2).get();
-  EXPECT_EQ("c", std::string(column->name.get()));
+  column = create_stmt->columns.at(2).get();
+  EXPECT_EQ("c", column->name);
   EXPECT_EQ(parser::ColumnDefinition::DataType::VARCHAR, column->type);
   EXPECT_TRUE(column->foreign_key_sink != nullptr);
   EXPECT_TRUE(column->foreign_key_sink->size() == 1);
@@ -817,8 +803,8 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_EQ(FKConstrMatchType::FULL, column->foreign_key_match_type);
 
   // Check Fourth column
-  column = create_stmt->columns->at(3).get();
-  EXPECT_EQ("d", std::string(column->name.get()));
+  column = create_stmt->columns.at(3).get();
+  EXPECT_EQ("d", column->name);
   EXPECT_EQ(parser::ColumnDefinition::DataType::INT, column->type);
   EXPECT_TRUE(column->check_expression != nullptr);
   EXPECT_EQ(ExpressionType::COMPARE_GREATERTHAN, column->check_expression->GetExpressionType());
@@ -838,7 +824,7 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_TRUE(check_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(0)));
 
   // Check Fifth column
-  column = create_stmt->columns->at(4).get();
+  column = create_stmt->columns.at(4).get();
   EXPECT_EQ(parser::ColumnDefinition::DataType::FOREIGN, column->type);
   EXPECT_TRUE(column->foreign_key_source != nullptr);
   EXPECT_TRUE(column->foreign_key_source->size() == 1);
@@ -853,8 +839,6 @@ TEST_F(PostgresParserTests, ConstraintTest) {
 
   delete stmt_list;
 }
-
-
 
 TEST_F(PostgresParserTests, DataTypeTest) {
   std::string query =
@@ -872,24 +856,24 @@ TEST_F(PostgresParserTests, DataTypeTest) {
   auto create_stmt = (parser::CreateStatement *)stmt_list->GetStatement(0);
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
   // Check column definition
-  EXPECT_EQ(create_stmt->columns->size(), 3);
+  EXPECT_EQ(create_stmt->columns.size(), 3);
 
   // Check First column
-  auto column = create_stmt->columns->at(0).get();
-  EXPECT_EQ("a", std::string(column->name.get()));
+  auto column = create_stmt->columns.at(0).get();
+  EXPECT_EQ("a", column->name);
   EXPECT_EQ(type::TypeId::VARCHAR, column->GetValueType(column->type));
   EXPECT_EQ(peloton::type::PELOTON_TEXT_MAX_LEN, column->varlen);
 
 
   // Check Second column
-  column = create_stmt->columns->at(1).get();
-  EXPECT_EQ("b", std::string(column->name.get()));
+  column = create_stmt->columns.at(1).get();
+  EXPECT_EQ("b", column->name);
   EXPECT_EQ(type::TypeId::VARCHAR, column->GetValueType(column->type));
   EXPECT_EQ(1024, column->varlen);
 
   // Check Third column
-  column = create_stmt->columns->at(2).get();
-  EXPECT_EQ("c", std::string(column->name.get()));
+  column = create_stmt->columns.at(2).get();
+  EXPECT_EQ("c", column->name);
   EXPECT_EQ(type::TypeId::VARBINARY, column->GetValueType(column->type));
   EXPECT_EQ(32, column->varlen);
 
@@ -921,22 +905,22 @@ TEST_F(PostgresParserTests, CreateTriggerTest) {
   // create type
   EXPECT_EQ(parser::CreateStatement::CreateType::kTrigger, create_trigger_stmt->type);
   // trigger name
-  EXPECT_EQ("check_update", std::string(create_trigger_stmt->trigger_name.get()));
+  EXPECT_EQ("check_update", create_trigger_stmt->trigger_name);
   // table name
   EXPECT_EQ("accounts", create_trigger_stmt->GetTableName());
 
   // funcname
   // the function invoked by this trigger
-  std::vector<char *> *funcname = create_trigger_stmt->trigger_funcname;
-  EXPECT_EQ(1, funcname->size());
-  EXPECT_EQ("check_account_update", std::string((*funcname)[0]));
+  std::vector<std::string> &funcname = create_trigger_stmt->trigger_funcname;
+  EXPECT_EQ(1, funcname.size());
+  EXPECT_EQ("check_account_update", funcname[0]);
   // args
   // arguments in the fuction
-  EXPECT_EQ(0, create_trigger_stmt->trigger_args->size());
+  EXPECT_EQ(0, create_trigger_stmt->trigger_args.size());
   // columns
-  std::vector<char *> *columns = create_trigger_stmt->trigger_columns;
-  EXPECT_EQ(1, columns->size());
-  EXPECT_EQ("balance", std::string((*columns)[0]));
+  std::vector<std::string> &columns = create_trigger_stmt->trigger_columns;
+  EXPECT_EQ(1, columns.size());
+  EXPECT_EQ("balance", columns[0]);
   // when
   // Check the expression tree of trigger_when is identical to the query
   // Need to check type and value of each node.
@@ -990,9 +974,9 @@ TEST_F(PostgresParserTests, DropTriggerTest) {
   // drop type
   EXPECT_EQ(parser::DropStatement::EntityType::kTrigger, drop_trigger_stmt->type);
   // trigger name
-  EXPECT_EQ("if_dist_exists", std::string(drop_trigger_stmt->trigger_name));
+  EXPECT_EQ("if_dist_exists", drop_trigger_stmt->trigger_name);
   // table name
-  EXPECT_EQ("films", std::string(drop_trigger_stmt->table_name_of_trigger));
+  EXPECT_EQ("films", drop_trigger_stmt->table_name_of_trigger);
   delete stmt_list;
 }
 
@@ -1008,7 +992,7 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
 
   // Check ADD(1,a)
-  auto fun_expr = (expression::FunctionExpression*) (select_stmt->select_list->at(0).get());
+  auto fun_expr = (expression::FunctionExpression*) (select_stmt->select_list.at(0).get());
   EXPECT_TRUE(fun_expr != nullptr);
   EXPECT_EQ("add", fun_expr->func_name_);
   EXPECT_EQ(2, fun_expr->GetChildrenSize());
@@ -1020,7 +1004,7 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ("a", tv_expr->GetColumnName());
 
   // Check chr(2)
-  fun_expr = (expression::FunctionExpression*) (select_stmt->select_list->at(1).get());
+  fun_expr = (expression::FunctionExpression*) (select_stmt->select_list.at(1).get());
   EXPECT_TRUE(fun_expr != nullptr);
   EXPECT_EQ("chr", fun_expr->func_name_);
   EXPECT_EQ(1, fun_expr->GetChildrenSize());

--- a/test/planner/planner_test.cpp
+++ b/test/planner/planner_test.cpp
@@ -45,10 +45,10 @@ TEST_F(PlannerTests, CreateDatabasePlanTest) {
   auto parse_tree_list = peloton_parser.BuildParseTree("CREATE DATABASE pelotondb;");
   // There should be only one statement in the statement list
   EXPECT_EQ(1, parse_tree_list->GetNumStatements());
-  auto parse_tree = parse_tree_list->GetStatements().at(0);
+  auto &parse_tree = parse_tree_list->GetStatements().at(0);
 
   std::unique_ptr<planner::CreatePlan> create_DB_plan(
-    new planner::CreatePlan((parser::CreateStatement *)parse_tree));
+    new planner::CreatePlan((parser::CreateStatement *)parse_tree.get()));
   EXPECT_EQ(0, create_DB_plan->GetDatabaseName().compare("pelotondb"));
   EXPECT_EQ(CreateType::DB, create_DB_plan->GetCreateType());
 }

--- a/test/planner/planner_test.cpp
+++ b/test/planner/planner_test.cpp
@@ -192,13 +192,9 @@ TEST_F(PlannerTests, UpdatePlanTestParameter) {
   std::unique_ptr<planner::UpdatePlan> update_plan(
       new planner::UpdatePlan(target_table, std::move(project_info)));
 
-<<<<<<< 2b8388800f17901c3bbd0977fe8f14d17fb7b2c6
   std::unique_ptr<planner::SeqScanPlan> seq_scan_node(
       new planner::SeqScanPlan(target_table, where_expr, column_ids));
   update_plan->AddChild(std::move(seq_scan_node));
-=======
-  update_statement->where.reset(cmp_expr);
->>>>>>> merge the latest code
 
   LOG_INFO("Plan created:\n%s", update_plan->GetInfo().c_str());
 

--- a/test/trigger/trigger_test.cpp
+++ b/test/trigger/trigger_test.cpp
@@ -87,13 +87,13 @@ class TriggerTests : public PelotonTest {
 
     auto table_ref = new parser::TableRef(TableReferenceType::NAME);
     parser::TableInfo *table_info = new parser::TableInfo();
-    table_info->table_name = table_name_c;
-    table_ref->table_info_ = table_info;
-    insert_node->table_ref_ = table_ref;
+    table_info->table_name.reset(table_name_c);
+    table_ref->table_info_.reset(table_info);
+    insert_node->table_ref_.reset(table_ref);
 
-    insert_node->columns = new std::vector<char *>;
-    insert_node->columns->push_back(col_1_c);
-    insert_node->columns->push_back(col_2_c);
+    insert_node->columns.reset(new std::vector<std::unique_ptr<char[]>>);
+    insert_node->columns->push_back(std::unique_ptr<char[]>(col_1_c));
+    insert_node->columns->push_back(std::unique_ptr<char[]>(col_2_c));
 
     insert_node->insert_values =
         new std::vector<std::vector<expression::AbstractExpression *> *>;
@@ -106,10 +106,10 @@ class TriggerTests : public PelotonTest {
     values_ptr->push_back(new expression::ConstantValueExpression(
         type::ValueFactory::GetVarcharValue(text)));
 
-    insert_node->select = new parser::SelectStatement();
+    insert_node->select.reset(new parser::SelectStatement());
 
-    planner::InsertPlan node(table, insert_node->columns,
-                             insert_node->insert_values);
+    planner::InsertPlan node(table, insert_node->columns.get(),
+                             insert_node->insert_values.get());
     executor::InsertExecutor executor(&node, context.get());
 
     EXPECT_TRUE(executor.Init());

--- a/test/trigger/trigger_test.cpp
+++ b/test/trigger/trigger_test.cpp
@@ -72,10 +72,6 @@ class TriggerTests : public PelotonTest {
     auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     auto txn = txn_manager.BeginTransaction();
 
-    char *table_name_c = cstrdup(table_name.c_str());
-    char *col_1_c = cstrdup(col_1.c_str());
-    char *col_2_c = cstrdup(col_2.c_str());
-
     auto table = catalog::Catalog::GetInstance()->GetTableWithName(
         DEFAULT_DB_NAME, std::string(table_name), txn);
 
@@ -87,29 +83,26 @@ class TriggerTests : public PelotonTest {
 
     auto table_ref = new parser::TableRef(TableReferenceType::NAME);
     parser::TableInfo *table_info = new parser::TableInfo();
-    table_info->table_name.reset(table_name_c);
+    table_info->table_name = table_name;
     table_ref->table_info_.reset(table_info);
     insert_node->table_ref_.reset(table_ref);
 
-    insert_node->columns.reset(new std::vector<std::unique_ptr<char[]>>);
-    insert_node->columns->push_back(std::unique_ptr<char[]>(col_1_c));
-    insert_node->columns->push_back(std::unique_ptr<char[]>(col_2_c));
+    insert_node->columns.push_back(col_1);
+    insert_node->columns.push_back(col_2);
 
-    insert_node->insert_values =
-        new std::vector<std::vector<expression::AbstractExpression *> *>;
-    auto values_ptr = new std::vector<expression::AbstractExpression *>;
-    insert_node->insert_values->push_back(values_ptr);
+    insert_node->insert_values.push_back(std::vector<std::unique_ptr<expression::AbstractExpression>>());
+    auto& values = insert_node->insert_values.at(0);
 
-    values_ptr->push_back(new expression::ConstantValueExpression(
-        type::ValueFactory::GetIntegerValue(number)));
+    values.push_back(std::unique_ptr<expression::AbstractExpression>(new expression::ConstantValueExpression(
+      type::ValueFactory::GetIntegerValue(number))));
 
-    values_ptr->push_back(new expression::ConstantValueExpression(
-        type::ValueFactory::GetVarcharValue(text)));
+    values.push_back(std::unique_ptr<expression::AbstractExpression>(new expression::ConstantValueExpression(
+      type::ValueFactory::GetVarcharValue(text))));
 
     insert_node->select.reset(new parser::SelectStatement());
 
-    planner::InsertPlan node(table, insert_node->columns.get(),
-                             insert_node->insert_values.get());
+    planner::InsertPlan node(table, &insert_node->columns,
+                             &insert_node->insert_values);
     executor::InsertExecutor executor(&node, context.get());
 
     EXPECT_TRUE(executor.Init());


### PR DESCRIPTION
fix issue #523. The unnecessary null pointer checks mainly exist in include/parser. I replace the raw pointers with unique_ptr to avoid explicit delete operations in destructor.