### PR TITLE
Simplifiy singletons

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -34,8 +34,8 @@ namespace catalog {
 
 // Get instance of the global catalog
 Catalog *Catalog::GetInstance(void) {
-  static std::unique_ptr<Catalog> global_catalog(new Catalog());
-  return global_catalog.get();
+  static Catalog global_catalog;
+  return &global_catalog;
 }
 
 /* Initialization of catalog, including:

--- a/src/catalog/column_catalog.cpp
+++ b/src/catalog/column_catalog.cpp
@@ -22,10 +22,8 @@ namespace catalog {
 ColumnCatalog *ColumnCatalog::GetInstance(storage::Database *pg_catalog,
                                           type::AbstractPool *pool,
                                           concurrency::Transaction *txn) {
-  static std::unique_ptr<ColumnCatalog> column_catalog(
-      new ColumnCatalog(pg_catalog, pool, txn));
-
-  return column_catalog.get();
+  static ColumnCatalog column_catalog{pg_catalog, pool, txn};
+  return &column_catalog;
 }
 
 ColumnCatalog::ColumnCatalog(storage::Database *pg_catalog,

--- a/src/catalog/column_stats_catalog.cpp
+++ b/src/catalog/column_stats_catalog.cpp
@@ -23,10 +23,8 @@ namespace catalog {
 
 ColumnStatsCatalog *ColumnStatsCatalog::GetInstance(
     concurrency::Transaction *txn) {
-  static std::unique_ptr<ColumnStatsCatalog> column_stats_catalog(
-      new ColumnStatsCatalog(txn));
-
-  return column_stats_catalog.get();
+  static ColumnStatsCatalog column_stats_catalog{txn};
+  return &column_stats_catalog;
 }
 
 ColumnStatsCatalog::ColumnStatsCatalog(concurrency::Transaction *txn)

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -23,10 +23,8 @@ namespace catalog {
 DatabaseCatalog *DatabaseCatalog::GetInstance(storage::Database *pg_catalog,
                                               type::AbstractPool *pool,
                                               concurrency::Transaction *txn) {
-  static std::unique_ptr<DatabaseCatalog> database_catalog(
-      new DatabaseCatalog(pg_catalog, pool, txn));
-
-  return database_catalog.get();
+  static DatabaseCatalog database_catalog{pg_catalog, pool, txn};
+  return &database_catalog;
 }
 
 DatabaseCatalog::DatabaseCatalog(storage::Database *pg_catalog,

--- a/src/catalog/database_metrics_catalog.cpp
+++ b/src/catalog/database_metrics_catalog.cpp
@@ -21,10 +21,8 @@ namespace catalog {
 
 DatabaseMetricsCatalog *DatabaseMetricsCatalog::GetInstance(
     concurrency::Transaction *txn) {
-  static std::unique_ptr<DatabaseMetricsCatalog> database_metrics_catalog(
-      new DatabaseMetricsCatalog(txn));
-
-  return database_metrics_catalog.get();
+  static DatabaseMetricsCatalog database_metrics_catalog{txn};
+  return &database_metrics_catalog;
 }
 
 DatabaseMetricsCatalog::DatabaseMetricsCatalog(concurrency::Transaction *txn)

--- a/src/catalog/index_catalog.cpp
+++ b/src/catalog/index_catalog.cpp
@@ -25,10 +25,8 @@ namespace catalog {
 IndexCatalog *IndexCatalog::GetInstance(storage::Database *pg_catalog,
                                         type::AbstractPool *pool,
                                         concurrency::Transaction *txn) {
-  static std::unique_ptr<IndexCatalog> index_catalog(
-      new IndexCatalog(pg_catalog, pool, txn));
-
-  return index_catalog.get();
+  static IndexCatalog index_catalog{pg_catalog, pool, txn};
+  return &index_catalog;
 }
 
 IndexCatalog::IndexCatalog(storage::Database *pg_catalog,

--- a/src/catalog/index_metrics_catalog.cpp
+++ b/src/catalog/index_metrics_catalog.cpp
@@ -21,10 +21,8 @@ namespace catalog {
 
 IndexMetricsCatalog *IndexMetricsCatalog::GetInstance(
     concurrency::Transaction *txn) {
-  static std::unique_ptr<IndexMetricsCatalog> index_metrics_catalog(
-      new IndexMetricsCatalog(txn));
-
-  return index_metrics_catalog.get();
+  static IndexMetricsCatalog index_metrics_catalog{txn};
+  return &index_metrics_catalog;
 }
 
 IndexMetricsCatalog::IndexMetricsCatalog(concurrency::Transaction *txn)

--- a/src/catalog/query_metrics_catalog.cpp
+++ b/src/catalog/query_metrics_catalog.cpp
@@ -22,10 +22,8 @@ namespace catalog {
 
 QueryMetricsCatalog *QueryMetricsCatalog::GetInstance(
     concurrency::Transaction *txn) {
-  static std::unique_ptr<QueryMetricsCatalog> query_metrics_catalog(
-      new QueryMetricsCatalog(txn));
-
-  return query_metrics_catalog.get();
+  static QueryMetricsCatalog query_metrics_catalog{txn};
+  return &query_metrics_catalog;
 }
 
 QueryMetricsCatalog::QueryMetricsCatalog(concurrency::Transaction *txn)

--- a/src/catalog/table_catalog.cpp
+++ b/src/catalog/table_catalog.cpp
@@ -23,9 +23,8 @@ namespace catalog {
 TableCatalog *TableCatalog::GetInstance(storage::Database *pg_catalog,
                                         type::AbstractPool *pool,
                                         concurrency::Transaction *txn) {
-  static std::unique_ptr<TableCatalog> table_catalog(
-      new TableCatalog(pg_catalog, pool, txn));
-  return table_catalog.get();
+  static TableCatalog table_catalog{pg_catalog, pool, txn};
+  return &table_catalog;
 }
 
 TableCatalog::TableCatalog(storage::Database *pg_catalog,

--- a/src/catalog/table_metrics_catalog.cpp
+++ b/src/catalog/table_metrics_catalog.cpp
@@ -21,10 +21,8 @@ namespace catalog {
 
 TableMetricsCatalog *TableMetricsCatalog::GetInstance(
     concurrency::Transaction *txn) {
-  static std::unique_ptr<TableMetricsCatalog> table_metrics_catalog(
-      new TableMetricsCatalog(txn));
-
-  return table_metrics_catalog.get();
+  static TableMetricsCatalog table_metrics_catalog{txn};
+  return &table_metrics_catalog;
 }
 
 TableMetricsCatalog::TableMetricsCatalog(concurrency::Transaction *txn)

--- a/src/optimizer/stats/stats_storage.cpp
+++ b/src/optimizer/stats/stats_storage.cpp
@@ -24,9 +24,9 @@ namespace peloton {
 namespace optimizer {
 
 // Get instance of the global stats storage
-StatsStorage *StatsStorage::GetInstance(void) {
-  static std::unique_ptr<StatsStorage> global_stats_storage(new StatsStorage());
-  return global_stats_storage.get();
+StatsStorage *StatsStorage::GetInstance() {
+  static StatsStorage global_stats_storage;
+  return &global_stats_storage;
 }
 
 /**

--- a/src/optimizer/stats/tuple_samples_storage.cpp
+++ b/src/optimizer/stats/tuple_samples_storage.cpp
@@ -24,10 +24,9 @@ namespace peloton {
 namespace optimizer {
 
 // Get instance of the global tuple samples storage
-TupleSamplesStorage *TupleSamplesStorage::GetInstance(void) {
-  static std::unique_ptr<TupleSamplesStorage> global_tuple_samples_storage(
-      new TupleSamplesStorage());
-  return global_tuple_samples_storage.get();
+TupleSamplesStorage *TupleSamplesStorage::GetInstance() {
+  static TupleSamplesStorage global_tuple_samples_storage;
+  return &global_tuple_samples_storage;
 }
 
 /**

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -18,16 +18,15 @@
 namespace peloton {
 namespace storage {
 
-StorageManager::~StorageManager() {}
+StorageManager::StorageManager() = default;
+
+StorageManager::~StorageManager() = default;
 
 // Get instance of the global catalog storage manager
-StorageManager *StorageManager::GetInstance(void) {
-  static std::unique_ptr<StorageManager> global_catalog_storage_manager(
-      new StorageManager());
-  return global_catalog_storage_manager.get();
+StorageManager *StorageManager::GetInstance() {
+  static StorageManager global_catalog_storage_manager;
+  return &global_catalog_storage_manager;
 }
-
-StorageManager::StorageManager() {}
 
 //===--------------------------------------------------------------------===//
 // GET WITH OID - DIRECTLY GET FROM STORAGE LAYER


### PR DESCRIPTION
I just noticed that a few parts of the system use overly complicated singleton instantiations. This PR cleans it up using simple and safe C++11 constructs. No functional changes.

Note: I'm not a huge fan of singletons. In fact, most of these singletons aren't needed if we have an overarching "Peloton" object (or something like that) that can guarantee one-time initialization of the various catalog tables. Then these catalog classes can be regular non-singleton class that provide transactional access to the underlying catalog tables.