### PR TITLE
Remove all delete calls in /test

### DIFF
--- a/src/include/planner/insert_plan.h
+++ b/src/include/planner/insert_plan.h
@@ -6,7 +6,7 @@
 //
 // Identification: src/include/planner/insert_plan.h
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -30,12 +30,11 @@ class InsertStatement;
 namespace planner {
 class InsertPlan : public AbstractPlan {
  public:
-  // This constructor takes in neither a project info nor a tuple
-  // It must be used when the input is a logical tile
+  // Construct when input is a logical tile - WARNING Not supported by codegen
   InsertPlan(storage::DataTable *table, oid_t bulk_insert_count = 1)
     : target_table_(table), bulk_insert_count_(bulk_insert_count) {}
 
-  // This constructor takes in a project info
+  // Construct with a project info
   InsertPlan(storage::DataTable *table,
              std::unique_ptr<const planner::ProjectInfo> &&project_info,
              oid_t bulk_insert_count = 1)
@@ -44,7 +43,7 @@ class InsertPlan : public AbstractPlan {
     LOG_TRACE("Creating an Insert Plan with a projection");
   }
 
-  // This constructor takes in a tuple
+  // Construct with a tuple - WARNING Not supported by codegen
   InsertPlan(storage::DataTable *table,
              std::unique_ptr<storage::Tuple> &&tuple,
              oid_t bulk_insert_count = 1)
@@ -53,11 +52,12 @@ class InsertPlan : public AbstractPlan {
     tuples_.push_back(std::move(tuple));
   }
 
+  // Construct with specific values - WARNING Not supported by the interpreter
   InsertPlan(storage::DataTable *table, const std::vector<std::string> *columns,
              const std::vector<std::vector<std::unique_ptr<
                  expression::AbstractExpression>>> *insert_values);
 
-  // Get a varlen pool (will construct the pool only if needed)
+  // Get a varlen pool - will construct the pool only if needed
   type::AbstractPool *GetPlanPool();
 
   inline PlanNodeType GetPlanNodeType() const { return PlanNodeType::INSERT; }
@@ -81,8 +81,9 @@ class InsertPlan : public AbstractPlan {
 
   const std::string GetInfo() const { return "InsertPlan"; }
 
+  // WARNING - Not Implemented
   std::unique_ptr<AbstractPlan> Copy() const {
-    // TODO: Add copying mechanism
+    LOG_INFO("InsertPlan Copy() not implemented");
     std::unique_ptr<AbstractPlan> dummy;
     return dummy;
   }

--- a/src/include/planner/insert_plan.h
+++ b/src/include/planner/insert_plan.h
@@ -30,7 +30,7 @@ class InsertStatement;
 namespace planner {
 class InsertPlan : public AbstractPlan {
  public:
-  // Construct when input is a logical tile - WARNING Not supported by codegen
+  // Construct when input is a logical tile
   InsertPlan(storage::DataTable *table, oid_t bulk_insert_count = 1)
     : target_table_(table), bulk_insert_count_(bulk_insert_count) {}
 
@@ -43,7 +43,7 @@ class InsertPlan : public AbstractPlan {
     LOG_TRACE("Creating an Insert Plan with a projection");
   }
 
-  // Construct with a tuple - WARNING Not supported by codegen
+  // Construct with a tuple
   InsertPlan(storage::DataTable *table,
              std::unique_ptr<storage::Tuple> &&tuple,
              oid_t bulk_insert_count = 1)
@@ -52,7 +52,7 @@ class InsertPlan : public AbstractPlan {
     tuples_.push_back(std::move(tuple));
   }
 
-  // Construct with specific values - WARNING Not supported by the interpreter
+  // Construct with specific values
   InsertPlan(storage::DataTable *table, const std::vector<std::string> *columns,
              const std::vector<std::vector<std::unique_ptr<
                  expression::AbstractExpression>>> *insert_values);

--- a/src/include/planner/insert_plan.h
+++ b/src/include/planner/insert_plan.h
@@ -14,6 +14,7 @@
 
 #include "planner/abstract_plan.h"
 #include "planner/project_info.h"
+#include "type/abstract_pool.h"
 
 namespace peloton {
 
@@ -31,23 +32,30 @@ class InsertPlan : public AbstractPlan {
  public:
   // This constructor takes in neither a project info nor a tuple
   // It must be used when the input is a logical tile
-  explicit InsertPlan(storage::DataTable *table, oid_t bulk_insert_count = 1);
+  InsertPlan(storage::DataTable *table, oid_t bulk_insert_count = 1)
+    : target_table_(table), bulk_insert_count_(bulk_insert_count) {}
 
   // This constructor takes in a project info
-  explicit InsertPlan(
-      storage::DataTable *table,
-      std::unique_ptr<const planner::ProjectInfo> &&project_info,
-      oid_t bulk_insert_count = 1);
+  InsertPlan(storage::DataTable *table,
+             std::unique_ptr<const planner::ProjectInfo> &&project_info,
+             oid_t bulk_insert_count = 1)
+    : target_table_(table), project_info_(std::move(project_info)),
+      bulk_insert_count_(bulk_insert_count) {
+    LOG_TRACE("Creating an Insert Plan with a projection");
+  }
 
   // This constructor takes in a tuple
-  explicit InsertPlan(storage::DataTable *table,
-                      std::unique_ptr<storage::Tuple> &&tuple,
-                      oid_t bulk_insert_count = 1);
+  InsertPlan(storage::DataTable *table,
+             std::unique_ptr<storage::Tuple> &&tuple,
+             oid_t bulk_insert_count = 1)
+    : target_table_(table), bulk_insert_count_(bulk_insert_count) {
+    LOG_TRACE("Creating an Insert Plan for one tuple");
+    tuples_.push_back(std::move(tuple));
+  }
 
-  explicit InsertPlan(
-      storage::DataTable *table, const std::vector<std::string> *columns,
-      const std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>> *
-          insert_values);
+  InsertPlan(storage::DataTable *table, const std::vector<std::string> *columns,
+             const std::vector<std::vector<std::unique_ptr<
+                 expression::AbstractExpression>>> *insert_values);
 
   // Get a varlen pool (will construct the pool only if needed)
   type::AbstractPool *GetPlanPool();
@@ -80,23 +88,23 @@ class InsertPlan : public AbstractPlan {
   }
 
  private:
-  /** @brief Target table. */
+  // Target table
   storage::DataTable *target_table_ = nullptr;
 
-  /** @brief Projection Info */
+  // Projection Info
   std::unique_ptr<const planner::ProjectInfo> project_info_;
 
-  /** @brief Tuple */
+  // Tuple
   std::vector<std::unique_ptr<storage::Tuple>> tuples_;
 
-  // <tuple_index, tuple_column_index, parameter_index>
+  // Parameter Information <tuple_index, tuple_column_index, parameter_index>
   std::unique_ptr<std::vector<std::tuple<oid_t, oid_t, oid_t>>>
       parameter_vector_;
 
-  // Parameter values
+  // Parameter value types
   std::unique_ptr<std::vector<type::TypeId>> params_value_type_;
 
-  /** @brief Number of times to insert */
+  // Number of times to insert
   oid_t bulk_insert_count_;
 
   // pool for variable length types

--- a/src/planner/insert_plan.cpp
+++ b/src/planner/insert_plan.cpp
@@ -143,21 +143,16 @@ void InsertPlan::SetParameterValues(std::vector<type::Value> *values) {
   LOG_TRACE("Set Parameter Values in Insert");
   PL_ASSERT(values->size() == parameter_vector_->size());
   for (unsigned int i = 0; i < values->size(); i++) {
-    auto param_type = params_value_type_->at(i);
-    auto &put_loc = parameter_vector_->at(i);
-    auto value = values->at(std::get<2>(put_loc));
-    type::Value val = value.CastAs(param_type);
-    switch (param_type) {
-      case type::TypeId::VARBINARY:
-      case type::TypeId::VARCHAR: {
-        tuples_[std::get<0>(put_loc)]->SetValue(std::get<1>(put_loc), val,
-                                                GetPlanPool());
-        break;
-      }
-      default: {
-        tuples_[std::get<0>(put_loc)]->SetValue(std::get<1>(put_loc), val);
-      }
-    }
+    auto type = params_value_type_->at(i);
+    auto &param_info = parameter_vector_->at(i);
+    auto tuple_idx = std::get<0>(param_info);
+    auto column_id = std::get<1>(param_info);
+    auto param_idx = std::get<2>(param_info);
+    type::Value value = values->at(param_idx).CastAs(type);
+    if (type == type::TypeId::VARCHAR || type == type::TypeId::VARBINARY)
+      tuples_[tuple_idx]->SetValue(column_id, value, GetPlanPool());
+    else
+      tuples_[tuple_idx]->SetValue(column_id, value);
   }
 }
 

--- a/src/planner/insert_plan.cpp
+++ b/src/planner/insert_plan.cpp
@@ -4,9 +4,9 @@
 //
 // insert_plan.cpp
 //
-// Identification: /peloton/src/planner/insert_plan.cpp
+// Identification: src/planner/insert_plan.cpp
 //
-// Copyright (c) 2015, Carnegie Mellon University Database Group
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -21,196 +21,138 @@
 namespace peloton {
 namespace planner {
 
-InsertPlan::InsertPlan(storage::DataTable *table, oid_t bulk_insert_count)
-    : target_table_(table), bulk_insert_count_(bulk_insert_count) {}
-
-// This constructor takes in a project info
-InsertPlan::InsertPlan(
-    storage::DataTable *table,
-    std::unique_ptr<const planner::ProjectInfo> &&project_info,
-    oid_t bulk_insert_count)
-    : target_table_(table),
-      project_info_(std::move(project_info)),
-      bulk_insert_count_(bulk_insert_count) {
-  LOG_TRACE("Creating an Insert Plan with a projection");
-}
-
-// This constructor takes in a tuple
 InsertPlan::InsertPlan(storage::DataTable *table,
-                       std::unique_ptr<storage::Tuple> &&tuple,
-                       oid_t bulk_insert_count)
-    : target_table_(table), bulk_insert_count_(bulk_insert_count) {
-  LOG_TRACE("Creating an Insert Plan for one tuple");
-  tuples_.push_back(std::move(tuple));
-}
-
-InsertPlan::InsertPlan(
-    storage::DataTable *table, const std::vector<std::string> *columns,
+    const std::vector<std::string> *columns,
     const std::vector<std::vector<
         std::unique_ptr<expression::AbstractExpression>>> *insert_values)
-    : bulk_insert_count_(insert_values->size()) {
+    : target_table_(table), bulk_insert_count_(insert_values->size()) {
   LOG_TRACE("Creating an Insert Plan with multiple expressions");
-
+  PL_ASSERT(target_table_);
   parameter_vector_.reset(new std::vector<std::tuple<oid_t, oid_t, oid_t>>());
   params_value_type_.reset(new std::vector<type::TypeId>);
 
-  target_table_ = table;
-
-  if (target_table_) {
-    const catalog::Schema *table_schema = target_table_->GetSchema();
-    // INSERT INTO table_name VALUES (val2, val2, ...)
-    if (columns->empty()) {
-      for (uint32_t tuple_idx = 0; tuple_idx < insert_values->size();
-           tuple_idx++) {
-        auto &values = (*insert_values)[tuple_idx];
-        PL_ASSERT(values.size() <= table_schema->GetColumnCount());
-        std::unique_ptr<storage::Tuple> tuple(
-            new storage::Tuple(table_schema, true));
-        int col_cntr = 0;
-        int param_index = 0;
-        for (auto &elem : values) {
-          // Default value to be inserted
-          if (elem == nullptr) {
-            // No default value
-            if (table_schema->GetDefaultValue(col_cntr) == nullptr) {
-              // exception handling ?
-              throw ConstraintException("No DEFAULT constraint !");
-            }
-            type::Value *v = table_schema->GetDefaultValue(col_cntr);
-            tuple->SetValue(col_cntr, std::move(*v), nullptr);
-          } else if (elem->GetExpressionType() ==
-                     ExpressionType::VALUE_PARAMETER) {
-            std::tuple<oid_t, oid_t, oid_t> pair =
-                std::make_tuple(tuple_idx, col_cntr, param_index++);
-            parameter_vector_->push_back(pair);
-            params_value_type_->push_back(
-                table_schema->GetColumn(col_cntr).GetType());
-          } else {
-            expression::ConstantValueExpression *const_expr_elem =
-                dynamic_cast<expression::ConstantValueExpression *>(elem.get());
-            type::Value const_expr_elem_val = (const_expr_elem->GetValue());
-            switch (const_expr_elem->GetValueType()) {
-              case type::TypeId::VARCHAR:
-              case type::TypeId::VARBINARY:
-                tuple->SetValue(col_cntr, const_expr_elem_val, GetPlanPool());
-                break;
-              default: {
-                tuple->SetValue(col_cntr, const_expr_elem_val, nullptr);
-              }
-            }
-          }
-          ++col_cntr;
-        }
-        tuples_.push_back(std::move(tuple));
-      }
-    }
-    // INSERT INTO table_name (col1, col2, ...) VALUES (val1, val2, ...);
-    else {
-      // columns has to be less than or equal that of schema
-      for (uint32_t tuple_idx = 0; tuple_idx < insert_values->size();
-           tuple_idx++) {
-        auto &values = (*insert_values)[tuple_idx];
-        PL_ASSERT(columns->size() <= table_schema->GetColumnCount());
-        std::unique_ptr<storage::Tuple> tuple(
-            new storage::Tuple(table_schema, true));
-        int param_index = 0;
-        auto &table_columns = table_schema->GetColumns();
-        auto query_columns = columns;
-        auto query_columns_cnt = query_columns->size();
-
-        // Update parameter info in the specified columns order
-        for (size_t pos = 0; pos < query_columns_cnt; pos++) {
-          auto col_name = query_columns->at(pos);
-          auto col_cntr = table_schema->GetColumnID(col_name);
-
-          PL_ASSERT(col_cntr != INVALID_OID);
-
-          // If it's varchar or varbinary then use data pool, otherwise
-          // allocate
-          // inline
-          auto col_type = table_schema->GetColumn(col_cntr).GetType();
+  auto *schema = target_table_->GetSchema();
+  // INSERT INTO table_name VALUES (val2, val2, ...)
+  if (columns->empty()) {
+    for (uint32_t tuple_idx = 0; tuple_idx < insert_values->size();
+         tuple_idx++) {
+      auto &values = (*insert_values)[tuple_idx];
+      PL_ASSERT(values.size() <= schema->GetColumnCount());
+      std::unique_ptr<storage::Tuple> tuple(new storage::Tuple(schema, true));
+      int column_id = 0, param_idx = 0;
+      for (uint32_t idx = 0; idx < values.size(); idx++, column_id++) {
+        auto &exp = values[idx];
+        if (exp == nullptr) {
+          type::Value *v = schema->GetDefaultValue(column_id);
+          if (v == nullptr)
+            throw ConstraintException("No DEFAULT constraint !");
+          tuple->SetValue(column_id, std::move(*v), nullptr);
+        } else if (exp->GetExpressionType() ==
+                   ExpressionType::VALUE_PARAMETER) {
+          std::tuple<oid_t, oid_t, oid_t> pair =
+              std::make_tuple(tuple_idx, column_id, param_idx++);
+          parameter_vector_->push_back(pair);
+          params_value_type_->push_back(
+              schema->GetColumn(column_id).GetType());
+        } else {
+          auto *const_exp =
+              dynamic_cast<expression::ConstantValueExpression *>(exp.get());
+          type::Value value = const_exp->GetValue();
+          auto type = const_exp->GetValueType();
           type::AbstractPool *data_pool = nullptr;
-          if (col_type == type::TypeId::VARCHAR ||
-              col_type == type::TypeId::VARBINARY)
+          if (type == type::TypeId::VARCHAR || type == type::TypeId::VARBINARY)
             data_pool = GetPlanPool();
-
-          LOG_TRACE("Column %d found in INSERT query, ExpressionType: %s",
-                    col_cntr,
-                    ExpressionTypeToString(values.at(pos)->GetExpressionType())
-                        .c_str());
-
-          if (values.at(pos)->GetExpressionType() ==
-              ExpressionType::VALUE_PARAMETER) {
-            std::tuple<oid_t, oid_t, oid_t> pair =
-                std::make_tuple(tuple_idx, col_cntr, param_index);
-            parameter_vector_->push_back(pair);
-            params_value_type_->push_back(
-                table_schema->GetColumn(col_cntr).GetType());
-            ++param_index;
-          } else {
-            expression::ConstantValueExpression *const_expr_elem =
-                dynamic_cast<expression::ConstantValueExpression *>(
-                    values.at(pos).get());
-            type::Value val = (const_expr_elem->GetValue());
-            tuple->SetValue(col_cntr, val, data_pool);
-          }
+          tuple->SetValue(column_id, value, data_pool);
         }
-        // Insert a null value for non-specified columns
-        auto table_columns_cnt = table_schema->GetColumnCount();
-        if (query_columns_cnt < table_columns_cnt) {
-          for (size_t col_cntr = 0; col_cntr < table_columns_cnt; col_cntr++) {
-            auto col = table_columns[col_cntr];
-            if (std::find_if(query_columns->begin(), query_columns->end(),
-                             [&col](const std::string &x) {
-                               return col.GetName() == x;
-                             }) == query_columns->end()) {
-              tuple->SetValue(col_cntr, type::ValueFactory::GetNullValueByType(
-                                            col.GetType()),
-                              nullptr);
-            }
-          }
-        }
-        LOG_TRACE("Tuple to be inserted: %s", tuple->GetInfo().c_str());
-        tuples_.push_back(std::move(tuple));
       }
+      tuples_.push_back(std::move(tuple));
     }
-  } else {
-    LOG_TRACE("Table does not exist!");
+  }
+  // INSERT INTO table_name (col1, col2, ...) VALUES (val1, val2, ...);
+  else {
+    PL_ASSERT(columns->size() <= schema->GetColumnCount());
+    for (uint32_t tuple_idx = 0; tuple_idx < insert_values->size();
+         tuple_idx++) {
+      auto &values = (*insert_values)[tuple_idx];
+      std::unique_ptr<storage::Tuple> tuple(new storage::Tuple(schema, true));
+      auto &table_columns = schema->GetColumns();
+      auto columns_cnt = columns->size();
+      int param_idx = 0;
+
+      // Update parameter info in the specified columns order
+      for (size_t pos = 0; pos < columns_cnt; pos++) {
+        auto column_id = schema->GetColumnID(columns->at(pos));
+        PL_ASSERT(column_id != INVALID_OID);
+
+        auto type = schema->GetColumn(column_id).GetType();
+        type::AbstractPool *data_pool = nullptr;
+        if (type == type::TypeId::VARCHAR || type == type::TypeId::VARBINARY)
+          data_pool = GetPlanPool();
+
+        LOG_TRACE("Column %d found in INSERT, ExpressionType: %s", column_id,
+                  ExpressionTypeToString(values.at(pos)->GetExpressionType())
+                      .c_str());
+
+        if (values.at(pos)->GetExpressionType() ==
+            ExpressionType::VALUE_PARAMETER) {
+          std::tuple<oid_t, oid_t, oid_t> pair =
+              std::make_tuple(tuple_idx, column_id, param_idx++);
+          parameter_vector_->push_back(pair);
+          params_value_type_->push_back(schema->GetColumn(column_id).GetType());
+        } else {
+          expression::ConstantValueExpression *const_exp =
+              dynamic_cast<expression::ConstantValueExpression *>(
+                  values.at(pos).get());
+          tuple->SetValue(column_id, const_exp->GetValue(), data_pool);
+        }
+      }
+
+      // Insert a null value for non-specified columns
+      auto table_columns_cnt = schema->GetColumnCount();
+      if (columns_cnt < table_columns_cnt) {
+        for (size_t column_id = 0; column_id < table_columns_cnt; column_id++) {
+          auto col = table_columns[column_id];
+          if (std::find_if(columns->begin(), columns->end(),
+                  [&col](const std::string &x) { return col.GetName() == x; })
+              == columns->end()) {
+            tuple->SetValue(column_id,
+                type::ValueFactory::GetNullValueByType(col.GetType()), nullptr);
+          }
+        }
+      }
+      LOG_TRACE("Tuple to be inserted: %s", tuple->GetInfo().c_str());
+      tuples_.push_back(std::move(tuple));
+    }
   }
 }
 
 type::AbstractPool *InsertPlan::GetPlanPool() {
-  // construct pool if needed
-  if (pool_.get() == nullptr) pool_.reset(new type::EphemeralPool());
-  // return pool
+  if (pool_.get() == nullptr)
+    pool_.reset(new type::EphemeralPool());
   return pool_.get();
 }
 
 void InsertPlan::SetParameterValues(std::vector<type::Value> *values) {
-  PL_ASSERT(values->size() == parameter_vector_->size());
   LOG_TRACE("Set Parameter Values in Insert");
-  for (unsigned int i = 0; i < values->size(); ++i) {
+  PL_ASSERT(values->size() == parameter_vector_->size());
+  for (unsigned int i = 0; i < values->size(); i++) {
     auto param_type = params_value_type_->at(i);
     auto &put_loc = parameter_vector_->at(i);
     auto value = values->at(std::get<2>(put_loc));
-    // LOG_TRACE("Setting value of type %s",
-    // ValueTypeToString(param_type).c_str());
-
+    type::Value val = value.CastAs(param_type);
     switch (param_type) {
       case type::TypeId::VARBINARY:
       case type::TypeId::VARCHAR: {
-        type::Value val = (value.CastAs(param_type));
         tuples_[std::get<0>(put_loc)]->SetValue(std::get<1>(put_loc), val,
                                                 GetPlanPool());
         break;
       }
       default: {
-        type::Value val = (value.CastAs(param_type));
-        tuples_[std::get<0>(put_loc)]->SetValue(std::get<1>(put_loc), val,
-                                                nullptr);
+        tuples_[std::get<0>(put_loc)]->SetValue(std::get<1>(put_loc), val);
       }
     }
   }
 }
-}
-}
+
+}  // namespace planner
+}  // namespace peloton

--- a/test/catalog/manager_test.cpp
+++ b/test/catalog/manager_test.cpp
@@ -45,20 +45,16 @@ void AddTileGroup(UNUSED_ATTRIBUTE uint64_t thread_id) {
                           "A", true);
   columns.push_back(column1);
 
-  catalog::Schema *schema1 = new catalog::Schema(columns);
+  std::unique_ptr<catalog::Schema> schema1(new catalog::Schema(columns));
   schemas.push_back(*schema1);
 
   std::map<oid_t, std::pair<oid_t, oid_t>> column_map;
   column_map[0] = std::make_pair(0, 0);
 
   for (oid_t txn_itr = 0; txn_itr < 100; txn_itr++) {
-    storage::TileGroup *tile_group = storage::TileGroupFactory::GetTileGroup(
-        INVALID_OID, INVALID_OID, INVALID_OID, nullptr, schemas, column_map, 3);
-
-    delete tile_group;
+    std::unique_ptr<storage::TileGroup> tile_group(storage::TileGroupFactory::GetTileGroup(
+        INVALID_OID, INVALID_OID, INVALID_OID, nullptr, schemas, column_map, 3));
   }
-
-  delete schema1;
 }
 
 TEST_F(ManagerTests, TransactionTest) {

--- a/test/catalog/tuple_schema_test.cpp
+++ b/test/catalog/tuple_schema_test.cpp
@@ -72,7 +72,7 @@ TEST_F(TupleSchemaTests, TupleSchemaFilteringTest) {
   ///////////////////////////////////////////////////////////////////
   
   std::vector<oid_t> subset{0, 2};
-  catalog::Schema *schema3_p = catalog::Schema::FilterSchema(&schema2, subset);
+  std::unique_ptr<catalog::Schema> schema3_p(catalog::Schema::FilterSchema(&schema2, subset));
   LOG_INFO("%s", schema3_p->GetInfo().c_str());
 
   EXPECT_NE(schema1, (*schema3_p));
@@ -82,7 +82,7 @@ TEST_F(TupleSchemaTests, TupleSchemaFilteringTest) {
   ///////////////////////////////////////////////////////////////////
   
   subset = {2, 0};
-  catalog::Schema *schema4_p = catalog::Schema::FilterSchema(&schema2, subset);
+  std::unique_ptr<catalog::Schema> schema4_p(catalog::Schema::FilterSchema(&schema2, subset));
   LOG_INFO("%s", schema4_p->GetInfo().c_str());
 
   EXPECT_EQ((*schema4_p), (*schema3_p));
@@ -93,15 +93,11 @@ TEST_F(TupleSchemaTests, TupleSchemaFilteringTest) {
   
   subset = {666, 0, 0, 0, 0, 0, 0, 2, 0, 2, 0, 2, 100, 101};
   
-  catalog::Schema *schema5_p = catalog::Schema::FilterSchema(&schema2, subset);
+  std::unique_ptr<catalog::Schema> schema5_p(catalog::Schema::FilterSchema(&schema2, subset));
   LOG_INFO("%s", schema5_p->GetInfo().c_str());
 
   EXPECT_EQ(schema5_p->GetColumnCount(), 2);
   EXPECT_EQ((*schema5_p), (*schema4_p));
-  
-  delete schema3_p;
-  delete schema4_p;
-  delete schema5_p;
   
   ///////////////////////////////////////////////////////////////////
   // All tests finished
@@ -136,7 +132,7 @@ TEST_F(TupleSchemaTests, TupleSchemaCopyTest) {
   ///////////////////////////////////////////////////////////////////
 
   std::vector<oid_t> subset{0, 2};
-  catalog::Schema *schema3_p = catalog::Schema::CopySchema(&schema1, subset);
+  std::unique_ptr<catalog::Schema> schema3_p(catalog::Schema::CopySchema(&schema1, subset));
   LOG_INFO("%s", schema3_p->GetInfo().c_str());
 
   EXPECT_NE(schema1, (*schema3_p));
@@ -146,7 +142,7 @@ TEST_F(TupleSchemaTests, TupleSchemaCopyTest) {
   ///////////////////////////////////////////////////////////////////
 
   subset = {2, 0};
-  catalog::Schema *schema4_p = catalog::Schema::CopySchema(&schema1, subset);
+  std::unique_ptr<catalog::Schema> schema4_p(catalog::Schema::CopySchema(&schema1, subset));
   LOG_INFO("%s", schema4_p->GetInfo().c_str());
 
   EXPECT_NE((*schema4_p), (*schema3_p));
@@ -157,16 +153,12 @@ TEST_F(TupleSchemaTests, TupleSchemaCopyTest) {
 
   subset = {0, 0, 0, 0, 0, 0, 2, 0, 2, 0, 2, 1};
 
-  catalog::Schema *schema5_p = catalog::Schema::CopySchema(&schema1, subset);
+  std::unique_ptr<catalog::Schema> schema5_p(catalog::Schema::CopySchema(&schema1, subset));
   LOG_INFO("%s", schema5_p->GetInfo().c_str());
 
   EXPECT_EQ(schema5_p->GetColumnCount(), subset.size());
   EXPECT_NE((*schema5_p), (*schema4_p));
   EXPECT_NE((*schema5_p), (*schema3_p));
-
-  delete schema3_p;
-  delete schema4_p;
-  delete schema5_p;
 
   ///////////////////////////////////////////////////////////////////
   // All tests finished

--- a/test/include/index/testing_index_util.h
+++ b/test/include/index/testing_index_util.h
@@ -60,6 +60,8 @@ class TestingIndexUtil {
   static index::Index *BuildIndex(const IndexType index_type,
                                   const bool unique_keys);
 
+  static void DestroyIndex(index::Index *index);
+
   /**
    * Insert helper function
    */

--- a/test/index/index_util_test.cpp
+++ b/test/index/index_util_test.cpp
@@ -131,7 +131,7 @@ static index::Index *BuildIndex() {
  * index_key: 3 0 1
  */
 TEST_F(IndexUtilTests, FindValueIndexTest) {
-  const index::Index *index_p = BuildIndex();
+  std::unique_ptr<index::Index> index_p(BuildIndex());
   bool ret;
 
   std::vector<std::pair<oid_t, oid_t>> value_index_list{};
@@ -227,8 +227,6 @@ TEST_F(IndexUtilTests, FindValueIndexTest) {
   EXPECT_EQ(ret, false);
   value_index_list.clear();
 
-  delete index_p;
-
   return;
 }
 
@@ -237,7 +235,7 @@ TEST_F(IndexUtilTests, FindValueIndexTest) {
  *                              conjunctions
  */
 TEST_F(IndexUtilTests, ConstructBoundaryKeyTest) {
-  index::Index *index_p = BuildIndex();
+  std::unique_ptr<index::Index> index_p(BuildIndex());
 
   // This is the output variable
   std::vector<std::pair<oid_t, oid_t>> value_index_list{};
@@ -262,8 +260,8 @@ TEST_F(IndexUtilTests, ConstructBoundaryKeyTest) {
 
   IndexScanPredicate isp{};
 
-  isp.AddConjunctionScanPredicate(index_p, value_list, tuple_column_id_list,
-                                  expr_list);
+  isp.AddConjunctionScanPredicate(index_p.get(), value_list,
+                                  tuple_column_id_list, expr_list);
 
   const std::vector<ConjunctionScanPredicate> &cl = isp.GetConjunctionList();
 
@@ -303,8 +301,8 @@ TEST_F(IndexUtilTests, ConstructBoundaryKeyTest) {
       ExpressionType::COMPARE_NOTEQUAL,
   };
 
-  isp.AddConjunctionScanPredicate(index_p, value_list, tuple_column_id_list,
-                                  expr_list);
+  isp.AddConjunctionScanPredicate(index_p.get(), value_list,
+                                  tuple_column_id_list, expr_list);
 
   const std::vector<ConjunctionScanPredicate> &cl2 = isp.GetConjunctionList();
 
@@ -335,8 +333,8 @@ TEST_F(IndexUtilTests, ConstructBoundaryKeyTest) {
       ExpressionType::COMPARE_EQUAL,
   };
 
-  isp2.AddConjunctionScanPredicate(index_p, value_list, tuple_column_id_list,
-                                   expr_list);
+  isp2.AddConjunctionScanPredicate(index_p.get(), value_list,
+                                   tuple_column_id_list, expr_list);
 
   const std::vector<ConjunctionScanPredicate> &cl3 = isp2.GetConjunctionList();
 
@@ -352,7 +350,6 @@ TEST_F(IndexUtilTests, ConstructBoundaryKeyTest) {
   ///////////////////////////////////////////////////////////////////
   // End of all test cases
   ///////////////////////////////////////////////////////////////////
-  delete index_p;
 
   return;
 }
@@ -361,7 +358,7 @@ TEST_F(IndexUtilTests, ConstructBoundaryKeyTest) {
  * BindKeyTest() - Tests binding values onto keys that are not bound
  */
 TEST_F(IndexUtilTests, BindKeyTest) {
-  index::Index *index_p = BuildIndex();
+  std::unique_ptr<index::Index> index_p(BuildIndex());
 
   // This is the output variable
   std::vector<std::pair<oid_t, oid_t>> value_index_list{};
@@ -386,8 +383,8 @@ TEST_F(IndexUtilTests, BindKeyTest) {
 
   IndexScanPredicate isp{};
 
-  isp.AddConjunctionScanPredicate(index_p, value_list, tuple_column_id_list,
-                                  expr_list);
+  isp.AddConjunctionScanPredicate(index_p.get(), value_list,
+                                  tuple_column_id_list, expr_list);
 
   const std::vector<ConjunctionScanPredicate> &cl = isp.GetConjunctionList();
 
@@ -415,7 +412,7 @@ TEST_F(IndexUtilTests, BindKeyTest) {
       type::ValueFactory::GetIntegerValue(200).Copy());
   type::Value val3 = (
       type::ValueFactory::GetIntegerValue(300).Copy());
-  isp.LateBindValues(index_p, {val1, val2, val3});
+  isp.LateBindValues(index_p.get(), {val1, val2, val3});
 
   // This is important - Since binding does not change the number of
   // binding points, and their information is preserved for next
@@ -429,7 +426,6 @@ TEST_F(IndexUtilTests, BindKeyTest) {
   ///////////////////////////////////////////////////////////////////
   // End of all tests
   ///////////////////////////////////////////////////////////////////
-  delete index_p;
 
   return;
 }

--- a/test/index/testing_index_util.cpp
+++ b/test/index/testing_index_util.cpp
@@ -36,11 +36,8 @@ void TestingIndexUtil::BasicTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
-      TestingIndexUtil::BuildIndex(index_type, false),
-      [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema();
-          delete index; });
+  std::unique_ptr<index::Index, void(*)(index::Index *)> index(
+      TestingIndexUtil::BuildIndex(index_type, false), DestroyIndex);
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   std::unique_ptr<storage::Tuple> key0(new storage::Tuple(key_schema, true));
@@ -69,11 +66,8 @@ void TestingIndexUtil::MultiMapInsertTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
-      TestingIndexUtil::BuildIndex(index_type, false),
-      [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema();
-          delete index; });
+  std::unique_ptr<index::Index, void(*)(index::Index *)> index(
+      TestingIndexUtil::BuildIndex(index_type, false), DestroyIndex);
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -109,11 +103,8 @@ void TestingIndexUtil::UniqueKeyInsertTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
-      TestingIndexUtil::BuildIndex(index_type, false),
-      [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema();
-          delete index; });
+  std::unique_ptr<index::Index, void(*)(index::Index *)> index(
+      TestingIndexUtil::BuildIndex(index_type, false), DestroyIndex);
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -136,11 +127,8 @@ void TestingIndexUtil::UniqueKeyDeleteTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
-      TestingIndexUtil::BuildIndex(index_type, false),
-      [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema();
-          delete index; });
+  std::unique_ptr<index::Index, void(*)(index::Index *)> index(
+      TestingIndexUtil::BuildIndex(index_type, false), DestroyIndex);
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -183,11 +171,8 @@ void TestingIndexUtil::NonUniqueKeyDeleteTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
-      TestingIndexUtil::BuildIndex(index_type, false),
-      [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema();
-          delete index; });
+  std::unique_ptr<index::Index, void(*)(index::Index *)> index(
+      TestingIndexUtil::BuildIndex(index_type, false), DestroyIndex);
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -228,11 +213,8 @@ void TestingIndexUtil::MultiThreadedInsertTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
-      TestingIndexUtil::BuildIndex(index_type, false),
-      [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema();
-          delete index; });
+  std::unique_ptr<index::Index, void(*)(index::Index *)> index(
+      TestingIndexUtil::BuildIndex(index_type, false), DestroyIndex);
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -270,11 +252,8 @@ void TestingIndexUtil::UniqueKeyMultiThreadedTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
-      TestingIndexUtil::BuildIndex(index_type, false),
-      [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema();
-          delete index; });
+  std::unique_ptr<index::Index, void(*)(index::Index *)> index(
+      TestingIndexUtil::BuildIndex(index_type, false), DestroyIndex);
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -366,11 +345,8 @@ void TestingIndexUtil::NonUniqueKeyMultiThreadedTest(const IndexType index_type)
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
-      TestingIndexUtil::BuildIndex(index_type, false),
-      [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema();
-          delete index; });
+  std::unique_ptr<index::Index, void(*)(index::Index *)> index(
+      TestingIndexUtil::BuildIndex(index_type, false), DestroyIndex);
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -563,11 +539,8 @@ void TestingIndexUtil::NonUniqueKeyMultiThreadedStressTest(const IndexType index
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
-      TestingIndexUtil::BuildIndex(index_type, false),
-      [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema();
-          delete index; });
+  std::unique_ptr<index::Index, void(*)(index::Index *)> index(
+      TestingIndexUtil::BuildIndex(index_type, false), DestroyIndex);
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -614,11 +587,8 @@ void TestingIndexUtil::NonUniqueKeyMultiThreadedStressTest2(const IndexType inde
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
-      TestingIndexUtil::BuildIndex(index_type, false),
-      [](index::Index *index) { 
-          delete index->GetMetadata()->GetTupleSchema();
-          delete index; });
+  std::unique_ptr<index::Index, void(*)(index::Index *)> index(
+      TestingIndexUtil::BuildIndex(index_type, false), DestroyIndex);
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -740,6 +710,11 @@ index::Index *TestingIndexUtil::BuildIndex(const IndexType index_type,
   EXPECT_EQ(unique_keys, index->HasUniqueKeys());
 
   return index;
+}
+
+void TestingIndexUtil::DestroyIndex(index::Index *index) {
+  delete index->GetMetadata()->GetTupleSchema();
+  delete index;
 }
 
 void TestingIndexUtil::InsertHelper(index::Index *index, type::AbstractPool *pool,

--- a/test/index/testing_index_util.cpp
+++ b/test/index/testing_index_util.cpp
@@ -39,7 +39,8 @@ void TestingIndexUtil::BasicTest(const IndexType index_type) {
   std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
       TestingIndexUtil::BuildIndex(index_type, false),
       [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema(); });
+          delete index->GetMetadata()->GetTupleSchema();
+          delete index; });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   std::unique_ptr<storage::Tuple> key0(new storage::Tuple(key_schema, true));
@@ -71,7 +72,8 @@ void TestingIndexUtil::MultiMapInsertTest(const IndexType index_type) {
   std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
       TestingIndexUtil::BuildIndex(index_type, false),
       [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema(); });
+          delete index->GetMetadata()->GetTupleSchema();
+          delete index; });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -110,7 +112,8 @@ void TestingIndexUtil::UniqueKeyInsertTest(const IndexType index_type) {
   std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
       TestingIndexUtil::BuildIndex(index_type, false),
       [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema(); });
+          delete index->GetMetadata()->GetTupleSchema();
+          delete index; });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -136,7 +139,8 @@ void TestingIndexUtil::UniqueKeyDeleteTest(const IndexType index_type) {
   std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
       TestingIndexUtil::BuildIndex(index_type, false),
       [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema(); });
+          delete index->GetMetadata()->GetTupleSchema();
+          delete index; });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -182,7 +186,8 @@ void TestingIndexUtil::NonUniqueKeyDeleteTest(const IndexType index_type) {
   std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
       TestingIndexUtil::BuildIndex(index_type, false),
       [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema(); });
+          delete index->GetMetadata()->GetTupleSchema();
+          delete index; });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -226,7 +231,8 @@ void TestingIndexUtil::MultiThreadedInsertTest(const IndexType index_type) {
   std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
       TestingIndexUtil::BuildIndex(index_type, false),
       [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema(); });
+          delete index->GetMetadata()->GetTupleSchema();
+          delete index; });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -267,7 +273,8 @@ void TestingIndexUtil::UniqueKeyMultiThreadedTest(const IndexType index_type) {
   std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
       TestingIndexUtil::BuildIndex(index_type, false),
       [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema(); });
+          delete index->GetMetadata()->GetTupleSchema();
+          delete index; });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -362,7 +369,8 @@ void TestingIndexUtil::NonUniqueKeyMultiThreadedTest(const IndexType index_type)
   std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
       TestingIndexUtil::BuildIndex(index_type, false),
       [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema(); });
+          delete index->GetMetadata()->GetTupleSchema();
+          delete index; });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -558,7 +566,8 @@ void TestingIndexUtil::NonUniqueKeyMultiThreadedStressTest(const IndexType index
   std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
       TestingIndexUtil::BuildIndex(index_type, false),
       [](index::Index *index) {
-          delete index->GetMetadata()->GetTupleSchema(); });
+          delete index->GetMetadata()->GetTupleSchema();
+          delete index; });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -608,7 +617,8 @@ void TestingIndexUtil::NonUniqueKeyMultiThreadedStressTest2(const IndexType inde
   std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
       TestingIndexUtil::BuildIndex(index_type, false),
       [](index::Index *index) { 
-          delete index->GetMetadata()->GetTupleSchema(); });
+          delete index->GetMetadata()->GetTupleSchema();
+          delete index; });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test

--- a/test/index/testing_index_util.cpp
+++ b/test/index/testing_index_util.cpp
@@ -36,8 +36,10 @@ void TestingIndexUtil::BasicTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index> index(
-      TestingIndexUtil::BuildIndex(index_type, false));
+  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
+      TestingIndexUtil::BuildIndex(index_type, false),
+      [](index::Index *index) {
+          delete index->GetMetadata()->GetTupleSchema(); });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   std::unique_ptr<storage::Tuple> key0(new storage::Tuple(key_schema, true));
@@ -59,8 +61,6 @@ void TestingIndexUtil::BasicTest(const IndexType index_type) {
   index->ScanKey(key0.get(), location_ptrs);
   EXPECT_EQ(location_ptrs.size(), 0);
   location_ptrs.clear();
-
-  delete index->GetMetadata()->GetTupleSchema();
 }
 
 void TestingIndexUtil::MultiMapInsertTest(const IndexType index_type) {
@@ -68,8 +68,10 @@ void TestingIndexUtil::MultiMapInsertTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index> index(
-      TestingIndexUtil::BuildIndex(index_type, false));
+  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
+      TestingIndexUtil::BuildIndex(index_type, false),
+      [](index::Index *index) {
+          delete index->GetMetadata()->GetTupleSchema(); });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -98,8 +100,6 @@ void TestingIndexUtil::MultiMapInsertTest(const IndexType index_type) {
   EXPECT_EQ(location_ptrs.size(), 1);
   EXPECT_EQ(location_ptrs[0]->block, TestingIndexUtil::item0->block);
   location_ptrs.clear();
-
-  delete index->GetMetadata()->GetTupleSchema();
 }
 
 void TestingIndexUtil::UniqueKeyInsertTest(const IndexType index_type) {
@@ -107,8 +107,10 @@ void TestingIndexUtil::UniqueKeyInsertTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index> index(
-      TestingIndexUtil::BuildIndex(index_type, false));
+  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
+      TestingIndexUtil::BuildIndex(index_type, false),
+      [](index::Index *index) {
+          delete index->GetMetadata()->GetTupleSchema(); });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -124,8 +126,6 @@ void TestingIndexUtil::UniqueKeyInsertTest(const IndexType index_type) {
   index->ScanKey(key0.get(), location_ptrs);
   EXPECT_EQ(1, location_ptrs.size());
   location_ptrs.clear();
-
-  delete index->GetMetadata()->GetTupleSchema();
 }
 
 void TestingIndexUtil::UniqueKeyDeleteTest(const IndexType index_type) {
@@ -133,8 +133,10 @@ void TestingIndexUtil::UniqueKeyDeleteTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index> index(
-      TestingIndexUtil::BuildIndex(index_type, true));
+  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
+      TestingIndexUtil::BuildIndex(index_type, false),
+      [](index::Index *index) {
+          delete index->GetMetadata()->GetTupleSchema(); });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -170,8 +172,6 @@ void TestingIndexUtil::UniqueKeyDeleteTest(const IndexType index_type) {
   location_ptrs.clear();
 
   LOG_INFO("INDEX:\n%s", index->GetInfo().c_str());
-
-  delete index->GetMetadata()->GetTupleSchema();
 }
 
 void TestingIndexUtil::NonUniqueKeyDeleteTest(const IndexType index_type) {
@@ -179,8 +179,10 @@ void TestingIndexUtil::NonUniqueKeyDeleteTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index> index(
-      TestingIndexUtil::BuildIndex(index_type, false));
+  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
+      TestingIndexUtil::BuildIndex(index_type, false),
+      [](index::Index *index) {
+          delete index->GetMetadata()->GetTupleSchema(); });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -214,8 +216,6 @@ void TestingIndexUtil::NonUniqueKeyDeleteTest(const IndexType index_type) {
   EXPECT_EQ(location_ptrs.size(), 1);
   EXPECT_EQ(location_ptrs[0]->block, TestingIndexUtil::item1->block);
   location_ptrs.clear();
-
-  delete index->GetMetadata()->GetTupleSchema();
 }
 
 void TestingIndexUtil::MultiThreadedInsertTest(const IndexType index_type) {
@@ -223,8 +223,10 @@ void TestingIndexUtil::MultiThreadedInsertTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index> index(
-      TestingIndexUtil::BuildIndex(index_type, false));
+  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
+      TestingIndexUtil::BuildIndex(index_type, false),
+      [](index::Index *index) {
+          delete index->GetMetadata()->GetTupleSchema(); });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -255,8 +257,6 @@ void TestingIndexUtil::MultiThreadedInsertTest(const IndexType index_type) {
   EXPECT_EQ(location_ptrs.size(), 1);
   EXPECT_EQ(location_ptrs[0]->block, TestingIndexUtil::item0->block);
   location_ptrs.clear();
-
-  delete index->GetMetadata()->GetTupleSchema();
 }
 
 void TestingIndexUtil::UniqueKeyMultiThreadedTest(const IndexType index_type) {
@@ -264,8 +264,10 @@ void TestingIndexUtil::UniqueKeyMultiThreadedTest(const IndexType index_type) {
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index> index(
-      TestingIndexUtil::BuildIndex(index_type, true));
+  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
+      TestingIndexUtil::BuildIndex(index_type, false),
+      [](index::Index *index) {
+          delete index->GetMetadata()->GetTupleSchema(); });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -350,8 +352,6 @@ void TestingIndexUtil::UniqueKeyMultiThreadedTest(const IndexType index_type) {
       ScanDirectionType::FORWARD, location_ptrs);
   EXPECT_EQ(location_ptrs.size(), 1);
   location_ptrs.clear();
-
-  delete index->GetMetadata()->GetTupleSchema();
 }
 
 void TestingIndexUtil::NonUniqueKeyMultiThreadedTest(const IndexType index_type) {
@@ -359,8 +359,10 @@ void TestingIndexUtil::NonUniqueKeyMultiThreadedTest(const IndexType index_type)
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index> index(
-      TestingIndexUtil::BuildIndex(index_type, false));
+  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
+      TestingIndexUtil::BuildIndex(index_type, false),
+      [](index::Index *index) {
+          delete index->GetMetadata()->GetTupleSchema(); });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -546,8 +548,6 @@ void TestingIndexUtil::NonUniqueKeyMultiThreadedTest(const IndexType index_type)
                   ScanDirectionType::BACKWARD, location_ptrs);
   EXPECT_EQ(3, location_ptrs.size());
   location_ptrs.clear();
-
-  delete index->GetMetadata()->GetTupleSchema();
 }
 
 void TestingIndexUtil::NonUniqueKeyMultiThreadedStressTest(const IndexType index_type) {
@@ -555,8 +555,10 @@ void TestingIndexUtil::NonUniqueKeyMultiThreadedStressTest(const IndexType index
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index> index(
-      TestingIndexUtil::BuildIndex(index_type, false));
+  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
+      TestingIndexUtil::BuildIndex(index_type, false),
+      [](index::Index *index) {
+          delete index->GetMetadata()->GetTupleSchema(); });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -596,8 +598,6 @@ void TestingIndexUtil::NonUniqueKeyMultiThreadedStressTest(const IndexType index
   index->ScanAllKeys(location_ptrs);
   EXPECT_EQ(location_ptrs.size(), 3 * scale_factor);
   location_ptrs.clear();
-
-  delete index->GetMetadata()->GetTupleSchema();
 }
 
 void TestingIndexUtil::NonUniqueKeyMultiThreadedStressTest2(const IndexType index_type) {
@@ -605,8 +605,10 @@ void TestingIndexUtil::NonUniqueKeyMultiThreadedStressTest2(const IndexType inde
   std::vector<ItemPointer *> location_ptrs;
 
   // INDEX
-  std::unique_ptr<index::Index> index(
-      TestingIndexUtil::BuildIndex(index_type, false));
+  std::unique_ptr<index::Index, std::function<void(index::Index *)>> index(
+      TestingIndexUtil::BuildIndex(index_type, false),
+      [](index::Index *index) { 
+          delete index->GetMetadata()->GetTupleSchema(); });
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test
@@ -649,8 +651,6 @@ void TestingIndexUtil::NonUniqueKeyMultiThreadedStressTest2(const IndexType inde
   }
 
   location_ptrs.clear();
-
-  delete index->GetMetadata()->GetTupleSchema();
 }
 
 

--- a/test/optimizer/operator_test.cpp
+++ b/test/optimizer/operator_test.cpp
@@ -30,8 +30,8 @@ TEST_F(OperatorTests, OperatorHashAndEqualTest){
   }
 
   // Generate having
-  expression::AbstractExpression* having =
-      new expression::ComparisonExpression(ExpressionType::COMPARE_EQUAL);
+  std::unique_ptr<expression::AbstractExpression> having(
+      new expression::ComparisonExpression(ExpressionType::COMPARE_EQUAL));
   auto col1 = new expression::TupleValueExpression("a");
   col1->SetBoundOid(0,0,1);
   auto col2 = new expression::TupleValueExpression("b");
@@ -41,34 +41,28 @@ TEST_F(OperatorTests, OperatorHashAndEqualTest){
 
   const size_t num_iter = 1000;
   // HashGroupBy
-  Operator l_group_by =
-      PhysicalHashGroupBy::make(cols, having);
-
+  Operator l_group_by = PhysicalHashGroupBy::make(cols, having.get());
   for (size_t i = 0; i<num_iter; i++) {
     std::random_shuffle(cols.begin(), cols.end());
 
-    Operator r_group_by =
-        PhysicalHashGroupBy::make(cols, having);
+    Operator r_group_by = PhysicalHashGroupBy::make(cols, having.get());
 
     EXPECT_EQ(l_group_by.Hash(), r_group_by.Hash());
     EXPECT_TRUE(l_group_by == r_group_by);
   }
 
   // SortGroupBy
-  l_group_by =
-      PhysicalSortGroupBy::make(cols, having);
+  l_group_by = PhysicalSortGroupBy::make(cols, having.get());
 
   for (size_t i = 0; i<num_iter; i++) {
     std::random_shuffle(cols.begin(), cols.end());
 
     Operator r_group_by =
-        PhysicalSortGroupBy::make(cols, having);
+        PhysicalSortGroupBy::make(cols, having.get());
 
     EXPECT_EQ(l_group_by.Hash(), r_group_by.Hash());
     EXPECT_TRUE(l_group_by == r_group_by);
   }
-
-  delete having;
 }
 
 }  // namespace test

--- a/test/parser/parser_utils_test.cpp
+++ b/test/parser/parser_utils_test.cpp
@@ -115,8 +115,8 @@ TEST_F(ParserUtilTests, BasicTest) {
   // Parsing
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    parser::SQLStatementList* stmt_list =
-        parser::PostgresParser::ParseSQLString(query.c_str());
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser::PostgresParser::ParseSQLString(query));
     EXPECT_TRUE(stmt_list->is_valid);
     if (stmt_list->is_valid == false) {
       LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -152,7 +152,6 @@ TEST_F(ParserUtilTests, BasicTest) {
           break;
       }
     }
-    delete stmt_list;
   }
 }
 

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -42,7 +42,8 @@ TEST_F(PostgresParserTests, BasicTest) {
   // Parsing
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    auto stmt_list = parser.BuildParseTree(query).release();
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser.BuildParseTree(query).release());
     EXPECT_TRUE(stmt_list->is_valid);
     if (stmt_list->is_valid == false) {
       LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -50,7 +51,6 @@ TEST_F(PostgresParserTests, BasicTest) {
     }
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
-    delete stmt_list;
   }
 }
 
@@ -67,7 +67,8 @@ TEST_F(PostgresParserTests, AggTest) {
   // Parsing
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    auto stmt_list = parser.BuildParseTree(query).release();
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser.BuildParseTree(query).release());
     EXPECT_TRUE(stmt_list->is_valid);
     if (stmt_list->is_valid == false) {
       LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -75,7 +76,6 @@ TEST_F(PostgresParserTests, AggTest) {
     }
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
-    delete stmt_list;
   }
 }
 
@@ -90,7 +90,8 @@ TEST_F(PostgresParserTests, GroupByTest) {
   // Parsing
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    auto stmt_list = parser.BuildParseTree(query).release();
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser.BuildParseTree(query).release());
 
     EXPECT_TRUE(stmt_list->is_valid);
     if (stmt_list->is_valid == false) {
@@ -99,8 +100,6 @@ TEST_F(PostgresParserTests, GroupByTest) {
     }
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
-
-    delete stmt_list;
   }
 }
 
@@ -108,7 +107,8 @@ TEST_F(PostgresParserTests, OrderByTest) {
   auto parser = parser::PostgresParser::GetInstance();
   // SELECT * FROM foo ORDER BY id;
   std::string query = "SELECT * FROM foo ORDER BY id;";
-  auto stmt_list = parser.BuildParseTree(query).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
   auto sql_stmt = stmt_list->statements[0].get();
   EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
   auto select_stmt = (parser::SelectStatement *)(sql_stmt);
@@ -121,11 +121,10 @@ TEST_F(PostgresParserTests, OrderByTest) {
   auto expr = order_by->exprs.at(0).get();
   EXPECT_EQ(expr->GetExpressionType(), ExpressionType::VALUE_TUPLE);
   EXPECT_EQ(((expression::TupleValueExpression *)expr)->GetColumnName(), "id");
-  delete stmt_list;
 
   // SELECT * FROM foo ORDER BY id ASC;
   query = "SELECT * FROM foo ORDER BY id ASC;";
-  stmt_list = parser.BuildParseTree(query).release();
+  stmt_list.reset(parser.BuildParseTree(query).release());
   sql_stmt = stmt_list->statements[0].get();
   EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
   select_stmt = (parser::SelectStatement *)(sql_stmt);
@@ -138,11 +137,10 @@ TEST_F(PostgresParserTests, OrderByTest) {
   expr = order_by->exprs.at(0).get();
   EXPECT_EQ(expr->GetExpressionType(), ExpressionType::VALUE_TUPLE);
   EXPECT_EQ(((expression::TupleValueExpression *)expr)->GetColumnName(), "id");
-  delete stmt_list;
 
   // SELECT * FROM foo ORDER BY id DESC;
   query = "SELECT * FROM foo ORDER BY id DESC;";
-  stmt_list = parser.BuildParseTree(query).release();
+  stmt_list.reset(parser.BuildParseTree(query).release());
   sql_stmt = stmt_list->statements[0].get();
   EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
   select_stmt = (parser::SelectStatement *)(sql_stmt);
@@ -155,11 +153,10 @@ TEST_F(PostgresParserTests, OrderByTest) {
   expr = order_by->exprs.at(0).get();
   EXPECT_EQ(expr->GetExpressionType(), ExpressionType::VALUE_TUPLE);
   EXPECT_EQ(((expression::TupleValueExpression *)expr)->GetColumnName(), "id");
-  delete stmt_list;
 
   // SELECT * FROM foo ORDER BY id, name;
   query = "SELECT * FROM foo ORDER BY id, name;";
-  stmt_list = parser.BuildParseTree(query).release();
+  stmt_list.reset(parser.BuildParseTree(query).release());
   sql_stmt = stmt_list->statements[0].get();
   EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
   select_stmt = (parser::SelectStatement *)(sql_stmt);
@@ -176,11 +173,10 @@ TEST_F(PostgresParserTests, OrderByTest) {
   EXPECT_EQ(expr->GetExpressionType(), ExpressionType::VALUE_TUPLE);
   EXPECT_EQ(((expression::TupleValueExpression *)expr)->GetColumnName(),
             "name");
-  delete stmt_list;
 
   // SELECT * FROM foo ORDER BY id, name;
   query = "SELECT * FROM foo ORDER BY id, name DESC;";
-  stmt_list = parser.BuildParseTree(query).release();
+  stmt_list.reset(parser.BuildParseTree(query).release());
   sql_stmt = stmt_list->statements[0].get();
   EXPECT_EQ(sql_stmt->GetType(), StatementType::SELECT);
   select_stmt = (parser::SelectStatement *)(sql_stmt);
@@ -198,7 +194,6 @@ TEST_F(PostgresParserTests, OrderByTest) {
   EXPECT_EQ(expr->GetExpressionType(), ExpressionType::VALUE_TUPLE);
   EXPECT_EQ(((expression::TupleValueExpression *)expr)->GetColumnName(),
             "name");
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, ConstTest) {
@@ -211,7 +206,8 @@ TEST_F(PostgresParserTests, ConstTest) {
   // Parsing
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    auto stmt_list = parser.BuildParseTree(query).release();
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser.BuildParseTree(query).release());
     EXPECT_TRUE(stmt_list->is_valid);
     if (stmt_list->is_valid == false) {
       LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -219,7 +215,6 @@ TEST_F(PostgresParserTests, ConstTest) {
     }
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
-    delete stmt_list;
   }
 }
 
@@ -245,7 +240,8 @@ TEST_F(PostgresParserTests, JoinTest) {
   // Parsing
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    auto stmt_list = parser.BuildParseTree(query).release();
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser.BuildParseTree(query).release());
     EXPECT_TRUE(stmt_list->is_valid);
     if (stmt_list->is_valid == false) {
       LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -266,7 +262,6 @@ TEST_F(PostgresParserTests, JoinTest) {
       LOG_INFO("condition 0 : %s", join_table->join->condition->GetInfo().c_str());
       LOG_INFO("condition 0 : %s", l_join->join->condition->GetInfo().c_str());
     }
-    delete stmt_list;
   }
 }
 
@@ -280,7 +275,8 @@ TEST_F(PostgresParserTests, NestedQueryTest) {
   // Parsing
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    auto stmt_list = parser.BuildParseTree(query).release();
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser.BuildParseTree(query).release());
     EXPECT_TRUE(stmt_list->is_valid);
     if (stmt_list->is_valid == false) {
       LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -288,7 +284,6 @@ TEST_F(PostgresParserTests, NestedQueryTest) {
     }
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
-    delete stmt_list;
   }
 }
 
@@ -304,7 +299,8 @@ TEST_F(PostgresParserTests, MultiTableTest) {
   // Parsing
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    auto stmt_list = parser.BuildParseTree(query).release();
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser.BuildParseTree(query).release());
     EXPECT_TRUE(stmt_list->is_valid);
     if (stmt_list->is_valid == false) {
       LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -312,7 +308,6 @@ TEST_F(PostgresParserTests, MultiTableTest) {
     }
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
-    delete stmt_list;
   }
 }
 
@@ -328,7 +323,8 @@ TEST_F(PostgresParserTests, ColumnUpdateTest) {
   // Parsing
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    auto stmt_list = parser.BuildParseTree(query).release();
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser.BuildParseTree(query).release());
     EXPECT_TRUE(stmt_list->is_valid);
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
 
@@ -373,8 +369,6 @@ TEST_F(PostgresParserTests, ColumnUpdateTest) {
     auto right_const = (expression::ConstantValueExpression *)(right_child);
 
     EXPECT_EQ(right_const->GetValue().ToString(), "2");
-
-    delete stmt_list;
   }
 }
 
@@ -383,7 +377,8 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
       "UPDATE STOCK SET S_QUANTITY = 48.0 , S_YTD = S_YTD + 1 "
       "WHERE S_I_ID = 68999 AND S_W_ID = 4";
   auto &parser = parser::PostgresParser::GetInstance();
-  parser::SQLStatementList *stmt_list = parser.BuildParseTree(query).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
 
   auto update_stmt = (parser::UpdateStatement *)stmt_list->GetStatements()[0].get();
@@ -424,8 +419,6 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   constant = (expression::ConstantValueExpression *)cond2->GetChild(1);
   EXPECT_TRUE(constant->GetValue().CompareEquals(
       type::ValueFactory::GetIntegerValue(4)));
-
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, StringUpdateTest) {
@@ -438,7 +431,8 @@ TEST_F(PostgresParserTests, StringUpdateTest) {
 
   auto parser = parser::PostgresParser::GetInstance();
   // Parsing
-  auto stmt_list = parser.BuildParseTree(queries[0]).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(queries[0]).release());
   auto stmt = stmt_list->GetStatement(0);
 
   // Check root type
@@ -496,8 +490,6 @@ TEST_F(PostgresParserTests, StringUpdateTest) {
       "2016-11-15 15:07:37");
   EXPECT_EQ(((expression::ConstantValueExpression *)value)->GetValueType(),
             type::TypeId::VARCHAR);
-
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, DeleteTest) {
@@ -510,7 +502,8 @@ TEST_F(PostgresParserTests, DeleteTest) {
   // Parsing
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    auto stmt_list = parser.BuildParseTree(query).release();
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser.BuildParseTree(query).release());
     EXPECT_TRUE(stmt_list->is_valid);
     if (stmt_list->is_valid == false) {
       LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -525,7 +518,6 @@ TEST_F(PostgresParserTests, DeleteTest) {
 
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
-    delete stmt_list;
   }
 }
 
@@ -539,7 +531,8 @@ TEST_F(PostgresParserTests, DeleteTestWithPredicate) {
   // Parsing
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    auto stmt_list = parser.BuildParseTree(query).release();
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser.BuildParseTree(query).release());
     EXPECT_TRUE(stmt_list->is_valid);
     if (stmt_list->is_valid == false) {
       LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -551,8 +544,6 @@ TEST_F(PostgresParserTests, DeleteTestWithPredicate) {
     auto delstmt = (parser::DeleteStatement *)stmt_list->GetStatement(0);
     EXPECT_EQ(delstmt->GetTableName(), "foo");
     EXPECT_TRUE(delstmt->expr != nullptr);
-
-    delete stmt_list;
   }
 }
 
@@ -565,7 +556,8 @@ TEST_F(PostgresParserTests, InsertTest) {
   auto parser = parser::PostgresParser::GetInstance();
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    auto stmt_list = parser.BuildParseTree(query).release();
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser.BuildParseTree(query).release());
     EXPECT_TRUE(stmt_list->is_valid);
     if (stmt_list->is_valid == false) {
       LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -594,7 +586,6 @@ TEST_F(PostgresParserTests, InsertTest) {
 
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
-    delete stmt_list;
   }
 }
 
@@ -609,7 +600,8 @@ TEST_F(PostgresParserTests, CreateTest) {
       "FOREIGN KEY (c_id) REFERENCES country (cid));";
 
   auto parser = parser::PostgresParser::GetInstance();
-  auto stmt_list = parser.BuildParseTree(query).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
   auto create_stmt = (parser::CreateStatement *)stmt_list->GetStatement(0);
   LOG_INFO("Statement List Info:\n%s", stmt_list->GetInfo().c_str());
@@ -637,36 +629,31 @@ TEST_F(PostgresParserTests, CreateTest) {
   EXPECT_EQ("c_id", column->foreign_key_source.at(0));
   EXPECT_EQ("cid", column->foreign_key_sink.at(0));
   EXPECT_EQ("country", column->table_info_->table_name);
-
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, TransactionTest) {
   auto parser = parser::PostgresParser::GetInstance();
-  auto stmt_list = parser.BuildParseTree("BEGIN TRANSACTION;").release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree("BEGIN TRANSACTION;").release());
   auto transac_stmt =
       (parser::TransactionStatement *)stmt_list->GetStatement(0);
   EXPECT_TRUE(stmt_list->is_valid);
   EXPECT_EQ(parser::TransactionStatement::kBegin, transac_stmt->type);
-  delete stmt_list;
 
-  stmt_list = parser.BuildParseTree("BEGIN;").release();
+  stmt_list.reset(parser.BuildParseTree("BEGIN;").release());
   transac_stmt = (parser::TransactionStatement *)stmt_list->GetStatement(0);
   EXPECT_TRUE(stmt_list->is_valid);
   EXPECT_EQ(parser::TransactionStatement::kBegin, transac_stmt->type);
-  delete stmt_list;
 
-  stmt_list = parser.BuildParseTree("COMMIT TRANSACTION;").release();
+  stmt_list.reset(parser.BuildParseTree("COMMIT TRANSACTION;").release());
   transac_stmt = (parser::TransactionStatement *)stmt_list->GetStatement(0);
   EXPECT_TRUE(stmt_list->is_valid);
   EXPECT_EQ(parser::TransactionStatement::kCommit, transac_stmt->type);
-  delete stmt_list;
 
-  stmt_list = parser.BuildParseTree("ROLLBACK;").release();
+  stmt_list.reset(parser.BuildParseTree("ROLLBACK;").release());
   transac_stmt = (parser::TransactionStatement *)stmt_list->GetStatement(0);
   EXPECT_TRUE(stmt_list->is_valid);
   EXPECT_EQ(parser::TransactionStatement::kRollback, transac_stmt->type);
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, CreateIndexTest) {
@@ -675,7 +662,8 @@ TEST_F(PostgresParserTests, CreateIndexTest) {
       "oorder (O_W_ID, O_D_ID);";
 
   auto parser = parser::PostgresParser::GetInstance();
-  auto stmt_list = parser.BuildParseTree(query).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
   auto create_stmt = (parser::CreateStatement *)stmt_list->GetStatement(0);
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
@@ -686,8 +674,6 @@ TEST_F(PostgresParserTests, CreateIndexTest) {
   EXPECT_TRUE(create_stmt->unique);
   EXPECT_EQ("o_w_id", create_stmt->index_attrs.at(0));
   EXPECT_EQ("o_d_id", create_stmt->index_attrs.at(1));
-
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, InsertIntoSelectTest) {
@@ -700,7 +686,8 @@ TEST_F(PostgresParserTests, InsertIntoSelectTest) {
   // Parsing
   UNUSED_ATTRIBUTE int ii = 0;
   for (auto query : queries) {
-    auto stmt_list = parser.BuildParseTree(query).release();
+    std::unique_ptr<parser::SQLStatementList> stmt_list(
+        parser.BuildParseTree(query).release());
     EXPECT_TRUE(stmt_list->is_valid);
     if (stmt_list->is_valid == false) {
       LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -716,7 +703,6 @@ TEST_F(PostgresParserTests, InsertIntoSelectTest) {
     EXPECT_EQ("bar",
               std::string(insert_stmt->select->from_table->GetTableName()));
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
-    delete stmt_list;
   }
 }
 
@@ -724,22 +710,20 @@ TEST_F(PostgresParserTests, CreateDbTest) {
   std::string query = "CREATE DATABASE tt";
 
   auto parser = parser::PostgresParser::GetInstance();
-  auto stmt_list = parser.BuildParseTree(query).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
   //  auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
   //  LOG_INFO("%s", stmt_list->GetInfo().c_str());
-
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, DistinctFromTest) {
   std::string query = "SELECT id, value FROM foo WHERE id IS DISTINCT FROM value;";
 
   auto parser = parser::PostgresParser::GetInstance();
-  auto stmt_list = parser.BuildParseTree(query).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
-
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, ConstraintTest) {
@@ -752,7 +736,8 @@ TEST_F(PostgresParserTests, ConstraintTest) {
       ");";
 
   auto parser = parser::PostgresParser::GetInstance();
-  auto stmt_list = parser.BuildParseTree(query).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
   //  auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
   //  LOG_INFO("%s", stmt_list->GetInfo().c_str());
@@ -831,8 +816,6 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_EQ(FKConstrActionType::SETDEFAULT, column->foreign_key_update_action);
   EXPECT_EQ(FKConstrActionType::NOACTION, column->foreign_key_delete_action);
   EXPECT_EQ(FKConstrMatchType::SIMPLE, column->foreign_key_match_type);
-
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, DataTypeTest) {
@@ -844,7 +827,8 @@ TEST_F(PostgresParserTests, DataTypeTest) {
       ");";
 
   auto parser = parser::PostgresParser::GetInstance();
-  auto stmt_list = parser.BuildParseTree(query).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
   //  auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
   //  LOG_INFO("%s", stmt_list->GetInfo().c_str());
@@ -871,8 +855,6 @@ TEST_F(PostgresParserTests, DataTypeTest) {
   EXPECT_EQ("c", column->name);
   EXPECT_EQ(type::TypeId::VARBINARY, column->GetValueType(column->type));
   EXPECT_EQ(32, column->varlen);
-
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, CreateTriggerTest) {
@@ -884,7 +866,8 @@ TEST_F(PostgresParserTests, CreateTriggerTest) {
       "FOR EACH ROW "
       "WHEN (OLD.balance <> NEW.balance) "
       "EXECUTE PROCEDURE check_account_update();";
-  auto stmt_list = parser.BuildParseTree(query).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
   if (!stmt_list->is_valid) {
     LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -949,15 +932,14 @@ TEST_F(PostgresParserTests, CreateTriggerTest) {
   EXPECT_FALSE(TRIGGER_FOR_INSERT(create_trigger_stmt->trigger_type));
   EXPECT_FALSE(TRIGGER_FOR_DELETE(create_trigger_stmt->trigger_type));
   EXPECT_FALSE(TRIGGER_FOR_TRUNCATE(create_trigger_stmt->trigger_type));
-
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, DropTriggerTest) {
   auto parser = parser::PostgresParser::GetInstance();
   std::string query =
     "DROP TRIGGER if_dist_exists ON films;";
-  auto stmt_list = parser.BuildParseTree(query).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
   if (!stmt_list->is_valid) {
     LOG_ERROR("Message: %s, line: %d, col: %d", stmt_list->parser_msg,
@@ -972,14 +954,14 @@ TEST_F(PostgresParserTests, DropTriggerTest) {
   EXPECT_EQ("if_dist_exists", drop_trigger_stmt->trigger_name);
   // table name
   EXPECT_EQ("films", drop_trigger_stmt->table_name_of_trigger);
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, FuncCallTest) {
   std::string query = "SELECT add(1,a), chr(99) FROM TEST WHERE FUN(b) > 2";
 
   auto parser = parser::PostgresParser::GetInstance();
-  auto stmt_list = parser.BuildParseTree(query).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
   //  auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
   //  LOG_INFO("%s", stmt_list->GetInfo().c_str());
@@ -1020,18 +1002,15 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   const_expr = (expression::ConstantValueExpression*) op_expr->GetChild(1);
   EXPECT_TRUE(const_expr != nullptr);
   EXPECT_TRUE(const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
-
-  delete stmt_list;
 }
 
 TEST_F(PostgresParserTests, CaseTest) {
   std::string query = "SELECT id, case when id=100 then 1 else 0 end from tbl;";
 
   auto parser = parser::PostgresParser::GetInstance();
-  auto stmt_list = parser.BuildParseTree(query).release();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
-
-  delete stmt_list;
 }
 
 

--- a/test/storage/data_table_test.cpp
+++ b/test/storage/data_table_test.cpp
@@ -72,7 +72,6 @@ TEST_F(DataTableTests, TransformTileGroupTest) {
   data_table->TransformTileGroup(0, theta);
 }
 
-std::unique_ptr<storage::DataTable> data_table_test_table;
 
 TEST_F(DataTableTests, GlobalTableTest) {
   const int tuple_count = TESTS_TUPLES_PER_TILEGROUP;
@@ -80,15 +79,12 @@ TEST_F(DataTableTests, GlobalTableTest) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
 
-  data_table_test_table.reset(
+  std::unique_ptr<storage::DataTable> data_table_test_table (
       TestingExecutorUtil::CreateTable(tuple_count, false));
   TestingExecutorUtil::PopulateTable(data_table_test_table.get(), tuple_count,
                                    false, false, true, txn);
 
   txn_manager.CommitTransaction(txn);
-
-  auto data_table_pointer = data_table_test_table.release();
-  delete data_table_pointer;
 }
 
 }  // namespace test

--- a/test/storage/temp_table_test.cpp
+++ b/test/storage/temp_table_test.cpp
@@ -48,7 +48,8 @@ TEST_F(TempTableTests, InsertTest) {
 
   // Then shove some tuples in it
   for (int i = 0; i < tuple_count; i++) {
-    storage::Tuple *tuple = new storage::Tuple(table.GetSchema(), true);
+    std::unique_ptr<storage::Tuple> tuple(
+        new storage::Tuple(table.GetSchema(), true));
     auto val1 = type::ValueFactory::GetIntegerValue(
         TestingExecutorUtil::PopulatedValue(i, 0));
     auto val2 = type::ValueFactory::GetIntegerValue(
@@ -60,13 +61,11 @@ TEST_F(TempTableTests, InsertTest) {
     tuple->SetValue(1, val2, pool);
     tuple->SetValue(2, val3, pool);
     tuple->SetValue(3, val4, pool);
-    table.InsertTuple(tuple);
+    table.InsertTuple(tuple.get());
 
     // Copy the first value so that we can just check that we are able to
     // correctly get the values back.
     values.push_back(val1);
-
-    delete tuple;
   }
 
   // Make sure that we have the correct count

--- a/test/storage/tile_test.cpp
+++ b/test/storage/tile_test.cpp
@@ -46,7 +46,7 @@ TEST_F(TileTests, BasicTest) {
   columns.push_back(column5);
 
   // Schema
-  catalog::Schema *schema = new catalog::Schema(columns);
+  std::unique_ptr<catalog::Schema> schema(new catalog::Schema(columns));
 
   // Column Names
   std::vector<std::string> column_names;
@@ -60,16 +60,19 @@ TEST_F(TileTests, BasicTest) {
   // Allocated Tuple Count
   const int tuple_count = 6;
 
-  storage::TileGroupHeader *header =
-      new storage::TileGroupHeader(BackendType::MM, tuple_count);
+  std::unique_ptr<storage::TileGroupHeader> header(
+      new storage::TileGroupHeader(BackendType::MM, tuple_count));
 
-  storage::Tile *tile = storage::TileFactory::GetTile(
+  std::unique_ptr<storage::Tile> tile(storage::TileFactory::GetTile(
       BackendType::MM, INVALID_OID, INVALID_OID, INVALID_OID, INVALID_OID,
-      header, *schema, nullptr, tuple_count);
+      header.get(), *schema, nullptr, tuple_count));
 
-  storage::Tuple *tuple1 = new storage::Tuple(schema, true);
-  storage::Tuple *tuple2 = new storage::Tuple(schema, true);
-  storage::Tuple *tuple3 = new storage::Tuple(schema, true);
+  std::unique_ptr<storage::Tuple> tuple1(new storage::Tuple(schema.get(),
+                                                            true));
+  std::unique_ptr<storage::Tuple> tuple2(new storage::Tuple(schema.get(),
+                                                            true));
+  std::unique_ptr<storage::Tuple> tuple3(new storage::Tuple(schema.get(),
+                                                            true));
   auto pool = tile->GetPool();
 
   tuple1->SetValue(0, type::ValueFactory::GetIntegerValue(1), pool);
@@ -91,16 +94,9 @@ TEST_F(TileTests, BasicTest) {
   tuple3->SetValue(3, type::ValueFactory::GetVarcharValue("jinwoong kim"), pool);
   tuple3->SetValue(4, type::ValueFactory::GetVarcharValue("jinwoong kim again"), pool);
 
-  tile->InsertTuple(0, tuple1);
-  tile->InsertTuple(1, tuple2);
-  tile->InsertTuple(2, tuple3);
-
-  delete tuple1;
-  delete tuple2;
-  delete tuple3;
-  delete tile;
-  delete header;
-  delete schema;
+  tile->InsertTuple(0, tuple1.get());
+  tile->InsertTuple(1, tuple2.get());
+  tile->InsertTuple(2, tuple3.get());
 }
 
 }  // namespace test

--- a/test/storage/tuple_test.cpp
+++ b/test/storage/tuple_test.cpp
@@ -6,7 +6,7 @@
 //
 // Identification: test/storage/tuple_test.cpp
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -44,9 +44,9 @@ TEST_F(TupleTests, BasicTest) {
   columns.push_back(column2);
   columns.push_back(column3);
 
-  catalog::Schema *schema(new catalog::Schema(columns));
+  std::unique_ptr<catalog::Schema> schema(new catalog::Schema(columns));
 
-  storage::Tuple *tuple(new storage::Tuple(schema, true));
+  std::unique_ptr<storage::Tuple> tuple(new storage::Tuple(schema.get(), true));
   auto pool = TestingHarness::GetInstance().GetTestingPool();
 
   tuple->SetValue(0, type::ValueFactory::GetIntegerValue(23), pool);
@@ -79,9 +79,6 @@ TEST_F(TupleTests, BasicTest) {
   EXPECT_EQ(0, tuple->GetUninlinedMemorySize());
 
   LOG_TRACE("%s", tuple->GetInfo().c_str());
-
-  delete tuple;
-  delete schema;
 }
 
 TEST_F(TupleTests, VarcharTest) {
@@ -103,9 +100,9 @@ TEST_F(TupleTests, VarcharTest) {
   columns.push_back(column3);
   columns.push_back(column4);
 
-  catalog::Schema *schema(new catalog::Schema(columns));
+  std::unique_ptr<catalog::Schema> schema(new catalog::Schema(columns));
 
-  storage::Tuple *tuple(new storage::Tuple(schema, true));
+  std::unique_ptr<storage::Tuple> tuple(new storage::Tuple(schema.get(), true));
   auto pool = TestingHarness::GetInstance().GetTestingPool();
 
   tuple->SetValue(0, type::ValueFactory::GetIntegerValue(23), pool);
@@ -150,9 +147,6 @@ TEST_F(TupleTests, VarcharTest) {
   // Make sure that our tuple tells us the right estimated size
   size_t expected_size = sizeof(int32_t) + value3.GetLength();
   EXPECT_EQ(expected_size, tuple->GetUninlinedMemorySize());
-
-  delete tuple;
-  delete schema;
 }
 
 }  // namespace test

--- a/test/trigger/trigger_test.cpp
+++ b/test/trigger/trigger_test.cpp
@@ -90,14 +90,17 @@ class TriggerTests : public PelotonTest {
     insert_node->columns.push_back(col_1);
     insert_node->columns.push_back(col_2);
 
-    insert_node->insert_values.push_back(std::vector<std::unique_ptr<expression::AbstractExpression>>());
+    insert_node->insert_values.push_back(
+        std::vector<std::unique_ptr<expression::AbstractExpression>>());
     auto& values = insert_node->insert_values.at(0);
 
-    values.push_back(std::unique_ptr<expression::AbstractExpression>(new expression::ConstantValueExpression(
-      type::ValueFactory::GetIntegerValue(number))));
+    values.push_back(std::unique_ptr<expression::AbstractExpression>(
+        new expression::ConstantValueExpression(
+            type::ValueFactory::GetIntegerValue(number))));
 
-    values.push_back(std::unique_ptr<expression::AbstractExpression>(new expression::ConstantValueExpression(
-      type::ValueFactory::GetVarcharValue(text))));
+    values.push_back(std::unique_ptr<expression::AbstractExpression>(
+        new expression::ConstantValueExpression(
+            type::ValueFactory::GetVarcharValue(text))));
 
     insert_node->select.reset(new parser::SelectStatement());
 

--- a/test/type/array_value_test.cpp
+++ b/test/type/array_value_test.cpp
@@ -52,7 +52,7 @@ int64_t RANDOM64() {
 }
 
 std::string RANDOM_STRING(size_t size) {
-  std::unique_ptr<char> str(new char[size]);
+  std::unique_ptr<char[]> str(new char[size]);
   for (size_t i = 0; i < size - 1; i++) str.get()[i] = RANDOM(26) + 'a';
   str.get()[size - 1] = '\0';
   std::string rand_string(str.get());

--- a/test/type/array_value_test.cpp
+++ b/test/type/array_value_test.cpp
@@ -52,11 +52,10 @@ int64_t RANDOM64() {
 }
 
 std::string RANDOM_STRING(size_t size) {
-  char *str = new char[size];
-  for (size_t i = 0; i < size - 1; i++) str[i] = RANDOM(26) + 'a';
-  str[size - 1] = '\0';
-  std::string rand_string(str);
-  delete[] str;
+  std::unique_ptr<char> str(new char[size]);
+  for (size_t i = 0; i < size - 1; i++) str.get()[i] = RANDOM(26) + 'a';
+  str.get()[size - 1] = '\0';
+  std::string rand_string(str.get());
   return rand_string;
 }
 

--- a/test/type/pool_test.cpp
+++ b/test/type/pool_test.cpp
@@ -2,11 +2,11 @@
 //
 //                         Peloton
 //
-// varlen_pool_test.cpp
+// pool_test.cpp
 //
-// Identification: test/common/varlen_pool_test.cpp
+// Identification: test/type/pool_test.cpp
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -52,7 +52,7 @@ size_t get_align(size_t size) {
 
 // Allocate and free once
 TEST_F(PoolTests, AllocateOnceTest) {
-  type::EphemeralPool *pool = new type::EphemeralPool();
+  std::unique_ptr<type::EphemeralPool> pool(new type::EphemeralPool());
   void *p = nullptr;
   size_t size;
   size = 40;
@@ -61,9 +61,7 @@ TEST_F(PoolTests, AllocateOnceTest) {
   EXPECT_TRUE(p != nullptr);
 
   pool->Free(p);
-
-  delete pool;
 }
 
-}
-}
+}  // namespace test
+}  // namespace peloton

--- a/test/type/type_util_test.cpp
+++ b/test/type/type_util_test.cpp
@@ -115,12 +115,12 @@ std::shared_ptr<storage::Tuple> TypeUtilTestsHelper(catalog::Schema* schema,
 
 TEST_F(TypeUtilTests, CompareEqualsRawTest) {
   // This is going to be a nasty ride, so strap yourself in...
-  catalog::Schema* schema = TypeUtilTestsGenerateSchema();
+  std::unique_ptr<catalog::Schema> schema(TypeUtilTestsGenerateSchema());
 
   std::vector<std::shared_ptr<storage::Tuple>> tuples = {
-      TypeUtilTestsHelper(schema, 0),
-      TypeUtilTestsHelper(schema, 1),  // Different than tuple0
-      TypeUtilTestsHelper(schema, 0),  // Same as tuple0
+      TypeUtilTestsHelper(schema.get(), 0),
+      TypeUtilTestsHelper(schema.get(), 1),  // Different than tuple0
+      TypeUtilTestsHelper(schema.get(), 0),  // Same as tuple0
   };
   LOG_TRACE("TUPLE0: %s", tuples[0]->GetInfo().c_str());
   LOG_TRACE("TUPLE1: %s", tuples[1]->GetInfo().c_str());
@@ -147,15 +147,14 @@ TEST_F(TypeUtilTests, CompareEqualsRawTest) {
       EXPECT_EQ(expected, result);
     }  // FOR (columns)
   }    // FOR (tuples)
-  delete schema;
 }
 
 TEST_F(TypeUtilTests, CompareLessThanRawTest) {
-  catalog::Schema* schema = TypeUtilTestsGenerateSchema();
+  std::unique_ptr<catalog::Schema> schema(TypeUtilTestsGenerateSchema());
   std::vector<std::shared_ptr<storage::Tuple>> tuples = {
-      TypeUtilTestsHelper(schema, 0),
-      TypeUtilTestsHelper(schema, 1),  // Different than tuple0
-      TypeUtilTestsHelper(schema, 0),  // Same as tuple0
+      TypeUtilTestsHelper(schema.get(), 0),
+      TypeUtilTestsHelper(schema.get(), 1),  // Different than tuple0
+      TypeUtilTestsHelper(schema.get(), 0),  // Same as tuple0
   };
 
   const int num_cols = (int)schema->GetColumnCount();
@@ -176,15 +175,14 @@ TEST_F(TypeUtilTests, CompareLessThanRawTest) {
       EXPECT_EQ(expected, result);
     }  // FOR (columns)
   }    // FOR (tuples)
-  delete schema;
 }
 
 TEST_F(TypeUtilTests, CompareGreaterThanRawTest) {
-  catalog::Schema* schema = TypeUtilTestsGenerateSchema();
+  std::unique_ptr<catalog::Schema> schema(TypeUtilTestsGenerateSchema());
   std::vector<std::shared_ptr<storage::Tuple>> tuples = {
-      TypeUtilTestsHelper(schema, 0),
-      TypeUtilTestsHelper(schema, 1),  // Different than tuple0
-      TypeUtilTestsHelper(schema, 0),  // Same as tuple0
+      TypeUtilTestsHelper(schema.get(), 0),
+      TypeUtilTestsHelper(schema.get(), 1),  // Different than tuple0
+      TypeUtilTestsHelper(schema.get(), 0),  // Same as tuple0
   };
 
   const int num_cols = (int)schema->GetColumnCount();
@@ -205,7 +203,6 @@ TEST_F(TypeUtilTests, CompareGreaterThanRawTest) {
       EXPECT_EQ(expected, result);
     }  // FOR (columns)
   }    // FOR (tuples)
-  delete schema;
 }
 
 TEST_F(TypeUtilTests, CompareStringsTest) {


### PR DESCRIPTION
This PR removes all the `delete` calls in our `test` directory by applying smart pointers.   This work started by simplifying the `InsertPlan` code to enhance parameterizaton later in this week, so it would be nice to merge it soon.

The code changes are straightforward, so someone could spend less than quarter an hour to review them. 