### PR TITLE
Handling syntax error in queries

### DIFF
--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1415,10 +1415,11 @@ parser::SQLStatementList* PostgresParser::ParseSQLString(const char* text) {
   auto result = pg_query_parse(text);
   if (result.error) {
     // Parse Error
+    std::string exception_msg = StringUtil::Format(
+        "%s at %d", result.error->message, result.error->cursorpos);
     pg_query_parse_finish(ctx);
     pg_query_free_parse_result(result);
-    throw ParserException(StringUtil::Format("%s at %d", result.error->message,
-                                             result.error->cursorpos));
+    throw ParserException(exception_msg);
   }
 
   // DEBUG only. Comment this out in release mode

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1415,6 +1415,8 @@ parser::SQLStatementList* PostgresParser::ParseSQLString(const char* text) {
   auto result = pg_query_parse(text);
   if (result.error) {
     // Parse Error
+    pg_query_parse_finish(ctx);
+    pg_query_free_parse_result(result);
     throw ParserException(StringUtil::Format("%s at %d", result.error->message,
                                              result.error->cursorpos));
   }

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -417,9 +417,13 @@ TEST_F(ParserTests, WrongQueryTest) {
   std::vector<std::string> queries;
   queries.push_back("SELECT;");
   queries.push_back("SELECT *;");
+  // Query with wrong syntax
+  queries.push_back("SECLECT *;");
+
   // Parsing
   for (auto query : queries) {
-    EXPECT_THROW(parser::PostgresParser::ParseSQLString(query.c_str()), Exception);
+    EXPECT_THROW(parser::PostgresParser::ParseSQLString(query.c_str()),
+                 Exception);
   }
 }
 }  // namespace test


### PR DESCRIPTION
This is the fix for issue #808 and it contains:
- Change the parser to throw ParserException when faced with a syntax error
- Formatted old code
- Added an extra test query with invalid syntax in parser_test.cpp
