### PR TITLE
Check projection expressions for compilation support

### DIFF
--- a/src/include/planner/abstract_plan.h
+++ b/src/include/planner/abstract_plan.h
@@ -106,11 +106,9 @@ class AbstractPlan : public Printable {
   // virtual
   //===--------------------------------------------------------------------===//
   virtual bool SerializeTo(SerializeOutput &output UNUSED_ATTRIBUTE) const {
-    PL_ASSERT(&output != nullptr);
     return false;
   }
   virtual bool DeserializeFrom(SerializeInput &input UNUSED_ATTRIBUTE) {
-    PL_ASSERT(&input != nullptr);
     return false;
   }
   virtual int SerializeSize() { return 0; }


### PR DESCRIPTION
This PR fixes #777.  Currently, we do not check each target expression in non-trivial projections for codegen support. We perform the check in this PR.