### PR TITLE
Fix for graceful shutdown when Peloton's port binding fails

### DIFF
--- a/src/include/wire/libevent_server.h
+++ b/src/include/wire/libevent_server.h
@@ -48,6 +48,7 @@ namespace wire {
 
 // Forward Declarations
 class LibeventThread;
+class LibeventMasterThread;
 
 // Libevent Thread States
 enum ConnState {
@@ -238,7 +239,7 @@ struct LibeventServer {
 
   struct event *ev_stop_;     // libevent stop event
   struct event *ev_timeout_;  // libevent timeout event
-  std::shared_ptr<LibeventThread> master_thread_;
+  std::shared_ptr<LibeventMasterThread> master_thread_;
   struct event_base *base_;  // libevent event_base
 
   // Flags for controlling server start/close status

--- a/src/include/wire/libevent_thread.h
+++ b/src/include/wire/libevent_thread.h
@@ -126,9 +126,11 @@ class LibeventMasterThread : public LibeventThread {
  public:
   LibeventMasterThread(const int num_threads, struct event_base *libevent_base);
 
-  void DispatchConnection(int new_conn_fd, short event_flags);
+  void Start();
 
-  void CloseConnection();
+  void Stop();
+
+  void DispatchConnection(int new_conn_fd, short event_flags);
 
   std::vector<std::shared_ptr<LibeventWorkerThread>> &GetWorkerThreads();
 

--- a/src/main/peloton/peloton.cpp
+++ b/src/main/peloton/peloton.cpp
@@ -44,13 +44,13 @@ int main(int argc, char *argv[]) {
     
     // Start Libevent Server    
     libeventserver.StartServer();
-
-    // Teardown
-    peloton::PelotonInit::Shutdown();
   }
   catch(peloton::ConnectionException exception){
     // Nothing to do here!
   }
+
+  // Teardown
+  peloton::PelotonInit::Shutdown();
 
   return 0;
 }


### PR DESCRIPTION
This PR is a quick fix for preventing a crash happening when Peloton is run with the port which is occupied with some other process.  The fix will let the worker threads start to run _after_ checking all the network ports are available.  