### PR TITLE
Remove STL headers from coverage

### DIFF
--- a/cmake/Modules/CoverallsGenerateGcov.cmake
+++ b/cmake/Modules/CoverallsGenerateGcov.cmake
@@ -200,12 +200,11 @@ foreach(GCDA ${GCDA_FILES})
 	# /path/to/project/root/subdir/the_file.c:creating '#path#to#project#root#subdir#the_file.c.gcov'
 	#
 	# If -p is not specified then the file is named only "the_file.c.gcov"
-  # The -r flag ensures gcov only looks are files with relative path names, and exclused files with
-  # absolute names (i.e., STL headers).
 	#
 	execute_process(
-		COMMAND ${GCOV_EXECUTABLE} -r -p -o ${GCDA_DIR} ${GCDA}
+		COMMAND ${GCOV_EXECUTABLE} -p -o ${GCDA_DIR} ${GCDA}
 		WORKING_DIRECTORY ${COV_PATH}
+		OUTPUT_QUIET
 	)
 endforeach()
 

--- a/cmake/Modules/CoverallsGenerateGcov.cmake
+++ b/cmake/Modules/CoverallsGenerateGcov.cmake
@@ -200,9 +200,11 @@ foreach(GCDA ${GCDA_FILES})
 	# /path/to/project/root/subdir/the_file.c:creating '#path#to#project#root#subdir#the_file.c.gcov'
 	#
 	# If -p is not specified then the file is named only "the_file.c.gcov"
+  # The -r flag ensures gcov only looks are files with relative path names, and exclused files with
+  # absolute names (i.e., STL headers).
 	#
 	execute_process(
-		COMMAND ${GCOV_EXECUTABLE} -p -o ${GCDA_DIR} ${GCDA}
+		COMMAND ${GCOV_EXECUTABLE} -r -p -o ${GCDA_DIR} ${GCDA}
 		WORKING_DIRECTORY ${COV_PATH}
 	)
 endforeach()


### PR DESCRIPTION
By default, `gcov` analyzes **all** included header files, including STL, boost, and LLVM headers. This is overkill. Moreover, it's been blowing up our builds because the log file size grows beyond 4MB.

This PR adds a flag to exclude library headers when performing code coverage.