### PR TITLE
Remove namespace 'expression' from ContainerTuple 

### DIFF
--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -114,7 +114,7 @@ void IndexTuner::BuildIndex(storage::DataTable* table,
 
     for (oid_t tuple_id = 0; tuple_id < active_tuple_count; tuple_id++) {
       // Setup container tuple
-      expression::ContainerTuple<storage::TileGroup> container_tuple(
+      ContainerTuple<storage::TileGroup> container_tuple(
           tile_group.get(), tuple_id);
 
       // Set the location

--- a/src/codegen/buffering_consumer.cpp
+++ b/src/codegen/buffering_consumer.cpp
@@ -35,7 +35,7 @@ WrappedTuple::WrappedTuple(const WrappedTuple &o)
     : ContainerTuple(&tuple_), tuple_(o.tuple_) {}
 
 WrappedTuple &WrappedTuple::operator=(const WrappedTuple &o) {
-  expression::ContainerTuple<std::vector<peloton::type::Value>>::operator=(o);
+  ContainerTuple<std::vector<peloton::type::Value>>::operator=(o);
   tuple_ = o.tuple_;
   return *this;
 }

--- a/src/executor/aggregate_executor.cpp
+++ b/src/executor/aggregate_executor.cpp
@@ -124,8 +124,8 @@ bool AggregateExecutor::DExecute() {
     LOG_TRACE("Looping over tile..");
 
     for (oid_t tuple_id : *tile) {
-      std::unique_ptr<expression::ContainerTuple<LogicalTile>> cur_tuple(
-          new expression::ContainerTuple<LogicalTile>(tile.get(), tuple_id));
+      std::unique_ptr<ContainerTuple<LogicalTile>> cur_tuple(
+          new ContainerTuple<LogicalTile>(tile.get(), tuple_id));
 
       if (aggregator->Advance(cur_tuple.get()) == false) {
         return false;

--- a/src/executor/aggregator.cpp
+++ b/src/executor/aggregator.cpp
@@ -114,8 +114,8 @@ bool Helper(const planner::AggregatePlan *node, AbstractAttributeAggregator **ag
    * 2) Evaluate filter predicate;
    * if fail, just return
    */
-  std::unique_ptr<expression::ContainerTuple<std::vector<type::Value>>>
-      aggref_tuple(new expression::ContainerTuple<std::vector<type::Value>>(
+  std::unique_ptr<ContainerTuple<std::vector<type::Value>>>
+      aggref_tuple(new ContainerTuple<std::vector<type::Value>>(
           &aggregate_values));
 
   auto predicate = node->GetPredicate();
@@ -230,7 +230,7 @@ bool HashAggregator::Advance(AbstractTuple *cur_tuple) {
 bool HashAggregator::Finalize() {
   for (auto entry : aggregates_map) {
     // Construct a container for the first tuple
-    expression::ContainerTuple<std::vector<type::Value>> first_tuple(
+    ContainerTuple<std::vector<type::Value>> first_tuple(
         &entry.second->first_tuple_values);
     if (Helper(node, entry.second->aggregates, output_table, &first_tuple,
                this->executor_context) == false) {

--- a/src/executor/hash_join_executor.cpp
+++ b/src/executor/hash_join_executor.cpp
@@ -108,7 +108,7 @@ bool HashJoinExecutor::DExecute() {
 
     // Go over the left tile
     for (auto left_tile_itr : *left_tile) {
-      const expression::ContainerTuple<executor::LogicalTile> left_tuple(
+      const ContainerTuple<executor::LogicalTile> left_tuple(
           left_tile, left_tile_itr, &hashed_col_ids);
 
       // Find matching tuples in the hash table built on top of the right table

--- a/src/executor/hybrid_scan_executor.cpp
+++ b/src/executor/hybrid_scan_executor.cpp
@@ -206,8 +206,7 @@ bool HybridScanExecutor::SeqScanUtil() {
         if (predicate_ == nullptr) {
           position_list.push_back(tuple_id);
         } else {
-          expression::ContainerTuple<storage::TileGroup> tuple(tile_group.get(),
-                                                               tuple_id);
+          ContainerTuple<storage::TileGroup> tuple(tile_group.get(), tuple_id);
           auto eval =
               predicate_->Evaluate(&tuple, nullptr, executor_context_).IsTrue();
           if (eval == true) {
@@ -215,8 +214,7 @@ bool HybridScanExecutor::SeqScanUtil() {
           }
         }
       } else {
-        expression::ContainerTuple<storage::TileGroup> tuple(tile_group.get(),
-                                                             tuple_id);
+        ContainerTuple<storage::TileGroup> tuple(tile_group.get(), tuple_id);
         auto eval =
             predicate_->Evaluate(&tuple, nullptr, executor_context_).IsTrue();
         if (eval == true) {

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -240,8 +240,8 @@ bool IndexScanExecutor::ExecPrimaryIndexLookup() {
         // if having predicate, then perform evaluation.
         if (predicate_ != nullptr) {
           LOG_TRACE("perform predicate evaluate");
-          expression::ContainerTuple<storage::TileGroup> tuple(
-              tile_group.get(), tuple_location.offset);
+          ContainerTuple<storage::TileGroup> tuple(tile_group.get(),
+                                                   tuple_location.offset);
           eval =
               predicate_->Evaluate(&tuple, nullptr, executor_context_).IsTrue();
         }
@@ -463,8 +463,8 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
                   tuple_location.offset);
 
         // Further check if the version has the secondary key
-        expression::ContainerTuple<storage::TileGroup> candidate_tuple(
-            tile_group.get(), tuple_location.offset);
+        ContainerTuple<storage::TileGroup> candidate_tuple(tile_group.get(),
+            tuple_location.offset);
 
         LOG_TRACE("candidate_tuple size: %s",
                   candidate_tuple.GetInfo().c_str());
@@ -631,8 +631,8 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
   auto &manager = catalog::Manager::GetInstance();
 
   auto tile_group = manager.GetTileGroup(tuple_location.block);
-  expression::ContainerTuple<storage::TileGroup> tuple(tile_group.get(),
-                                                       tuple_location.offset);
+  ContainerTuple<storage::TileGroup> tuple(tile_group.get(),
+                                           tuple_location.offset);
 
   // This is the end of loop
   oid_t cond_num = key_column_ids_.size();

--- a/src/executor/insert_executor.cpp
+++ b/src/executor/insert_executor.cpp
@@ -95,8 +95,7 @@ bool InsertExecutor::DExecute() {
 
     // Go over the logical tile
     for (oid_t tuple_id : *logical_tile) {
-      expression::ContainerTuple<LogicalTile> cur_tuple(logical_tile.get(),
-                                                        tuple_id);
+      ContainerTuple<LogicalTile> cur_tuple(logical_tile.get(), tuple_id);
 
       // Materialize the logical tile tuple
       for (oid_t column_itr = 0; column_itr < column_count; column_itr++) {

--- a/src/executor/merge_join_executor.cpp
+++ b/src/executor/merge_join_executor.cpp
@@ -133,10 +133,9 @@ bool MergeJoinExecutor::DExecute() {
   LogicalTile::PositionListsBuilder pos_lists_builder(left_tile, right_tile);
 
   while ((left_end_row > left_start_row) && (right_end_row > right_start_row)) {
-    expression::ContainerTuple<executor::LogicalTile> left_tuple(
-        left_tile, left_start_row);
-    expression::ContainerTuple<executor::LogicalTile> right_tuple(
-        right_tile, right_start_row);
+    ContainerTuple<executor::LogicalTile> left_tuple(left_tile, left_start_row);
+    ContainerTuple<executor::LogicalTile> right_tuple(right_tile,
+                                                      right_start_row);
     bool not_matching_tuple_pair = false;
 
     // Evaluate and compare the join clauses
@@ -248,9 +247,8 @@ size_t MergeJoinExecutor::Advance(LogicalTile *tile, size_t start_row,
   if (start_row >= tuple_count) return start_row;
 
   while (end_row < tuple_count) {
-    expression::ContainerTuple<executor::LogicalTile> this_tuple(tile,
-                                                                 this_row);
-    expression::ContainerTuple<executor::LogicalTile> next_tuple(tile, end_row);
+    ContainerTuple<executor::LogicalTile> this_tuple(tile, this_row);
+    ContainerTuple<executor::LogicalTile> next_tuple(tile, end_row);
 
     bool diff = false;
 

--- a/src/executor/nested_loop_join_executor.cpp
+++ b/src/executor/nested_loop_join_executor.cpp
@@ -107,8 +107,8 @@ bool NestedLoopJoinExecutor::DExecute() {
     // If left tile result is not done, continue the left tuples
     if (!left_tile_done_) {
       // Tuple result
-      expression::ContainerTuple<executor::LogicalTile> left_tuple(
-          left_tile_.get(), left_tile_row_itr_);
+      ContainerTuple<executor::LogicalTile> left_tuple(left_tile_.get(),
+                                                       left_tile_row_itr_);
 
       // Grab the values
       std::vector<type::Value> join_values;
@@ -142,8 +142,8 @@ bool NestedLoopJoinExecutor::DExecute() {
           // First, copy the elements in left logical tile's tuple
           LOG_TRACE("Insert a tuple into the output logical tile");
 
-          expression::ContainerTuple<executor::LogicalTile> right_tuple(
-              right_tile.get(), right_tile_row_itr);
+          ContainerTuple<executor::LogicalTile> right_tuple(right_tile.get(),
+              right_tile_row_itr);
 
           if (predicate_ != nullptr) {
             auto eval = predicate_->Evaluate(&left_tuple, &right_tuple,

--- a/src/executor/populate_index_executor.cpp
+++ b/src/executor/populate_index_executor.cpp
@@ -76,7 +76,7 @@ bool PopulateIndexExecutor::DExecute() {
 
       // Go over all tuples in the logical tile
       for (oid_t tuple_id : *tile) {
-        expression::ContainerTuple<LogicalTile> cur_tuple(tile, tuple_id);
+        ContainerTuple<LogicalTile> cur_tuple(tile, tuple_id);
 
         // Materialize the logical tile tuple
         for (oid_t column_itr = 0; column_itr < column_ids_.size();

--- a/src/executor/projection_executor.cpp
+++ b/src/executor/projection_executor.cpp
@@ -105,8 +105,7 @@ bool ProjectionExecutor::DExecute() {
     oid_t new_tuple_id = 0;
     for (oid_t old_tuple_id : *source_tile) {
       storage::Tuple *buffer = new storage::Tuple(schema_, true);
-      expression::ContainerTuple<LogicalTile> tuple(source_tile.get(),
-                                                    old_tuple_id);
+      ContainerTuple<LogicalTile> tuple(source_tile.get(), old_tuple_id);
       project_info_->Evaluate(buffer, &tuple, nullptr, executor_context_);
 
       // Insert projected tuple into the new tile

--- a/src/executor/seq_scan_executor.cpp
+++ b/src/executor/seq_scan_executor.cpp
@@ -98,7 +98,7 @@ bool SeqScanExecutor::DExecute() {
       if (predicate_ != nullptr) {
         // Invalidate tuples that don't satisfy the predicate.
         for (oid_t tuple_id : *tile) {
-          expression::ContainerTuple<LogicalTile> tuple(tile.get(), tuple_id);
+          ContainerTuple<LogicalTile> tuple(tile.get(), tuple_id);
           auto eval = predicate_->Evaluate(&tuple, nullptr, executor_context_);
           if (eval.IsFalse()) {
             // if (predicate_->Evaluate(&tuple, nullptr, executor_context_)
@@ -180,8 +180,8 @@ bool SeqScanExecutor::DExecute() {
               return res;
             }
           } else {
-            expression::ContainerTuple<storage::TileGroup> tuple(
-                tile_group.get(), tuple_id);
+            ContainerTuple<storage::TileGroup> tuple(tile_group.get(),
+                                                     tuple_id);
             LOG_TRACE("Evaluate predicate for a tuple");
             auto eval =
                 predicate_->Evaluate(&tuple, nullptr, executor_context_);

--- a/src/executor/update_executor.cpp
+++ b/src/executor/update_executor.cpp
@@ -98,8 +98,7 @@ bool UpdateExecutor::PerformUpdatePrimaryKey(bool is_owner,
 
   storage::Tuple new_tuple(target_table_schema, true);
 
-  expression::ContainerTuple<storage::TileGroup> old_tuple(tile_group,
-                                                           physical_tuple_id);
+  ContainerTuple<storage::TileGroup> old_tuple(tile_group, physical_tuple_id);
 
   project_info_->Evaluate(&new_tuple, &old_tuple, nullptr, executor_context_);
 
@@ -216,8 +215,8 @@ bool UpdateExecutor::DExecute() {
         // We have already owned a version
 
         // Make a copy of the original tuple and allocate a new tuple
-        expression::ContainerTuple<storage::TileGroup> old_tuple(
-            tile_group, physical_tuple_id);
+        ContainerTuple<storage::TileGroup> old_tuple(tile_group,
+                                                     physical_tuple_id);
         // Execute the projections
         project_info_->Evaluate(&old_tuple, &old_tuple, nullptr,
                                 executor_context_);
@@ -274,11 +273,11 @@ bool UpdateExecutor::DExecute() {
           auto &manager = catalog::Manager::GetInstance();
           auto new_tile_group = manager.GetTileGroup(new_location.block);
 
-          expression::ContainerTuple<storage::TileGroup> new_tuple(
-              new_tile_group.get(), new_location.offset);
+          ContainerTuple<storage::TileGroup> new_tuple(new_tile_group.get(),
+                                                       new_location.offset);
 
-          expression::ContainerTuple<storage::TileGroup> old_tuple(
-              tile_group, physical_tuple_id);
+          ContainerTuple<storage::TileGroup> old_tuple(tile_group,
+                                                       physical_tuple_id);
 
           // perform projection from old version to new version.
           // this triggers in-place update, and we do not need to allocate

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -283,8 +283,8 @@ void TransactionLevelGCManager::UnlinkVersion(
     return;
   }
 
-  expression::ContainerTuple<storage::TileGroup> current_tuple(
-      tile_group.get(), location.offset);
+  ContainerTuple<storage::TileGroup> current_tuple(tile_group.get(),
+                                                   location.offset);
 
   storage::DataTable *table =
       dynamic_cast<storage::DataTable *>(tile_group->GetAbstractTable());

--- a/src/include/codegen/buffering_consumer.h
+++ b/src/include/codegen/buffering_consumer.h
@@ -31,7 +31,7 @@ namespace codegen {
 // A wrapped class for output tuples
 //===----------------------------------------------------------------------===//
 class WrappedTuple
-    : public expression::ContainerTuple<std::vector<peloton::type::Value>> {
+    : public ContainerTuple<std::vector<peloton::type::Value>> {
  public:
   // Basic Constructor
   WrappedTuple(peloton::type::Value *vals, uint32_t num_vals);

--- a/src/include/common/container_tuple.h
+++ b/src/include/common/container_tuple.h
@@ -24,7 +24,6 @@
 #include "type/value.h"
 
 namespace peloton {
-namespace expression {
 
 //===--------------------------------------------------------------------===//
 // Container Tuple wrapping a tile group or logical tile.
@@ -292,5 +291,4 @@ class ContainerTuple<storage::TileGroup> : public AbstractTuple {
   const std::vector<oid_t> *column_ids_ = nullptr;
 };
 
-}  // namespace expression
 }  // namespace peloton

--- a/src/include/executor/aggregator.h
+++ b/src/include/executor/aggregator.h
@@ -342,7 +342,7 @@ class SortedAggregator : public AbstractAggregator {
  private:
   //  AbstractTuple *prev_tuple = nullptr;
   std::vector<type::Value> delegate_tuple_values_;
-  const expression::ContainerTuple<std::vector<type::Value>> delegate_tuple_;
+  const ContainerTuple<std::vector<type::Value>> delegate_tuple_;
   const size_t num_input_columns_;
   AbstractAttributeAggregator **aggregates;
 };

--- a/src/include/executor/hash_executor.h
+++ b/src/include/executor/hash_executor.h
@@ -40,11 +40,11 @@ class HashExecutor : public AbstractExecutor {
 
   /** @brief Type definitions for hash table */
   typedef std::unordered_map<
-      expression::ContainerTuple<LogicalTile>,
+      ContainerTuple<LogicalTile>,
       std::unordered_set<std::pair<size_t, oid_t>,
                          boost::hash<std::pair<size_t, oid_t>>>,
-      expression::ContainerTupleHasher<LogicalTile>,
-      expression::ContainerTupleComparator<LogicalTile>> HashMapType;
+      ContainerTupleHasher<LogicalTile>,
+      ContainerTupleComparator<LogicalTile>> HashMapType;
 
   inline HashMapType &GetHashTable() { return this->hash_table_; }
 

--- a/src/include/executor/hash_set_op_executor.h
+++ b/src/include/executor/hash_set_op_executor.h
@@ -61,9 +61,9 @@ class HashSetOpExecutor : public AbstractExecutor {
 
   /** @brief Type definitions for hash table */
   typedef std::unordered_map<
-      expression::ContainerTuple<LogicalTile>, counter_pair_t,
-      expression::ContainerTupleHasher<LogicalTile>,
-      expression::ContainerTupleComparator<LogicalTile>> HashSetOpMapType;
+      ContainerTuple<LogicalTile>, counter_pair_t,
+      ContainerTupleHasher<LogicalTile>,
+      ContainerTupleComparator<LogicalTile>> HashSetOpMapType;
 
   /* Helper functions */
 

--- a/src/main/tpcc/tpcc_workload.cpp
+++ b/src/main/tpcc/tpcc_workload.cpp
@@ -384,8 +384,8 @@ std::vector<std::vector<type::Value >> ExecuteRead(executor::AbstractExecutor* e
     LOG_TRACE("result column count = %d\n", (int)column_count);
 
     for (oid_t tuple_id : *result_tile) {
-      expression::ContainerTuple<executor::LogicalTile> cur_tuple(result_tile.get(),
-                                                                  tuple_id);
+      ContainerTuple<executor::LogicalTile> cur_tuple(result_tile.get(),
+                                                      tuple_id);
       std::vector<type::Value > tuple_values;
       for (oid_t column_itr = 0; column_itr < column_count; column_itr++){
          auto value = cur_tuple.GetValue(column_itr);

--- a/src/main/ycsb/ycsb_workload.cpp
+++ b/src/main/ycsb/ycsb_workload.cpp
@@ -291,8 +291,8 @@ std::vector<std::vector<type::Value >> ExecuteRead(executor::AbstractExecutor* e
     LOG_TRACE("result column count = %d\n", (int)column_count);
 
     for (oid_t tuple_id : *result_tile) {
-      expression::ContainerTuple<executor::LogicalTile> cur_tuple(result_tile.get(),
-                                                                  tuple_id);
+      ContainerTuple<executor::LogicalTile> cur_tuple(result_tile.get(),
+                                                      tuple_id);
       std::vector<type::Value > tuple_values;
       for (oid_t column_itr = 0; column_itr < column_count; column_itr++){
          auto value = cur_tuple.GetValue(column_itr);

--- a/test/common/container_tuple_test.cpp
+++ b/test/common/container_tuple_test.cpp
@@ -36,7 +36,7 @@ TEST_F(ContainerTupleTests, VectorValue) {
   values.push_back(type::ValueFactory::GetDecimalValue(3.14));
   values.push_back(type::ValueFactory::GetVarcharValue("Hello from ContainerTupleTest"));
 
-  expression::ContainerTuple<std::vector<type::Value>> ctuple(&values);
+  ContainerTuple<std::vector<type::Value>> ctuple(&values);
 
   for (size_t i = 0; i < values.size(); i++) {
     LOG_INFO("%s", ctuple.GetValue(i).GetInfo().c_str());

--- a/test/executor/join_test.cpp
+++ b/test/executor/join_test.cpp
@@ -912,7 +912,7 @@ oid_t CountTuplesWithNullFields(executor::LogicalTile *logical_tile) {
 
   // Go over the tile
   for (auto logical_tile_itr : *logical_tile) {
-    const expression::ContainerTuple<executor::LogicalTile> join_tuple(
+    const ContainerTuple<executor::LogicalTile> join_tuple(
         logical_tile, logical_tile_itr);
 
     // Go over all the fields and check for null values
@@ -940,7 +940,7 @@ void ValidateJoinLogicalTile(executor::LogicalTile *logical_tile) {
   // Check the attribute values
   // Go over the tile
   for (auto logical_tile_itr : *logical_tile) {
-    const expression::ContainerTuple<executor::LogicalTile> join_tuple(
+    const ContainerTuple<executor::LogicalTile> join_tuple(
         logical_tile, logical_tile_itr);
 
     // Check the join fields
@@ -965,7 +965,7 @@ void ValidateNestedLoopJoinLogicalTile(executor::LogicalTile *logical_tile) {
   // Check the attribute values
   // Go over the tile
   for (auto logical_tile_itr : *logical_tile) {
-    const expression::ContainerTuple<executor::LogicalTile> join_tuple(
+    const ContainerTuple<executor::LogicalTile> join_tuple(
         logical_tile, logical_tile_itr);
 
     // Check the join fields


### PR DESCRIPTION
ContainerTuple is in src/common, but was still under namespace expression.  This PR removes namespace expression from ContainerTuple, for the sake of clarification and also of reading the code more effectively.

This is simple and straightforward, so it can be merged after the build passes.