### PR TITLE
Switch DATE type to be int32

### DIFF
--- a/src/catalog/index_catalog.cpp
+++ b/src/catalog/index_catalog.cpp
@@ -47,7 +47,7 @@ IndexCatalogObject::IndexCatalogObject(executor::LogicalTile *tile, int tupleId)
   while (std::getline(ss, tok, ' ')) {
     key_attrs.push_back(std::stoi(tok));
   }
-  LOG_DEBUG("the size for indexed key is %lu", key_attrs.size());
+  LOG_TRACE("the size for indexed key is %lu", key_attrs.size());
 }
 
 IndexCatalog *IndexCatalog::GetInstance(storage::Database *pg_catalog,

--- a/src/executor/hash_join_executor.cpp
+++ b/src/executor/hash_join_executor.cpp
@@ -101,7 +101,6 @@ bool HashJoinExecutor::DExecute() {
 
     // Get the hash table from the hash executor
     auto &hash_table = hash_executor_->GetHashTable();
-//    auto &hashed_col_ids = hash_executor_->GetHashKeyIds();
     std::vector<const expression::AbstractExpression *> left_hashed_cols;
     this->GetPlanNode<planner::HashJoinPlan>().GetLeftHashKeys(left_hashed_cols);
 

--- a/src/include/type/boolean_type.h
+++ b/src/include/type/boolean_type.h
@@ -38,6 +38,10 @@ class BooleanType : public Type {
   CmpBool CompareGreaterThanEquals(const Value& left,
                                    const Value& right) const override;
 
+  // Other mathematical functions
+  Value Min(const Value& left, const Value& right) const override;
+  Value Max(const Value& left, const Value& right) const override;
+
   // Decimal types are always inlined
   bool IsInlined(const Value&) const override { return true; }
 

--- a/src/include/type/limits.h
+++ b/src/include/type/limits.h
@@ -35,7 +35,7 @@ static const int32_t PELOTON_INT32_MAX = INT_MAX;
 static const int64_t PELOTON_INT64_MAX = LLONG_MAX;
 static const uint64_t PELOTON_UINT64_MAX = ULLONG_MAX - 1;
 static const double PELOTON_DECIMAL_MAX = DBL_MAX;
-static const uint64_t PELOTON_TIMESTAMP_MAX = 11231999986399999999U;
+static const uint64_t PELOTON_TIMESTAMP_MAX = 11231999986399999999U; // ???
 static const int32_t PELOTON_DATE_MAX = INT_MAX;
 static const int8_t PELOTON_BOOLEAN_MAX = 1;
 

--- a/src/include/type/limits.h
+++ b/src/include/type/limits.h
@@ -26,7 +26,7 @@ static const int32_t PELOTON_INT32_MIN = (INT_MIN + 1);
 static const int64_t PELOTON_INT64_MIN = (LLONG_MIN + 1);
 static const double PELOTON_DECIMAL_MIN = FLT_LOWEST;
 static const uint64_t PELOTON_TIMESTAMP_MIN = 0;
-static const uint32_t PELOTON_DATE_MIN = 0;
+static const int32_t PELOTON_DATE_MIN = (INT_MIN + 1);
 static const int8_t PELOTON_BOOLEAN_MIN = 0;
 
 static const int8_t PELOTON_INT8_MAX = SCHAR_MAX;
@@ -36,7 +36,7 @@ static const int64_t PELOTON_INT64_MAX = LLONG_MAX;
 static const uint64_t PELOTON_UINT64_MAX = ULLONG_MAX - 1;
 static const double PELOTON_DECIMAL_MAX = DBL_MAX;
 static const uint64_t PELOTON_TIMESTAMP_MAX = 11231999986399999999U;
-static const uint64_t PELOTON_DATE_MAX = INT_MAX;
+static const int32_t PELOTON_DATE_MAX = INT_MAX;
 static const int8_t PELOTON_BOOLEAN_MAX = 1;
 
 static const uint32_t PELOTON_VALUE_NULL = UINT_MAX;
@@ -44,7 +44,7 @@ static const int8_t PELOTON_INT8_NULL = SCHAR_MIN;
 static const int16_t PELOTON_INT16_NULL = SHRT_MIN;
 static const int32_t PELOTON_INT32_NULL = INT_MIN;
 static const int64_t PELOTON_INT64_NULL = LLONG_MIN;
-static const uint64_t PELOTON_DATE_NULL = 0;
+static const int32_t PELOTON_DATE_NULL = INT_MIN;
 static const uint64_t PELOTON_TIMESTAMP_NULL = ULLONG_MAX;
 static const double PELOTON_DECIMAL_NULL = DBL_LOWEST;
 static const int8_t PELOTON_BOOLEAN_NULL = SCHAR_MIN;

--- a/src/include/type/timestamp_type.h
+++ b/src/include/type/timestamp_type.h
@@ -33,8 +33,8 @@ class TimestampType : public Type {
   CmpBool CompareGreaterThanEquals(const Value& left, const Value &right) const override;
   
   // Other mathematical functions
-  virtual Value Min(const Value& left, const Value &right) const override;
-  virtual Value Max(const Value& left, const Value &right) const override;
+  Value Min(const Value& left, const Value &right) const override;
+  Value Max(const Value& left, const Value &right) const override;
 
   bool IsInlined(const Value&) const override { return true; }
 

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -617,6 +617,9 @@ enum class CreateType {
   CONSTRAINT = 4,             // constraint create type
   TRIGGER = 5                 // trigger create type
 };
+std::string CreateTypeToString(CreateType type);
+CreateType StringToCreateType(const std::string &str);
+std::ostream &operator<<(std::ostream &os, const CreateType &type);
 
 //===--------------------------------------------------------------------===//
 // Drop Types
@@ -630,9 +633,9 @@ enum class DropType {
   CONSTRAINT = 4,             // constraint drop type
   TRIGGER = 5                 // trigger drop type
 };
-std::string CreateTypeToString(CreateType type);
-CreateType StringToCreateType(const std::string &str);
-std::ostream &operator<<(std::ostream &os, const CreateType &type);
+std::string DropTypeToString(DropType type);
+DropType StringToDropType(const std::string &str);
+std::ostream &operator<<(std::ostream &os, const DropType &type);
 
 //===--------------------------------------------------------------------===//
 // Statement Types
@@ -867,6 +870,7 @@ enum class FKConstrMatchType {
 //===--------------------------------------------------------------------===//
 // Set Operation Types
 //===--------------------------------------------------------------------===//
+
 enum class SetOpType {
   INVALID = INVALID_TYPE_ID,
   INTERSECT = 1,
@@ -1245,13 +1249,18 @@ typedef std::vector<DirectMap> DirectMapList;
 //===--------------------------------------------------------------------===//
 // Optimizer
 //===--------------------------------------------------------------------===//
+
 enum class PropertyType {
+  INVALID = INVALID_TYPE_ID,
   PREDICATE,
   COLUMNS,
   DISTINCT,
   SORT,
   LIMIT,
 };
+std::string PropertyTypeToString(PropertyType type);
+PropertyType StringToPropertyType(const std::string &str);
+std::ostream &operator<<(std::ostream &os, const PropertyType &type);
 
 namespace expression {
 class AbstractExpression;
@@ -1282,7 +1291,7 @@ typedef std::unordered_set<std::shared_ptr<expression::AbstractExpression>,
                            expression::ExprHasher,
                            expression::ExprEqualCmp> ExprSet;
 
-std::string PropertyTypeToString(PropertyType type);
+
 
 //===--------------------------------------------------------------------===//
 // Wire protocol typedefs

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -61,7 +61,7 @@ class Value : public Printable {
 
   // SMALLINT
   Value(TypeId type, int16_t i);
-  // INTEGER and PARAMETER_OFFSET
+  // INTEGER and PARAMETER_OFFSET and DATE
   Value(TypeId type, int32_t i);
   // BIGINT
   Value(TypeId type, int64_t i);
@@ -324,7 +324,7 @@ class Value : public Printable {
     int32_t integer;
     int64_t bigint;
     double decimal;
-    uint32_t date;
+    int32_t date;
     uint64_t timestamp;
     char *varlen;
     const char *const_varlen;

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -125,6 +125,9 @@ class ValueFactory {
       case TypeId::TIMESTAMP:
         ret_value = GetTimestampValue(PELOTON_TIMESTAMP_NULL);
         break;
+      case TypeId::DATE:
+        ret_value = GetDateValue(PELOTON_DATE_NULL);
+        break;
       case TypeId::VARCHAR:
         ret_value = GetVarcharValue(nullptr, false, nullptr);
         break;
@@ -160,6 +163,8 @@ class ValueFactory {
         return GetDecimalValue((double)0);
       case TypeId::TIMESTAMP:
         return GetTimestampValue(0);
+      case TypeId::DATE:
+        return GetDateValue(0);
       case TypeId::VARCHAR:
         return GetVarcharValue(zero_string);
       case TypeId::VARBINARY:

--- a/src/optimizer/child_property_generator.cpp
+++ b/src/optimizer/child_property_generator.cpp
@@ -297,6 +297,10 @@ void ChildPropertyGenerator::AggregateHelper(const BaseOperatorNode *op) {
         provided_property.AddProperty(prop);
         break;
       }
+      default: {
+        LOG_ERROR("Unexpected PropertyType '%s'",
+                  PropertyTypeToString(prop->Type()).c_str());
+      }
     }
   }
   // Add child PropertySort for SortGroupBy if not already do so
@@ -392,6 +396,10 @@ void ChildPropertyGenerator::JoinHelper(const BaseOperatorNode *op) {
         }
 
         break;
+      }
+      default: {
+        LOG_ERROR("Unexpected PropertyType '%s'",
+                  PropertyTypeToString(prop->Type()).c_str());
       }
     }
   }

--- a/src/type/boolean_type.cpp
+++ b/src/type/boolean_type.cpp
@@ -73,6 +73,20 @@ CmpBool BooleanType::CompareGreaterThanEquals(const Value& left,
   return BOOLEAN_COMPARE_FUNC(>=);
 }
 
+Value BooleanType::Min(const Value& left, const Value& right) const {
+  PL_ASSERT(left.CheckComparable(right));
+  if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
+  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
+  return right.Copy();
+}
+
+Value BooleanType::Max(const Value& left, const Value& right) const {
+  PL_ASSERT(left.CheckComparable(right));
+  if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
+  if (left.CompareGreaterThanEquals(right) == CMP_TRUE) return left.Copy();
+  return right.Copy();
+}
+
 std::string BooleanType::ToString(const Value& val) const {
   if (val.IsTrue()) return "true";
   if (val.IsFalse()) return "false";

--- a/src/type/date_type.cpp
+++ b/src/type/date_type.cpp
@@ -123,7 +123,7 @@ void DateType::SerializeTo(const Value& val, char* storage,
 Value DateType::DeserializeFrom(const char* storage,
                                 const bool inlined UNUSED_ATTRIBUTE,
                                 AbstractPool* pool UNUSED_ATTRIBUTE) const {
-  uint32_t val = *reinterpret_cast<const uint32_t*>(storage);
+  int32_t val = *reinterpret_cast<const int32_t*>(storage);
   return Value(type_id_, static_cast<int32_t>(val));
 }
 Value DateType::DeserializeFrom(SerializeInput& in UNUSED_ATTRIBUTE,

--- a/src/type/date_type.cpp
+++ b/src/type/date_type.cpp
@@ -22,41 +22,41 @@ DateType::DateType() : Type(TypeId::DATE) {}
 CmpBool DateType::CompareEquals(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CMP_NULL;
-  return GetCmpBool(left.GetAs<uint32_t>() == right.GetAs<uint32_t>());
+  return GetCmpBool(left.GetAs<int32_t>() == right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareNotEquals(const Value& left,
                                    const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (right.IsNull()) return CMP_NULL;
-  return GetCmpBool(left.GetAs<uint32_t>() != right.GetAs<uint32_t>());
+  return GetCmpBool(left.GetAs<int32_t>() != right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareLessThan(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CMP_NULL;
-  return GetCmpBool(left.GetAs<uint32_t>() < right.GetAs<uint32_t>());
+  return GetCmpBool(left.GetAs<int32_t>() < right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareLessThanEquals(const Value& left,
                                         const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CMP_NULL;
-  return GetCmpBool(left.GetAs<uint32_t>() <= right.GetAs<uint32_t>());
+  return GetCmpBool(left.GetAs<int32_t>() <= right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareGreaterThan(const Value& left,
                                      const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CMP_NULL;
-  return GetCmpBool(left.GetAs<uint32_t>() > right.GetAs<uint32_t>());
+  return GetCmpBool(left.GetAs<int32_t>() > right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareGreaterThanEquals(const Value& left,
                                            const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CMP_NULL;
-  return GetCmpBool(left.GetAs<uint32_t>() >= right.GetAs<uint32_t>());
+  return GetCmpBool(left.GetAs<int32_t>() >= right.GetAs<int32_t>());
 }
 
 Value DateType::Min(const Value& left, const Value& right) const {
@@ -76,7 +76,7 @@ Value DateType::Max(const Value& left, const Value& right) const {
 // Debug
 std::string DateType::ToString(const Value& val) const {
   if (val.IsNull()) return "date_null";
-  uint32_t tm = val.value_.date;
+  int32_t tm = val.value_.date;
   tm /= 1000000;
   tm /= 100000;
   uint16_t year = tm % 10000;
@@ -102,11 +102,11 @@ std::string DateType::ToString(const Value& val) const {
 
 // Compute a hash value
 size_t DateType::Hash(const Value& val) const {
-  return std::hash<uint32_t>{}(val.value_.date);
+  return std::hash<int32_t>{}(val.value_.date);
 }
 
 void DateType::HashCombine(const Value& val, size_t& seed) const {
-  val.hash_combine<uint32_t>(seed, val.value_.date);
+  val.hash_combine<int32_t>(seed, val.value_.date);
 }
 
 void DateType::SerializeTo(const Value& val, SerializeOutput& out) const {
@@ -116,7 +116,7 @@ void DateType::SerializeTo(const Value& val, SerializeOutput& out) const {
 void DateType::SerializeTo(const Value& val, char* storage,
                            bool inlined UNUSED_ATTRIBUTE,
                            AbstractPool* pool UNUSED_ATTRIBUTE) const {
-  *reinterpret_cast<uint32_t*>(storage) = val.value_.date;
+  *reinterpret_cast<int32_t*>(storage) = val.value_.date;
 }
 
 // Deserialize a value of the given type from the given storage space.

--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -67,20 +67,16 @@ CmpBool TimestampType::CompareGreaterThanEquals(const Value& left, const Value &
 
 Value TimestampType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull())
-    return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CMP_TRUE)
-      return left.Copy();
+  if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
+  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value TimestampType::Max(const Value& left, const Value& right) const {
-    PL_ASSERT(left.CheckComparable(right));
-    if (left.IsNull() || right.IsNull())
-        return left.OperateNull(right);
-    if (left.CompareGreaterThan(right) == CMP_TRUE)
-        return left.Copy();
-    return right.Copy();
+  PL_ASSERT(left.CheckComparable(right));
+  if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
+  if (left.CompareGreaterThanEquals(right) == CMP_TRUE) return left.Copy();
+  return right.Copy();
 }
 
 // Debug

--- a/src/type/type.cpp
+++ b/src/type/type.cpp
@@ -139,9 +139,10 @@ Value Type::GetMinValue(TypeId type_id) {
       return Value(type_id, (int64_t)PELOTON_INT64_MIN);
     case DECIMAL:
       return Value(type_id, PELOTON_DECIMAL_MIN);
-    case DATE:
     case TIMESTAMP:
-      return Value(type_id, 0);
+      return Value(type_id, PELOTON_TIMESTAMP_MIN);
+    case DATE:
+      return Value(type_id, PELOTON_DATE_MIN);
     case VARCHAR:
       return Value(type_id, "");
     case VARBINARY:
@@ -160,7 +161,6 @@ Value Type::GetMaxValue(TypeId type_id) {
       return Value(type_id, (int8_t)PELOTON_INT8_MAX);
     case SMALLINT:
       return Value(type_id, (int16_t)PELOTON_INT16_MAX);
-    case DATE:
     case INTEGER:
       return Value(type_id, (int32_t)PELOTON_INT32_MAX);
     case BIGINT:
@@ -169,6 +169,8 @@ Value Type::GetMaxValue(TypeId type_id) {
       return Value(type_id, PELOTON_DECIMAL_MAX);
     case TIMESTAMP:
       return Value(type_id, PELOTON_TIMESTAMP_MAX);
+    case DATE:
+      return Value(type_id, PELOTON_DATE_MAX);
     case VARCHAR:
       return Value(type_id, nullptr, 0, false);
     case VARBINARY:

--- a/src/type/types.cpp
+++ b/src/type/types.cpp
@@ -338,6 +338,9 @@ std::string CreateTypeToString(CreateType type) {
     case CreateType::CONSTRAINT: {
       return "CONSTRAINT";
     }
+    case CreateType::TRIGGER: {
+      return "TRIGGER";
+    }
     default: {
       throw ConversionException(StringUtil::Format(
           "No string conversion for CreateType value '%d'",
@@ -359,6 +362,8 @@ CreateType StringToCreateType(const std::string& str) {
     return CreateType::INDEX;
   } else if (upper_str == "CONSTRAINT") {
     return CreateType::CONSTRAINT;
+  } else if (upper_str == "TRIGGER") {
+    return CreateType::TRIGGER;
   } else {
     throw ConversionException(StringUtil::Format(
         "No CreateType conversion from string '%s'", upper_str.c_str()));
@@ -370,50 +375,104 @@ std::ostream& operator<<(std::ostream& os, const CreateType& type) {
   return os;
 }
 
+std::string DropTypeToString(DropType type) {
+  switch (type) {
+    case DropType::INVALID: {
+      return "INVALID";
+    }
+    case DropType::DB: {
+      return "DB";
+    }
+    case DropType::TABLE: {
+      return "TABLE";
+    }
+    case DropType::INDEX: {
+      return "INDEX";
+    }
+    case DropType::CONSTRAINT: {
+      return "CONSTRAINT";
+    }
+    case DropType::TRIGGER: {
+      return "TRIGGER";
+    }
+    default: {
+      throw ConversionException(StringUtil::Format(
+          "No string conversion for DropType value '%d'",
+          static_cast<int>(type)));
+    }
+  }
+  return "INVALID";
+}
+
+DropType StringToDropType(const std::string& str) {
+  std::string upper_str = StringUtil::Upper(str);
+  if (upper_str == "INVALID") {
+    return DropType::INVALID;
+  } else if (upper_str == "DB") {
+    return DropType::DB;
+  } else if (upper_str == "TABLE") {
+    return DropType::TABLE;
+  } else if (upper_str == "INDEX") {
+    return DropType::INDEX;
+  } else if (upper_str == "CONSTRAINT") {
+    return DropType::CONSTRAINT;
+  } else if (upper_str == "TRIGGER") {
+    return DropType::TRIGGER;
+  } else {
+    throw ConversionException(StringUtil::Format(
+        "No DropType conversion from string '%s'", upper_str.c_str()));
+  }
+  return DropType::INVALID;
+}
+std::ostream& operator<<(std::ostream& os, const DropType& type) {
+  os << DropTypeToString(type);
+  return os;
+}
+
 //===--------------------------------------------------------------------===//
 // Statement - String Utilities
 //===--------------------------------------------------------------------===//
 
 std::string StatementTypeToString(StatementType type) {
   switch (type) {
+    case StatementType::INVALID: {
+      return "INVALID";
+    }
     case StatementType::SELECT: {
       return "SELECT";
-    }
-    case StatementType::ALTER: {
-      return "ALTER";
-    }
-    case StatementType::CREATE: {
-      return "CREATE";
-    }
-    case StatementType::DELETE: {
-      return "DELETE";
-    }
-    case StatementType::DROP: {
-      return "DROP";
-    }
-    case StatementType::EXECUTE: {
-      return "EXECUTE";
-    }
-    case StatementType::COPY: {
-      return "COPY";
     }
     case StatementType::INSERT: {
       return "INSERT";
     }
-    case StatementType::INVALID: {
-      return "INVALID";
+    case StatementType::UPDATE: {
+      return "UPDATE";
+    }
+    case StatementType::DELETE: {
+      return "DELETE";
+    }
+    case StatementType::CREATE: {
+      return "CREATE";
+    }
+    case StatementType::DROP: {
+      return "DROP";
     }
     case StatementType::PREPARE: {
       return "PREPARE";
     }
+    case StatementType::EXECUTE: {
+      return "EXECUTE";
+    }
     case StatementType::RENAME: {
       return "RENAME";
+    }
+    case StatementType::ALTER: {
+      return "ALTER";
     }
     case StatementType::TRANSACTION: {
       return "TRANSACTION";
     }
-    case StatementType::UPDATE: {
-      return "UPDATE";
+    case StatementType::COPY: {
+      return "COPY";
     }
     case StatementType::ANALYZE: {
       return "ANALYZE";
@@ -455,6 +514,8 @@ StatementType StringToStatementType(const std::string& str) {
     return StatementType::TRANSACTION;
   } else if (upper_str == "COPY") {
     return StatementType::COPY;
+  } else if (upper_str == "ANALYZE") {
+    return StatementType::ANALYZE;
   } else {
     throw ConversionException(StringUtil::Format(
         "No StatementType conversion from string '%s'", upper_str.c_str()));
@@ -2599,23 +2660,61 @@ std::ostream& operator<<(std::ostream& os, const GCVersionType& type) {
 //===--------------------------------------------------------------------===//
 // Optimizer
 //===--------------------------------------------------------------------===//
+
 std::string PropertyTypeToString(PropertyType type) {
   switch (type) {
-    case PropertyType::SORT:
-      return "SORT";
-    case PropertyType::COLUMNS:
-      return "COLUMNS";
-    case PropertyType::PREDICATE:
+    case PropertyType::INVALID: {
+      return "INVALID";
+    }
+    case PropertyType::PREDICATE: {
       return "PREDICATE";
-    case PropertyType::DISTINCT:
+    }
+    case PropertyType::COLUMNS: {
+      return "COLUMNS";
+    }
+    case PropertyType::DISTINCT: {
       return "DISTINCT";
-    case PropertyType::LIMIT:
+    }
+    case PropertyType::SORT: {
+      return "SORT";
+    }
+    case PropertyType::LIMIT: {
       return "LIMIT";
-    default:
-      throw ConversionException(StringUtil::Format("No string conversion for PropertyType value '%d'",
-                                                   static_cast<int>(type)));
+    }
+    default: {
+      throw ConversionException(StringUtil::Format(
+          "No string conversion for PropertyType value '%d'",
+          static_cast<int>(type)));
+    }
   }
   return "INVALID";
+}
+
+PropertyType StringToPropertyType(const std::string& str) {
+  std::string upper_str = StringUtil::Upper(str);
+  if (upper_str == "INVALID") {
+    return PropertyType::INVALID;
+  } else if (upper_str == "PREDICATE") {
+    return PropertyType::PREDICATE;
+  } else if (upper_str == "COLUMNS") {
+    return PropertyType::COLUMNS;
+  } else if (upper_str == "DISTINCT") {
+    return PropertyType::DISTINCT;
+  } else if (upper_str == "SORT") {
+    return PropertyType::SORT;
+  } else if (upper_str == "LIMIT") {
+    return PropertyType::LIMIT;
+  } else {
+    throw ConversionException(
+        StringUtil::Format("No PropertyType conversion from string '%s'",
+                           upper_str.c_str()));
+  }
+  return PropertyType::INVALID;
+}
+
+std::ostream& operator<<(std::ostream& os, const PropertyType& type) {
+  os << PropertyTypeToString(type);
+  return os;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -409,6 +409,9 @@ bool Value::CheckComparable(const Value &o) const {
     case TypeId::TIMESTAMP:
       if (o.GetTypeId() == TypeId::TIMESTAMP) return true;
       break;
+    case TypeId::DATE:
+      if (o.GetTypeId() == TypeId::DATE) return true;
+      break;
     default:
       break;
   } // SWITCH

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -129,21 +129,17 @@ CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
 }
 
 Value VarlenType::Min(const Value& left, const Value& right) const {
-    PL_ASSERT(left.CheckComparable(right));
-    if (left.IsNull() || right.IsNull())
-        return left.OperateNull(right);
-    if (left.CompareLessThan(right) == CMP_TRUE)
-        return left.Copy();
-    return right.Copy();
+  PL_ASSERT(left.CheckComparable(right));
+  if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
+  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
+  return right.Copy();
 }
 
 Value VarlenType::Max(const Value& left, const Value& right) const {
-    PL_ASSERT(left.CheckComparable(right));
-    if (left.IsNull() || right.IsNull())
-        return left.OperateNull(right);
-    if (left.CompareGreaterThan(right) == CMP_TRUE)
-        return left.Copy();
-    return right.Copy();
+  PL_ASSERT(left.CheckComparable(right));
+  if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
+  if (left.CompareGreaterThanEquals(right) == CMP_TRUE) return left.Copy();
+  return right.Copy();
 }
 
 std::string VarlenType::ToString(const Value &val) const {

--- a/test/sql/insert_sql_test.cpp
+++ b/test/sql/insert_sql_test.cpp
@@ -23,7 +23,7 @@
 namespace peloton {
 namespace test {
 
-class InsertSQLTest : public PelotonTest {};
+class InsertSQLTests : public PelotonTest {};
 
 void CreateAndLoadTable() {
   // Create a table first
@@ -54,7 +54,7 @@ void CreateAndLoadTable3() {
       "CREATE TABLE test3(a INT, b CHAR(4), c VARCHAR(10));");
 }
 
-TEST_F(InsertSQLTest, InsertOneValue) {
+TEST_F(InsertSQLTests, InsertOneValue) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
@@ -97,7 +97,7 @@ TEST_F(InsertSQLTest, InsertOneValue) {
   txn_manager.CommitTransaction(txn);
 }
 
-TEST_F(InsertSQLTest, InsertMultipleValues) {
+TEST_F(InsertSQLTests, InsertMultipleValues) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
@@ -140,7 +140,7 @@ TEST_F(InsertSQLTest, InsertMultipleValues) {
   txn_manager.CommitTransaction(txn);
 }
 
-TEST_F(InsertSQLTest, InsertSpecifyColumns) {
+TEST_F(InsertSQLTests, InsertSpecifyColumns) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
@@ -183,7 +183,7 @@ TEST_F(InsertSQLTest, InsertSpecifyColumns) {
   txn_manager.CommitTransaction(txn);
 }
 
-TEST_F(InsertSQLTest, InsertTooLargeVarchar) {
+TEST_F(InsertSQLTests, InsertTooLargeVarchar) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
@@ -221,7 +221,7 @@ TEST_F(InsertSQLTest, InsertTooLargeVarchar) {
   txn_manager.CommitTransaction(txn);
 }
 
-TEST_F(InsertSQLTest, InsertIntoSelectSimple) {
+TEST_F(InsertSQLTests, InsertIntoSelectSimple) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);

--- a/test/sql/typelimit_sql_test.cpp
+++ b/test/sql/typelimit_sql_test.cpp
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// typelimit_sql_test.cpp
+//
+// Identification: test/sql/typelimit_sql_test.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <memory>
+
+#include "catalog/catalog.h"
+#include "common/harness.h"
+#include "concurrency/transaction_manager_factory.h"
+#include "sql/testing_sql_util.h"
+
+namespace peloton {
+namespace test {
+
+class TypeLimitSQLTests : public PelotonTest {};
+
+const std::vector<type::TypeId> typeLimitSQLTestTypes = {
+    type::TypeId::BOOLEAN,  type::TypeId::TINYINT,
+    type::TypeId::SMALLINT, type::TypeId::INTEGER,
+    // FIXME type::TypeId::BIGINT,
+    // FIXME type::TypeId::DECIMAL,
+    // FIXME type::TypeId::TIMESTAMP,
+    // FIXME type::TypeId::DATE
+};
+
+void CreateAndLoadTable(std::string table_name, type::TypeId col_type) {
+  std::string sql = StringUtil::Format("CREATE TABLE %s(id INT PRIMARY KEY, b %s);",
+                                       table_name.c_str(),
+                                       TypeIdToString(col_type).c_str());
+  LOG_TRACE("SQL: %s", sql.c_str());
+  TestingSQLUtil::ExecuteSQLQuery(sql);
+}
+
+/**
+ * Check whether we can INSERT values that we have reserved for our NULL indicators
+ * The DBMS should throw an error to prevent you from doing that
+ */
+TEST_F(TypeLimitSQLTests, InsertInvalidMinValue) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+
+  for (auto col_type : typeLimitSQLTestTypes) {
+    // CREATE TABLE that contains a column for each type
+    std::string table_name = "tbl" + TypeIdToString(col_type);
+    CreateAndLoadTable(table_name, col_type);
+
+    // Then try to insert the min value
+    std::ostringstream os;
+    os << "INSERT INTO " << table_name << " VALUES (1, ";
+    switch (col_type) {
+      case type::TypeId::BOOLEAN:
+        os << (int32_t)type::PELOTON_BOOLEAN_NULL;
+        break;
+      case type::TypeId::TINYINT:
+        os << (int32_t)type::PELOTON_INT8_NULL;
+        break;
+      case type::TypeId::SMALLINT:
+        os << type::PELOTON_INT16_NULL;
+        break;
+      case type::TypeId::INTEGER:
+        os << type::PELOTON_INT32_NULL;
+        break;
+      case type::TypeId::BIGINT:
+        os << type::PELOTON_INT64_NULL;
+        break;
+      case type::TypeId::DECIMAL:
+        os << type::PELOTON_DECIMAL_NULL;
+        break;
+      case type::TypeId::TIMESTAMP:
+        os << type::PELOTON_TIMESTAMP_NULL;
+        break;
+      case type::TypeId::DATE:
+        os << type::PELOTON_DATE_NULL;
+        break;
+      default: {
+        // Nothing to do!
+      }
+    } // SWITCH
+    os << ");";
+    // This should throw an error because the query
+    // is trying to insert a value that is not in a valid range for the type
+    auto result = TestingSQLUtil::ExecuteSQLQuery(os.str());
+    LOG_DEBUG("%s => %s", TypeIdToString(col_type).c_str(), os.str().c_str());
+    EXPECT_EQ(ResultType::FAILURE, result);
+  }
+
+  // free the database just created
+  txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/sql/typelimit_sql_test.cpp
+++ b/test/sql/typelimit_sql_test.cpp
@@ -25,9 +25,9 @@ class TypeLimitSQLTests : public PelotonTest {};
 const std::vector<type::TypeId> typeLimitSQLTestTypes = {
     type::TypeId::BOOLEAN,  type::TypeId::TINYINT,
     type::TypeId::SMALLINT, type::TypeId::INTEGER,
+    type::TypeId::TIMESTAMP,
     // FIXME type::TypeId::BIGINT,
     // FIXME type::TypeId::DECIMAL,
-    // FIXME type::TypeId::TIMESTAMP,
     // FIXME type::TypeId::DATE
 };
 
@@ -90,7 +90,7 @@ TEST_F(TypeLimitSQLTests, InsertInvalidMinValue) {
     // This should throw an error because the query
     // is trying to insert a value that is not in a valid range for the type
     auto result = TestingSQLUtil::ExecuteSQLQuery(os.str());
-    LOG_DEBUG("%s => %s", TypeIdToString(col_type).c_str(), os.str().c_str());
+    LOG_TRACE("%s => %s", TypeIdToString(col_type).c_str(), os.str().c_str());
     EXPECT_EQ(ResultType::FAILURE, result);
   }
 

--- a/test/type/date_value_test.cpp
+++ b/test/type/date_value_test.cpp
@@ -111,9 +111,9 @@ TEST_F(DateValueTests, ComparisonTest) {
 }
 
 TEST_F(DateValueTests, NullToStringTest) {
-  auto valNull = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
+  auto val_null = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
 
-  EXPECT_EQ(valNull.ToString(), "date_null");
+  EXPECT_EQ(val_null.ToString(), "date_null");
 }
 
 TEST_F(DateValueTests, HashTest) {
@@ -161,24 +161,24 @@ TEST_F(DateValueTests, CopyTest) {
 TEST_F(DateValueTests, CastTest) {
   type::Value result;
 
-  auto strNull = type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
-  auto valNull = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
+  auto str_null = type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  auto val_null = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
 
-  result = valNull.CastAs(type::TypeId::DATE);
+  result = val_null.CastAs(type::TypeId::DATE);
   EXPECT_TRUE(result.IsNull());
-  EXPECT_EQ(result.CompareEquals(valNull) == type::CMP_NULL, true);
-  EXPECT_EQ(result.GetTypeId(), valNull.GetTypeId());
+  EXPECT_EQ(result.CompareEquals(val_null) == type::CMP_NULL, true);
+  EXPECT_EQ(result.GetTypeId(), val_null.GetTypeId());
 
-  result = valNull.CastAs(type::TypeId::VARCHAR);
+  result = val_null.CastAs(type::TypeId::VARCHAR);
   EXPECT_TRUE(result.IsNull());
-  EXPECT_EQ(result.CompareEquals(strNull) == type::CMP_NULL, true);
-  EXPECT_EQ(result.GetTypeId(), strNull.GetTypeId());
+  EXPECT_EQ(result.CompareEquals(str_null) == type::CMP_NULL, true);
+  EXPECT_EQ(result.GetTypeId(), str_null.GetTypeId());
 
-  EXPECT_THROW(valNull.CastAs(type::TypeId::BOOLEAN), peloton::Exception);
+  EXPECT_THROW(val_null.CastAs(type::TypeId::BOOLEAN), peloton::Exception);
 
-  auto valValid =
+  auto val_valid =
       type::ValueFactory::GetDateValue(static_cast<int32_t>(1481746648));
-  result = valValid.CastAs(type::TypeId::VARCHAR);
+  result = val_valid.CastAs(type::TypeId::VARCHAR);
   EXPECT_FALSE(result.IsNull());
 }
 

--- a/test/type/date_value_test.cpp
+++ b/test/type/date_value_test.cpp
@@ -1,0 +1,186 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// date_value_test.cpp
+//
+// Identification: test/common/date_value_test.cpp
+//
+// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/harness.h"
+#include "type/date_type.h"
+#include "type/value_factory.h"
+
+namespace peloton {
+namespace test {
+
+//===--------------------------------------------------------------------===//
+// Date Value Test
+//===--------------------------------------------------------------------===//
+
+class DateValueTests : public PelotonTest {};
+
+TEST_F(DateValueTests, ComparisonTest) {
+  std::vector<ExpressionType> compares = {
+      ExpressionType::COMPARE_EQUAL,
+      ExpressionType::COMPARE_NOTEQUAL,
+      ExpressionType::COMPARE_LESSTHAN,
+      ExpressionType::COMPARE_LESSTHANOREQUALTO,
+      ExpressionType::COMPARE_GREATERTHAN,
+      ExpressionType::COMPARE_GREATERTHANOREQUALTO};
+
+  int32_t values[] = {1000000000, 2000000000, type::PELOTON_DATE_NULL};
+
+  type::CmpBool result;
+  type::Value val0;
+  type::Value val1;
+
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      bool expected_null = false;
+
+      // VALUE #0
+      if (values[i] == type::PELOTON_DATE_NULL) {
+        val0 = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
+        expected_null = true;
+      } else {
+        val0 = type::ValueFactory::GetDateValue(
+            static_cast<int32_t>(values[i]));
+      }
+
+      // VALUE #1
+      if (values[j] == type::PELOTON_DATE_NULL) {
+        val1 = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
+        expected_null = true;
+      } else {
+        val1 = type::ValueFactory::GetDateValue(
+            static_cast<int32_t>(values[j]));
+      }
+      bool temp = expected_null;
+
+      for (auto etype : compares) {
+        bool expected;
+        expected_null = temp;
+        switch (etype) {
+          case ExpressionType::COMPARE_EQUAL:
+            expected = values[i] == values[j];
+            result = val0.CompareEquals(val1);
+            break;
+          case ExpressionType::COMPARE_NOTEQUAL:
+            expected = values[i] != values[j];
+            result = val0.CompareNotEquals(val1);
+            if (!val1.IsNull() && expected_null) {
+              expected_null = false;
+            }
+            break;
+          case ExpressionType::COMPARE_LESSTHAN:
+            expected = values[i] < values[j];
+            result = val0.CompareLessThan(val1);
+            break;
+          case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+            expected = values[i] <= values[j];
+            result = val0.CompareLessThanEquals(val1);
+            break;
+          case ExpressionType::COMPARE_GREATERTHAN:
+            expected = values[i] > values[j];
+            result = val0.CompareGreaterThan(val1);
+            break;
+          case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+            expected = values[i] >= values[j];
+            result = val0.CompareGreaterThanEquals(val1);
+            break;
+          default:
+            throw Exception("Unexpected comparison");
+        }  // SWITCH
+        LOG_TRACE("%s %s %s => %d | %d\n", val0.ToString().c_str(),
+                  ExpressionTypeToString(etype).c_str(),
+                  val1.ToString().c_str(), expected, result);
+
+        if (expected_null) {
+          EXPECT_EQ(expected_null, result == type::CMP_NULL);
+        } else {
+          EXPECT_EQ(expected, result == type::CMP_TRUE);
+          EXPECT_EQ(!expected, result == type::CMP_FALSE);
+        }
+      }
+    }
+  }
+}
+
+TEST_F(DateValueTests, NullToStringTest) {
+  auto valNull = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
+
+  EXPECT_EQ(valNull.ToString(), "date_null");
+}
+
+TEST_F(DateValueTests, HashTest) {
+  int32_t values[] = {1000000000, 2000000000, type::PELOTON_DATE_NULL};
+
+  type::Value result;
+  type::Value val0;
+  type::Value val1;
+
+  for (int i = 0; i < 2; i++) {
+    if (values[i] == type::PELOTON_DATE_NULL) {
+      val0 = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
+    } else {
+      val0 = type::ValueFactory::GetDateValue(
+          static_cast<int32_t>(values[i]));
+    }
+    for (int j = 0; j < 2; j++) {
+      if (values[j] == type::PELOTON_DATE_NULL) {
+        val1 = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
+      } else {
+        val1 = type::ValueFactory::GetDateValue(
+            static_cast<int32_t>(values[j]));
+      }
+
+      result = type::ValueFactory::GetBooleanValue(val0.CompareEquals(val1));
+      auto hash0 = val0.Hash();
+      auto hash1 = val1.Hash();
+
+      if (result.IsTrue()) {
+        EXPECT_EQ(hash0, hash1);
+      } else {
+        EXPECT_NE(hash0, hash1);
+      }
+    }
+  }
+}
+
+TEST_F(DateValueTests, CopyTest) {
+  type::Value val0 =
+      type::ValueFactory::GetDateValue(static_cast<int32_t>(1000000));
+  type::Value val1 = val0.Copy();
+  EXPECT_EQ(val0.CompareEquals(val1) == type::CMP_TRUE, true);
+}
+
+TEST_F(DateValueTests, CastTest) {
+  type::Value result;
+
+  auto strNull = type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  auto valNull = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
+
+  result = valNull.CastAs(type::TypeId::DATE);
+  EXPECT_TRUE(result.IsNull());
+  EXPECT_EQ(result.CompareEquals(valNull) == type::CMP_NULL, true);
+  EXPECT_EQ(result.GetTypeId(), valNull.GetTypeId());
+
+  result = valNull.CastAs(type::TypeId::VARCHAR);
+  EXPECT_TRUE(result.IsNull());
+  EXPECT_EQ(result.CompareEquals(strNull) == type::CMP_NULL, true);
+  EXPECT_EQ(result.GetTypeId(), strNull.GetTypeId());
+
+  EXPECT_THROW(valNull.CastAs(type::TypeId::BOOLEAN), peloton::Exception);
+
+  auto valValid =
+      type::ValueFactory::GetDateValue(static_cast<int32_t>(1481746648));
+  result = valValid.CastAs(type::TypeId::VARCHAR);
+  EXPECT_FALSE(result.IsNull());
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/type/type_test.cpp
+++ b/test/type/type_test.cpp
@@ -30,7 +30,7 @@ class TypeTests : public PelotonTest {};
 const std::vector<type::TypeId> typeTestTypes = {
     type::TypeId::BOOLEAN,   type::TypeId::TINYINT, type::TypeId::SMALLINT,
     type::TypeId::INTEGER,   type::TypeId::BIGINT,  type::TypeId::DECIMAL,
-    type::TypeId::TIMESTAMP,
+    type::TypeId::TIMESTAMP, type::TypeId::DATE
     // type::TypeId::VARCHAR
 };
 

--- a/test/type/type_util_test.cpp
+++ b/test/type/type_util_test.cpp
@@ -208,5 +208,42 @@ TEST_F(TypeUtilTests, CompareGreaterThanRawTest) {
   }    // FOR (tuples)
   delete schema;
 }
+
+TEST_F(TypeUtilTests, CompareStringsTest) {
+  std::string char1 = "a";
+  std::string char2 = "z";
+
+  std::vector<bool> is_upper = { false, true };
+
+  // 'a' should always be less than 'z'
+  for (int i = 0; i < 10; i++) {
+    for (bool upper1 : is_upper) {
+      std::string str1 = StringUtil::Repeat(char1, i);
+      if (upper1) {
+        // FIXME
+        // str1 = StringUtil::Upper(str1);
+      }
+
+      for (int j = 1; j < 10; j++) {
+        std::string str2 = StringUtil::Repeat(char2, j);
+        for (bool upper2 : is_upper) {
+          if (upper2) {
+            // FIXME
+            // str2 = StringUtil::Upper(str2);
+          }
+
+          type::CmpBool result = type::GetCmpBool(
+              type::TypeUtil::CompareStrings(str1.c_str(), i,
+                                             str2.c_str(), j) < 0);
+          if (result != type::CmpBool::CMP_TRUE) {
+            LOG_ERROR("INVALID '%s' < '%s'", str1.c_str(), str2.c_str());
+          }
+          EXPECT_EQ(type::CmpBool::CMP_TRUE, result);
+        } // FOR (upper2)
+      } // FOR (str2)
+    } // FOR (upper1)
+  } // FOR (str1)
 }
-}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/type/type_util_test.cpp
+++ b/test/type/type_util_test.cpp
@@ -213,11 +213,9 @@ TEST_F(TypeUtilTests, CompareStringsTest) {
   std::string char1 = "a";
   std::string char2 = "z";
 
-  std::vector<bool> is_upper = { false, true };
-
   // 'a' should always be less than 'z'
   for (int i = 0; i < 10; i++) {
-    for (bool upper1 : is_upper) {
+    for (bool upper1 : {false, true}) {
       std::string str1 = StringUtil::Repeat(char1, i);
       if (upper1) {
         // FIXME
@@ -226,7 +224,7 @@ TEST_F(TypeUtilTests, CompareStringsTest) {
 
       for (int j = 1; j < 10; j++) {
         std::string str2 = StringUtil::Repeat(char2, j);
-        for (bool upper2 : is_upper) {
+        for (bool upper2 : {false, true}) {
           if (upper2) {
             // FIXME
             // str2 = StringUtil::Upper(str2);

--- a/test/type/types_test.cpp
+++ b/test/type/types_test.cpp
@@ -119,6 +119,11 @@ TEST_F(TypesTests, TypeIdTest) {
 
     auto newVal = peloton::StringToTypeId(str);
     EXPECT_EQ(val, newVal);
+
+    // TODO: Need to change TypeId to enum class
+    // std::ostringstream os;
+    // os << val;
+    // EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
@@ -136,7 +141,7 @@ TEST_F(TypesTests, StatementTypeTest) {
       StatementType::DROP,    StatementType::PREPARE,
       StatementType::EXECUTE, StatementType::RENAME,
       StatementType::ALTER,   StatementType::TRANSACTION,
-      StatementType::COPY};
+      StatementType::COPY,    StatementType::ANALYZE};
 
   // Make sure that ToString and FromString work
   for (auto val : list) {
@@ -182,6 +187,7 @@ TEST_F(TypesTests, ExpressionTypeTest) {
       ExpressionType::COMPARE_LIKE,
       ExpressionType::COMPARE_NOTLIKE,
       ExpressionType::COMPARE_IN,
+      ExpressionType::COMPARE_DISTINCT_FROM,
       ExpressionType::CONJUNCTION_AND,
       ExpressionType::CONJUNCTION_OR,
       ExpressionType::VALUE_CONSTANT,
@@ -441,6 +447,10 @@ TEST_F(TypesTests, ConstraintTypeTest) {
 
     auto newVal = peloton::StringToConstraintType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
@@ -463,6 +473,10 @@ TEST_F(TypesTests, LoggingTypeTest) {
 
     auto newVal = peloton::StringToLoggingType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
@@ -484,6 +498,10 @@ TEST_F(TypesTests, CheckpointingTypeTest) {
 
     auto newVal = peloton::StringToCheckpointingType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
@@ -505,6 +523,10 @@ TEST_F(TypesTests, GarbageCollectionTypeTest) {
 
     auto newVal = peloton::StringToGarbageCollectionType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
@@ -527,6 +549,10 @@ TEST_F(TypesTests, ProtocolTypeTest) {
 
     auto newVal = peloton::StringToProtocolType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
@@ -549,6 +575,10 @@ TEST_F(TypesTests, EpochTypeTest) {
 
     auto newVal = peloton::StringToEpochType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
@@ -573,6 +603,10 @@ TEST_F(TypesTests, TimestampTypeTest) {
 
     auto newVal = peloton::StringToTimestampType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
@@ -597,6 +631,10 @@ TEST_F(TypesTests, VisibilityTypeTest) {
 
     auto newVal = peloton::StringToVisibilityType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
@@ -620,6 +658,10 @@ TEST_F(TypesTests, VisibilityIdTypeTest) {
 
     auto newVal = peloton::StringToVisibilityIdType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
@@ -646,6 +688,10 @@ TEST_F(TypesTests, IsolationLevelTypeTest) {
 
     auto newVal = peloton::StringToIsolationLevelType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
@@ -669,6 +715,10 @@ TEST_F(TypesTests, ConflictAvoidanceTypeTest) {
 
     auto newVal = peloton::StringToConflictAvoidanceType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
@@ -677,7 +727,6 @@ TEST_F(TypesTests, ConflictAvoidanceTypeTest) {
   EXPECT_THROW(peloton::ConflictAvoidanceTypeToString(static_cast<ConflictAvoidanceType>(-99999)),
                peloton::Exception);
 }
-
 
 TEST_F(TypesTests, RWTypeTest) {
   std::vector<RWType> list = {
@@ -697,12 +746,394 @@ TEST_F(TypesTests, RWTypeTest) {
 
     auto newVal = peloton::StringToRWType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage
   std::string invalid("WU TANG");
   EXPECT_THROW(peloton::StringToRWType(invalid), peloton::Exception);
   EXPECT_THROW(peloton::RWTypeToString(static_cast<RWType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, CreateTypeTest) {
+  std::vector<CreateType> list = {
+      CreateType::INVALID,
+      CreateType::DB,
+      CreateType::TABLE,
+      CreateType::INDEX,
+      CreateType::CONSTRAINT,
+      CreateType::TRIGGER,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::CreateTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToCreateType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("WU TANG");
+  EXPECT_THROW(peloton::StringToCreateType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::CreateTypeToString(static_cast<CreateType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, DropTypeTest) {
+  std::vector<DropType> list = {
+      DropType::INVALID,
+      DropType::DB,
+      DropType::TABLE,
+      DropType::INDEX,
+      DropType::CONSTRAINT,
+      DropType::TRIGGER,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::DropTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToDropType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("WU TANG");
+  EXPECT_THROW(peloton::StringToDropType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::DropTypeToString(static_cast<DropType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, AggregateTypeTest) {
+  std::vector<AggregateType> list = {
+      AggregateType::INVALID,
+      AggregateType::SORTED,
+      AggregateType::HASH,
+      AggregateType::PLAIN,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::AggregateTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToAggregateType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("WU TANG");
+  EXPECT_THROW(peloton::StringToAggregateType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::AggregateTypeToString(static_cast<AggregateType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, QuantifierTypeTest) {
+  std::vector<QuantifierType> list = {
+      QuantifierType::NONE,
+      QuantifierType::ANY,
+      QuantifierType::ALL,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::QuantifierTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToQuantifierType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("WU TANG");
+  EXPECT_THROW(peloton::StringToQuantifierType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::QuantifierTypeToString(static_cast<QuantifierType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, TableReferenceTypeTest) {
+  std::vector<TableReferenceType> list = {
+      TableReferenceType::INVALID,
+      TableReferenceType::NAME,
+      TableReferenceType::SELECT,
+      TableReferenceType::JOIN,
+      TableReferenceType::CROSS_PRODUCT,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::TableReferenceTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToTableReferenceType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("WU TANG");
+  EXPECT_THROW(peloton::StringToTableReferenceType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::TableReferenceTypeToString(static_cast<TableReferenceType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, InsertTypeTest) {
+  std::vector<InsertType> list = {
+      InsertType::INVALID,
+      InsertType::VALUES,
+      InsertType::SELECT,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::InsertTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToInsertType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("WU TANG");
+  EXPECT_THROW(peloton::StringToInsertType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::InsertTypeToString(static_cast<InsertType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, CopyTypeTest) {
+  std::vector<CopyType> list = {
+      CopyType::INVALID,
+      CopyType::IMPORT_CSV,
+      CopyType::IMPORT_TSV,
+      CopyType::EXPORT_CSV,
+      CopyType::EXPORT_STDOUT,
+      CopyType::EXPORT_OTHER,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::CopyTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToCopyType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("WU TANG");
+  EXPECT_THROW(peloton::StringToCopyType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::CopyTypeToString(static_cast<CopyType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, PayloadTypeTest) {
+  std::vector<PayloadType> list = {
+      PayloadType::INVALID,
+      PayloadType::CLIENT_REQUEST,
+      PayloadType::CLIENT_RESPONSE,
+      PayloadType::STOP,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::PayloadTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToPayloadType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("Squirrels All Around");
+  EXPECT_THROW(peloton::StringToPayloadType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::PayloadTypeToString(static_cast<PayloadType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, TaskPriorityTypeTest) {
+  std::vector<TaskPriorityType> list = {
+      TaskPriorityType::INVALID,
+      TaskPriorityType::LOW,
+      TaskPriorityType::NORMAL,
+      TaskPriorityType::HIGH,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::TaskPriorityTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToTaskPriorityType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("WU TANG");
+  EXPECT_THROW(peloton::StringToTaskPriorityType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::TaskPriorityTypeToString(static_cast<TaskPriorityType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, SetOpTypeTest) {
+  std::vector<SetOpType> list = {
+      SetOpType::INVALID,
+      SetOpType::INTERSECT,
+      SetOpType::INTERSECT_ALL,
+      SetOpType::EXCEPT,
+      SetOpType::EXCEPT_ALL,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::SetOpTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToSetOpType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("WU TANG");
+  EXPECT_THROW(peloton::StringToSetOpType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::SetOpTypeToString(static_cast<SetOpType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, LogRecordTypeTest) {
+  std::vector<LogRecordType> list = {
+      LogRecordType::INVALID,
+      LogRecordType::TRANSACTION_BEGIN,
+      LogRecordType::TRANSACTION_COMMIT,
+      LogRecordType::TUPLE_INSERT,
+      LogRecordType::TUPLE_DELETE,
+      LogRecordType::TUPLE_UPDATE,
+      LogRecordType::EPOCH_BEGIN,
+      LogRecordType::EPOCH_END,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::LogRecordTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToLogRecordType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("WU TANG");
+  EXPECT_THROW(peloton::StringToLogRecordType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::LogRecordTypeToString(static_cast<LogRecordType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, PropertyTypeTest) {
+  std::vector<PropertyType> list = {
+      PropertyType::INVALID,
+      PropertyType::PREDICATE,
+      PropertyType::COLUMNS,
+      PropertyType::DISTINCT,
+      PropertyType::SORT,
+      PropertyType::LIMIT,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::PropertyTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToPropertyType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("WU TANG");
+  EXPECT_THROW(peloton::StringToPropertyType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::PropertyTypeToString(static_cast<PropertyType>(-99999)),
+               peloton::Exception);
+}
+
+TEST_F(TypesTests, EntityTypeTest) {
+  std::vector<EntityType> list = {
+      EntityType::INVALID,
+      EntityType::TABLE,
+      EntityType::SCHEMA,
+      EntityType::INDEX,
+      EntityType::VIEW,
+      EntityType::PREPARED_STATEMENT,
+  };
+
+  // Make sure that ToString and FromString work
+  for (auto val : list) {
+    std::string str = peloton::EntityTypeToString(val);
+    EXPECT_TRUE(str.size() > 0);
+
+    auto newVal = peloton::StringToEntityType(str);
+    EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
+  }
+
+  // Then make sure that we can't cast garbage
+  std::string invalid("The terrier is passed out right now");
+  EXPECT_THROW(peloton::StringToEntityType(invalid), peloton::Exception);
+  EXPECT_THROW(peloton::EntityTypeToString(static_cast<EntityType>(-99999)),
                peloton::Exception);
 }
 
@@ -725,6 +1156,10 @@ TEST_F(TypesTests, GCVersionTypeTest) {
 
     auto newVal = peloton::StringToGCVersionType(str);
     EXPECT_EQ(val, newVal);
+
+    std::ostringstream os;
+    os << val;
+    EXPECT_EQ(str, os.str());
   }
 
   // Then make sure that we can't cast garbage

--- a/test/type/value_factory_test.cpp
+++ b/test/type/value_factory_test.cpp
@@ -30,6 +30,12 @@ namespace test {
 
 class ValueFactoryTests : public PelotonTest {};
 
+const std::vector<type::TypeId> valueFactoryTestTypes = {
+    type::TypeId::BOOLEAN,   type::TypeId::TINYINT, type::TypeId::SMALLINT,
+    type::TypeId::INTEGER,   type::TypeId::BIGINT,  type::TypeId::DECIMAL,
+    type::TypeId::TIMESTAMP, type::TypeId::DATE
+};
+
 #define RANDOM_DECIMAL() ((double)rand() / (double)rand())
 
 int8_t RANDOM8() {
@@ -53,6 +59,13 @@ int64_t RANDOM64() {
   if (ret != type::PELOTON_INT64_NULL)
     return ret;
   return 1;
+}
+
+TEST_F(ValueFactoryTests, ZeroValueTest) {
+  for (auto col_type : valueFactoryTestTypes) {
+    auto zeroVal = type::ValueFactory::GetZeroValueByType(col_type);
+    EXPECT_FALSE(zeroVal.IsNull());
+  }
 }
 
 TEST_F(ValueFactoryTests, PeekValueTest) {
@@ -134,49 +147,28 @@ TEST_F(ValueFactoryTests, CastTest) {
 
 TEST_F(ValueFactoryTests, SerializationTest) {
   peloton::CopySerializeOutput out;
-  type::Value(type::TypeId::TINYINT, (int8_t)type::PELOTON_INT8_MAX).SerializeTo(out);
-  type::Value(type::TypeId::TINYINT, (int8_t)type::PELOTON_INT8_MIN).SerializeTo(out);
-  type::Value(type::TypeId::SMALLINT, (int16_t)type::PELOTON_INT16_MAX).SerializeTo(out);
-  type::Value(type::TypeId::SMALLINT, (int16_t)type::PELOTON_INT16_MIN).SerializeTo(out);
-  type::Value(type::TypeId::INTEGER, (int32_t)type::PELOTON_INT32_MAX).SerializeTo(out);
-  type::Value(type::TypeId::INTEGER, (int32_t)type::PELOTON_INT32_MIN).SerializeTo(out);
-  type::Value(type::TypeId::BIGINT, (int64_t)type::PELOTON_INT64_MAX).SerializeTo(out);
-  type::Value(type::TypeId::BIGINT, (int64_t)type::PELOTON_INT64_MIN).SerializeTo(out);
-  type::Value(type::TypeId::DECIMAL, type::PELOTON_DECIMAL_MAX).SerializeTo(out);
-  type::Value(type::TypeId::DECIMAL, type::PELOTON_DECIMAL_MIN).SerializeTo(out);
+  for (auto col_type : valueFactoryTestTypes) {
+    type::Type::GetMinValue(col_type).SerializeTo(out);
+    type::Type::GetMaxValue(col_type).SerializeTo(out);
+  }
 
   peloton::CopySerializeInput in(out.Data(), out.Size());
-  type::Value v1 = (type::Value::DeserializeFrom(in, type::Type::GetInstance(type::TypeId::TINYINT)->GetTypeId(), nullptr));
-  EXPECT_EQ(v1.GetTypeId(), type::TypeId::TINYINT);
-  EXPECT_EQ(v1.GetAs<int8_t>(), type::PELOTON_INT8_MAX);
-  type::Value v2 = (type::Value::DeserializeFrom(in, type::Type::GetInstance(type::TypeId::TINYINT)->GetTypeId(), nullptr));
-  EXPECT_EQ(v2.GetTypeId(), type::TypeId::TINYINT);
-  EXPECT_EQ(v2.GetAs<int8_t>(), type::PELOTON_INT8_MIN);
-  type::Value v3 = (type::Value::DeserializeFrom(in, type::Type::GetInstance(type::TypeId::SMALLINT)->GetTypeId(), nullptr));
-  EXPECT_EQ(v3.GetTypeId(), type::TypeId::SMALLINT);
-  EXPECT_EQ(v3.GetAs<int16_t>(), type::PELOTON_INT16_MAX);
-  type::Value v4 = (type::Value::DeserializeFrom(in, type::Type::GetInstance(type::TypeId::SMALLINT)->GetTypeId(), nullptr));
-  EXPECT_EQ(v4.GetTypeId(), type::TypeId::SMALLINT);
-  EXPECT_EQ(v4.GetAs<int16_t>(), type::PELOTON_INT16_MIN);
-  type::Value v5 = (type::Value::DeserializeFrom(in, type::Type::GetInstance(type::TypeId::INTEGER)->GetTypeId(), nullptr));
-  EXPECT_EQ(v5.GetTypeId(), type::TypeId::INTEGER);
-  EXPECT_EQ(v5.GetAs<int32_t>(), type::PELOTON_INT32_MAX);
-  type::Value v6 = (type::Value::DeserializeFrom(in, type::Type::GetInstance(type::TypeId::INTEGER)->GetTypeId(), nullptr));
-  EXPECT_EQ(v6.GetTypeId(), type::TypeId::INTEGER);
-  EXPECT_EQ(v6.GetAs<int32_t>(), type::PELOTON_INT32_MIN);
-  type::Value v7 = (type::Value::DeserializeFrom(in, type::Type::GetInstance(type::TypeId::BIGINT)->GetTypeId(), nullptr));
-  EXPECT_EQ(v7.GetTypeId(), type::TypeId::BIGINT);
-  EXPECT_EQ(v7.GetAs<int64_t>(), type::PELOTON_INT64_MAX);
-  type::Value v8 = (type::Value::DeserializeFrom(in, type::Type::GetInstance(type::TypeId::BIGINT)->GetTypeId(), nullptr));
-  EXPECT_EQ(v8.GetTypeId(), type::TypeId::BIGINT);
-  EXPECT_EQ(v8.GetAs<int64_t>(), type::PELOTON_INT64_MIN);
-
-  type::Value v9 = (type::Value::DeserializeFrom(in, type::Type::GetInstance(type::TypeId::DECIMAL)->GetTypeId(), nullptr));
-  EXPECT_EQ(v9.GetTypeId(), type::TypeId::DECIMAL);
-  EXPECT_EQ(v9.GetAs<double>(), type::PELOTON_DECIMAL_MAX);
-  type::Value v10 = (type::Value::DeserializeFrom(in, type::Type::GetInstance(type::TypeId::DECIMAL)->GetTypeId(), nullptr));
-  EXPECT_EQ(v10.GetTypeId(), type::TypeId::DECIMAL);
-  EXPECT_EQ(v10.GetAs<double>(), type::PELOTON_DECIMAL_MIN);
+  for (auto col_type : valueFactoryTestTypes) {
+    for (int i = 0; i < 2; i++) {
+      type::Value v = (type::Value::DeserializeFrom(in, type::Type::GetInstance(col_type)->GetTypeId(), nullptr));
+      EXPECT_EQ(v.GetTypeId(), col_type);
+      type::Value expected;
+      // MIN
+      if (i == 0) {
+        expected = type::Type::GetMinValue(col_type);
+      }
+        // MAX
+      else {
+        expected = type::Type::GetMaxValue(col_type);
+      }
+      EXPECT_EQ(type::CMP_TRUE, v.CompareEquals(expected));
+    }
+  }
 }
 
 }

--- a/test/type/value_test.cpp
+++ b/test/type/value_test.cpp
@@ -66,19 +66,18 @@ TEST_F(ValueTests, MinMaxTest) {
 
     // Special case for VARCHAR
     if (col_type == type::TypeId::VARCHAR) {
-      maxVal = type::ValueFactory::GetVarcharValue(std::string("A"), nullptr);
+      maxVal = type::ValueFactory::GetVarcharValue(std::string("AAA"), nullptr);
       minVal = type::ValueFactory::GetVarcharValue(std::string("ZZZ"), nullptr);
+      EXPECT_EQ(type::CMP_FALSE, minVal.CompareLessThan(maxVal));
+      EXPECT_EQ(type::CMP_FALSE, maxVal.CompareGreaterThan(minVal));
     }
 
-    LOG_TRACE("MinMax: %s", TypeIdToString(col_type).c_str());
-
     // FIXME: Broken types!!!
-    if (col_type == type::TypeId::BOOLEAN) continue;
     if (col_type == type::TypeId::VARCHAR) continue;
-    if (col_type == type::TypeId::TIMESTAMP) continue;
+    LOG_DEBUG("MinMax: %s", TypeIdToString(col_type).c_str());
 
     // Check that we always get the correct MIN value
-    EXPECT_EQ(type::CMP_TRUE, maxVal.Min(minVal).CompareEquals(minVal));
+    EXPECT_EQ(type::CMP_TRUE, minVal.Min(minVal).CompareEquals(minVal));
     EXPECT_EQ(type::CMP_TRUE, minVal.Min(maxVal).CompareEquals(minVal));
     EXPECT_EQ(type::CMP_TRUE, minVal.Min(minVal).CompareEquals(minVal));
 

--- a/test/type/value_test.cpp
+++ b/test/type/value_test.cpp
@@ -32,44 +32,44 @@ const std::vector<type::TypeId> valueTestTypes = {
 
 TEST_F(ValueTests, HashTest) {
   for (auto col_type : valueTestTypes) {
-    auto maxVal = type::Type::GetMaxValue(col_type);
-    auto minVal = type::Type::GetMinValue(col_type);
+    auto max_val = type::Type::GetMaxValue(col_type);
+    auto min_val = type::Type::GetMinValue(col_type);
 
     // Special case for VARCHAR
     if (col_type == type::TypeId::VARCHAR) {
-      maxVal = type::ValueFactory::GetVarcharValue(std::string("XXX"), nullptr);
-      minVal = type::ValueFactory::GetVarcharValue(std::string("YYY"), nullptr);
+      max_val = type::ValueFactory::GetVarcharValue(std::string("XXX"), nullptr);
+      min_val = type::ValueFactory::GetVarcharValue(std::string("YYY"), nullptr);
     }
     LOG_TRACE("%s => MAX:%s <-> MIN:%s", TypeIdToString(col_type).c_str(),
-              maxVal.ToString().c_str(), minVal.ToString().c_str());
+              max_val.ToString().c_str(), min_val.ToString().c_str());
 
     // They should not be equal
-    EXPECT_EQ(type::CmpBool::CMP_FALSE, maxVal.CompareEquals(minVal));
+    EXPECT_EQ(type::CmpBool::CMP_FALSE, max_val.CompareEquals(min_val));
 
     // Nor should their hash values be equal
-    auto maxHash = maxVal.Hash();
-    auto minHash = minVal.Hash();
-    EXPECT_NE(maxHash, minHash);
+    auto max_hash = max_val.Hash();
+    auto min_hash = min_val.Hash();
+    EXPECT_NE(max_hash, min_hash);
 
     // But if I copy the first value then the hashes should be the same
-    auto copyVal = maxVal.Copy();
+    auto copyVal = max_val.Copy();
     auto copyHash = copyVal.Hash();
-    EXPECT_EQ(type::CmpBool::CMP_TRUE, maxVal.CompareEquals(copyVal));
-    EXPECT_EQ(maxHash, copyHash);
+    EXPECT_EQ(type::CmpBool::CMP_TRUE, max_val.CompareEquals(copyVal));
+    EXPECT_EQ(max_hash, copyHash);
   }  // FOR
 }
 
 TEST_F(ValueTests, MinMaxTest) {
   for (auto col_type : valueTestTypes) {
-    auto maxVal = type::Type::GetMaxValue(col_type);
-    auto minVal = type::Type::GetMinValue(col_type);
+    auto max_val = type::Type::GetMaxValue(col_type);
+    auto min_val = type::Type::GetMinValue(col_type);
 
     // Special case for VARCHAR
     if (col_type == type::TypeId::VARCHAR) {
-      maxVal = type::ValueFactory::GetVarcharValue(std::string("AAA"), nullptr);
-      minVal = type::ValueFactory::GetVarcharValue(std::string("ZZZ"), nullptr);
-      EXPECT_EQ(type::CMP_FALSE, minVal.CompareLessThan(maxVal));
-      EXPECT_EQ(type::CMP_FALSE, maxVal.CompareGreaterThan(minVal));
+      max_val = type::ValueFactory::GetVarcharValue(std::string("AAA"), nullptr);
+      min_val = type::ValueFactory::GetVarcharValue(std::string("ZZZ"), nullptr);
+      EXPECT_EQ(type::CMP_FALSE, min_val.CompareLessThan(max_val));
+      EXPECT_EQ(type::CMP_FALSE, max_val.CompareGreaterThan(min_val));
     }
 
     // FIXME: Broken types!!!
@@ -77,14 +77,14 @@ TEST_F(ValueTests, MinMaxTest) {
     LOG_DEBUG("MinMax: %s", TypeIdToString(col_type).c_str());
 
     // Check that we always get the correct MIN value
-    EXPECT_EQ(type::CMP_TRUE, minVal.Min(minVal).CompareEquals(minVal));
-    EXPECT_EQ(type::CMP_TRUE, minVal.Min(maxVal).CompareEquals(minVal));
-    EXPECT_EQ(type::CMP_TRUE, minVal.Min(minVal).CompareEquals(minVal));
+    EXPECT_EQ(type::CMP_TRUE, min_val.Min(min_val).CompareEquals(min_val));
+    EXPECT_EQ(type::CMP_TRUE, min_val.Min(max_val).CompareEquals(min_val));
+    EXPECT_EQ(type::CMP_TRUE, min_val.Min(min_val).CompareEquals(min_val));
 
     // Check that we always get the correct MAX value
-    EXPECT_EQ(type::CMP_TRUE, maxVal.Max(minVal).CompareEquals(maxVal));
-    EXPECT_EQ(type::CMP_TRUE, minVal.Max(maxVal).CompareEquals(maxVal));
-    EXPECT_EQ(type::CMP_TRUE, maxVal.Max(minVal).CompareEquals(maxVal));
+    EXPECT_EQ(type::CMP_TRUE, max_val.Max(min_val).CompareEquals(max_val));
+    EXPECT_EQ(type::CMP_TRUE, min_val.Max(max_val).CompareEquals(max_val));
+    EXPECT_EQ(type::CMP_TRUE, max_val.Max(min_val).CompareEquals(max_val));
   } // FOR
 }
 


### PR DESCRIPTION
The `DATE` type was originally set to be uint32_t. The problem with this is that we had set `PELOTON_DATE_MIN` to be the same as `PELOTON_DATE_NULL`, which means that you could never have null dates.

This PR switches the `DATE` to be a int32_t. I also added new tests because the coverage for this code was nearly zero.

It also includes SQL tests that check whether we check that you can't insert the min values for types and end up with nulls.

I also fixed Value::Min/Max for some types.

https://www.youtube.com/watch?v=1XV-dWStHOI