### PR TITLE
Tidy Up Delete/Update Planner

### DIFF
--- a/src/catalog/abstract_catalog.cpp
+++ b/src/catalog/abstract_catalog.cpp
@@ -111,7 +111,7 @@ bool AbstractCatalog::DeleteWithIndexScan(oid_t index_offset,
       new executor::ExecutorContext(txn));
 
   // Delete node
-  planner::DeletePlan delete_node(catalog_table_, false);
+  planner::DeletePlan delete_node(catalog_table_);
   executor::DeleteExecutor delete_executor(&delete_node, context.get());
 
   // Index scan as child node

--- a/src/include/planner/delete_plan.h
+++ b/src/include/planner/delete_plan.h
@@ -12,22 +12,13 @@
 
 #pragma once
 
-#include "catalog/schema.h"
-#include "type/types.h"
-#include "parser/table_ref.h"
 #include "planner/abstract_plan.h"
+#include "type/types.h"
 
 namespace peloton {
 
 namespace storage {
 class DataTable;
-}
-
-namespace expression {
-class AbstractExpression;
-}
-namespace concurrency {
-class Transaction;
 }
 
 namespace planner {
@@ -36,38 +27,24 @@ class DeletePlan : public AbstractPlan {
  public:
   DeletePlan() = delete;
 
-  ~DeletePlan() {
-    if (predicate_ != nullptr) {
-      delete predicate_;
-    }
-  }
+  ~DeletePlan() {}
 
-  DeletePlan(storage::DataTable *table, bool truncate);
-
-  DeletePlan(storage::DataTable *table,
-             const expression::AbstractExpression *predicate);
+  DeletePlan(storage::DataTable *table);
 
   storage::DataTable *GetTable() const { return target_table_; }
-
-  bool GetTruncate() const { return truncate_; }
-
-  void SetParameterValues(std::vector<type::Value> *values) override;
 
   PlanNodeType GetPlanNodeType() const override { return PlanNodeType::DELETE; }
 
   const std::string GetInfo() const override { return "DeletePlan"; }
 
+  void SetParameterValues(std::vector<type::Value> *values) override;
+
   std::unique_ptr<AbstractPlan> Copy() const override {
-    return std::unique_ptr<AbstractPlan>(
-        new DeletePlan(target_table_, truncate_));
+    return std::unique_ptr<AbstractPlan>(new DeletePlan(target_table_));
   }
 
  private:
   storage::DataTable *target_table_ = nullptr;
-
-  expression::AbstractExpression *predicate_ = nullptr;
-
-  bool truncate_ = false;
 
  private:
   DISALLOW_COPY_AND_MOVE(DeletePlan);

--- a/src/include/planner/update_plan.h
+++ b/src/include/planner/update_plan.h
@@ -16,12 +16,6 @@
 #include "planner/abstract_plan.h"
 #include "planner/project_info.h"
 #include "type/types.h"
-<<<<<<< 1ac48311dca16978f6cf47687b0b4c57d1e24380
-#include "parser/table_ref.h"
-#include "catalog/schema.h"
-#include "concurrency/transaction.h"
-=======
->>>>>>> Tidy up Delete Plan and Update Plan
 
 namespace peloton {
 

--- a/src/include/planner/update_plan.h
+++ b/src/include/planner/update_plan.h
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include "catalog/schema.h"
 #include "parser/update_statement.h"
 #include "planner/abstract_plan.h"
 #include "planner/project_info.h"

--- a/src/include/planner/update_plan.h
+++ b/src/include/planner/update_plan.h
@@ -6,25 +6,25 @@
 //
 // Identification: src/include/planner/update_plan.h
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
 #pragma once
 
-#include "../parser/update_statement.h"
+#include "catalog/schema.h"
+#include "parser/update_statement.h"
 #include "planner/abstract_plan.h"
 #include "planner/project_info.h"
 #include "type/types.h"
+<<<<<<< 1ac48311dca16978f6cf47687b0b4c57d1e24380
 #include "parser/table_ref.h"
 #include "catalog/schema.h"
 #include "concurrency/transaction.h"
+=======
+>>>>>>> Tidy up Delete Plan and Update Plan
 
 namespace peloton {
-
-namespace expression {
-class Expression;
-}
 
 namespace storage {
 class DataTable;
@@ -36,41 +36,24 @@ class UpdatePlan : public AbstractPlan {
  public:
   UpdatePlan() = delete;
 
-  explicit UpdatePlan(storage::DataTable *table,
-                      std::unique_ptr<const planner::ProjectInfo> project_info);
+  UpdatePlan(storage::DataTable *table,
+             std::unique_ptr<const planner::ProjectInfo> project_info);
 
-  // FIXME: Should remove when the simple_optimizer tears down
-  explicit UpdatePlan(const parser::UpdateStatement *parse_tree);
-
-  // FIXME: Should remove when the simple_optimizer tears down
-  explicit UpdatePlan(const parser::UpdateStatement *parse_tree,
-                      std::vector<oid_t> &key_column_ids,
-                      std::vector<ExpressionType> &expr_types,
-                      std::vector<type::Value> &values, oid_t &index_id);
-
-  inline ~UpdatePlan() {
-    if (where_ != nullptr) {
-      delete (where_);
-    }
-
-    for (size_t update_itr = 0; update_itr < updates_.size(); ++update_itr) {
-      delete (updates_[update_itr]);
-    }
-  }
+  ~UpdatePlan() {}
 
   const planner::ProjectInfo *GetProjectInfo() const {
     return project_info_.get();
   }
 
-  inline PlanNodeType GetPlanNodeType() const { return PlanNodeType::UPDATE; }
-
   storage::DataTable *GetTable() const { return target_table_; }
 
-  const std::string GetInfo() const { return "UpdatePlan"; }
+  bool GetUpdatePrimaryKey() const { return update_primary_key_; }
 
   void SetParameterValues(std::vector<type::Value> *values);
 
-  bool GetUpdatePrimaryKey() const { return update_primary_key_; }
+  PlanNodeType GetPlanNodeType() const { return PlanNodeType::UPDATE; }
+
+  const std::string GetInfo() const { return "UpdatePlan"; }
 
   std::unique_ptr<AbstractPlan> Copy() const {
     return std::unique_ptr<AbstractPlan>(
@@ -78,26 +61,10 @@ class UpdatePlan : public AbstractPlan {
   }
 
  private:
-  // Initialize private members and construct colum_ids given a UpdateStatement.
-  void BuildInitialUpdatePlan(const parser::UpdateStatement *parse_tree,
-                              std::vector<oid_t> &columns,
-                              concurrency::Transaction *txn);
-
-  /** @brief Target table. */
   storage::DataTable *target_table_;
 
-  /** @brief Projection info */
   std::unique_ptr<const planner::ProjectInfo> project_info_;
 
-  // FIXME: Should remove when the simple_optimizer tears down
-  // Vector of Update clauses
-  std::vector<parser::UpdateClause *> updates_;
-
-  // FIXME: Should remove when the simple_optimizer tears down
-  // The where condition
-  expression::AbstractExpression *where_;
-
-  // Whether update primary key
   bool update_primary_key_;
 
  private:

--- a/src/main/tpcc/tpcc_delivery.cpp
+++ b/src/main/tpcc/tpcc_delivery.cpp
@@ -302,7 +302,7 @@ bool RunDelivery(const size_t &thread_id){
     executor::IndexScanExecutor new_order_delete_index_scan_executor(&new_order_delete_idex_scan_node, context.get());
 
     // Construct delete executor
-    planner::DeletePlan new_order_delete_node(new_order_table, false);
+    planner::DeletePlan new_order_delete_node(new_order_table);
 
     executor::DeleteExecutor new_order_delete_executor(&new_order_delete_node, context.get());
 

--- a/src/optimizer/operator_to_plan_transformer.cpp
+++ b/src/optimizer/operator_to_plan_transformer.cpp
@@ -359,15 +359,8 @@ void OperatorToPlanTransformer::Visit(const PhysicalInsertSelect *op) {
 }
 
 void OperatorToPlanTransformer::Visit(const PhysicalDelete *op) {
-  // TODO: Support index scan
-  auto scan_plan = (planner::AbstractScan *)children_plans_[0].get();
-  PL_ASSERT(scan_plan != nullptr);
-
-  // Add predicates. The predicate should already be evaluated in Scan.
-  // Currently, the delete executor does not use predicate at all.
-  const expression::AbstractExpression *predicates = scan_plan->GetPredicate();
   unique_ptr<planner::AbstractPlan> delete_plan(
-      new planner::DeletePlan(op->target_table, predicates));
+      new planner::DeletePlan(op->target_table));
 
   // Add child
   delete_plan->AddChild(move(children_plans_[0]));

--- a/src/planner/delete_plan.cpp
+++ b/src/planner/delete_plan.cpp
@@ -11,39 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "planner/delete_plan.h"
-
-#include "parser/delete_statement.h"
-#include "catalog/catalog.h"
-#include "expression/expression_util.h"
 #include "storage/data_table.h"
 
 namespace peloton {
-
-namespace expression {
-class TupleValueExpression;
-}
 namespace planner {
 
-DeletePlan::DeletePlan(storage::DataTable *table, bool truncate)
-    : target_table_(table), truncate_(truncate) {
+DeletePlan::DeletePlan(storage::DataTable *table) : target_table_(table) {
   LOG_TRACE("Creating a Delete Plan");
-}
-
-// Creates the delete plan. The scan plan should be added outside
-DeletePlan::DeletePlan(storage::DataTable *table,
-                       const expression::AbstractExpression *predicate)
-    : target_table_(table) {
-  // if expr is null , delete all tuples from table
-  if (predicate == nullptr) {
-    LOG_TRACE("No expression, setting truncate to true");
-    predicate = nullptr;
-    truncate_ = true;
-  } else {
-    LOG_TRACE("Replacing COLUMN_REF with TupleValueExpressions");
-    predicate_ = predicate->Copy();
-    expression::ExpressionUtil::TransformExpression(target_table_->GetSchema(),
-                                                    predicate_);
-  }
 }
 
 void DeletePlan::SetParameterValues(std::vector<type::Value> *values) {

--- a/src/planner/update_plan.cpp
+++ b/src/planner/update_plan.cpp
@@ -11,11 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "planner/update_plan.h"
-
 #include "planner/project_info.h"
-#include "type/types.h"
-
 #include "storage/data_table.h"
+#include "type/types.h"
 
 namespace peloton {
 namespace planner {

--- a/src/planner/update_plan.cpp
+++ b/src/planner/update_plan.cpp
@@ -2,34 +2,20 @@
 //
 //                         Peloton
 //
-// drop_plan.cpp
+// update_plan.cpp
 //
-// Identification: src/planner/drop_plan.cpp
+// Identification: src/planner/update_plan.cpp
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
 #include "planner/update_plan.h"
 
-#include "parser/update_statement.h"
 #include "planner/project_info.h"
 #include "type/types.h"
 
-#include "catalog/catalog.h"
-#include "expression/expression_util.h"
-#include "parser/table_ref.h"
 #include "storage/data_table.h"
-
-#include "planner/abstract_plan.h"
-#include "planner/abstract_scan_plan.h"
-#include "planner/index_scan_plan.h"
-#include "planner/seq_scan_plan.h"
-
-#include "planner/abstract_plan.h"
-#include "planner/abstract_scan_plan.h"
-#include "planner/index_scan_plan.h"
-#include "planner/seq_scan_plan.h"
 
 namespace peloton {
 namespace planner {
@@ -38,7 +24,6 @@ UpdatePlan::UpdatePlan(storage::DataTable *table,
                        std::unique_ptr<const planner::ProjectInfo> project_info)
     : target_table_(table),
       project_info_(std::move(project_info)),
-      where_(NULL),
       update_primary_key_(false) {
   LOG_TRACE("Creating an Update Plan");
 
@@ -53,126 +38,8 @@ UpdatePlan::UpdatePlan(storage::DataTable *table,
   }
 }
 
-// FIXME: Should remove when the simple_optimizer tears down
-//  Initializes the update plan without adding any child nodes and
-//  retrieves column ids for the child scan plan.
-void UpdatePlan::BuildInitialUpdatePlan(const parser::UpdateStatement *parse_tree,
-                                        std::vector<oid_t> &column_ids,
-                                        concurrency::Transaction *txn) {
-  LOG_TRACE("Creating an Update Plan");
-  auto t_ref = parse_tree->table;
-  auto table_name = std::string(t_ref->GetTableName());
-  auto database_name = t_ref->GetDatabaseName();
-  LOG_TRACE("Update database %s table %s", database_name, table_name.c_str());
-  target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
-      database_name, table_name, txn);
-  PL_ASSERT(target_table_ != nullptr);
-
-  for (auto update_clause : *parse_tree->updates) {
-    updates_.push_back(update_clause->Copy());
-  }
-  TargetList tlist;
-  DirectMapList dmlist;
-  oid_t col_id;
-  auto schema = target_table_->GetSchema();
-
-  for (auto update : updates_) {
-    // get oid_t of the column and push it to the vector;
-    col_id = schema->GetColumnID(std::string(update->column));
-    column_ids.push_back(col_id);
-    auto *update_expr = update->value->Copy();
-    expression::ExpressionUtil::TransformExpression(target_table_->GetSchema(),
-                                                    update_expr);
-
-    planner::DerivedAttribute attribute{update_expr};
-    attribute.attribute_info.name = update->column;
-    tlist.emplace_back(col_id, attribute);
-  }
-
-  auto &schema_columns = schema->GetColumns();
-  for (uint i = 0; i < schema_columns.size(); i++) {
-    bool is_in_target_list = false;
-    for (auto col_id : column_ids) {
-      if (schema_columns[i].column_name == schema_columns[col_id].column_name) {
-        is_in_target_list = true;
-        break;
-      }
-    }
-    if (is_in_target_list == false)
-      dmlist.emplace_back(i, std::pair<oid_t, oid_t>(0, i));
-  }
-
-  std::unique_ptr<const planner::ProjectInfo> project_info(
-      new planner::ProjectInfo(std::move(tlist), std::move(dmlist)));
-  project_info_ = std::move(project_info);
-
-  if (parse_tree->where != nullptr)
-    where_ = parse_tree->where->Copy();
-  else
-    where_ = nullptr;
-  expression::ExpressionUtil::TransformExpression(target_table_->GetSchema(),
-                                                  where_);
-}
-
-// FIXME: Should remove when the simple_optimizer tears down
-// Creates the update plan with sequential scan.
-UpdatePlan::UpdatePlan(const parser::UpdateStatement *parse_tree)
-    : update_primary_key_(false) {
-  std::vector<oid_t> column_ids;
-  BuildInitialUpdatePlan(parse_tree, column_ids, nullptr);
-
-  // Set primary key update flag
-  for (auto update_clause : updates_) {
-    std::string column_name = update_clause->column;
-
-    oid_t column_id = target_table_->GetSchema()->GetColumnID(column_name);
-    update_primary_key_ =
-        target_table_->GetSchema()->GetColumn(column_id).IsPrimary();
-  }
-
-  LOG_TRACE("Creating a sequential scan plan");
-  std::unique_ptr<planner::SeqScanPlan> seq_scan_node(new planner::SeqScanPlan(
-      target_table_, where_ != nullptr ? where_->Copy() : nullptr, column_ids));
-  AddChild(std::move(seq_scan_node));
-}
-
-// FIXME: Should remove when the simple_optimizer tears down
-// Creates the update plan with index scan.
-UpdatePlan::UpdatePlan(const parser::UpdateStatement *parse_tree,
-                       std::vector<oid_t> &key_column_ids,
-                       std::vector<ExpressionType> &expr_types,
-                       std::vector<type::Value> &values, oid_t &index_id)
-    : update_primary_key_(false) {
-  std::vector<oid_t> column_ids;
-  BuildInitialUpdatePlan(parse_tree, column_ids, nullptr);
-
-  // Set primary key update flag
-  for (auto update_clause : updates_) {
-    std::string column_name = update_clause->column;
-
-    oid_t column_id = target_table_->GetSchema()->GetColumnID(column_name);
-    update_primary_key_ =
-        target_table_->GetSchema()->GetColumn(column_id).IsPrimary();
-  }
-
-  // Create index scan desc
-  std::vector<expression::AbstractExpression *> runtime_keys;
-  auto index = target_table_->GetIndex(index_id);
-  planner::IndexScanPlan::IndexScanDesc index_scan_desc(
-      index, key_column_ids, expr_types, values, runtime_keys);
-  // Create plan node.
-  LOG_TRACE("Creating a index scan plan");
-  auto predicate_cpy = where_ == nullptr ? nullptr : where_->Copy();
-  std::unique_ptr<planner::IndexScanPlan> index_scan_node(
-      new planner::IndexScanPlan(target_table_, predicate_cpy, column_ids,
-                                 index_scan_desc, true));
-  LOG_TRACE("Index scan plan created");
-  AddChild(std::move(index_scan_node));
-}
-
 void UpdatePlan::SetParameterValues(std::vector<type::Value> *values) {
   LOG_TRACE("Setting parameter values in Update");
-
   auto &children = GetChildren();
   // One sequential scan
   children[0]->SetParameterValues(values);

--- a/test/codegen/delete_translator_test.cpp
+++ b/test/codegen/delete_translator_test.cpp
@@ -56,7 +56,7 @@ TEST_F(DeleteTranslatorTest, DeleteAllTuples) {
   EXPECT_EQ(NumRowsInTestTable(), GetTestTable(TestTableId1()).GetTupleCount());
 
   std::unique_ptr<planner::DeletePlan> delete_plan{
-      new planner::DeletePlan(&GetTestTable(TestTableId1()), nullptr)};
+      new planner::DeletePlan(&GetTestTable(TestTableId1()))};
   std::unique_ptr<planner::AbstractPlan> scan{new planner::SeqScanPlan(
       &GetTestTable(TestTableId1()), nullptr, {0, 1, 2})};
   delete_plan->AddChild(std::move(scan));
@@ -87,7 +87,7 @@ TEST_F(DeleteTranslatorTest, DeleteWithSimplePredicate) {
       CmpGteExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(40));
 
   std::unique_ptr<planner::DeletePlan> delete_plan{
-      new planner::DeletePlan(&GetTestTable(TestTableId2()), nullptr)};
+      new planner::DeletePlan(&GetTestTable(TestTableId2()))};
   std::unique_ptr<planner::AbstractPlan> scan{new planner::SeqScanPlan(
       &GetTestTable(TestTableId2()), a_gt_40.release(), {0, 1, 2})};
   delete_plan->AddChild(std::move(scan));
@@ -129,7 +129,7 @@ TEST_F(DeleteTranslatorTest, DeleteWithCompositePredicate) {
       ExpressionType::CONJUNCTION_AND, b_eq_21.release(), a_gt_20.release());
 
   std::unique_ptr<planner::DeletePlan> delete_plan{
-      new planner::DeletePlan(&GetTestTable(TestTableId3()), nullptr)};
+      new planner::DeletePlan(&GetTestTable(TestTableId3()))};
   std::unique_ptr<planner::AbstractPlan> scan{new planner::SeqScanPlan(
       &GetTestTable(TestTableId3()), conj_eq, {0, 1, 2})};
   delete_plan->AddChild(std::move(scan));
@@ -168,7 +168,7 @@ TEST_F(DeleteTranslatorTest, DeleteWithModuloPredicate) {
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 0), std::move(b_mod_1));
 
   std::unique_ptr<planner::DeletePlan> delete_plan{
-      new planner::DeletePlan(&GetTestTable(TestTableId4()), nullptr)};
+      new planner::DeletePlan(&GetTestTable(TestTableId4()))};
   std::unique_ptr<planner::AbstractPlan> scan{new planner::SeqScanPlan(
       &GetTestTable(TestTableId4()), a_eq_b_mod_1.release(), {0, 1, 2})};
   delete_plan->AddChild(std::move(scan));

--- a/test/concurrency/testing_transaction_util.cpp
+++ b/test/concurrency/testing_transaction_util.cpp
@@ -315,7 +315,7 @@ bool TestingTransactionUtil::ExecuteDelete(
       new executor::ExecutorContext(transaction));
 
   // Delete
-  planner::DeletePlan delete_node(table, false);
+  planner::DeletePlan delete_node(table);
   executor::DeleteExecutor delete_executor(&delete_node, context.get());
 
   auto predicate = MakePredicate(id);

--- a/test/executor/mutate_test.cpp
+++ b/test/executor/mutate_test.cpp
@@ -150,7 +150,7 @@ void DeleteTuple(storage::DataTable *table,
   std::vector<storage::Tuple *> tuples;
 
   // Delete
-  planner::DeletePlan delete_node(table, false);
+  planner::DeletePlan delete_node(table);
   executor::DeleteExecutor delete_executor(&delete_node, context.get());
 
   // Predicate

--- a/test/planner/planner_test.cpp
+++ b/test/planner/planner_test.cpp
@@ -17,11 +17,14 @@
 #include "expression/operator_expression.h"
 #include "expression/parameter_value_expression.h"
 #include "expression/tuple_value_expression.h"
+#include "expression/expression_util.h"
 #include "parser/statements.h"
 #include "planner/delete_plan.h"
+#include "planner/attribute_info.h"
 #include "planner/plan_util.h"
-#include "planner/update_plan.h"
+#include "planner/project_info.h"
 #include "planner/seq_scan_plan.h"
+#include "planner/update_plan.h"
 
 namespace peloton {
 namespace test {
@@ -125,44 +128,67 @@ TEST_F(PlannerTests, UpdatePlanTestParameter) {
 
   // UPDATE department_table SET name = $0 WHERE id = $1
   txn = txn_manager.BeginTransaction();
-  parser::UpdateStatement *update_statement = new parser::UpdateStatement();
-  parser::TableRef *table_ref =
-      new parser::TableRef(peloton::TableReferenceType::JOIN);
 
-  auto name = new char[strlen("department_table") + 1]();
-  strcpy(name, "department_table");
-  auto table_info = new parser::TableInfo();
-  table_info->table_name = name;
-  table_ref->table_info_ = table_info;
-  update_statement->table = table_ref;
-  // Value val =
-  //    type::ValueFactory::GetNullValue();  // The value is not important
-  // at this point
+  auto table_name = std::string("department_table");
+  auto database_name = DEFAULT_DB_NAME;
+  auto target_table = catalog::Catalog::GetInstance()->GetTableWithName(
+      database_name, table_name);
+  auto schema = target_table->GetSchema();
 
-  // name = $0
-  auto update = new parser::UpdateClause();
-  auto column = new char[5]();
-  strcpy(column, "name");
-  update->column = column;
-  auto parameter_expr = new expression::ParameterValueExpression(0);
-  update->value = parameter_expr;
-  auto updates = new std::vector<parser::UpdateClause *>();
-  updates->push_back(update);
-  update_statement->updates = updates;
+  TargetList tlist;
+  DirectMapList dmlist;
+  oid_t col_id;
+  std::vector<oid_t> column_ids;
 
-  // id = $1
-  parameter_expr = new expression::ParameterValueExpression(1);
-  auto tuple_expr =
+  col_id = schema->GetColumnID(std::string("name"));
+  column_ids.push_back(col_id);
+  auto *update_expr = new expression::ParameterValueExpression(0);
+  expression::ExpressionUtil::TransformExpression(target_table->GetSchema(),
+                                                  update_expr);
+
+  planner::DerivedAttribute attribute(update_expr);
+  attribute.attribute_info.type = update_expr->ResultType();
+  attribute.attribute_info.name = std::string("name");
+  tlist.emplace_back(col_id, attribute);
+
+  auto *parameter_expr = new expression::ParameterValueExpression(1);
+  auto *tuple_expr =
       new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 0);
-  auto cmp_expr = new expression::ComparisonExpression(
-      ExpressionType::COMPARE_EQUAL, tuple_expr, parameter_expr);
+  auto *where_expr = new expression::ComparisonExpression(
+                     ExpressionType::COMPARE_EQUAL, tuple_expr, parameter_expr);
 
-  update_statement->where = cmp_expr;
+  auto &schema_columns = schema->GetColumns();
+  for (uint i = 0; i < schema_columns.size(); i++) {
+    bool is_in_target_list = false;
+    for (auto col_id : column_ids) {
+      if (schema_columns[i].column_name == schema_columns[col_id].column_name) {
+        is_in_target_list = true;
+        break;
+      }
+    }
+    if (is_in_target_list == false)
+      dmlist.emplace_back(i, std::pair<oid_t, oid_t>(0, i));
+  }
 
-  auto update_plan = new planner::UpdatePlan(update_statement);
+  column_ids.clear();
+  for (uint i = 0; i < schema_columns.size(); i++) {
+    column_ids.emplace_back(i);
+  }
+
+  std::unique_ptr<const planner::ProjectInfo> project_info(
+      new planner::ProjectInfo(std::move(tlist), std::move(dmlist)));
+
+  std::unique_ptr<planner::UpdatePlan> update_plan(
+      new planner::UpdatePlan(target_table, std::move(project_info)));
+
+  std::unique_ptr<planner::SeqScanPlan> seq_scan_node(
+      new planner::SeqScanPlan(target_table, where_expr, column_ids));
+  update_plan->AddChild(std::move(seq_scan_node));
+
   LOG_INFO("Plan created:\n%s", update_plan->GetInfo().c_str());
 
-  auto values = new std::vector<type::Value>();
+  std::unique_ptr<std::vector<type::Value>> values(
+      new std::vector<type::Value>());
 
   // name = CS, id = 1
   LOG_INFO("Binding values");
@@ -170,17 +196,13 @@ TEST_F(PlannerTests, UpdatePlanTestParameter) {
   values->push_back(type::ValueFactory::GetIntegerValue(1).Copy());
 
   // bind values to parameters in plan
-  update_plan->SetParameterValues(values);
+  update_plan->SetParameterValues(values.get());
   txn_manager.CommitTransaction(txn);
 
   // free the database just created
   txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
-
-  delete values;
-  delete update_statement;
-  delete update_plan;
 }
 
 TEST_F(PlannerTests, InsertPlanTestParameter) {

--- a/test/planner/planner_test.cpp
+++ b/test/planner/planner_test.cpp
@@ -59,24 +59,21 @@ TEST_F(PlannerTests, DeletePlanTestParameter) {
 
   // id = $0
   txn = txn_manager.BeginTransaction();
-  auto parameter_expr = new expression::ParameterValueExpression(0);
-  auto tuple_expr =
+  auto *parameter_expr = new expression::ParameterValueExpression(0);
+  auto *tuple_expr =
       new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 0);
-  auto cmp_expr = new expression::ComparisonExpression(
-      ExpressionType::COMPARE_EQUAL, tuple_expr, parameter_expr);
+  auto *scan_expr =
+      new expression::ComparisonExpression(ExpressionType::COMPARE_EQUAL,
+                                           tuple_expr, parameter_expr);
 
   auto target_table = catalog::Catalog::GetInstance()->GetTableWithName(
       DEFAULT_DB_NAME, "department_table", txn);
 
   // Create delete plan
-  planner::DeletePlan *delete_plan =
-      new planner::DeletePlan(target_table, cmp_expr);
+  std::unique_ptr<planner::DeletePlan> delete_plan(
+      new planner::DeletePlan(target_table));
 
   // Create sequential scan plan
-  expression::AbstractExpression *scan_expr =
-      (delete_plan->GetPredicate() == nullptr
-           ? nullptr
-           : delete_plan->GetPredicate()->Copy());
   LOG_TRACE("Creating a sequential scan plan");
   std::unique_ptr<planner::SeqScanPlan> seq_scan_node(
       new planner::SeqScanPlan(target_table, scan_expr, {}));
@@ -86,24 +83,21 @@ TEST_F(PlannerTests, DeletePlanTestParameter) {
   delete_plan->AddChild(std::move(seq_scan_node));
 
   LOG_INFO("Plan created:\n%s",
-           planner::PlanUtil::GetInfo(delete_plan).c_str());
+           planner::PlanUtil::GetInfo(delete_plan.get()).c_str());
 
-  auto values = new std::vector<type::Value>();
+  std::unique_ptr<std::vector<type::Value>> values(
+      new std::vector<type::Value>());
 
   // id = 15
   LOG_INFO("Binding values");
   values->push_back(type::ValueFactory::GetIntegerValue(15).Copy());
 
   // bind values to parameters in plan
-  delete_plan->SetParameterValues(values);
+  delete_plan->SetParameterValues(values.get());
 
   // free the database just created
   catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
-
-  delete values;
-  delete cmp_expr;
-  delete delete_plan;
 }
 
 TEST_F(PlannerTests, UpdatePlanTestParameter) {


### PR DESCRIPTION
This quick PR removes the redundant code in the Update/Delete plans.   

`DeletePlan`'s constructor now only accepts the target table object, and nothing else.  The predicate/truncate information will be obtained from its child `SeqScanPlan`(or `IndexScanPlan` in the future). `UpdatePlan` also has only one constructor, from now on, which receives the target table and ProjectInfo objects. All the related code has also been fixed, such as optimizer, tests, etc.

I separated these from the codegen PR, for a review, and other planners such as `InsertPlan` will also have to be cleaned up.