### PR TITLE
Implement function Length

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -930,6 +930,12 @@ void Catalog::InitializeFunctions() {
                                     function::StringFunctions::OctetLength},
           txn);
       AddBuiltinFunction(
+          "length", {type::TypeId::VARCHAR}, type::TypeId::INTEGER,
+          internal_lang, "Length",
+          function::BuiltInFuncType{OperatorId::Length,
+                                    function::StringFunctions::Length},
+          txn);
+      AddBuiltinFunction(
           "repeat", {type::TypeId::VARCHAR, type::TypeId::INTEGER},
           type::TypeId::VARCHAR, internal_lang, "Repeat",
           function::BuiltInFuncType{OperatorId::Repeat,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -933,7 +933,7 @@ void Catalog::InitializeFunctions() {
           "length", {type::TypeId::VARCHAR}, type::TypeId::INTEGER,
           internal_lang, "Length",
           function::BuiltInFuncType{OperatorId::Length,
-                                    function::StringFunctions::Length},
+                                    function::StringFunctions::_Length},
           txn);
       AddBuiltinFunction(
           "repeat", {type::TypeId::VARCHAR, type::TypeId::INTEGER},

--- a/src/codegen/proxy/string_functions_proxy.cpp
+++ b/src/codegen/proxy/string_functions_proxy.cpp
@@ -20,7 +20,6 @@ namespace codegen {
 
 DEFINE_METHOD(peloton::function, StringFunctions, Ascii);
 DEFINE_METHOD(peloton::function, StringFunctions, Like);
-
 DEFINE_METHOD(peloton::function, StringFunctions, Length);
 
 }  // namespace codegen

--- a/src/codegen/proxy/string_functions_proxy.cpp
+++ b/src/codegen/proxy/string_functions_proxy.cpp
@@ -21,5 +21,7 @@ namespace codegen {
 DEFINE_METHOD(peloton::function, StringFunctions, Ascii);
 DEFINE_METHOD(peloton::function, StringFunctions, Like);
 
+DEFINE_METHOD(peloton::function, StringFunctions, Length);
+
 }  // namespace codegen
 }  // namespace peloton

--- a/src/codegen/type/varchar_type.cpp
+++ b/src/codegen/type/varchar_type.cpp
@@ -177,91 +177,92 @@ struct Like : public TypeSystem::BinaryOperator {
 
     // return value
     return Value{Boolean::Instance(), raw_ret};
+  }
+};
 
-    struct Length : public TypeSystem::UnaryOperator {
-      bool SupportsType(const Type &type) const override {
-        return type.GetSqlType() == Varchar::Instance();
-      }
-
-      Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
-        return Integer::Instance();
-      }
-
-      Value DoWork(CodeGen &codegen, const Value &val) const override {
-        llvm::Value *raw_ret = codegen.Call(StringFunctionsProxy::Length,
-                                            {val.GetValue(), val.GetLength()});
-        return Value{Integer::Instance(), raw_ret};
-      }
-    };
-
-    //===----------------------------------------------------------------------===//
-    // TYPE SYSTEM CONSTRUCTION
-    //===----------------------------------------------------------------------===//
-
-    // The list of types a SQL varchar type can be implicitly casted to
-    const std::vector<peloton::type::TypeId> kImplicitCastingTable = {
-        peloton::type::TypeId::VARCHAR};
-
-    // Explicit casting rules
-    static std::vector<TypeSystem::CastInfo> kExplicitCastingTable = {};
-
-    // Comparison operations
-    static CompareVarchar kCompareVarchar;
-    static std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {
-        {kCompareVarchar}};
-
-    // Unary operators
-    static Ascii kAscii;
-    static Length kLength;
-    static std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
-        {OperatorId::Ascii, kAscii}, {OperatorId::Length, kLength}};
-
-    // Binary operations
-    static Like kLike;
-    static std::vector<TypeSystem::BinaryOpInfo> kBinaryOperatorTable = {
-        {OperatorId::Like, kLike}};
-
-    // Nary operations
-    static std::vector<TypeSystem::NaryOpInfo> kNaryOperatorTable = {};
-
-  }  // anonymous namespace
-
-  //===----------------------------------------------------------------------===//
-  // TINYINT TYPE CONFIGURATION
-  //===----------------------------------------------------------------------===//
-
-  // Initialize the VARCHAR SQL type with the configured type system
-  Varchar::Varchar()
-      : SqlType(peloton::type::TypeId::VARCHAR),
-        type_system_(kImplicitCastingTable, kExplicitCastingTable,
-                     kComparisonTable, kUnaryOperatorTable,
-                     kBinaryOperatorTable, kNaryOperatorTable) {}
-
-  Value Varchar::GetMinValue(UNUSED_ATTRIBUTE CodeGen &codegen) const {
-    throw Exception{"The VARCHAR type does not have a minimum value ..."};
+struct Length : public TypeSystem::UnaryOperator {
+  bool SupportsType(const Type &type) const override {
+    return type.GetSqlType() == Varchar::Instance();
   }
 
-  Value Varchar::GetMaxValue(UNUSED_ATTRIBUTE CodeGen &codegen) const {
-    throw Exception{"The VARCHAR type does not have a maximum value ..."};
+  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+    return Integer::Instance();
   }
 
-  Value Varchar::GetNullValue(CodeGen &codegen) const {
-    return Value{Type{TypeId(), true}, codegen.NullPtr(codegen.CharPtrType()),
-                 codegen.Const32(0), codegen.ConstBool(true)};
+  Value DoWork(CodeGen &codegen, const Value &val) const override {
+    llvm::Value *raw_ret = codegen.Call(StringFunctionsProxy::Length,
+                                        {val.GetValue(), val.GetLength()});
+    return Value{Integer::Instance(), raw_ret};
   }
+};
 
-  void Varchar::GetTypeForMaterialization(CodeGen &codegen,
-                                          llvm::Type *&val_type,
-                                          llvm::Type *&len_type) const {
-    val_type = codegen.CharPtrType();
-    len_type = codegen.Int32Type();
-  }
+//===----------------------------------------------------------------------===//
+// TYPE SYSTEM CONSTRUCTION
+//===----------------------------------------------------------------------===//
 
-  llvm::Function *Varchar::GetOutputFunction(
-      CodeGen &codegen, UNUSED_ATTRIBUTE const Type &type) const {
-    // TODO: We should use the length information in the type?
-    return ValuesRuntimeProxy::OutputVarchar.GetFunction(codegen);
-  }
+// The list of types a SQL varchar type can be implicitly casted to
+const std::vector<peloton::type::TypeId> kImplicitCastingTable = {
+    peloton::type::TypeId::VARCHAR};
+
+// Explicit casting rules
+static std::vector<TypeSystem::CastInfo> kExplicitCastingTable = {};
+
+// Comparison operations
+static CompareVarchar kCompareVarchar;
+static std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {
+    {kCompareVarchar}};
+
+// Unary operators
+static Ascii kAscii;
+static Length kLength;
+static std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
+    {OperatorId::Ascii, kAscii}, {OperatorId::Length, kLength}};
+
+// Binary operations
+static Like kLike;
+static std::vector<TypeSystem::BinaryOpInfo> kBinaryOperatorTable = {
+    {OperatorId::Like, kLike}};
+
+// Nary operations
+static std::vector<TypeSystem::NaryOpInfo> kNaryOperatorTable = {};
+
+}  // anonymous namespace
+
+//===----------------------------------------------------------------------===//
+// TINYINT TYPE CONFIGURATION
+//===----------------------------------------------------------------------===//
+
+// Initialize the VARCHAR SQL type with the configured type system
+Varchar::Varchar()
+    : SqlType(peloton::type::TypeId::VARCHAR),
+      type_system_(kImplicitCastingTable, kExplicitCastingTable,
+                   kComparisonTable, kUnaryOperatorTable, kBinaryOperatorTable,
+                   kNaryOperatorTable) {}
+
+Value Varchar::GetMinValue(UNUSED_ATTRIBUTE CodeGen &codegen) const {
+  throw Exception{"The VARCHAR type does not have a minimum value ..."};
+}
+
+Value Varchar::GetMaxValue(UNUSED_ATTRIBUTE CodeGen &codegen) const {
+  throw Exception{"The VARCHAR type does not have a maximum value ..."};
+}
+
+Value Varchar::GetNullValue(CodeGen &codegen) const {
+  return Value{Type{TypeId(), true}, codegen.NullPtr(codegen.CharPtrType()),
+               codegen.Const32(0), codegen.ConstBool(true)};
+}
+
+void Varchar::GetTypeForMaterialization(CodeGen &codegen, llvm::Type *&val_type,
+                                        llvm::Type *&len_type) const {
+  val_type = codegen.CharPtrType();
+  len_type = codegen.Int32Type();
+}
+
+llvm::Function *Varchar::GetOutputFunction(
+    CodeGen &codegen, UNUSED_ATTRIBUTE const Type &type) const {
+  // TODO: We should use the length information in the type?
+  return ValuesRuntimeProxy::OutputVarchar.GetFunction(codegen);
+}
 
 }  // namespace type
 }  // namespace codegen

--- a/src/codegen/type/varchar_type.cpp
+++ b/src/codegen/type/varchar_type.cpp
@@ -177,77 +177,91 @@ struct Like : public TypeSystem::BinaryOperator {
 
     // return value
     return Value{Boolean::Instance(), raw_ret};
+
+    struct Length : public TypeSystem::UnaryOperator {
+      bool SupportsType(const Type &type) const override {
+        return type.GetSqlType() == Varchar::Instance();
+      }
+
+      Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+        return Integer::Instance();
+      }
+
+      Value DoWork(CodeGen &codegen, const Value &val) const override {
+        llvm::Value *raw_ret = codegen.Call(StringFunctionsProxy::Length,
+                                            {val.GetValue(), val.GetLength()});
+        return Value{Integer::Instance(), raw_ret};
+      }
+    };
+
+    //===----------------------------------------------------------------------===//
+    // TYPE SYSTEM CONSTRUCTION
+    //===----------------------------------------------------------------------===//
+
+    // The list of types a SQL varchar type can be implicitly casted to
+    const std::vector<peloton::type::TypeId> kImplicitCastingTable = {
+        peloton::type::TypeId::VARCHAR};
+
+    // Explicit casting rules
+    static std::vector<TypeSystem::CastInfo> kExplicitCastingTable = {};
+
+    // Comparison operations
+    static CompareVarchar kCompareVarchar;
+    static std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {
+        {kCompareVarchar}};
+
+    // Unary operators
+    static Ascii kAscii;
+    static Length kLength;
+    static std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
+        {OperatorId::Ascii, kAscii}, {OperatorId::Length, kLength}};
+
+    // Binary operations
+    static Like kLike;
+    static std::vector<TypeSystem::BinaryOpInfo> kBinaryOperatorTable = {
+        {OperatorId::Like, kLike}};
+
+    // Nary operations
+    static std::vector<TypeSystem::NaryOpInfo> kNaryOperatorTable = {};
+
+  }  // anonymous namespace
+
+  //===----------------------------------------------------------------------===//
+  // TINYINT TYPE CONFIGURATION
+  //===----------------------------------------------------------------------===//
+
+  // Initialize the VARCHAR SQL type with the configured type system
+  Varchar::Varchar()
+      : SqlType(peloton::type::TypeId::VARCHAR),
+        type_system_(kImplicitCastingTable, kExplicitCastingTable,
+                     kComparisonTable, kUnaryOperatorTable,
+                     kBinaryOperatorTable, kNaryOperatorTable) {}
+
+  Value Varchar::GetMinValue(UNUSED_ATTRIBUTE CodeGen &codegen) const {
+    throw Exception{"The VARCHAR type does not have a minimum value ..."};
   }
-};
 
-//===----------------------------------------------------------------------===//
-// TYPE SYSTEM CONSTRUCTION
-//===----------------------------------------------------------------------===//
+  Value Varchar::GetMaxValue(UNUSED_ATTRIBUTE CodeGen &codegen) const {
+    throw Exception{"The VARCHAR type does not have a maximum value ..."};
+  }
 
-// The list of types a SQL varchar type can be implicitly casted to
-const std::vector<peloton::type::TypeId> kImplicitCastingTable = {
-    peloton::type::TypeId::VARCHAR};
+  Value Varchar::GetNullValue(CodeGen &codegen) const {
+    return Value{Type{TypeId(), true}, codegen.NullPtr(codegen.CharPtrType()),
+                 codegen.Const32(0), codegen.ConstBool(true)};
+  }
 
-// Explicit casting rules
-static std::vector<TypeSystem::CastInfo> kExplicitCastingTable = {};
+  void Varchar::GetTypeForMaterialization(CodeGen &codegen,
+                                          llvm::Type *&val_type,
+                                          llvm::Type *&len_type) const {
+    val_type = codegen.CharPtrType();
+    len_type = codegen.Int32Type();
+  }
 
-// Comparison operations
-static CompareVarchar kCompareVarchar;
-static std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {
-    {kCompareVarchar}};
-
-// Unary operators
-static Ascii kAscii;
-static std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
-    {OperatorId::Ascii, kAscii}
-};
-
-// Binary operations
-static Like kLike;
-static std::vector<TypeSystem::BinaryOpInfo> kBinaryOperatorTable = {
-    {OperatorId::Like, kLike}
-};
-
-// Nary operations
-static std::vector<TypeSystem::NaryOpInfo> kNaryOperatorTable = {};
-
-}  // anonymous namespace
-
-//===----------------------------------------------------------------------===//
-// TINYINT TYPE CONFIGURATION
-//===----------------------------------------------------------------------===//
-
-// Initialize the VARCHAR SQL type with the configured type system
-Varchar::Varchar()
-    : SqlType(peloton::type::TypeId::VARCHAR),
-      type_system_(kImplicitCastingTable, kExplicitCastingTable,
-                   kComparisonTable, kUnaryOperatorTable, kBinaryOperatorTable,
-                   kNaryOperatorTable) {}
-
-Value Varchar::GetMinValue(UNUSED_ATTRIBUTE CodeGen &codegen) const {
-  throw Exception{"The VARCHAR type does not have a minimum value ..."};
-}
-
-Value Varchar::GetMaxValue(UNUSED_ATTRIBUTE CodeGen &codegen) const {
-  throw Exception{"The VARCHAR type does not have a maximum value ..."};
-}
-
-Value Varchar::GetNullValue(CodeGen &codegen) const {
-  return Value{Type{TypeId(), true}, codegen.NullPtr(codegen.CharPtrType()),
-               codegen.Const32(0), codegen.ConstBool(true)};
-}
-
-void Varchar::GetTypeForMaterialization(CodeGen &codegen, llvm::Type *&val_type,
-                                        llvm::Type *&len_type) const {
-  val_type = codegen.CharPtrType();
-  len_type = codegen.Int32Type();
-}
-
-llvm::Function *Varchar::GetOutputFunction(
-    CodeGen &codegen, UNUSED_ATTRIBUTE const Type &type) const {
-  // TODO: We should use the length information in the type?
-  return ValuesRuntimeProxy::OutputVarchar.GetFunction(codegen);
-}
+  llvm::Function *Varchar::GetOutputFunction(
+      CodeGen &codegen, UNUSED_ATTRIBUTE const Type &type) const {
+    // TODO: We should use the length information in the type?
+    return ValuesRuntimeProxy::OutputVarchar.GetFunction(codegen);
+  }
 
 }  // namespace type
 }  // namespace codegen

--- a/src/function/string_functions.cpp
+++ b/src/function/string_functions.cpp
@@ -266,7 +266,7 @@ type::Value StringFunctions::BTrim(const std::vector<type::Value> &args) {
 uint32_t StringFunctions::Length(UNUSED_ATTRIBUTE const char *str,
                                  uint32_t length) {
   PL_ASSERT(str != nullptr);
-  return length > 0 ? length - 1 : length;
+  return length;
 }
 
 // The length of the string

--- a/src/function/string_functions.cpp
+++ b/src/function/string_functions.cpp
@@ -263,8 +263,8 @@ type::Value StringFunctions::BTrim(const std::vector<type::Value> &args) {
   return (type::ValueFactory::GetVarcharValue(str));
 }
 
-}  // namespace peloton
-uint32_t StringFunctions::Length(const char *str, uint32_t length) {
+uint32_t StringFunctions::Length(UNUSED_ATTRIBUTE const char *str,
+                                 uint32_t length) {
   PL_ASSERT(str != nullptr);
   return length;
 }

--- a/src/function/string_functions.cpp
+++ b/src/function/string_functions.cpp
@@ -266,10 +266,10 @@ type::Value StringFunctions::BTrim(const std::vector<type::Value> &args) {
 uint32_t StringFunctions::Length(UNUSED_ATTRIBUTE const char *str,
                                  uint32_t length) {
   PL_ASSERT(str != nullptr);
-  return length;
+  return length > 0 ? length - 1 : length;
 }
 
-// Length of the argument.
+// The length of the string
 type::Value StringFunctions::_Length(const std::vector<type::Value> &args) {
   PL_ASSERT(args.size() == 1);
   if (args[0].IsNull()) {

--- a/src/function/string_functions.cpp
+++ b/src/function/string_functions.cpp
@@ -269,5 +269,16 @@ uint32_t StringFunctions::Length(const char *str, uint32_t length) {
   return length;
 }
 
+// Length of the argument.
+type::Value StringFunctions::_Length(const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 1);
+  if (args[0].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
+  }
+
+  uint32_t ret = Length(args[0].GetAs<const char *>(), args[0].GetLength());
+  return type::ValueFactory::GetIntegerValue(ret);
+}
+
 }  // namespace function
 }  // namespace peloton

--- a/src/function/string_functions.cpp
+++ b/src/function/string_functions.cpp
@@ -263,5 +263,11 @@ type::Value StringFunctions::BTrim(const std::vector<type::Value> &args) {
   return (type::ValueFactory::GetVarcharValue(str));
 }
 
+}  // namespace peloton
+uint32_t StringFunctions::Length(const char *str, uint32_t length) {
+  PL_ASSERT(str != nullptr);
+  return length;
+}
+
 }  // namespace function
 }  // namespace peloton

--- a/src/include/codegen/proxy/string_functions_proxy.h
+++ b/src/include/codegen/proxy/string_functions_proxy.h
@@ -21,6 +21,7 @@ PROXY(StringFunctions) {
   // Proxy everything in function::StringFunctions
   DECLARE_METHOD(Ascii);
   DECLARE_METHOD(Like);
+  DECLARE_METHOD(Length);
 };
 
 }  // namespace codegen

--- a/src/include/function/string_functions.h
+++ b/src/include/function/string_functions.h
@@ -62,6 +62,10 @@ class StringFunctions {
   // Remove the longest string consisting only of characters in characters
   // from the start and end of string
   static type::Value BTrim(const std::vector<type::Value> &args);
+
+  // This function is used by LLVM engine
+  // Length will return the number of characters in the given string
+  static uint32_t Length(const char *str, uint32_t length);
 };
 
 }  // namespace function

--- a/src/include/function/string_functions.h
+++ b/src/include/function/string_functions.h
@@ -66,6 +66,7 @@ class StringFunctions {
   // This function is used by LLVM engine
   // Length will return the number of characters in the given string
   static uint32_t Length(const char *str, uint32_t length);
+  static type::Value _Length(const std::vector<type::Value> &args);
 };
 
 }  // namespace function

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -1033,6 +1033,7 @@ enum class OperatorId : uint32_t {
   Substr,
   CharLength,
   OctetLength,
+  Length,
   Repeat,
   Replace,
   LTrim,
@@ -1296,12 +1297,11 @@ typedef std::vector<MultiTableExpression> MultiTablePredicates;
 // Mapping of Expression -> Column Offset created by operator
 typedef std::unordered_map<std::shared_ptr<expression::AbstractExpression>,
                            unsigned, expression::ExprHasher,
-                           expression::ExprEqualCmp>
-    ExprMap;
+                           expression::ExprEqualCmp> ExprMap;
 // Used in optimizer to speed up expression comparsion
 typedef std::unordered_set<std::shared_ptr<expression::AbstractExpression>,
-                           expression::ExprHasher, expression::ExprEqualCmp>
-    ExprSet;
+                           expression::ExprHasher,
+                           expression::ExprEqualCmp> ExprSet;
 
 //===--------------------------------------------------------------------===//
 // Wire protocol typedefs

--- a/test/function/string_functions_test.cpp
+++ b/test/function/string_functions_test.cpp
@@ -277,14 +277,13 @@ TEST_F(StringFunctionsTests, BTrimTest) {
 
 TEST_F(StringFunctionsTests, LengthTest) {
   const char column_char = 'A';
-  int expected = 1;
+  int expected = 0;
   std::string str = "";
   for (int i = 0; i < 52; i++) {
-    str += (char) (column_char + i);
-    expected++; 
+    str += (char)(column_char + i);
+    expected++;
 
-    std::vector<type::Value> args = {
-        type::ValueFactory::GetVarcharValue(str)};
+    std::vector<type::Value> args = {type::ValueFactory::GetVarcharValue(str)};
 
     auto result = function::StringFunctions::_Length(args);
     EXPECT_FALSE(result.IsNull());

--- a/test/function/string_functions_test.cpp
+++ b/test/function/string_functions_test.cpp
@@ -275,5 +275,27 @@ TEST_F(StringFunctionsTests, BTrimTest) {
   }
 }
 
+TEST_F(StringFunctionsTests, LengthTest) {
+  const char column_char = 'A';
+  int expected = 1;
+  std::string str = "";
+  for (int i = 0; i < 52; i++) {
+    str += (char) (column_char + i);
+    expected++; 
+
+    std::vector<type::Value> args = {
+        type::ValueFactory::GetVarcharValue(str)};
+
+    auto result = function::StringFunctions::_Length(args);
+    EXPECT_FALSE(result.IsNull());
+    EXPECT_EQ(expected, result.GetAs<int>());
+  }
+  // NULL CHECK
+  std::vector<type::Value> args = {
+      type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR)};
+  auto result = function::StringFunctions::_Length(args);
+  EXPECT_TRUE(result.IsNull());
+}
+
 }  // namespace test
 }  // namespace peloton

--- a/test/function/string_functions_test.cpp
+++ b/test/function/string_functions_test.cpp
@@ -32,32 +32,38 @@ class StringFunctionsTests : public PelotonTest {};
 
 TEST_F(StringFunctionsTests, LikeTest) {
   //-------------- match ---------------- //
-  std::string s1 = "forbes \\avenue"; // "forbes \avenue"
-  std::string p1 = "%b_s \\\\avenue"; // "%b_s \\avenue"
-  EXPECT_TRUE(function::StringFunctions::Like(s1.c_str(), s1.size(), p1.c_str(), p1.size()));
+  std::string s1 = "forbes \\avenue";  // "forbes \avenue"
+  std::string p1 = "%b_s \\\\avenue";  // "%b_s \\avenue"
+  EXPECT_TRUE(function::StringFunctions::Like(s1.c_str(), s1.size(), p1.c_str(),
+                                              p1.size()));
 
-  std::string s2 = "for%bes avenue%"; // "for%bes avenue%"
-  std::string p2 = "for%bes a_enue\\%"; // "for%bes a_enue%"
-  EXPECT_TRUE(function::StringFunctions::Like(s2.c_str(), s2.size(), p2.c_str(), p2.size()));
+  std::string s2 = "for%bes avenue%";    // "for%bes avenue%"
+  std::string p2 = "for%bes a_enue\\%";  // "for%bes a_enue%"
+  EXPECT_TRUE(function::StringFunctions::Like(s2.c_str(), s2.size(), p2.c_str(),
+                                              p2.size()));
 
-  std::string s3 = "Allison"; // "Allison"
-  std::string p3 = "%lison"; // "%lison"
-  EXPECT_TRUE(function::StringFunctions::Like(s3.c_str(), s3.size(), p3.c_str(), p3.size()));
-
-  //----------Exact Match------------//
-  std::string s5 = "Allison"; // "Allison"
-  std::string p5 = "Allison"; // "Allison"
-  EXPECT_TRUE(function::StringFunctions::Like(s5.c_str(), s5.size(), p5.c_str(), p5.size()));
+  std::string s3 = "Allison";  // "Allison"
+  std::string p3 = "%lison";   // "%lison"
+  EXPECT_TRUE(function::StringFunctions::Like(s3.c_str(), s3.size(), p3.c_str(),
+                                              p3.size()));
 
   //----------Exact Match------------//
-  std::string s6 = "Allison"; // "Allison"
-  std::string p6 = "A%llison"; // "A%llison"
-  EXPECT_TRUE(function::StringFunctions::Like(s6.c_str(), s6.size(), p6.c_str(), p6.size()));
+  std::string s5 = "Allison";  // "Allison"
+  std::string p5 = "Allison";  // "Allison"
+  EXPECT_TRUE(function::StringFunctions::Like(s5.c_str(), s5.size(), p5.c_str(),
+                                              p5.size()));
+
+  //----------Exact Match------------//
+  std::string s6 = "Allison";   // "Allison"
+  std::string p6 = "A%llison";  // "A%llison"
+  EXPECT_TRUE(function::StringFunctions::Like(s6.c_str(), s6.size(), p6.c_str(),
+                                              p6.size()));
 
   //-------------- not match ----------------//
-  std::string s4 = "forbes avenue"; // "forbes avenue"
-  std::string p4 = "f_bes avenue"; // "f_bes avenue"
-  EXPECT_FALSE(function::StringFunctions::Like(s4.c_str(), s4.size(), p4.c_str(), p4.size()));
+  std::string s4 = "forbes avenue";  // "forbes avenue"
+  std::string p4 = "f_bes avenue";   // "f_bes avenue"
+  EXPECT_FALSE(function::StringFunctions::Like(s4.c_str(), s4.size(),
+                                               p4.c_str(), p4.size()));
 }
 
 TEST_F(StringFunctionsTests, AsciiTest) {
@@ -277,7 +283,7 @@ TEST_F(StringFunctionsTests, BTrimTest) {
 
 TEST_F(StringFunctionsTests, LengthTest) {
   const char column_char = 'A';
-  int expected = 0;
+  int expected = 1;
   std::string str = "";
   for (int i = 0; i < 52; i++) {
     str += (char)(column_char + i);

--- a/test/sql/string_functions_sql_test.cpp
+++ b/test/sql/string_functions_sql_test.cpp
@@ -64,7 +64,7 @@ TEST_F(StringFunctionTest, LengthTest) {
                                   rows_affected, error_message);
   for (i = 0; i < 32; i++) {
     std::string resultStr(TestingSQLUtil::GetResultValueAsString(result, i));
-    std::string expectedStr(std::to_string(i + 1));
+    std::string expectedStr(std::to_string(i + 2));
     EXPECT_EQ(resultStr, expectedStr);
   }
 

--- a/test/sql/string_functions_sql_test.cpp
+++ b/test/sql/string_functions_sql_test.cpp
@@ -2,7 +2,12 @@
 //
 //                         Peloton
 //
-// Compression Testing Script
+// string_functions_sql_test.cpp
+//
+// Identification: test/sql/string_functions_sql_test.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
 //===----------------------------------------------------------------------===//
 #include <memory>
 #include <math.h>
@@ -19,8 +24,8 @@ namespace peloton {
 namespace test {
 class StringFunctionTest : public PelotonTest {};
 /*
-The following test inserts 500 tuples in the datatable.
-Each tuple inserted is of the form (i, i * 'a' ), where i belongs to [0,500)
+The following test inserts 32 tuples in the datatable.
+Each tuple inserted is of the form (i, i * 'a' ), where i belongs to [0,32)
 We then perform a sequential scan on the table and retrieve the id and length
 of the second column.
 */
@@ -34,17 +39,17 @@ TEST_F(StringFunctionTest, LengthTest) {
   txn = txn_manager.BeginTransaction();
 
   TestingSQLUtil::ExecuteSQLQuery(
-      "CREATE TABLE foo(id integer, name varchar(500));");
+      "CREATE TABLE foo(id integer, name varchar(32));");
   int i;
   std::string s = "'", t = "'";
-  for (i = 0; i < 500; i++) {
+  for (i = 0; i < 32; i++) {
     s += "a";
     t = s + "'";
     std::string os =
         "insert into foo values(" + std::to_string(i) + ", " + t + ");";
     TestingSQLUtil::ExecuteSQLQuery(os);
   }
-  EXPECT_EQ(i, 500);
+  EXPECT_EQ(i, 32);
 
   std::vector<StatementResult> result;
   std::vector<FieldInfo> tuple_descriptor;
@@ -57,7 +62,7 @@ TEST_F(StringFunctionTest, LengthTest) {
   os << "select length(name) from foo;";
   TestingSQLUtil::ExecuteSQLQuery(os.str(), result, tuple_descriptor,
                                   rows_affected, error_message);
-  for (i = 0; i < 500; i++) {
+  for (i = 0; i < 32; i++) {
     std::string resultStr(TestingSQLUtil::GetResultValueAsString(result, i));
     std::string expectedStr(std::to_string(i + 1));
     EXPECT_EQ(resultStr, expectedStr);
@@ -67,5 +72,6 @@ TEST_F(StringFunctionTest, LengthTest) {
   catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
 }
-}
-}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/sql/stringfunctions_sql_test.cpp
+++ b/test/sql/stringfunctions_sql_test.cpp
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// Compression Testing Script
+//===----------------------------------------------------------------------===//
+#include <memory>
+#include <math.h>
+#include "sql/testing_sql_util.h"
+#include "catalog/catalog.h"
+#include "storage/database.h"
+#include "storage/data_table.h"
+#include "concurrency/testing_transaction_util.h"
+#include "common/harness.h"
+#include "executor/create_executor.h"
+#include "planner/create_plan.h"
+
+namespace peloton {
+namespace test {
+class StringFunctionTest : public PelotonTest {};
+/*
+The following test inserts 500 tuples in the datatable.
+Each tuple inserted is of the form (i, i * 'a' ), where i belongs to [0,500)
+We then perform a sequential scan on the table and retrieve the id and length
+of the second column.
+*/
+TEST_F(StringFunctionTest, LengthTest) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
+  catalog::Catalog::GetInstance()->Bootstrap();
+  txn_manager.CommitTransaction(txn);
+  // Create a t
+  txn = txn_manager.BeginTransaction();
+
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE foo(id integer, name varchar(500));");
+  int i;
+  std::string s = "'", t = "'";
+  for (i = 0; i < 500; i++) {
+    s += "a";
+    t = s + "'";
+    std::string os =
+        "insert into foo values(" + std::to_string(i) + ", " + t + ");";
+    TestingSQLUtil::ExecuteSQLQuery(os);
+  }
+  EXPECT_EQ(i, 500);
+
+  std::vector<StatementResult> result;
+  std::vector<FieldInfo> tuple_descriptor;
+  std::string error_message;
+
+  int rows_affected;
+  std::ostringstream os;
+  txn_manager.CommitTransaction(txn);
+
+  os << "select length(name) from foo;";
+  TestingSQLUtil::ExecuteSQLQuery(os.str(), result, tuple_descriptor,
+                                  rows_affected, error_message);
+  for (i = 0; i < 500; i++) {
+    std::string resultStr(TestingSQLUtil::GetResultValueAsString(result, i));
+    std::string expectedStr(std::to_string(i + 1));
+    EXPECT_EQ(resultStr, expectedStr);
+  }
+
+  txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+}
+}


### PR DESCRIPTION
In this PR we implement `Length` SQL function for the LLVM engine. Now we can support queries like `SELECT length(a) FROM table`. We also add a test case in `string_functions_test.cpp`.