### PR TITLE
Reduce CPU spikes from the thread pool

### DIFF
--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -22,6 +22,7 @@
 #include "concurrency/transaction_manager_factory.h"
 #include "gc/gc_manager_factory.h"
 #include "settings/settings_manager.h"
+#include "threadpool/mono_queue_pool.h"
 
 namespace peloton {
 
@@ -36,6 +37,9 @@ void PelotonInit::Initialize() {
 
   // set max thread number.
   thread_pool.Initialize(0, std::thread::hardware_concurrency() + 3);
+
+  // start worker pool
+  threadpool::MonoQueuePool::GetInstance().Startup();
 
   int parallelism = (std::thread::hardware_concurrency() + 3) / 4;
   storage::DataTable::SetActiveTileGroupCount(parallelism);
@@ -95,6 +99,9 @@ void PelotonInit::Shutdown() {
 
   // shut down epoch.
   concurrency::EpochManagerFactory::GetInstance().StopEpoch();
+
+  // stop worker pool
+  threadpool::MonoQueuePool::GetInstance().Shutdown();
 
   thread_pool.Shutdown();
 

--- a/src/include/threadpool/worker_pool.h
+++ b/src/include/threadpool/worker_pool.h
@@ -28,15 +28,20 @@ namespace threadpool{
 class WorkerPool {
  public:
   // submit a threadpool for asynchronous execution.
-  WorkerPool(const size_t num_threads, TaskQueue *task_queue);
-  ~WorkerPool() { this->Shutdown(); }
+  WorkerPool(const size_t num_workers, TaskQueue *task_queue);
 
+  // explicitly start up the pool
+  void Startup();
+
+  // explicitly shut down the pool
   void Shutdown();
 
  private:
   friend class Worker;
 
-  std::vector<std::unique_ptr<Worker>> worker_threads_;
+  std::vector<std::unique_ptr<Worker>> workers_;
+
+  size_t num_workers_;
   TaskQueue* task_queue_;
 };
 

--- a/src/threadpool/worker_pool.cpp
+++ b/src/threadpool/worker_pool.cpp
@@ -15,21 +15,23 @@
 namespace peloton {
 namespace threadpool {
 
-WorkerPool::WorkerPool(size_t num_threads, TaskQueue *task_queue) {
-  task_queue_ = task_queue;
-  for (size_t thread_id = 0; thread_id < num_threads; thread_id++) {
+WorkerPool::WorkerPool(size_t num_workers, TaskQueue *task_queue) :
+  num_workers_(num_workers), task_queue_(task_queue) {}
+
+void WorkerPool::Startup() {
+  for (size_t i = 0; i < num_workers_; i++) {
     // start thread on construction
     std::unique_ptr<Worker> worker(new Worker());
     worker->Start(task_queue_);
-    worker_threads_.push_back(std::move(worker));
+    workers_.push_back(std::move(worker));
   }
 }
 
 void WorkerPool::Shutdown() {
-  for (auto &thread : worker_threads_) {
-    thread->Stop();
+  for (auto &worker: workers_) {
+    worker->Stop();
   }
-  worker_threads_.clear();
+  workers_.clear();
 }
 
 }  // namespace threadpool


### PR DESCRIPTION
This PR reduces the CPU spikes from polling the task queue, and start up the thread pool at the beginning of the initialization stage of the peloton execution.  More discussions have been done in the mailing list and handling threads in peloton may have to be revisited further in near future. 

In addition, checking up the startup status and starting up the worker threads at submitting a new task is inevitable at this moment, because all the test cases were written in the way that this task pool had never existed and including startup() calls in all the test cases is a pain.  