### PR TITLE
Pretty print configuration

### DIFF
--- a/src/include/catalog/settings_catalog.h
+++ b/src/include/catalog/settings_catalog.h
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include "catalog/abstract_catalog.h"
@@ -19,12 +18,11 @@ namespace peloton {
 namespace catalog {
 
 class SettingsCatalog : public AbstractCatalog {
-public:
+ public:
   ~SettingsCatalog();
 
   // Global Singleton
-  static SettingsCatalog *GetInstance(
-          concurrency::Transaction *txn = nullptr);
+  static SettingsCatalog *GetInstance(concurrency::Transaction *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -32,9 +30,9 @@ public:
   bool InsertSetting(const std::string &name, const std::string &value,
                      type::TypeId value_type, const std::string &description,
                      const std::string &min_value, const std::string &max_value,
-                     const std::string &default_value,
-                     bool is_mutable, bool is_persistent,
-                     type::AbstractPool *pool, concurrency::Transaction *txn);
+                     const std::string &default_value, bool is_mutable,
+                     bool is_persistent, type::AbstractPool *pool,
+                     concurrency::Transaction *txn);
 
   bool DeleteSetting(const std::string &name, concurrency::Transaction *txn);
 
@@ -60,7 +58,7 @@ public:
     // Add new columns here in creation order
   };
 
-private:
+ private:
   SettingsCatalog(concurrency::Transaction *txn);
 
   enum class IndexId {

--- a/src/main/peloton/peloton.cpp
+++ b/src/main/peloton/peloton.cpp
@@ -13,21 +13,22 @@
 #include <iostream>
 
 #include <gflags/gflags.h>
-#include "settings/settings_manager.h"
+
 #include "common/init.h"
 #include "common/logger.h"
 #include "network/network_manager.h"
+#include "settings/settings_manager.h"
 
 DECLARE_bool(help);
 
 // Peloton process begins execution here.
 int main(int argc, char *argv[]) {
-
   // Parse the command line flags
   ::google::ParseCommandLineNonHelpFlags(&argc, &argv, true);
 
   // If "-h" or "-help" is passed in, set up the help messages.
-  if (peloton::settings::SettingsManager::GetBool(peloton::settings::SettingId::h) ||
+  if (peloton::settings::SettingsManager::GetBool(
+          peloton::settings::SettingId::h) ||
       FLAGS_help) {
     FLAGS_help = true;
     ::google::SetUsageMessage("Usage Info: \n");
@@ -35,7 +36,8 @@ int main(int argc, char *argv[]) {
   }
 
   // Print settings
-  if (peloton::settings::SettingsManager::GetBool(peloton::settings::SettingId::display_settings)) {
+  if (peloton::settings::SettingsManager::GetBool(
+          peloton::settings::SettingId::display_settings)) {
     auto settings = peloton::settings::SettingsManager::GetInstance();
     settings->ShowInfo();
   }
@@ -46,11 +48,10 @@ int main(int argc, char *argv[]) {
 
     // Create NetworkManager object
     peloton::network::NetworkManager network_manager;
-    
+
     // Start NetworkManager
     network_manager.StartServer();
-  }
-  catch(peloton::ConnectionException exception){
+  } catch (peloton::ConnectionException exception) {
     // Nothing to do here!
   }
 

--- a/src/settings/README.md
+++ b/src/settings/README.md
@@ -1,9 +1,11 @@
 # Settings
-There are two major parts in this PR:
+There are two major components to Peloton settings:
 - SettingsCatalog
 - SettingsManager
+
 ## SettingsCatalog
-I create a new catalog table 'pg_settings' to store configuration information which contains several columns:
+All settings are stored in the 'pg_settings' catalog table. pg_settings
+contains the following columns to track configuration information:
 - name (varchar) : the name of a parameter
 - value (varchar) : the current value of a parameter
 - value_type (integer) : the type (type::TypeId) of the value
@@ -13,27 +15,40 @@ I create a new catalog table 'pg_settings' to store configuration information wh
 - default_value (varchar) : default value
 - is_mutable (boolean) : be true if the parameter is allowed to modify during the system running
 - is_persistent (boolean) : be true if the value should be restored from logs/checkpoints when the system restarts
+
 ## SettingsManager
-This is a wrapper of SettingsCatalog. It provides several APIs: DefineSetting, GetValue and SetValue. 
-It also provides util functions such as GetInt(id) and SetInt(id, value) for easy to use.
-SettingsManager keeps a map from name to value which is used during bootstrap before catalog being initialized.
+This is a programmatic wrapper around SettingsCatalog. It provides
+several APIs: `DefineSetting`, `GetValue` and `SetValue` for defining,
+retrieving and setting configuration values at runtime.
+It also provides utility functions such as `GetInt(id`) and
+`SetInt(id, value)` for simplified and typed access to configuration.
+SettingsManager keeps a map from name to value which is used during
+bootstrap before catalog being initialized.
+
 ## SettingId
-SettingId is an enum class contains members whose names are the same as the names of parameters.
+SettingId is an enum class contains members whose names are the same as
+the names of parameters.
+
 ## How To Use It
-When you want to add a new parameter, define it with macros SETTING_(int, bool, string) in *include/settings/settings.h*
+When you want to add a new parameter, define it with macros
+`SETTING_(int, bool, string)` in *include/settings/settings.h*
 For example:
-`//CONFIG_int(name, description, default_value, is_mutable, is_persistent)`
-`CONFIG_int(port, "Peloton port (default: 15721)", 15721, false, false)`
+```
+// CONFIG_int(name, description, default_value, is_mutable, is_persistent)
+CONFIG_int(port, "Peloton port (default: 15721)", 15721, false, false)
+```
 The macro defined in *include/settings/settings_macro.h* will be exposed as four types of content on demand:
 - a gflags definition
 - a gflags declaration
 - a member in SettingId 
 - a statement of SettingsManager::DefineSetting
 
-To get or set values, use util funciton of SettingsManager. For example:
+To get or set values, use the utility functions of `SettingsManager`.
+For example:
 `SettingsManager::GetInt(SettingId::port)`
 `SettingsManager::SetBool(SettingId::index_tuner, true)`
 
 ### TODO
 - Support more types, not only INTEGER, BOOLEAN, STRING
-- Support validation check, I leave blank in min_value and max_value temporarily.
+- Support validation check, I leave blank in min_value and max_value
+temporarily.

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include <gflags/gflags.h>
+
 #include "type/types.h"
 
 // gflags DEFINE


### PR DESCRIPTION
After the settings PR, the `-display_settings` configuration parameter wasn't printing the configuration nicely on startup. This PR fixes it, cleaned up the settings README, and ran the code formatter. No functional changes.