### PR TITLE
Fix hash_join_executor in the interpreted engine

### DIFF
--- a/src/executor/hash_join_executor.cpp
+++ b/src/executor/hash_join_executor.cpp
@@ -101,7 +101,6 @@ bool HashJoinExecutor::DExecute() {
 
     // Get the hash table from the hash executor
     auto &hash_table = hash_executor_->GetHashTable();
-//    auto &hashed_col_ids = hash_executor_->GetHashKeyIds();
     std::vector<const expression::AbstractExpression *> left_hashed_cols;
     this->GetPlanNode<planner::HashJoinPlan>().GetLeftHashKeys(left_hashed_cols);
 

--- a/src/executor/hash_join_executor.cpp
+++ b/src/executor/hash_join_executor.cpp
@@ -15,6 +15,7 @@
 #include "executor/logical_tile_factory.h"
 #include "executor/hash_join_executor.h"
 #include "expression/abstract_expression.h"
+#include "expression/tuple_value_expression.h"
 #include "common/container_tuple.h"
 
 namespace peloton {
@@ -100,7 +101,17 @@ bool HashJoinExecutor::DExecute() {
 
     // Get the hash table from the hash executor
     auto &hash_table = hash_executor_->GetHashTable();
-    auto &hashed_col_ids = hash_executor_->GetHashKeyIds();
+//    auto &hashed_col_ids = hash_executor_->GetHashKeyIds();
+    std::vector<const expression::AbstractExpression *> left_hashed_cols;
+    this->GetPlanNode<planner::HashJoinPlan>().GetLeftHashKeys(left_hashed_cols);
+
+    std::vector<oid_t> left_hashed_col_ids;
+    for (auto &hashkey : left_hashed_cols) {
+      PL_ASSERT(hashkey->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+      auto tuple_value =
+          reinterpret_cast<const expression::TupleValueExpression *>(hashkey);
+      left_hashed_col_ids.push_back(tuple_value->GetColumnId());
+    }
 
     oid_t prev_tile = INVALID_OID;
     std::unique_ptr<LogicalTile> output_tile;
@@ -109,19 +120,19 @@ bool HashJoinExecutor::DExecute() {
     // Go over the left tile
     for (auto left_tile_itr : *left_tile) {
       const ContainerTuple<executor::LogicalTile> left_tuple(
-          left_tile, left_tile_itr, &hashed_col_ids);
+          left_tile, left_tile_itr, &left_hashed_col_ids);
 
       // Find matching tuples in the hash table built on top of the right table
       auto right_tuples = hash_table.find(left_tuple);
 
       if (right_tuples != hash_table.end()) {
     	// Not yet supported due to assertion in gettomg right_tuples->first
-//    	if (predicate_ != nullptr) {
-//    		auto eval = predicate_->Evaluate(&left_tuple, &right_tuples->first,
-//					executor_context_);
-//			if (eval.IsFalse())
-//				continue;
-//    	}
+    	if (predicate_ != nullptr) {
+    		auto eval = predicate_->Evaluate(&left_tuple, &right_tuples->first,
+					executor_context_);
+			if (eval.IsFalse())
+				continue;
+    	}
 
         RecordMatchedLeftRow(left_result_tiles_.size() - 1, left_tile_itr);
 

--- a/src/include/common/container_tuple.h
+++ b/src/include/common/container_tuple.h
@@ -91,9 +91,11 @@ class ContainerTuple : public AbstractTuple {
    */
   bool EqualsNoSchemaCheck(const ContainerTuple<T> &other) const {
     if (column_ids_) {
-      for (auto &column_itr : *column_ids_) {
-        type::Value lhs = (GetValue(column_itr));
-        type::Value rhs = (other.GetValue(column_itr));
+      if (column_ids_->size() != other.column_ids_->size())
+        return false;
+      for (size_t idx = 0; idx<column_ids_->size(); idx++) {
+        type::Value lhs = (GetValue(column_ids_->at(idx)));
+        type::Value rhs = (other.GetValue(other.column_ids_->at(idx)));
         if (lhs.CompareNotEquals(rhs) == type::CMP_TRUE) {
           return false;
         }

--- a/test/executor/join_test.cpp
+++ b/test/executor/join_test.cpp
@@ -723,7 +723,9 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, JoinType join_type,
 
       // Create hash join plan node.
       planner::HashJoinPlan hash_join_plan_node(join_type, std::move(predicate),
-                                                std::move(projection), schema);
+                                                std::move(projection), schema,
+                                                left_hash_keys,
+                                                right_hash_keys);
 
       // Construct the hash join executor
       executor::HashJoinExecutor hash_join_executor(&hash_join_plan_node,


### PR DESCRIPTION
The hash_join_executor in the interpreted engine has been broken for a while. This PR fixes several issues related to the correctness problem:
- Use correct left column ids derived from the left hash keys in the hash_join_plan to probe the hash table
- Modify the comparator for ContainerTuple to make sure that the probe check is correct
- Support predicate evaluation in the executor

Since I have never touched the codes for ContainerTuple before, I need someone to help review this PR.

This PR is the first step to fix #807, the next step is to support predicate push-down so that the memory consumption can be reduced significantly. I will send another PR soon.