### PR TITLE
Fix for building at trace log level

### DIFF
--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cinttypes>
 #include "concurrency/timestamp_ordering_transaction_manager.h"
 
 #include "catalog/manager.h"
@@ -737,7 +738,7 @@ void TimestampOrderingTransactionManager::PerformDelete(
 
 ResultType TimestampOrderingTransactionManager::CommitTransaction(
     Transaction *const current_txn) {
-  LOG_TRACE("Committing peloton txn : %lu ", current_txn->GetTransactionId());
+  LOG_TRACE("Committing peloton txn : %" PRId64, current_txn->GetTransactionId());
 
   //////////////////////////////////////////////////////////
   //// handle READ_ONLY
@@ -925,7 +926,7 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
   // a pre-declared read-only transaction will never abort.
   PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 
-  LOG_TRACE("Aborting peloton txn : %lu ", current_txn->GetTransactionId());
+  LOG_TRACE("Aborting peloton txn : %" PRId64, current_txn->GetTransactionId());
   auto &manager = catalog::Manager::GetInstance();
 
   auto &rw_set = current_txn->GetReadWriteSet();

--- a/src/executor/delete_executor.cpp
+++ b/src/executor/delete_executor.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cinttypes>
 #include "executor/delete_executor.h"
 #include "executor/executor_context.h"
 
@@ -89,7 +90,7 @@ bool DeleteExecutor::DExecute() {
 
   LOG_TRACE("Source tile info: %s", source_tile->GetInfo().c_str());
 
-  LOG_TRACE("Transaction ID: %lu",
+  LOG_TRACE("Transaction ID: %" PRId64,
             executor_context_->GetTransaction()->GetTransactionId());
 
   auto executor_pool = executor_context_->GetPool();

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "executor/plan_executor.h"
+#include <cinttypes>
 
 #include "codegen/buffering_consumer.h"
 #include "codegen/query_compiler.h"
@@ -46,7 +47,7 @@ void PlanExecutor::ExecutePlan(
     const std::vector<int> &result_format,
     executor::ExecuteResult &p_status) {
   PL_ASSERT(plan != nullptr && txn != nullptr);
-  LOG_TRACE("PlanExecutor Start (Txn ID=%lu)", txn->GetTransactionId());
+  LOG_TRACE("PlanExecutor Start (Txn ID=%" PRId64")", txn->GetTransactionId());
 
   result.clear();
   std::unique_ptr<executor::ExecutorContext> executor_context(
@@ -149,7 +150,7 @@ int PlanExecutor::ExecutePlan(const planner::AbstractPlan *plan,
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   PL_ASSERT(txn);
-  LOG_TRACE("Txn ID = %lu ", txn->GetTransactionId());
+  LOG_TRACE("Txn ID = %" PRId64, txn->GetTransactionId());
 
   std::unique_ptr<executor::ExecutorContext> executor_context(
       new executor::ExecutorContext(txn, params));

--- a/src/include/optimizer/stats/hyperloglog.h
+++ b/src/include/optimizer/stats/hyperloglog.h
@@ -43,7 +43,7 @@ class HyperLogLog {
 
   uint64_t EstimateCardinality() {
     uint64_t cardinality = hll_->Estimate();
-    LOG_TRACE("Estimated cardinality: %lu", cardinality);
+    LOG_TRACE("Estimated cardinality: %" PRId64, cardinality);
     return cardinality;
   }
 

--- a/src/network/service/peloton_service.cpp
+++ b/src/network/service/peloton_service.cpp
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <iostream>
+#include <cinttypes>
 
 namespace peloton {
 namespace network {
@@ -250,7 +251,7 @@ void PelotonService::Heartbeat(::google::protobuf::RpcController* controller,
   // If request is not null, this is a rpc  call, server should handle the
   // reqeust
   if (request != NULL) {
-    LOG_TRACE("Received from client, sender site: %d, last_txn_id: %ld",
+    LOG_TRACE("Received from client, sender site: %d, last_txn_id: %" PRId64,
               request->sender_site(), request->last_transaction_id());
 
     response->set_sender_site(9876);

--- a/src/optimizer/stats/tuple_sampler.cpp
+++ b/src/optimizer/stats/tuple_sampler.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cinttypes>
 #include "optimizer/stats/tuple_sampler.h"
 
 #include "storage/data_table.h"
@@ -82,7 +83,7 @@ bool TupleSampler::GetTupleInTileGroup(storage::TileGroup *tile_group,
   // Reference: TileGroupHeader::GetActiveTupleCount()
   // Check whether the transaction ID is invalid.
   txn_id_t tuple_txn_id = tile_group_header->GetTransactionId(tuple_offset);
-  LOG_TRACE("transaction ID: %lu", tuple_txn_id);
+  LOG_TRACE("transaction ID: %" PRId64, tuple_txn_id);
   if (tuple_txn_id == INVALID_TXN_ID) {
     return false;
   }

--- a/src/planner/create_plan.cpp
+++ b/src/planner/create_plan.cpp
@@ -58,25 +58,25 @@ CreatePlan::CreatePlan(parser::CreateStatement *parse_tree) {
   
         type::TypeId val = col->GetValueType(col->type);
   
-        LOG_TRACE("Column name: %s.%s; Is primary key: %d", table_name.c_str(), col->name, col->primary);
+        LOG_TRACE("Column name: %s.%s; Is primary key: %d", table_name.c_str(), col->name.c_str(), col->primary);
   
         // Check main constraints
         if (col->primary) {
           catalog::Constraint constraint(ConstraintType::PRIMARY, "con_primary");
           column_constraints.push_back(constraint);
-          LOG_TRACE("Added a primary key constraint on column \"%s.%s\"", table_name.c_str(), col->name);
+          LOG_TRACE("Added a primary key constraint on column \"%s.%s\"", table_name.c_str(), col->name.c_str());
         }
   
         if (col->not_null) {
           catalog::Constraint constraint(ConstraintType::NOTNULL, "con_not_null");
           column_constraints.push_back(constraint);
-          LOG_TRACE("Added a not-null constraint on column \"%s.%s\"", table_name.c_str(), col->name);
+          LOG_TRACE("Added a not-null constraint on column \"%s.%s\"", table_name.c_str(), col->name.c_str());
         }
   
         if (col->unique) {
           catalog::Constraint constraint(ConstraintType::UNIQUE, "con_unique");
           column_constraints.push_back(constraint);
-          LOG_TRACE("Added a unique constraint on column \"%s.%s\"", table_name.c_str(), col->name);
+          LOG_TRACE("Added a unique constraint on column \"%s.%s\"", table_name.c_str(), col->name.c_str());
         }
   
         /* **************** */
@@ -93,7 +93,7 @@ CreatePlan::CreatePlan(parser::CreateStatement *parse_tree) {
             constraint.addDefaultValue(v);
             column_constraints.push_back(constraint);
             LOG_TRACE("Added a default constraint %s on column \"%s.%s\"",
-                      v.ToString().c_str(), table_name.c_str(), col->name);
+                      v.ToString().c_str(), table_name.c_str(), col->name.c_str());
           }
         }
   
@@ -111,7 +111,7 @@ CreatePlan::CreatePlan(parser::CreateStatement *parse_tree) {
             constraint.AddCheck(std::move(col->check_expression->GetExpressionType()), std::move(tmp_value));
             column_constraints.push_back(constraint);
             LOG_TRACE("Added a check constraint on column \"%s.%s\"",
-                      table_name.c_str(), col->name);
+                      table_name.c_str(), col->name.c_str());
           }
         }
   

--- a/src/planner/insert_plan.cpp
+++ b/src/planner/insert_plan.cpp
@@ -136,7 +136,7 @@ InsertPlan::InsertPlan(
 
           LOG_TRACE("Column %d found in INSERT query, ExpressionType: %s",
                     col_cntr,
-                    ExpressionTypeToString(values->at(pos)->GetExpressionType())
+                    ExpressionTypeToString(values.at(pos)->GetExpressionType())
                         .c_str());
 
           if (values.at(pos)->GetExpressionType() ==

--- a/src/statistics/stats_aggregator.cpp
+++ b/src/statistics/stats_aggregator.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cinttypes>
 #include "statistics/stats_aggregator.h"
 
 #include "catalog/catalog.h"
@@ -72,7 +73,7 @@ void StatsAggregator::Aggregate(int64_t &interval_cnt, double &alpha,
   LOG_TRACE(
       "\n//////////////////////////////////////////////////////"
       "//////////////////////////////////////////////////////\n");
-  LOG_TRACE("TIME ELAPSED: %ld sec", interval_cnt);
+  LOG_TRACE("TIME ELAPSED: %" PRId64 " sec", interval_cnt);
 
   aggregated_stats_.Reset();
   std::thread::id this_id = aggregator_thread_.get_id();


### PR DESCRIPTION
Fixes https://github.com/cmu-db/peloton/issues/869

uint64_t variables are resolved to **unsigned long long** on OS X and **unsigned long int** on linux. Log lines with uint64_t variables can be made portable with PRId64 macro.

Also fixes other minor bugs in trace level logs.