### PR TITLE
Consistent namespace closure

### DIFF
--- a/src/brain/clusterer.cpp
+++ b/src/brain/clusterer.cpp
@@ -155,5 +155,5 @@ const std::string Clusterer::GetInfo() const {
   return os.str();
 }
 
-}  // End brain namespace
-}  // End peloton namespace
+}  // namespace brain
+}  // namespace peloton

--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -636,5 +636,5 @@ void LoadStatsFromFile(const std::string &path) {
   return;
 }
 
-}  // End brain namespace
-}  // End peloton namespace
+}  // namespace brain
+}  // namespace peloton

--- a/src/brain/layout_tuner.cpp
+++ b/src/brain/layout_tuner.cpp
@@ -198,5 +198,5 @@ void LayoutTuner::ClearTables() {
   }
 }
 
-}  // End brain namespace
-}  // End peloton namespace
+}  // namespace brain
+}  // namespace peloton

--- a/src/brain/sample.cpp
+++ b/src/brain/sample.cpp
@@ -129,5 +129,5 @@ bool Sample::operator==(const Sample &other) const {
   return true;
 }
 
-}  // End brain namespace
-}  // End peloton namespace
+}  // namespace brain
+}  // namespace peloton

--- a/src/catalog/abstract_catalog.cpp
+++ b/src/catalog/abstract_catalog.cpp
@@ -264,5 +264,5 @@ void AbstractCatalog::AddIndex(const std::vector<oid_t> &key_attrs,
             index_name.c_str(), (int)catalog_table_->GetOid());
 }
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/column_catalog.cpp
+++ b/src/catalog/column_catalog.cpp
@@ -335,5 +335,5 @@ type::TypeId ColumnCatalog::GetColumnType(oid_t table_oid,
   return column_type;
 }
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/column_stats_catalog.cpp
+++ b/src/catalog/column_stats_catalog.cpp
@@ -233,5 +233,5 @@ size_t ColumnStatsCatalog::GetTableStats(
   return tuple_count;
 }
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/constraint.cpp
+++ b/src/catalog/constraint.cpp
@@ -25,5 +25,5 @@ const std::string Constraint::GetInfo() const {
   return os.str();
 }
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -149,5 +149,5 @@ oid_t DatabaseCatalog::GetDatabaseOid(const std::string &database_name,
   return database_oid;
 }
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/database_metrics_catalog.cpp
+++ b/src/catalog/database_metrics_catalog.cpp
@@ -96,5 +96,5 @@ oid_t DatabaseMetricsCatalog::GetTimeStamp(oid_t database_oid,
   return time_stamp;
 }
 
-}  // end of namespace catalog
-}  // end of namespace peloton
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/index_catalog.cpp
+++ b/src/catalog/index_catalog.cpp
@@ -366,5 +366,5 @@ std::vector<oid_t> IndexCatalog::GetIndexedAttributes(
   return key_attrs;
 }
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/index_metrics_catalog.cpp
+++ b/src/catalog/index_metrics_catalog.cpp
@@ -81,5 +81,5 @@ bool IndexMetricsCatalog::DeleteIndexMetrics(oid_t index_oid,
   return DeleteWithIndexScan(index_offset, values, txn);
 }
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/manager.cpp
+++ b/src/catalog/manager.cpp
@@ -82,5 +82,5 @@ void Manager::ClearIndirectionArray() {
   indirection_array_locator_.Clear(empty_indirection_array_);
 }
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/query_metrics_catalog.cpp
+++ b/src/catalog/query_metrics_catalog.cpp
@@ -174,5 +174,5 @@ int64_t QueryMetricsCatalog::GetNumParams(const std::string &name,
   return num_params;
 }
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/schema.cpp
+++ b/src/catalog/schema.cpp
@@ -316,5 +316,5 @@ bool Schema::operator==(const Schema &other) const {
 
 bool Schema::operator!=(const Schema &other) const { return !(*this == other); }
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/table_catalog.cpp
+++ b/src/catalog/table_catalog.cpp
@@ -266,5 +266,5 @@ std::vector<std::string> TableCatalog::GetTableNames(
   return table_names;
 }
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/table_metrics_catalog.cpp
+++ b/src/catalog/table_metrics_catalog.cpp
@@ -81,5 +81,5 @@ bool TableMetricsCatalog::DeleteTableMetrics(oid_t table_oid,
   return DeleteWithIndexScan(index_offset, values, txn);
 }
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -36,7 +36,7 @@ void *do_allocation(size_t size, bool do_throw) {
 
 void do_deletion(void *location) { free(location); }
 
-}  // End peloton namespace
+}  // namespace peloton
 
 void *operator new(size_t size) throw(std::bad_alloc) {
   return peloton::do_allocation(size, true);

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -106,4 +106,4 @@ void PelotonInit::SetUpThread() {}
 
 void PelotonInit::TearDownThread() {}
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/common/stack_trace.cpp
+++ b/src/common/stack_trace.cpp
@@ -143,4 +143,4 @@ void RegisterSignalHandlers() {
   signal(SIGFPE, SignalHandler);
 }
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -1113,5 +1113,5 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
   return ResultType::ABORTED;
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/concurrency/transaction.cpp
+++ b/src/concurrency/transaction.cpp
@@ -183,5 +183,5 @@ const std::string Transaction::GetInfo() const {
   return os.str();
 }
 
-}  // End concurrency namespace
-}  // End peloton namespace
+}  // namespace concurrency
+}  // namespace peloton

--- a/src/configuration/configuration.cpp
+++ b/src/configuration/configuration.cpp
@@ -43,8 +43,8 @@ void PrintConfiguration(){
 
 }
 
-}  // End configuration namespace
-}  // End peloton namespace
+}  // namespace configuration
+}  // namespace peloton
 
 //===----------------------------------------------------------------------===//
 // FILE LOCATIONS

--- a/src/container/circular_buffer.cpp
+++ b/src/container/circular_buffer.cpp
@@ -41,4 +41,4 @@ void CIRCULAR_BUFFER_TYPE::Clear() { circular_buffer_.clear(); }
 // Explicit template instantiation
 template class CircularBuffer<double>;
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/container/cuckoo_map.cpp
+++ b/src/container/cuckoo_map.cpp
@@ -100,4 +100,4 @@ template class CuckooMap<std::thread::id,
 
 template class CuckooMap<oid_t, std::shared_ptr<stats::IndexMetric>>;
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/container/lock_free_array.cpp
+++ b/src/container/lock_free_array.cpp
@@ -153,4 +153,4 @@ template class LockFreeArray<std::shared_ptr<storage::IndirectionArray>>;
 
 template class LockFreeArray<oid_t>;
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/executor/append_executor.cpp
+++ b/src/executor/append_executor.cpp
@@ -53,5 +53,5 @@ bool AppendExecutor::DExecute() {
   return false;
 }
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/executor/hash_executor.cpp
+++ b/src/executor/hash_executor.cpp
@@ -118,5 +118,5 @@ bool HashExecutor::DExecute() {
   return false;
 }
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/executor/hash_set_op_executor.cpp
+++ b/src/executor/hash_set_op_executor.cpp
@@ -188,5 +188,5 @@ bool HashSetOpExecutor::CalculateCopies(HashSetOpMapType &htable) {
   return true;
 }
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/executor/limit_executor.cpp
+++ b/src/executor/limit_executor.cpp
@@ -84,5 +84,5 @@ bool LimitExecutor::DExecute() {
   return false;
 }
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/executor/logical_tile.cpp
+++ b/src/executor/logical_tile.cpp
@@ -782,5 +782,5 @@ std::unique_ptr<storage::Tile> LogicalTile::Materialize() {
   return dest_tile;
 }
 
-}  // End executor namespace
-}  // End peloton namespace
+}  // namespace executor
+}  // namespace peloton

--- a/src/executor/order_by_executor.cpp
+++ b/src/executor/order_by_executor.cpp
@@ -234,5 +234,5 @@ bool OrderByExecutor::DoSort() {
   return true;
 }
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/executor/populate_index_executor.cpp
+++ b/src/executor/populate_index_executor.cpp
@@ -104,5 +104,5 @@ bool PopulateIndexExecutor::DExecute() {
   return false;
 }
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/executor/projection_executor.cpp
+++ b/src/executor/projection_executor.cpp
@@ -126,5 +126,5 @@ bool ProjectionExecutor::DExecute() {
   return false;
 }
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/include/brain/clusterer.h
+++ b/src/include/brain/clusterer.h
@@ -90,5 +90,5 @@ class Clusterer : public Printable {
   oid_t sample_column_count_;
 };
 
-}  // End brain namespace
-}  // End peloton namespace
+}  // namespace brain
+}  // namespace peloton

--- a/src/include/brain/index_tuner.h
+++ b/src/include/brain/index_tuner.h
@@ -188,5 +188,5 @@ class IndexTuner {
   bool visibility_mode_ = false;
 };
 
-}  // End brain namespace
-}  // End peloton namespace
+}  // namespace brain
+}  // namespace peloton

--- a/src/include/brain/layout_tuner.h
+++ b/src/include/brain/layout_tuner.h
@@ -107,5 +107,5 @@ class LayoutTuner {
 
 };
 
-}  // End brain namespace
-}  // End peloton namespace
+}  // namespace brain
+}  // namespace peloton

--- a/src/include/brain/sample.h
+++ b/src/include/brain/sample.h
@@ -105,8 +105,8 @@ class Sample : public Printable {
 
 };
 
-}  // End brain namespace
-}  // End peloton namespace
+}  // namespace brain
+}  // namespace peloton
 
 namespace std {
 

--- a/src/include/catalog/abstract_catalog.h
+++ b/src/include/catalog/abstract_catalog.h
@@ -89,5 +89,5 @@ class AbstractCatalog {
   storage::DataTable *catalog_table_;
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/column.h
+++ b/src/include/catalog/column.h
@@ -139,5 +139,5 @@ class Column : public Printable {
   std::vector<Constraint> constraints;
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/column_catalog.h
+++ b/src/include/catalog/column_catalog.h
@@ -82,5 +82,5 @@ class ColumnCatalog : public AbstractCatalog {
   std::unique_ptr<catalog::Schema> InitializeSchema();
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/column_stats_catalog.h
+++ b/src/include/catalog/column_stats_catalog.h
@@ -115,5 +115,5 @@ class ColumnStatsCatalog : public AbstractCatalog {
   };
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/constraint.h
+++ b/src/include/catalog/constraint.h
@@ -71,5 +71,5 @@ class Constraint : public Printable {
 
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -63,5 +63,5 @@ class DatabaseCatalog : public AbstractCatalog {
   std::unique_ptr<catalog::Schema> InitializeSchema();
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/database_metrics_catalog.h
+++ b/src/include/catalog/database_metrics_catalog.h
@@ -74,5 +74,5 @@ class DatabaseMetricsCatalog : public AbstractCatalog {
   };
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/foreign_key.h
+++ b/src/include/catalog/foreign_key.h
@@ -76,5 +76,5 @@ class ForeignKey {
   std::string fk_name;
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/index_catalog.h
+++ b/src/include/catalog/index_catalog.h
@@ -83,5 +83,5 @@ class IndexCatalog : public AbstractCatalog {
   std::unique_ptr<catalog::Schema> InitializeSchema();
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/index_metrics_catalog.h
+++ b/src/include/catalog/index_metrics_catalog.h
@@ -79,5 +79,5 @@ class IndexMetricsCatalog : public AbstractCatalog {
   };
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/manager.h
+++ b/src/include/catalog/manager.h
@@ -108,5 +108,5 @@ class Manager {
   static std::shared_ptr<storage::IndirectionArray> empty_indirection_array_;
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/query_metrics_catalog.h
+++ b/src/include/catalog/query_metrics_catalog.h
@@ -102,5 +102,5 @@ class QueryMetricsCatalog : public AbstractCatalog {
   };
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -212,5 +212,5 @@ class Schema : public Printable {
   std::vector<oid_t> indexed_columns_;
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/table_catalog.h
+++ b/src/include/catalog/table_catalog.h
@@ -70,5 +70,5 @@ class TableCatalog : public AbstractCatalog {
   std::unique_ptr<catalog::Schema> InitializeSchema();
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/table_metrics_catalog.h
+++ b/src/include/catalog/table_metrics_catalog.h
@@ -79,5 +79,5 @@ class TableMetricsCatalog : public AbstractCatalog {
   };
 };
 
-}  // End catalog namespace
-}  // End peloton namespace
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -428,4 +428,4 @@ class ConnectionException : public Exception {
       : Exception(EXCEPTION_TYPE_CONNECTION, msg) {}
 };
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/include/common/init.h
+++ b/src/include/common/init.h
@@ -33,4 +33,4 @@ class PelotonInit {
   static void TearDownThread();
 };
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/include/common/iterator.h
+++ b/src/include/common/iterator.h
@@ -29,4 +29,4 @@ class Iterator {
   virtual ~Iterator() {}
 };
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/include/common/logger.h
+++ b/src/include/common/logger.h
@@ -178,6 +178,6 @@ inline void outputLogHeader_(const char *file, int line, const char *func,
             type);
 }
 
-}  // End peloton namespace
+}  // namespace peloton
 
 #endif

--- a/src/include/common/macros.h
+++ b/src/include/common/macros.h
@@ -147,4 +147,4 @@ namespace peloton {
 #define LLVM_VERSION_EQ(major, minor) \
   (LLVM_VERSION_MAJOR == (major) && LLVM_VERSION_MINOR == (minor))
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/include/common/platform.h
+++ b/src/include/common/platform.h
@@ -172,4 +172,4 @@ static inline uint64_t NextPowerOf2(uint64_t n) {
 #endif
 }
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/include/common/sql_node_visitor.h
+++ b/src/include/common/sql_node_visitor.h
@@ -90,4 +90,4 @@ class SqlNodeVisitor {
   virtual void Visit(expression::TupleValueExpression *expr);
 };
 
-} /* namespace peloton */
+}  // namespace peloton

--- a/src/include/common/stack_trace.h
+++ b/src/include/common/stack_trace.h
@@ -20,4 +20,4 @@ void PrintStackTrace(FILE *out = ::stderr,
 
 void SignalHandler(int signum);
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/include/common/thread_pool.h
+++ b/src/include/common/thread_pool.h
@@ -99,4 +99,4 @@ class ThreadPool {
   std::vector<std::unique_ptr<std::thread>> dedicated_threads_;
 };
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/include/concurrency/transaction.h
+++ b/src/include/concurrency/transaction.h
@@ -190,5 +190,5 @@ class Transaction : public Printable {
 
 };
 
-}  // End concurrency namespace
-}  // End peloton namespace
+}  // namespace concurrency
+}  // namespace peloton

--- a/src/include/concurrency/transaction_manager.h
+++ b/src/include/concurrency/transaction_manager.h
@@ -173,5 +173,5 @@ class TransactionManager {
   static ConflictAvoidanceType conflict_avoidance_;
 
 };
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/configuration/configuration.h
+++ b/src/include/configuration/configuration.h
@@ -95,6 +95,6 @@ namespace configuration {
 // Print configuration
 void PrintConfiguration();
 
-}  // End configuration namespace
-}  // End peloton namespace
+}  // namespace configuration
+}  // namespace peloton
 

--- a/src/include/executor/hash_executor.h
+++ b/src/include/executor/hash_executor.h
@@ -73,5 +73,5 @@ class HashExecutor : public AbstractExecutor {
   size_t result_itr = 0;
 };
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/include/executor/hash_set_op_executor.h
+++ b/src/include/executor/hash_set_op_executor.h
@@ -89,5 +89,5 @@ class HashSetOpExecutor : public AbstractExecutor {
   size_t next_tile_to_return_ = 0;
 };
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/include/executor/limit_executor.h
+++ b/src/include/executor/limit_executor.h
@@ -50,5 +50,5 @@ class LimitExecutor : public AbstractExecutor {
   size_t num_returned_ = 0;
 };
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/include/executor/order_by_executor.h
+++ b/src/include/executor/order_by_executor.h
@@ -114,5 +114,5 @@ class OrderByExecutor : public AbstractExecutor {
   uint64_t limit_offset_ = 0;
 };
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/include/executor/populate_index_executor.h
+++ b/src/include/executor/populate_index_executor.h
@@ -60,5 +60,5 @@ class PopulateIndexExecutor : public AbstractExecutor {
   bool done_ = false;
 };
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/include/executor/projection_executor.h
+++ b/src/include/executor/projection_executor.h
@@ -49,5 +49,5 @@ class ProjectionExecutor : public AbstractExecutor {
   bool finished_ = false;
 };
 
-} /* namespace executor */
-} /* namespace peloton */
+}  // namespace executor
+}  // namespace peloton

--- a/src/include/expression/abstract_expression.h
+++ b/src/include/expression/abstract_expression.h
@@ -213,5 +213,5 @@ class ExprHasher {
   }
 };
 
-}  // End expression namespace
-}  // End peloton namespace
+}  // namespace expression
+}  // namespace peloton

--- a/src/include/expression/aggregate_expression.h
+++ b/src/include/expression/aggregate_expression.h
@@ -127,5 +127,5 @@ class AggregateExpression : public AbstractExpression {
   const planner::AttributeInfo *ai_;
 };
 
-}  // End expression namespace
-}  // End peloton namespace
+}  // namespace expression
+}  // namespace peloton

--- a/src/include/expression/case_expression.h
+++ b/src/include/expression/case_expression.h
@@ -110,5 +110,5 @@ class CaseExpression : public AbstractExpression {
   AbsExprPtr default_expr_;
 };
 
-}  // End expression namespace
-}  // End peloton namespace
+}  // namespace expression
+}  // namespace peloton

--- a/src/include/expression/comparison_expression.h
+++ b/src/include/expression/comparison_expression.h
@@ -82,5 +82,5 @@ class ComparisonExpression : public AbstractExpression {
       : AbstractExpression(other) {}
 };
 
-}  // End expression namespace
-}  // End peloton namespace
+}  // namespace expression
+}  // namespace peloton

--- a/src/include/expression/conjunction_expression.h
+++ b/src/include/expression/conjunction_expression.h
@@ -70,5 +70,5 @@ class ConjunctionExpression : public AbstractExpression {
       : AbstractExpression(other) {}
 };
 
-}  // End expression namespace
-}  // End peloton namespace
+}  // namespace expression
+}  // namespace peloton

--- a/src/include/expression/function_expression.h
+++ b/src/include/expression/function_expression.h
@@ -121,5 +121,5 @@ class FunctionExpression : public AbstractExpression {
   }
 };
 
-}  // End expression namespace
-}  // End peloton namespace
+}  // namespace expression
+}  // namespace peloton

--- a/src/include/expression/operator_expression.h
+++ b/src/include/expression/operator_expression.h
@@ -118,5 +118,5 @@ class OperatorUnaryMinusExpression : public AbstractExpression {
       : AbstractExpression(other) {}
 };
 
-}  // End expression namespace
-}  // End peloton namespace
+}  // namespace expression
+}  // namespace peloton

--- a/src/include/expression/parameter_value_expression.h
+++ b/src/include/expression/parameter_value_expression.h
@@ -51,5 +51,5 @@ class ParameterValueExpression : public AbstractExpression {
       : AbstractExpression(other), value_idx_(other.value_idx_) {}
 };
 
-}  // End expression namespace
-}  // End peloton namespace
+}  // namespace expression
+}  // namespace peloton

--- a/src/include/expression/star_expression.h
+++ b/src/include/expression/star_expression.h
@@ -43,5 +43,5 @@ class StarExpression : public AbstractExpression {
  private:
 };
 
-}  // End expression namespace
-}  // End peloton namespace
+}  // namespace expression
+}  // namespace peloton

--- a/src/include/index/bwtree_index.h
+++ b/src/include/index/bwtree_index.h
@@ -121,5 +121,5 @@ class BWTreeIndex : public Index {
   MapType container;
 };
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/include/index/compact_ints_key.h
+++ b/src/include/index/compact_ints_key.h
@@ -638,5 +638,5 @@ class CompactIntsHasher {
   }
 };
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/include/index/generic_key.h
+++ b/src/include/index/generic_key.h
@@ -191,5 +191,5 @@ struct GenericHasher : std::unary_function<GenericKey<KeySize>, std::size_t> {
   GenericHasher(){};
 };
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/include/index/index.h
+++ b/src/include/index/index.h
@@ -404,5 +404,5 @@ class Index : public Printable {
   std::atomic<size_t> indexed_tile_group_offset;
 };
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/include/index/index_factory.h
+++ b/src/include/index/index_factory.h
@@ -49,5 +49,5 @@ class IndexFactory {
   static Index *GetSkipListGenericKeyIndex(IndexMetadata *metadata);
 };
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/include/index/index_util.h
+++ b/src/include/index/index_util.h
@@ -86,5 +86,5 @@ class IndexUtil {
 
 
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/include/index/scan_optimizer.h
+++ b/src/include/index/scan_optimizer.h
@@ -714,5 +714,5 @@ class IndexScanPredicate {
   inline bool IsFullIndexScan() const { return full_index_scan_; }
 };
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/include/index/skiplist.h
+++ b/src/include/index/skiplist.h
@@ -27,5 +27,5 @@ class SkipList {
   // TODO: Add your declarations here
 };
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/include/index/skiplist_index.h
+++ b/src/include/index/skiplist_index.h
@@ -96,5 +96,5 @@ class SkipListIndex : public Index {
   MapType container;
 };
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/include/index/tuple_key.h
+++ b/src/include/index/tuple_key.h
@@ -308,5 +308,5 @@ class TupleKeyEqualityChecker {
   TupleKeyEqualityChecker() {}
 };
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/include/networking/connection_manager.h
+++ b/src/include/networking/connection_manager.h
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include "common/mutex.h"
@@ -21,6 +20,7 @@
 
 namespace peloton {
 namespace networking {
+
 //===--------------------------------------------------------------------===//
 // Connection Manager
 // Connection Manager can be used by both server and client
@@ -69,5 +69,5 @@ class ConnectionManager {
   std::map<NetworkAddress, Connection*> client_conn_pool_;
 };
 
-}  // End peloton networking
+}  // namespace networking
 }  // namespace peloton

--- a/src/include/networking/connection_manager.h
+++ b/src/include/networking/connection_manager.h
@@ -70,4 +70,4 @@ class ConnectionManager {
 };
 
 }  // End peloton networking
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/include/optimizer/column.h
+++ b/src/include/optimizer/column.h
@@ -87,5 +87,5 @@ class ExprColumn : public Column {
 
 catalog::Column GetSchemaColumnFromOptimizerColumn(Column *column);
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/optimizer/stats/column_stats.h
+++ b/src/include/optimizer/stats/column_stats.h
@@ -91,5 +91,5 @@ class ColumnStats {
   }
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/optimizer/stats/column_stats_collector.h
+++ b/src/include/optimizer/stats/column_stats_collector.h
@@ -84,5 +84,5 @@ class ColumnStatsCollector {
   void operator=(const ColumnStatsCollector&);
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/optimizer/stats/cost.h
+++ b/src/include/optimizer/stats/cost.h
@@ -147,5 +147,5 @@ class Cost {
       std::vector<oid_t>& columns);
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/optimizer/stats/count_min_sketch.h
+++ b/src/include/optimizer/stats/count_min_sketch.h
@@ -171,5 +171,5 @@ class CountMinSketch {
   }
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/optimizer/stats/histogram.h
+++ b/src/include/optimizer/stats/histogram.h
@@ -282,5 +282,5 @@ class Histogram {
   };
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/optimizer/stats/hyperloglog.h
+++ b/src/include/optimizer/stats/hyperloglog.h
@@ -59,5 +59,5 @@ class HyperLogLog {
   libcount::HLL* hll_;
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/optimizer/stats/selectivity.h
+++ b/src/include/optimizer/stats/selectivity.h
@@ -94,5 +94,5 @@ class Selectivity {
   }
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/optimizer/stats/stats_util.h
+++ b/src/include/optimizer/stats/stats_util.h
@@ -95,5 +95,5 @@ class StatsUtil {
     return hash[0];
   }
 };
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/optimizer/stats/table_stats.h
+++ b/src/include/optimizer/stats/table_stats.h
@@ -88,5 +88,5 @@ class TableStats {
       col_name_to_stats_map_;
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/optimizer/stats/table_stats_collector.h
+++ b/src/include/optimizer/stats/table_stats_collector.h
@@ -51,5 +51,5 @@ class TableStatsCollector {
   void InitColumnStatsCollectors();
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/optimizer/stats/tuple_sampler.h
+++ b/src/include/optimizer/stats/tuple_sampler.h
@@ -48,5 +48,5 @@ class TupleSampler {
   std::vector<std::unique_ptr<storage::Tuple>> sampled_tuples;
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/optimizer/stats/value_condition.h
+++ b/src/include/optimizer/stats/value_condition.h
@@ -47,5 +47,5 @@ class ValueCondition {
         value{value} {}
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/parser/abstract_parser.h
+++ b/src/include/parser/abstract_parser.h
@@ -37,5 +37,5 @@ class AbstractParser {
       const std::string &query_string) = 0;
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/analyze_statement.h
+++ b/src/include/parser/analyze_statement.h
@@ -71,5 +71,5 @@ class AnalyzeStatement : public SQLStatement {
   const std::string INVALID_NAME = "";
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/copy_statement.h
+++ b/src/include/parser/copy_statement.h
@@ -55,5 +55,5 @@ class CopyStatement : public SQLStatement {
   char delimiter;
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -232,5 +232,5 @@ class CreateStatement : public TableRefStatement {
   bool unique = false;
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/delete_statement.h
+++ b/src/include/parser/delete_statement.h
@@ -57,5 +57,5 @@ class DeleteStatement : public SQLStatement {
   expression::AbstractExpression* expr;
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -61,5 +61,5 @@ class DropStatement : public TableRefStatement {
   bool missing;
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/execute_statement.h
+++ b/src/include/parser/execute_statement.h
@@ -53,5 +53,5 @@ class ExecuteStatement : public SQLStatement {
   std::vector<expression::AbstractExpression*>* parameters;
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -85,5 +85,5 @@ class InsertStatement : SQLStatement {
   TableRef* table_ref_;
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/parse_node_visitor.h
+++ b/src/include/parser/parse_node_visitor.h
@@ -47,5 +47,5 @@ class ParseNodeVisitor {
   virtual void visit(const SelectParse *) = 0;
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/include/parser/parser_utils.h
+++ b/src/include/parser/parser_utils.h
@@ -27,5 +27,5 @@ void GetExpressionInfo(const expression::AbstractExpression* expr,
                        uint num_indent);
 std::string CharsToStringDestructive(char * str);
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -221,5 +221,5 @@ class PostgresParser {
   static parser::AnalyzeStatement* VacuumTransform(VacuumStmt* root);
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/prepare_statement.h
+++ b/src/include/parser/prepare_statement.h
@@ -77,5 +77,5 @@ class PrepareStatement : public SQLStatement {
       placeholders;
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/select_statement.h
+++ b/src/include/parser/select_statement.h
@@ -165,5 +165,5 @@ class SelectStatement : public SQLStatement {
   }
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/sql_statement.h
+++ b/src/include/parser/sql_statement.h
@@ -120,5 +120,5 @@ class SQLStatementList : public Printable {
   int error_col;
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/table_ref.h
+++ b/src/include/parser/table_ref.h
@@ -98,5 +98,5 @@ class JoinDefinition {
   void Accept(SqlNodeVisitor* v) const { v->Visit(this); }
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/transaction_statement.h
+++ b/src/include/parser/transaction_statement.h
@@ -40,5 +40,5 @@ class TransactionStatement : public SQLStatement {
   CommandType type;
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/parser/update_statement.h
+++ b/src/include/parser/update_statement.h
@@ -93,5 +93,5 @@ class UpdateStatement : public SQLStatement {
   expression::AbstractExpression* where = nullptr;
 };
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/include/storage/abstract_table.h
+++ b/src/include/storage/abstract_table.h
@@ -154,5 +154,5 @@ class AbstractTable : public Printable {
   bool own_schema_;
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/backend_manager.h
+++ b/src/include/storage/backend_manager.h
@@ -77,5 +77,5 @@ class BackendManager {
   size_t allocation_count = 0;
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -378,5 +378,5 @@ class DataTable : public AbstractTable {
   static oid_t invalid_tile_group_id;
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/database.h
+++ b/src/include/storage/database.h
@@ -91,5 +91,5 @@ class Database : public Printable {
   std::mutex database_mutex;
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/masked_tuple.h
+++ b/src/include/storage/masked_tuple.h
@@ -83,5 +83,5 @@ class MaskedTuple : public AbstractTuple {
 // Implementation
 //===--------------------------------------------------------------------===//
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/table_factory.h
+++ b/src/include/storage/table_factory.h
@@ -44,5 +44,5 @@ class TableFactory {
   static bool DropDataTable(oid_t database_oid, oid_t table_oid);
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/temp_table.h
+++ b/src/include/storage/temp_table.h
@@ -130,5 +130,5 @@ class TempTable : public AbstractTable {
   size_t number_of_tuples_ = 0;
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/tile.h
+++ b/src/include/storage/tile.h
@@ -304,5 +304,5 @@ class TileFactory {
   }
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/tile_group.h
+++ b/src/include/storage/tile_group.h
@@ -223,5 +223,5 @@ class TileGroup : public Printable {
   column_map_type column_map;
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/tile_group_factory.h
+++ b/src/include/storage/tile_group_factory.h
@@ -36,5 +36,5 @@ class TileGroupFactory {
                                  int tuple_count);
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/tile_group_header.h
+++ b/src/include/storage/tile_group_header.h
@@ -288,5 +288,5 @@ class TileGroupHeader : public Printable {
   Spinlock tile_header_lock;
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/tile_group_iterator.h
+++ b/src/include/storage/tile_group_iterator.h
@@ -62,5 +62,5 @@ class TileGroupIterator : public Iterator<std::shared_ptr<TileGroup>> {
   oid_t tile_group_itr_;
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/tuple.h
+++ b/src/include/storage/tuple.h
@@ -283,5 +283,5 @@ class TupleComparator {
   }
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/storage/tuple_iterator.h
+++ b/src/include/storage/tuple_iterator.h
@@ -81,5 +81,5 @@ class TupleIterator : public Iterator<Tuple> {
   oid_t tuple_length;
 };
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/include/tcop/tcop.h
+++ b/src/include/tcop/tcop.h
@@ -115,5 +115,5 @@ class TrafficCop {
                      std::vector<storage::DataTable *> &target_tables);
 };
 
-}  // End tcop namespace
-}  // End peloton namespace
+}  // namespace tcop
+}  // namespace peloton

--- a/src/include/type/serializer.h
+++ b/src/include/type/serializer.h
@@ -256,4 +256,4 @@ class ExportSerializeOutput {
   size_t capacity_;
 };
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -1218,4 +1218,4 @@ typedef unsigned char uchar;
 /* type for buffer of bytes */
 typedef std::vector<uchar> ByteBuf;
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/include/util/hash_util.h
+++ b/src/include/util/hash_util.h
@@ -60,4 +60,4 @@ class HashUtil {
 };
 
 
-} /* namespace peloton */
+}  // namespace peloton

--- a/src/include/wire/marshal.h
+++ b/src/include/wire/marshal.h
@@ -177,5 +177,5 @@ extern void PacketGetByte(InputPacket *rpkt, uchar &result);
 */
 extern void GetStringToken(InputPacket *pkt, std::string &result);
 
-}  // End wire namespace
-}  // End peloton namespace
+}  // namespace wire
+}  // namespace peloton

--- a/src/include/wire/packet_manager.h
+++ b/src/include/wire/packet_manager.h
@@ -225,5 +225,5 @@ class PacketManager {
   static std::mutex packet_managers_mutex_;
 };
 
-}  // End wire namespace
-}  // End peloton namespace
+}  // namespace wire
+}  // namespace peloton

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -322,5 +322,5 @@ template class BWTreeIndex<TupleKey, ItemPointer *, TupleKeyComparator,
                            TupleKeyEqualityChecker, TupleKeyHasher,
                            ItemPointerComparator, ItemPointerHashFunc>;
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/index/index.cpp
+++ b/src/index/index.cpp
@@ -389,5 +389,5 @@ bool Index::IsDirty() const { return dirty; }
  */
 void Index::ResetDirty() { dirty = false; }
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/index/index_factory.cpp
+++ b/src/index/index_factory.cpp
@@ -358,5 +358,5 @@ std::string IndexFactory::GetInfo(IndexMetadata *metadata,
   return (os.str());
 }
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/index/index_util.cpp
+++ b/src/index/index_util.cpp
@@ -358,5 +358,5 @@ std::string IndexUtil::Debug(Index *index) {
   return (os.str());
 }
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/index/skiplist.cpp
+++ b/src/index/skiplist.cpp
@@ -17,5 +17,5 @@ namespace index {
 
 // Add your function definitions here
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/index/skiplist_index.cpp
+++ b/src/index/skiplist_index.cpp
@@ -160,5 +160,5 @@ template class SkipListIndex<
 template class SkipListIndex<TupleKey, ItemPointer *, TupleKeyComparator,
                              TupleKeyEqualityChecker, ItemPointerComparator>;
 
-}  // End index namespace
-}  // End peloton namespace
+}  // namespace index
+}  // namespace peloton

--- a/src/networking/connection_manager.cpp
+++ b/src/networking/connection_manager.cpp
@@ -264,5 +264,5 @@ bool ConnectionManager::DeleteConn(Connection* conn) {
   return DeleteConn(addr);
 }
 
-}  // End peloton networking
+}  // namespace networking
 }  // namespace peloton

--- a/src/networking/connection_manager.cpp
+++ b/src/networking/connection_manager.cpp
@@ -265,4 +265,4 @@ bool ConnectionManager::DeleteConn(Connection* conn) {
 }
 
 }  // End peloton networking
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/optimizer/binding.cpp
+++ b/src/optimizer/binding.cpp
@@ -180,5 +180,5 @@ std::shared_ptr<OperatorExpression> ItemBindingIterator::Next() {
   return current_binding_;
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/child_property_generator.cpp
+++ b/src/optimizer/child_property_generator.cpp
@@ -431,5 +431,5 @@ void ChildPropertyGenerator::JoinHelper(const BaseOperatorNode *op) {
 
   output_.push_back(make_pair(provided_property, child_input_propertys));
 }
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/column_manager.cpp
+++ b/src/optimizer/column_manager.cpp
@@ -69,5 +69,5 @@ Column *ColumnManager::AddExprColumn(type::TypeId type, int size,
   return col;
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/cost_and_stats_calculator.cpp
+++ b/src/optimizer/cost_and_stats_calculator.cpp
@@ -132,5 +132,5 @@ void CostAndStatsCalculator::Visit(const PhysicalDistinct *) {
   output_cost_ = 0;
 };
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/group_expression.cpp
+++ b/src/optimizer/group_expression.cpp
@@ -86,5 +86,5 @@ bool GroupExpression::operator==(const GroupExpression &r) {
   return eq;
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/memo.cpp
+++ b/src/optimizer/memo.cpp
@@ -87,5 +87,5 @@ GroupID Memo::AddNewGroup(std::shared_ptr<GroupExpression> gexpr) {
   return new_group_id;
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/operator_expression.cpp
+++ b/src/optimizer/operator_expression.cpp
@@ -35,5 +35,5 @@ OperatorExpression::Children() const {
 
 const Operator &OperatorExpression::Op() const { return op; }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/operator_node.cpp
+++ b/src/optimizer/operator_node.cpp
@@ -70,5 +70,5 @@ bool Operator::operator==(const Operator &r) {
 
 bool Operator::defined() const { return node != nullptr; }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/operator_to_plan_transformer.cpp
+++ b/src/optimizer/operator_to_plan_transformer.cpp
@@ -702,5 +702,5 @@ void OperatorToPlanTransformer::VisitOpExpression(
   op->Op().Accept(this);
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/operators.cpp
+++ b/src/optimizer/operators.cpp
@@ -679,5 +679,5 @@ bool OperatorNode<LeafOperator>::IsPhysical() const {
   return false;
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/pattern.cpp
+++ b/src/optimizer/pattern.cpp
@@ -27,5 +27,5 @@ const std::vector<std::shared_ptr<Pattern>> &Pattern::Children() const {
 
 OpType Pattern::Type() const { return _type; }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/properties.cpp
+++ b/src/optimizer/properties.cpp
@@ -248,5 +248,5 @@ std::string PropertyPredicate::ToString() const {
   return PropertyTypeToString(Type()) + "\n";
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/property.cpp
+++ b/src/optimizer/property.cpp
@@ -29,5 +29,5 @@ bool Property::operator>=(const Property &r) const {
   return Type() == r.Type();
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/property_enforcer.cpp
+++ b/src/optimizer/property_enforcer.cpp
@@ -57,5 +57,5 @@ void PropertyEnforcer::Visit(const PropertyPredicate *) {}
   
 
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/property_set.cpp
+++ b/src/optimizer/property_set.cpp
@@ -94,5 +94,5 @@ hash_t PropertySet::Hash() const {
   return hash;
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/query_property_extractor.cpp
+++ b/src/optimizer/query_property_extractor.cpp
@@ -129,5 +129,5 @@ void QueryPropertyExtractor::Visit(
 void QueryPropertyExtractor::Visit(
     UNUSED_ATTRIBUTE const parser::AnalyzeStatement *op) {}
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/query_to_operator_transformer.cpp
+++ b/src/optimizer/query_to_operator_transformer.cpp
@@ -284,5 +284,5 @@ void QueryToOperatorTransformer::Visit(
 void QueryToOperatorTransformer::Visit(
     UNUSED_ATTRIBUTE const parser::AnalyzeStatement *op) {}
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/rule_impls.cpp
+++ b/src/optimizer/rule_impls.cpp
@@ -726,5 +726,5 @@ void OuterJoinToOuterHashJoin::Transform(
   return;
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/stats.cpp
+++ b/src/optimizer/stats.cpp
@@ -19,5 +19,5 @@ namespace optimizer {
 // Stats
 //===--------------------------------------------------------------------===//
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/stats/column_stats_collector.cpp
+++ b/src/optimizer/stats/column_stats_collector.cpp
@@ -58,5 +58,5 @@ double ColumnStatsCollector::GetFracNull() {
   return (static_cast<double>(null_count_) / total_count_);
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/stats/cost.cpp
+++ b/src/optimizer/stats/cost.cpp
@@ -229,5 +229,5 @@ size_t Cost::GetEstimatedGroupByRows(
   return static_cast<size_t>(rows + max_cardinality / 2);
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/stats/selectivity.cpp
+++ b/src/optimizer/stats/selectivity.cpp
@@ -176,5 +176,5 @@ double Selectivity::Like(const std::shared_ptr<TableStats> &table_stats,
   return DEFAULT_SELECTIVITY;
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/stats/stats_storage.cpp
+++ b/src/optimizer/stats/stats_storage.cpp
@@ -320,5 +320,5 @@ ResultType StatsStorage::AnalayzeStatsForColumns(
   return ResultType::FAILURE;
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/stats/tuple_sampler.cpp
+++ b/src/optimizer/stats/tuple_sampler.cpp
@@ -120,5 +120,5 @@ std::vector<std::unique_ptr<storage::Tuple>> &TupleSampler::GetSampledTuples() {
   return sampled_tuples;
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/stats/tuple_samples_storage.cpp
+++ b/src/optimizer/stats/tuple_samples_storage.cpp
@@ -222,5 +222,5 @@ void TupleSamplesStorage::GetColumnSamples(
   }
 }
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/tuple_sample.cpp
+++ b/src/optimizer/tuple_sample.cpp
@@ -22,5 +22,5 @@ TupleSample::TupleSample(std::vector<Column *> columns,
                          storage::TileGroup *sampled_tuples)
     : columns(columns), sampled_tuples(sampled_tuples) {}
 
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/optimizer/util.cpp
+++ b/src/optimizer/util.cpp
@@ -21,6 +21,7 @@
 namespace peloton {
 namespace optimizer {
 namespace util {
+
 /**
  * This function checks whether the current expression can enable index
  * scan for the statement. If it is index searchable, returns true and
@@ -340,6 +341,6 @@ std::unique_ptr<planner::AbstractPlan> CreateCopyPlan(
   return copy_plan;
 }
 
-} /* namespace util */
-} /* namespace optimizer */
-} /* namespace peloton */
+}  // namespace util
+}  // namespace optimizer
+}  // namespace peloton

--- a/src/parser/abstract_parser.cpp
+++ b/src/parser/abstract_parser.cpp
@@ -23,5 +23,5 @@ AbstractParser::~AbstractParser() {
   // Nothing to do here !
 }
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/parser/parser_utils.cpp
+++ b/src/parser/parser_utils.cpp
@@ -279,5 +279,5 @@ std::string CharsToStringDestructive(char* str) {
   }
 }
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1370,5 +1370,5 @@ std::unique_ptr<parser::SQLStatementList> PostgresParser::BuildParseTree(
   return sql_stmt;
 }
 
-}  // End pgparser namespace
-}  // End peloton namespace
+}  // namespace pgparser
+}  // namespace peloton

--- a/src/parser/sql_statement.cpp
+++ b/src/parser/sql_statement.cpp
@@ -74,5 +74,5 @@ const std::string SQLStatementList::GetInfo() const {
   return os.str();
 }
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/parser/table_ref.cpp
+++ b/src/parser/table_ref.cpp
@@ -30,5 +30,5 @@ TableRef::~TableRef() {
   }
 }
 
-}  // End parser namespace
-}  // End peloton namespace
+}  // namespace parser
+}  // namespace peloton

--- a/src/storage/abstract_table.cpp
+++ b/src/storage/abstract_table.cpp
@@ -119,5 +119,5 @@ const std::string AbstractTable::GetInfo() const {
   return output.str();
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/storage/backend_manager.cpp
+++ b/src/storage/backend_manager.cpp
@@ -545,5 +545,5 @@ void BackendManager::Sync(BackendType type, void *address, size_t length) {
   }
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1097,5 +1097,5 @@ column_map_type DataTable::GetDefaultLayout() const {
   return default_partition_;
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/storage/database.cpp
+++ b/src/storage/database.cpp
@@ -181,5 +181,5 @@ void Database::setDBName(const std::string &database_name) {
   Database::database_name = database_name;
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/storage/table_factory.cpp
+++ b/src/storage/table_factory.cpp
@@ -55,5 +55,5 @@ bool TableFactory::DropDataTable(oid_t database_oid, oid_t table_oid) {
   return true;
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/storage/temp_table.cpp
+++ b/src/storage/temp_table.cpp
@@ -136,5 +136,5 @@ std::string TempTable::GetName() const {
   return (os.str());
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/storage/tile.cpp
+++ b/src/storage/tile.cpp
@@ -522,5 +522,5 @@ TupleIterator Tile::GetIterator() { return TupleIterator(this); }
 //	return NULL;
 //}
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/storage/tile_group.cpp
+++ b/src/storage/tile_group.cpp
@@ -404,5 +404,5 @@ const std::string TileGroup::GetInfo() const {
   return os.str();
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/storage/tile_group_factory.cpp
+++ b/src/storage/tile_group_factory.cpp
@@ -45,5 +45,5 @@ TileGroup *TileGroupFactory::GetTileGroup(
   return tile_group;
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/storage/tile_group_header.cpp
+++ b/src/storage/tile_group_header.cpp
@@ -241,5 +241,5 @@ oid_t TileGroupHeader::GetActiveTupleCount() const {
   return active_tuple_slots;
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/storage/tile_group_iterator.cpp
+++ b/src/storage/tile_group_iterator.cpp
@@ -32,5 +32,5 @@ bool TileGroupIterator::HasNext() {
   return (tile_group_itr_ < table_->GetTileGroupCount());
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/storage/tuple.cpp
+++ b/src/storage/tuple.cpp
@@ -446,5 +446,5 @@ const std::string Tuple::GetInfo() const {
   return os.str();
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/tcop/tcop.cpp
+++ b/src/tcop/tcop.cpp
@@ -488,5 +488,5 @@ FieldInfo TrafficCop::GetColumnFieldForAggregates(std::string name,
                          field_size);
 }
 
-}  // End tcop namespace
-}  // End peloton namespace
+}  // namespace tcop
+}  // namespace peloton

--- a/src/type/types.cpp
+++ b/src/type/types.cpp
@@ -2556,4 +2556,4 @@ std::string OperatorIdToString(OperatorId op_id) {
   }
 }
 
-}  // End peloton namespace
+}  // namespace peloton

--- a/src/wire/libevent_socket.cpp
+++ b/src/wire/libevent_socket.cpp
@@ -526,5 +526,5 @@ void LibeventSocket::Reset() {
   next_response_ = 0;
 }
 
-}  // End wire namespace
-}  // End peloton namespace
+}  // namespace wire
+}  // namespace peloton

--- a/src/wire/marshal.cpp
+++ b/src/wire/marshal.cpp
@@ -163,5 +163,5 @@ void PacketPutCbytes(OutputPacket *pkt, const uchar *b, int len) {
   pkt->len += len;
 }
 
-}  // end wire
-}  // end peloton
+}  // namespace wire
+}  // namespace peloton

--- a/src/wire/packet_manager.cpp
+++ b/src/wire/packet_manager.cpp
@@ -1127,6 +1127,6 @@ void PacketManager::Reset() {
   traffic_cop_->Reset();
 }
 
-}  // End wire namespace
-}  // End peloton namespace
+}  // namespace wire
+}  // namespace peloton
 

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -223,5 +223,5 @@ TEST_F(BinderCorrectnessTest, DeleteStatementTest) {
   catalog_ptr->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
 }
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/brain/brain_util_test.cpp
+++ b/test/brain/brain_util_test.cpp
@@ -81,5 +81,5 @@ TEST_F(BrainUtilTests, LoadIndexStatisticsFileTest) {
   }
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/brain/clusterer_test.cpp
+++ b/test/brain/clusterer_test.cpp
@@ -83,5 +83,5 @@ TEST_F(ClustererTests, BasicTest) {
 
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/brain/index_tuner_test.cpp
+++ b/test/brain/index_tuner_test.cpp
@@ -144,5 +144,5 @@ TEST_F(IndexTunerTests, BasicTest) {
 
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/brain/layout_tuner_test.cpp
+++ b/test/brain/layout_tuner_test.cpp
@@ -128,5 +128,5 @@ TEST_F(LayoutTunerTests, BasicTest) {
 
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -219,5 +219,5 @@ TEST_F(CatalogTests, DroppingCatalog) {
   EXPECT_NE(catalog, nullptr);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/catalog/constraints_test.cpp
+++ b/test/catalog/constraints_test.cpp
@@ -262,5 +262,5 @@ TEST_F(ConstraintsTests, ForeignKeyInsertTest) {
 #endif
 */
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/catalog/manager_test.cpp
+++ b/test/catalog/manager_test.cpp
@@ -70,5 +70,5 @@ TEST_F(ManagerTests, TransactionTest) {
   // EXPECT_EQ(catalog::Manager::GetInstance().GetCurrentTileGroupId(), 800);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/catalog/tuple_schema_test.cpp
+++ b/test/catalog/tuple_schema_test.cpp
@@ -175,5 +175,5 @@ TEST_F(TupleSchemaTests, TupleSchemaCopyTest) {
   return;
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/common/cache_test.cpp
+++ b/test/common/cache_test.cpp
@@ -317,5 +317,5 @@ TEST_F(CacheTests, Updating) {
   }
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/common/container_tuple_test.cpp
+++ b/test/common/container_tuple_test.cpp
@@ -44,5 +44,5 @@ TEST_F(ContainerTupleTests, VectorValue) {
   }
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/common/harness.cpp
+++ b/test/common/harness.cpp
@@ -59,5 +59,5 @@ type::AbstractPool* TestingHarness::GetTestingPool() {
 
 oid_t TestingHarness::GetNextTileGroupId() { return ++tile_group_id_counter; }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/common/logger_test.cpp
+++ b/test/common/logger_test.cpp
@@ -29,5 +29,5 @@ TEST_F(LoggerTests, BasicTest) {
   LOG_ERROR("error message");
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/common/thread_pool_test.cpp
+++ b/test/common/thread_pool_test.cpp
@@ -74,5 +74,5 @@ TEST_F(ThreadPoolTests, BasicTest) {
   thread_pool.Shutdown();
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/concurrency/anomaly_test.cpp
+++ b/test/concurrency/anomaly_test.cpp
@@ -807,5 +807,5 @@ TEST_F(AnomalyTests, StressTest) {
   }
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/concurrency/decentralized_epoch_manager_test.cpp
+++ b/test/concurrency/decentralized_epoch_manager_test.cpp
@@ -137,6 +137,6 @@ TEST_F(DecentralizedEpochManagerTests, MultipleThreadsTest) {
 }
 
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton
 

--- a/test/concurrency/local_epoch_test.cpp
+++ b/test/concurrency/local_epoch_test.cpp
@@ -92,6 +92,6 @@ TEST_F(LocalEpochTests, TransactionTest) {
 }
 
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton
 

--- a/test/concurrency/multi_granularity_access_test.cpp
+++ b/test/concurrency/multi_granularity_access_test.cpp
@@ -227,5 +227,5 @@ TEST_F(MultiGranularityAccessTests, MultiTransactionTest) {
  }
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/concurrency/mvcc_test.cpp
+++ b/test/concurrency/mvcc_test.cpp
@@ -166,5 +166,5 @@ TEST_F(MVCCTests, VersionChainTest) {
   }
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/concurrency/serializable_transaction_test.cpp
+++ b/test/concurrency/serializable_transaction_test.cpp
@@ -297,5 +297,5 @@ TEST_F(SerializableTransactionTests, AbortTest) {
   }
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/concurrency/timestamp_ordering_transaction_manager_test.cpp
+++ b/test/concurrency/timestamp_ordering_transaction_manager_test.cpp
@@ -29,5 +29,5 @@ TEST_F(TimestampOrderingTransactionManagerTests, Test) {
   EXPECT_TRUE(true);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/container/cuckoo_map_test.cpp
+++ b/test/container/cuckoo_map_test.cpp
@@ -93,5 +93,5 @@ TEST_F(CuckooMapTests, SharedPointerTest) {
 
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/container/lock_free_array_test.cpp
+++ b/test/container/lock_free_array_test.cpp
@@ -65,5 +65,5 @@ TEST_F(LockFreeArrayTests, SharedPointerTest) {
 
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/executor/copy_test.cpp
+++ b/test/executor/copy_test.cpp
@@ -139,5 +139,5 @@ TEST_F(CopyTests, Copying) {
   txn_manager.CommitTransaction(txn);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -166,5 +166,5 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   txn_manager.CommitTransaction(txn);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/executor/create_test.cpp
+++ b/test/executor/create_test.cpp
@@ -69,5 +69,5 @@ TEST_F(CreateTests, CreatingTable) {
   txn_manager.CommitTransaction(txn);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -257,5 +257,5 @@ TEST_F(DeleteTests, VariousOperations) {
   txn_manager.CommitTransaction(txn);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/executor/drop_test.cpp
+++ b/test/executor/drop_test.cpp
@@ -72,5 +72,5 @@ TEST_F(DropTests, DroppingTable) {
   txn_manager.CommitTransaction(txn);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/executor/insert_test.cpp
+++ b/test/executor/insert_test.cpp
@@ -147,5 +147,5 @@ TEST_F(InsertTests, InsertRecord) {
   txn_manager.CommitTransaction(txn);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/executor/logical_tile_test.cpp
+++ b/test/executor/logical_tile_test.cpp
@@ -206,5 +206,5 @@ TEST_F(LogicalTileTests, TileMaterializationTest) {
   LOG_TRACE("%s", logical_tile->GetInfo().c_str());
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -334,5 +334,5 @@ TEST_F(UpdateTests, UpdatingOld) {
   txn_manager.CommitTransaction(txn);
 }
 }  // namespace?
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/gc/garbage_collection_test.cpp
+++ b/test/gc/garbage_collection_test.cpp
@@ -293,5 +293,5 @@ TEST_F(GarbageCollectionTests, DeleteTest) {
   }
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/gc/transaction_level_gc_manager_test.cpp
+++ b/test/gc/transaction_level_gc_manager_test.cpp
@@ -200,6 +200,6 @@ TEST_F(TransactionLevelGCManagerTests, GCTest) {
 }
 
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton
 

--- a/test/include/common/harness.h
+++ b/test/include/common/harness.h
@@ -123,5 +123,5 @@ class PelotonTest : public ::testing::Test {
   }
 };
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/include/logging/testing_logging_util.h
+++ b/test/include/logging/testing_logging_util.h
@@ -273,5 +273,5 @@ class LoggingScheduler {
   }
 };
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/index/bwtree_index_test.cpp
+++ b/test/index/bwtree_index_test.cpp
@@ -65,5 +65,5 @@ TEST_F(BwTreeIndexTests, NonUniqueKeyMultiThreadedStressTest2) {
   TestingIndexUtil::NonUniqueKeyMultiThreadedStressTest2(IndexType::BWTREE);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/index/index_intskey_test.cpp
+++ b/test/index/index_intskey_test.cpp
@@ -240,5 +240,5 @@ TEST_F(IndexIntsKeyTests, IndexIntsKeyTest) {
 // IndexIntsKeyHelper(IndexType::BTREE);
 // }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/index/index_util_test.cpp
+++ b/test/index/index_util_test.cpp
@@ -434,5 +434,5 @@ TEST_F(IndexUtilTests, BindKeyTest) {
   return;
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/index/skiplist_index_test.cpp
+++ b/test/index/skiplist_index_test.cpp
@@ -66,5 +66,5 @@ TEST_F(SkipListIndexTests, BasicTest) {
 //  TestingIndexUtil::NonUniqueKeyMultiThreadedStressTest2(IndexType::SKIPLIST);
 //}
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/logging/buffer_pool_test.cpp
+++ b/test/logging/buffer_pool_test.cpp
@@ -178,5 +178,5 @@
 //   frontend_thread.join();
 // }
 
-// }  // End test namespace
-// }  // End peloton namespace
+// }  // namespace test
+// }  // namespace peloton

--- a/test/logging/checkpoint_test.cpp
+++ b/test/logging/checkpoint_test.cpp
@@ -244,5 +244,5 @@
 //   thread.join();
 // }
 
-// }  // End test namespace
-// }  // End peloton namespace
+// }  // namespace test
+// }  // namespace peloton

--- a/test/logging/logging_test.cpp
+++ b/test/logging/logging_test.cpp
@@ -379,6 +379,6 @@
 //   log_manager.EndLogging();
 // }
 
-// }  // End test namespace
-// }  // End peloton namespace
+// }  // namespace test
+// }  // namespace peloton
 // >>>>>>> master

--- a/test/logging/logging_util_test.cpp
+++ b/test/logging/logging_util_test.cpp
@@ -31,5 +31,5 @@
 //   EXPECT_EQ(status, true);
 // }
 
-// }  // End test namespace
-// }  // End peloton namespace
+// }  // namespace test
+// }  // namespace peloton

--- a/test/logging/recovery_test.cpp
+++ b/test/logging/recovery_test.cpp
@@ -452,5 +452,5 @@
 //   EXPECT_EQ(recovery_table->GetTileGroupCount(), 2);
 // }
 
-// }  // End test namespace
-// }  // End peloton namespace
+// }  // namespace test
+// }  // namespace peloton

--- a/test/logging/testing_logging_util.cpp
+++ b/test/logging/testing_logging_util.cpp
@@ -353,5 +353,5 @@
 
 // void LoggingScheduler::Cleanup() { log_manager->ResetFrontendLoggers(); }
 
-// }  // End test namespace
-// }  // End peloton namespace
+// }  // namespace test
+// }  // namespace peloton

--- a/test/logging/write_behind_logging_test.cpp
+++ b/test/logging/write_behind_logging_test.cpp
@@ -163,6 +163,6 @@
 // //   txn_manager.AbortTransaction(txn);
 // // }
 
-// }  // End test namespace
-// }  // End peloton namespace
+// }  // namespace test
+// }  // namespace peloton
 

--- a/test/optimizer/column_stats_collector_test.cpp
+++ b/test/optimizer/column_stats_collector_test.cpp
@@ -116,5 +116,5 @@ TEST_F(ColumnStatsCollectorTests, DecimalTest) {
   EXPECT_EQ(colstats.GetCardinality(), 3);
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/cost_test.cpp
+++ b/test/optimizer/cost_test.cpp
@@ -123,5 +123,5 @@ TEST_F(CostTests, ConjunctionTest) {
   EXPECT_LE(output->num_rows, 11626);
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/histogram_test.cpp
+++ b/test/optimizer/histogram_test.cpp
@@ -143,5 +143,5 @@ TEST_F(HistogramTests, SumTest) {
   EXPECT_EQ(h.Sum(6), 1);
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/hyperloglog_test.cpp
+++ b/test/optimizer/hyperloglog_test.cpp
@@ -165,5 +165,5 @@ TEST_F(HyperLogLogTests, DataTypeTest) {
   hll.EstimateCardinality();
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/old_optimizer_test.cpp
+++ b/test/optimizer/old_optimizer_test.cpp
@@ -179,5 +179,5 @@ TEST_F(OldOptimizerTests, UpdateDelWithIndexScanTest) {
   txn_manager.CommitTransaction(txn);
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/operator_test.cpp
+++ b/test/optimizer/operator_test.cpp
@@ -71,5 +71,5 @@ TEST_F(OperatorTests, OperatorHashAndEqualTest){
   delete having;
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/operator_transformer_test.cpp
+++ b/test/optimizer/operator_transformer_test.cpp
@@ -155,5 +155,5 @@ TEST_F(OperatorTransformerTests, JoinTransformationTest) {
                  "A.b = B.b");
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/optimizer_rule_test.cpp
+++ b/test/optimizer/optimizer_rule_test.cpp
@@ -63,5 +63,5 @@ TEST_F(OptimizerRuleTests, SimpleRuleApplyTest) {
   EXPECT_EQ(outputs.size(), 1);
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -166,5 +166,5 @@ TEST_F(OptimizerTests, HashJoinTest) {
   txn_manager.CommitTransaction(txn);
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/selectivity_test.cpp
+++ b/test/optimizer/selectivity_test.cpp
@@ -244,5 +244,5 @@ TEST_F(SelectivityTests, EqualSelectivityTest) {
   txn_manager.CommitTransaction(txn);
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/stats_storage_test.cpp
+++ b/test/optimizer/stats_storage_test.cpp
@@ -253,5 +253,5 @@ TEST_F(StatsStorageTests, GetTableStatsTest) {
   EXPECT_EQ(table_stats->num_rows, tuple_count);
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/table_stats_collector_test.cpp
+++ b/test/optimizer/table_stats_collector_test.cpp
@@ -141,5 +141,5 @@ TEST_F(TableStatsCollectorTests, MultiColumnTableTest) {
   txn_manager.CommitTransaction(txn);
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/table_stats_test.cpp
+++ b/test/optimizer/table_stats_test.cpp
@@ -97,5 +97,5 @@ TEST_F(TableStatsTests, UpdateTests) {
   EXPECT_EQ(table_stats.GetColumnStats("col2"), nullptr);
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/tuple_sampler_test.cpp
+++ b/test/optimizer/tuple_sampler_test.cpp
@@ -55,5 +55,5 @@ TEST_F(TupleSamplerTests, SampleCountTest) {
   EXPECT_EQ(sampled_tuples.size(), 10);
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/tuple_samples_storage_test.cpp
+++ b/test/optimizer/tuple_samples_storage_test.cpp
@@ -165,5 +165,5 @@ TEST_F(TupleSamplesStorageTests, CollectSamplesForTableTest) {
                                             data_table->GetOid());
 }
 
-} /* namespace test */
-} /* namespace peloton */
+}  // namespace test
+}  // namespace peloton

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -423,5 +423,5 @@ TEST_F(ParserTests, WrongQueryTest) {
     EXPECT_THROW(parser::PostgresParser::ParseSQLString(query.c_str()), Exception);
   }
 }
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -950,5 +950,5 @@ TEST_F(PostgresParserTests, CaseTest) {
 }
 
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/performance/index_performance_test.cpp
+++ b/test/performance/index_performance_test.cpp
@@ -372,5 +372,5 @@ TEST_F(IndexPerformanceTests, BwTreeMultiThreadedTest) {
 //  TestIndexPerformance(IndexType::BTREE);
 //}
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/planner/planner_test.cpp
+++ b/test/planner/planner_test.cpp
@@ -338,5 +338,5 @@ TEST_F(PlannerTests, InsertPlanTestParameterColumns) {
 }
 
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/storage/backend_manager_test.cpp
+++ b/test/storage/backend_manager_test.cpp
@@ -54,5 +54,5 @@ TEST_F(StorageManagerTests, BasicTest) {
   }
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/storage/data_table_test.cpp
+++ b/test/storage/data_table_test.cpp
@@ -91,5 +91,5 @@ TEST_F(DataTableTests, GlobalTableTest) {
   delete data_table_pointer;
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/storage/database_test.cpp
+++ b/test/storage/database_test.cpp
@@ -71,5 +71,5 @@ TEST_F(DatabaseTests, AddDropTableTest) {
   EXPECT_FALSE(storage_manager->HasDatabase(db_id));
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/storage/masked_tuple_test.cpp
+++ b/test/storage/masked_tuple_test.cpp
@@ -104,5 +104,5 @@ TEST_F(MaskedTupleTests, BasicTest) {
   delete key_schema;
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/storage/temp_table_test.cpp
+++ b/test/storage/temp_table_test.cpp
@@ -104,5 +104,5 @@ TEST_F(TempTableTests, InsertTest) {
   EXPECT_EQ(tuple_count, found_tuple_count);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/storage/tile_group_iterator_test.cpp
+++ b/test/storage/tile_group_iterator_test.cpp
@@ -58,5 +58,5 @@ TEST_F(TileGroupIteratorTests, BasicTest) {
   EXPECT_EQ(allocated_tilegroup_count, actual_tile_group_count);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/storage/tile_group_test.cpp
+++ b/test/storage/tile_group_test.cpp
@@ -544,5 +544,5 @@ TEST_F(TileGroupTests, TileCopyTest) {
   delete schema;
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/storage/tile_test.cpp
+++ b/test/storage/tile_test.cpp
@@ -103,5 +103,5 @@ TEST_F(TileTests, BasicTest) {
   delete schema;
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/storage/tuple_test.cpp
+++ b/test/storage/tuple_test.cpp
@@ -154,5 +154,5 @@ TEST_F(TupleTests, VarcharTest) {
   delete schema;
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/type/boolean_value_test.cpp
+++ b/test/type/boolean_value_test.cpp
@@ -212,5 +212,5 @@ TEST_F(BooleanValueTests, CastTest) {
                peloton::Exception);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/type/timestamp_value_test.cpp
+++ b/test/type/timestamp_value_test.cpp
@@ -182,5 +182,5 @@ TEST_F(TimestampValueTests, CastTest) {
   EXPECT_FALSE(result.IsNull());
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/type/types_test.cpp
+++ b/test/type/types_test.cpp
@@ -695,5 +695,5 @@ TEST_F(TypesTests, ConflictAvoidanceTypeTest) {
                peloton::Exception);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/util/file_util_test.cpp
+++ b/test/util/file_util_test.cpp
@@ -69,5 +69,5 @@ TEST_F(FileUtilTests, ExistsTest) {
   EXPECT_FALSE(FileUtil::Exists("/thereisnowaythatyoucouldhavethisfilename"));
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/util/string_util_test.cpp
+++ b/test/util/string_util_test.cpp
@@ -192,5 +192,5 @@ TEST_F(StringUtilTests, SplitTest) {
   }  // FOR
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/util/stringbox_util_test.cpp
+++ b/test/util/stringbox_util_test.cpp
@@ -50,5 +50,5 @@ TEST_F(StringBoxUtilTests, BoxTest) {
   CheckBox(result, "Today I didn't", 4);
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/wire/prepare_stmt_test.cpp
+++ b/test/wire/prepare_stmt_test.cpp
@@ -103,5 +103,5 @@ TEST_F(PrepareStmtTests, PrepareStatementTest) {
   LOG_INFO("Peloton has shut down");
 }
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton

--- a/test/wire/simple_query_test.cpp
+++ b/test/wire/simple_query_test.cpp
@@ -210,5 +210,5 @@ TEST_F(SimpleQueryTests, SimpleQueryTest) {
 //  LOG_INFO("[ScalabilityTest] Peloton has shut down");
 //}
 
-}  // End test namespace
-}  // End peloton namespace
+}  // namespace test
+}  // namespace peloton


### PR DESCRIPTION
The format of how we close namespaces is inconsistent. I've seen:

- `} /* namespace <x> */`
- `} // End namespace <x>`
- `}   // namespace <x>`

This set off my OCD. I don't care what specific format we use, so long as we're consistent. 
 Analyzing our source, the last option is already the most popular and aligns with existing style guides. A quick find-sed standardizes on the last format.