### PR TITLE
Add date_trunc function

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,3 +8,9 @@ TabWidth: 2
 
 # No tabs
 UseTab: Never
+
+# Don't automatically derive the alignment of & and *
+DerivePointerAlignment: false
+
+# Always align pointer and reference to the right
+PointerAlignment: Right

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -203,7 +203,10 @@ void BindNodeVisitor::Visit(expression::FunctionExpression *expr) {
   // we have to do the string comparison to find out the corresponding
   // DatePartType when scanning every tuple.
   auto func_name = expr->GetFuncName();
-  if (func_name == "date_trunc" || func_name == "extract") {
+  auto func_operator_id =
+      function::BuiltInFunctions::GetFuncBySQLName(func_name).op_id;
+  if (func_operator_id == OperatorId::DateTrunc ||
+      func_operator_id == OperatorId::Extract) {
     // Check the type of the first argument. Should be VARCHAR
     auto date_part = expr->GetChild(0);
     if (date_part->GetValueType() != type::TypeId::VARCHAR) {

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -203,7 +203,7 @@ void BindNodeVisitor::Visit(expression::FunctionExpression *expr) {
   // we have to do the string comparison to find out the corresponding
   // DatePartType when scanning every tuple.
   auto func_name = expr->GetFuncName();
-  if (func_name == "date_trunc" or expr->GetFuncName() == "extract") {
+  if (func_name == "date_trunc" or func_name == "extract") {
     // Check the type of the first argument. Should be VARCHAR
     auto date_part = expr->GetChild(0);
     if (date_part->GetValueType() != type::TypeId::VARCHAR) {

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -203,7 +203,7 @@ void BindNodeVisitor::Visit(expression::FunctionExpression *expr) {
   // we have to do the string comparison to find out the corresponding
   // DatePartType when scanning every tuple.
   auto func_name = expr->GetFuncName();
-  if (func_name == "date_trunc" or func_name == "extract") {
+  if (func_name == "date_trunc" || func_name == "extract") {
     // Check the type of the first argument. Should be VARCHAR
     auto date_part = expr->GetChild(0);
     if (date_part->GetValueType() != type::TypeId::VARCHAR) {

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -202,13 +202,15 @@ void BindNodeVisitor::Visit(expression::FunctionExpression *expr) {
   // Specialize the first argument (DatePartType) for date functions, otherwise
   // we have to do the string comparison to find out the corresponding
   // DatePartType when scanning every tuple.
-  auto func_name = expr->GetFuncName();
-  if (func_name == "date_trunc" || func_name == "extract") {
+  auto func_op_id = expr->GetFunc().op_id;
+  if (func_op_id == OperatorId::DateTrunc ||
+      func_op_id == OperatorId::Extract) {
     // Check the type of the first argument. Should be VARCHAR
     auto date_part = expr->GetChild(0);
     if (date_part->GetValueType() != type::TypeId::VARCHAR) {
       throw Exception(EXCEPTION_TYPE_EXPRESSION,
-                      "Incorrect argument type to function: " + func_name +
+                      "Incorrect argument type to function: " +
+                          expr->GetFuncName() +
                           ". Argument 0 expected type VARCHAR but found " +
                           TypeIdToString(date_part->GetValueType()) + ".");
     }

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -202,15 +202,13 @@ void BindNodeVisitor::Visit(expression::FunctionExpression *expr) {
   // Specialize the first argument (DatePartType) for date functions, otherwise
   // we have to do the string comparison to find out the corresponding
   // DatePartType when scanning every tuple.
-  auto func_op_id = expr->GetFunc().op_id;
-  if (func_op_id == OperatorId::DateTrunc ||
-      func_op_id == OperatorId::Extract) {
+  auto func_name = expr->GetFuncName();
+  if (func_name == "date_trunc" || func_name == "extract") {
     // Check the type of the first argument. Should be VARCHAR
     auto date_part = expr->GetChild(0);
     if (date_part->GetValueType() != type::TypeId::VARCHAR) {
       throw Exception(EXCEPTION_TYPE_EXPRESSION,
-                      "Incorrect argument type to function: " +
-                          expr->GetFuncName() +
+                      "Incorrect argument type to function: " + func_name +
                           ". Argument 0 expected type VARCHAR but found " +
                           TypeIdToString(date_part->GetValueType()) + ".");
     }

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -13,18 +13,18 @@
 #include "catalog/catalog.h"
 
 #include "catalog/column_catalog.h"
-#include "catalog/index_catalog.h"
 #include "catalog/database_catalog.h"
 #include "catalog/database_metrics_catalog.h"
-#include "catalog/table_catalog.h"
-#include "catalog/table_metrics_catalog.h"
+#include "catalog/index_catalog.h"
 #include "catalog/index_metrics_catalog.h"
+#include "catalog/language_catalog.h"
+#include "catalog/proc_catalog.h"
 #include "catalog/query_metrics_catalog.h"
 #include "catalog/settings_catalog.h"
-#include "concurrency/transaction_manager_factory.h"
+#include "catalog/table_catalog.h"
+#include "catalog/table_metrics_catalog.h"
 #include "catalog/trigger_catalog.h"
-#include "catalog/proc_catalog.h"
-#include "catalog/language_catalog.h"
+#include "concurrency/transaction_manager_factory.h"
 #include "function/date_functions.h"
 #include "function/decimal_functions.h"
 #include "function/string_functions.h"
@@ -1025,6 +1025,10 @@ void Catalog::InitializeFunctions() {
           function::BuiltInFuncType{OperatorId::Extract,
                                     function::DateFunctions::Extract},
           txn);
+      AddBuiltinFunction(
+          "date_trunc", {type::TypeId::INTEGER, type::TypeId::TIMESTAMP},
+          type::TypeId::TIMESTAMP, internal_lang, "DateTrunc",
+          function::BuiltInFuncType{OperatorId::DateTrunc, NULL}, txn);
     } catch (CatalogException &e) {
       txn_manager.AbortTransaction(txn);
       throw & e;

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1030,7 +1030,7 @@ void Catalog::InitializeFunctions() {
           "date_trunc", {type::TypeId::INTEGER, type::TypeId::TIMESTAMP},
           type::TypeId::TIMESTAMP, internal_lang, "DateTrunc",
           function::BuiltInFuncType{OperatorId::DateTrunc,
-                                    function::DateFunctions::Extract},
+                                    function::TimestampFunctions::_DateTrunc},
           txn);
     } catch (CatalogException &e) {
       txn_manager.AbortTransaction(txn);

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -817,7 +817,7 @@ void Catalog::AddBuiltinFunction(
                                              txn)) {
     throw CatalogException("Failed to add function " + func_name);
   }
-  function::BuiltInFunctions::AddFunction(name, func_name, func);
+  function::BuiltInFunctions::AddFunction(func_name, func);
 }
 
 const FunctionData Catalog::GetFunction(
@@ -849,7 +849,7 @@ const FunctionData Catalog::GetFunction(
   result.argument_types_ = argument_types;
   result.func_name_ = proc_catalog_obj->GetSrc();
   result.return_type_ = proc_catalog_obj->GetRetType();
-  result.func_ = function::BuiltInFunctions::GetFuncBySourceName(result.func_name_);
+  result.func_ = function::BuiltInFunctions::GetFuncByName(result.func_name_);
 
   if (result.func_.impl == nullptr) {
     txn_manager.AbortTransaction(txn);
@@ -1027,7 +1027,7 @@ void Catalog::InitializeFunctions() {
                                     function::DateFunctions::Extract},
           txn);
       AddBuiltinFunction(
-          "date_trunc", {type::TypeId::INTEGER, type::TypeId::TIMESTAMP},
+          "date_trunc", {type::TypeId::VARCHAR, type::TypeId::TIMESTAMP},
           type::TypeId::TIMESTAMP, internal_lang, "DateTrunc",
           function::BuiltInFuncType{OperatorId::DateTrunc,
                                     function::TimestampFunctions::_DateTrunc},

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -28,6 +28,7 @@
 #include "function/date_functions.h"
 #include "function/decimal_functions.h"
 #include "function/string_functions.h"
+#include "function/timestamp_functions.h"
 #include "index/index_factory.h"
 #include "storage/storage_manager.h"
 #include "storage/table_factory.h"
@@ -1028,7 +1029,9 @@ void Catalog::InitializeFunctions() {
       AddBuiltinFunction(
           "date_trunc", {type::TypeId::INTEGER, type::TypeId::TIMESTAMP},
           type::TypeId::TIMESTAMP, internal_lang, "DateTrunc",
-          function::BuiltInFuncType{OperatorId::DateTrunc, NULL}, txn);
+          function::BuiltInFuncType{OperatorId::DateTrunc,
+                                    function::DateFunctions::Extract},
+          txn);
     } catch (CatalogException &e) {
       txn_manager.AbortTransaction(txn);
       throw & e;

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -817,7 +817,7 @@ void Catalog::AddBuiltinFunction(
                                              txn)) {
     throw CatalogException("Failed to add function " + func_name);
   }
-  function::BuiltInFunctions::AddFunction(func_name, func);
+  function::BuiltInFunctions::AddFunction(name, func_name, func);
 }
 
 const FunctionData Catalog::GetFunction(
@@ -849,7 +849,7 @@ const FunctionData Catalog::GetFunction(
   result.argument_types_ = argument_types;
   result.func_name_ = proc_catalog_obj->GetSrc();
   result.return_type_ = proc_catalog_obj->GetRetType();
-  result.func_ = function::BuiltInFunctions::GetFuncByName(result.func_name_);
+  result.func_ = function::BuiltInFunctions::GetFuncBySourceName(result.func_name_);
 
   if (result.func_.impl == nullptr) {
     txn_manager.AbortTransaction(txn);

--- a/src/codegen/proxy/timestamp_functions_proxy.cpp
+++ b/src/codegen/proxy/timestamp_functions_proxy.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// timestamp_functions_proxy.cpp
+//
+// Identification: src/codegen/proxy/timestamp_functions_proxy.cpp
+//
+// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "function/timestamp_functions.h"
+#include "codegen/proxy/timestamp_functions_proxy.h"
+#include "codegen/proxy/type_builder.h"
+
+namespace peloton {
+namespace codegen {
+
+DEFINE_METHOD(peloton::function, TimestampFunctions, DateTrunc);
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/codegen/type/integer_type.cpp
+++ b/src/codegen/type/integer_type.cpp
@@ -377,6 +377,8 @@ struct Modulo : public TypeSystem::BinaryOperator {
 };
 
 // DateTrunc
+// TODO(lma): Move this to the Timestamp type once the function lookup logic is
+// corrected.
 struct DateTrunc : public TypeSystem::BinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {

--- a/src/codegen/type/integer_type.cpp
+++ b/src/codegen/type/integer_type.cpp
@@ -11,10 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "codegen/type/integer_type.h"
-#include "codegen/type/timestamp_type.h"
 
 #include "codegen/lang/if.h"
-#include "codegen/proxy/timestamp_functions_proxy.h"
 #include "codegen/proxy/values_runtime_proxy.h"
 #include "codegen/type/boolean_type.h"
 #include "codegen/value.h"
@@ -376,33 +374,6 @@ struct Modulo : public TypeSystem::BinaryOperator {
   }
 };
 
-// DateTrunc
-// TODO(lma): Move this to the Timestamp type once the function lookup logic is
-// corrected.
-struct DateTrunc : public TypeSystem::BinaryOperator {
-  bool SupportsTypes(const Type &left_type,
-                     const Type &right_type) const override {
-    return left_type.GetSqlType() == Integer::Instance() &&
-           right_type.GetSqlType() == Timestamp::Instance();
-  }
-
-  Type ResultType(UNUSED_ATTRIBUTE const Type &left_type,
-                  UNUSED_ATTRIBUTE const Type &right_type) const override {
-    return Type{Timestamp::Instance()};
-  }
-
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               UNUSED_ATTRIBUTE OnError on_error) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
-
-    // TODO(lma): I actually don't know whether this should be called
-    // TimestampFunctionsProxy or IntegerFunctionsProxy...
-    llvm::Value *raw_ret = codegen.Call(TimestampFunctionsProxy::DateTrunc,
-                                        {left.GetValue(), right.GetValue()});
-    return Value{Timestamp::Instance(), raw_ret};
-  }
-};
-
 //===----------------------------------------------------------------------===//
 // TYPE SYSTEM CONSTRUCTION
 //===----------------------------------------------------------------------===//
@@ -444,11 +415,13 @@ static Sub kSubOp;
 static Mul kMulOp;
 static Div kDivOp;
 static Modulo kModuloOp;
-static DateTrunc kDateTrunc;
 static std::vector<TypeSystem::BinaryOpInfo> kBinaryOperatorTable = {
-    {OperatorId::Add, kAddOp},    {OperatorId::Sub, kSubOp},
-    {OperatorId::Mul, kMulOp},    {OperatorId::Div, kDivOp},
-    {OperatorId::Mod, kModuloOp}, {OperatorId::DateTrunc, kDateTrunc}};
+    {OperatorId::Add, kAddOp},
+    {OperatorId::Sub, kSubOp},
+    {OperatorId::Mul, kMulOp},
+    {OperatorId::Div, kDivOp},
+    {OperatorId::Mod, kModuloOp},
+};
 
 // Nary operations
 static std::vector<TypeSystem::NaryOpInfo> kNaryOperatorTable = {};

--- a/src/codegen/type/timestamp_type.cpp
+++ b/src/codegen/type/timestamp_type.cpp
@@ -12,7 +12,6 @@
 
 #include "codegen/type/timestamp_type.h"
 
-#include "codegen/proxy/timestamp_functions_proxy.h"
 #include "codegen/proxy/values_runtime_proxy.h"
 #include "codegen/type/boolean_type.h"
 #include "codegen/type/date_type.h"
@@ -107,28 +106,6 @@ struct CompareTimestamp : public TypeSystem::Comparison {
   }
 };
 
-// DateTrunc
-struct DateTrunc : public TypeSystem::BinaryOperator {
-  bool SupportsTypes(const Type &left_type,
-                     const Type &right_type) const override {
-    return left_type.GetSqlType() == Integer::Instance() &&
-           right_type.GetSqlType() == Timestamp::Instance();
-  }
-
-  Type ResultType(UNUSED_ATTRIBUTE const Type &left_type,
-                  UNUSED_ATTRIBUTE const Type &right_type) const override {
-    return Type{Timestamp::Instance()};
-  }
-
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               UNUSED_ATTRIBUTE OnError on_error) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
-    llvm::Value *raw_ret = codegen.Call(TimestampFunctionsProxy::DateTrunc,
-                                        {left.GetValue(), right.GetLength()});
-    return Value{Timestamp::Instance(), raw_ret};
-  }
-};
-
 // The list of types a SQL timestamp type can be implicitly casted to
 const std::vector<peloton::type::TypeId> kImplicitCastingTable = {
     peloton::type::TypeId::DATE, peloton::type::TypeId::TIMESTAMP};
@@ -144,9 +121,7 @@ static std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {
 
 static std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {};
 
-static DateTrunc kDateTrunc;
-static std::vector<TypeSystem::BinaryOpInfo> kBinaryOperatorTable = {
-    {OperatorId::DateTrunc, kDateTrunc}};
+static std::vector<TypeSystem::BinaryOpInfo> kBinaryOperatorTable = {};
 
 // Nary operations
 static std::vector<TypeSystem::NaryOpInfo> kNaryOperatorTable = {};

--- a/src/function/date_functions.cpp
+++ b/src/function/date_functions.cpp
@@ -10,12 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "function/date_functions.h"
 
 #include <date/date.h>
-#include <inttypes.h>
 #include <date/iso_week.h>
+#include <inttypes.h>
 
 #include "common/logger.h"
 #include "type/types.h"

--- a/src/function/functions.cpp
+++ b/src/function/functions.cpp
@@ -15,31 +15,16 @@
 namespace peloton {
 namespace function {
 
-std::unordered_map<std::string, BuiltInFuncType>
-    BuiltInFunctions::kSourceNameFuncMap;
-std::unordered_map<std::string, BuiltInFuncType>
-    BuiltInFunctions::kSQLNameFuncMap;
+std::unordered_map<std::string, BuiltInFuncType> BuiltInFunctions::kFuncMap;
 
-void BuiltInFunctions::AddFunction(const std::string &sql_func_name,
-                                   const std::string &source_func_name,
+void BuiltInFunctions::AddFunction(const std::string &func_name,
                                    BuiltInFuncType func) {
-  kSourceNameFuncMap.emplace(source_func_name, func);
-  kSQLNameFuncMap.emplace(sql_func_name, func);
+  kFuncMap.emplace(func_name, func);
 }
 
-BuiltInFuncType BuiltInFunctions::GetFuncBySourceName(
-    const std::string &func_name) {
-  auto func = kSourceNameFuncMap.find(func_name);
-  if (func == kSourceNameFuncMap.end()) {
-    return {OperatorId::Invalid, nullptr};
-  }
-  return func->second;
-}
-
-BuiltInFuncType BuiltInFunctions::GetFuncBySQLName(
-    const std::string &func_name) {
-  auto func = kSQLNameFuncMap.find(func_name);
-  if (func == kSQLNameFuncMap.end()) {
+BuiltInFuncType BuiltInFunctions::GetFuncByName(const std::string &func_name) {
+  auto func = kFuncMap.find(func_name);
+  if (func == kFuncMap.end()) {
     return {OperatorId::Invalid, nullptr};
   }
   return func->second;

--- a/src/function/functions.cpp
+++ b/src/function/functions.cpp
@@ -15,16 +15,31 @@
 namespace peloton {
 namespace function {
 
-std::unordered_map<std::string, BuiltInFuncType> BuiltInFunctions::kFuncMap;
+std::unordered_map<std::string, BuiltInFuncType>
+    BuiltInFunctions::kSourceNameFuncMap;
+std::unordered_map<std::string, BuiltInFuncType>
+    BuiltInFunctions::kSQLNameFuncMap;
 
-void BuiltInFunctions::AddFunction(const std::string &func_name,
+void BuiltInFunctions::AddFunction(const std::string &sql_func_name,
+                                   const std::string &source_func_name,
                                    BuiltInFuncType func) {
-  kFuncMap.emplace(func_name, func);
+  kSourceNameFuncMap.emplace(source_func_name, func);
+  kSQLNameFuncMap.emplace(sql_func_name, func);
 }
 
-BuiltInFuncType BuiltInFunctions::GetFuncByName(const std::string &func_name) {
-  auto func = kFuncMap.find(func_name);
-  if (func == kFuncMap.end()) {
+BuiltInFuncType BuiltInFunctions::GetFuncBySourceName(
+    const std::string &func_name) {
+  auto func = kSourceNameFuncMap.find(func_name);
+  if (func == kSourceNameFuncMap.end()) {
+    return {OperatorId::Invalid, nullptr};
+  }
+  return func->second;
+}
+
+BuiltInFuncType BuiltInFunctions::GetFuncBySQLName(
+    const std::string &func_name) {
+  auto func = kSQLNameFuncMap.find(func_name);
+  if (func == kSQLNameFuncMap.end()) {
     return {OperatorId::Invalid, nullptr};
   }
   return func->second;

--- a/src/function/timestamp_functions.cpp
+++ b/src/function/timestamp_functions.cpp
@@ -28,7 +28,7 @@ namespace function {
 uint64_t TimestampFunctions::DateTrunc(uint32_t date_part_type,
                                        uint64_t value) {
   DatePartType date_part =
-      *reinterpret_cast<const DatePartType*>(&date_part_type);
+      *reinterpret_cast<const DatePartType *>(&date_part_type);
 
   uint64_t timestamp = value;
   uint64_t result = 0;
@@ -131,5 +131,18 @@ uint64_t TimestampFunctions::DateTrunc(uint32_t date_part_type,
   return (result);
 }
 
-}  // namespace expression
+type::Value TimestampFunctions::_DateTrunc(
+    const std::vector<type::Value> &args) {
+  uint32_t date_part = args[0].GetAs<uint32_t>();
+  uint64_t timestamp = args[1].GetAs<uint64_t>();
+  type::Value result;
+
+  if (timestamp == type::PELOTON_TIMESTAMP_NULL) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::TIMESTAMP);
+  }
+
+  uint64_t ret = DateTrunc(date_part, timestamp);
+  return type::ValueFactory::GetTimestampValue(ret);
+}
+}  // namespace function
 }  // namespace peloton

--- a/src/function/timestamp_functions.cpp
+++ b/src/function/timestamp_functions.cpp
@@ -1,0 +1,127 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// timestamp_functions.cpp
+//
+// Identification: src/function/timestamp_functions.cpp
+//
+// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "function/timestamp_functions.h"
+
+#include <date/date.h>
+#include <date/iso_week.h>
+#include <inttypes.h>
+
+#include "common/logger.h"
+#include "type/limits.h"
+#include "type/types.h"
+#include "type/value.h"
+#include "type/value_factory.h"
+
+namespace peloton {
+namespace function {
+
+uint64_t TimestampFunctions::DateTrunc(uint32_t date_part_type,
+                                       uint64_t value) {
+  DatePartType date_part =
+      *reinterpret_cast<const DatePartType*>(&date_part_type);
+
+  uint64_t timestamp = value;
+  uint64_t result = 0;
+
+  if (timestamp == type::PELOTON_TIMESTAMP_NULL) {
+    return type::PELOTON_TIMESTAMP_NULL;
+  }
+
+  uint32_t micro = timestamp % 1000000;
+  timestamp /= 1000000;
+  uint32_t hour_min_sec = timestamp % 100000;
+  hour_min_sec /= 60;
+  uint16_t min = hour_min_sec % 60;
+  hour_min_sec /= 60;
+  uint16_t hour = hour_min_sec % 24;
+  timestamp /= 100000;
+  uint16_t year = timestamp % 10000;
+  timestamp /= 10000;
+  timestamp /= 27;  // skip time zone
+  uint16_t day = timestamp % 32;
+  timestamp /= 32;
+  uint16_t month = timestamp;
+
+  uint8_t quarter = (month - 1) / 3 + 1;
+
+  date::year_month_day ymd = date::year_month_day{
+      date::year{year}, date::month{month}, date::day{day}};
+  iso_week::year_weeknum_weekday yww = iso_week::year_weeknum_weekday{ymd};
+
+  uint16_t dow = ((unsigned)yww.weekday()) == 7 ? 0 : (unsigned)yww.weekday();
+
+  switch (date_part) {
+    case DatePartType::CENTURY: {
+      result = ((32 + 1) * 27 * 10000 + year - year % 100) * 100000 * 1000000;
+      break;
+    }
+    case DatePartType::DAY: {
+      result = ((month * 32 + day) * 27 * 10000 + year) * 100000 * 1000000;
+      break;
+    }
+    case DatePartType::DECADE: {
+      result = ((32 + 1) * 27 * 10000 + year - year % 10) * 100000 * 1000000;
+      break;
+    }
+    case DatePartType::HOUR: {
+      result = (((month * 32 + day) * 27 * 10000 + year - year % 100) * 100000 +
+                hour * 86400) *
+               1000000;
+      break;
+    }
+    case DatePartType::MICROSECOND: {
+      result = value;
+      break;
+    }
+    case DatePartType::MILLENNIUM: {
+      result = ((32 + 1) * 27 * 10000 + year - year % 1000) * 100000 * 1000000;
+      break;
+    }
+    case DatePartType::MILLISECOND: {
+      result = value - micro % 1000;
+      break;
+    }
+    case DatePartType::MINUTE: {
+      result = value - micro - min * 1000000;
+      break;
+    }
+    case DatePartType::MONTH: {
+      result = ((month * 32 + 1) * 27 * 10000 + year) * 100000 * 1000000;
+      break;
+    }
+    case DatePartType::QUARTER: {
+      result = ((((quarter - 1) * 3 + 1) * 32 + 1) * 27 * 10000 + year) *
+               100000 * 1000000;
+      break;
+    }
+    case DatePartType::SECOND: {
+      result = value - micro;
+      break;
+    }
+    case DatePartType::WEEK: {
+      result =
+          ((month * 32 + day - dow) * 27 * 10000 + year) * 100000 * 1000000;
+      break;
+    }
+    case DatePartType::YEAR: {
+      result = ((32 + 1) * 27 * 10000 + year) * 100000 * 1000000;
+      break;
+    }
+    default: { result = type::PELOTON_TIMESTAMP_NULL; }
+  };
+
+  return (result);
+}
+
+}  // namespace expression
+}  // namespace peloton

--- a/src/function/timestamp_functions.cpp
+++ b/src/function/timestamp_functions.cpp
@@ -18,8 +18,6 @@
 
 #include "common/logger.h"
 #include "type/limits.h"
-#include "type/types.h"
-#include "type/value.h"
 #include "type/value_factory.h"
 
 namespace peloton {

--- a/src/function/timestamp_functions.cpp
+++ b/src/function/timestamp_functions.cpp
@@ -25,8 +25,7 @@ namespace function {
 
 uint64_t TimestampFunctions::DateTrunc(uint32_t date_part_type,
                                        uint64_t value) {
-  DatePartType date_part =
-      *reinterpret_cast<const DatePartType *>(&date_part_type);
+  DatePartType date_part = static_cast<DatePartType>(date_part_type);
 
   uint64_t timestamp = value;
   uint64_t result = 0;

--- a/src/function/timestamp_functions.cpp
+++ b/src/function/timestamp_functions.cpp
@@ -145,6 +145,7 @@ uint64_t TimestampFunctions::DateTrunc(const char *date_part_type,
 type::Value TimestampFunctions::_DateTrunc(
     const std::vector<type::Value> &args) {
   char *date_part = args[0].GetAs<char *>();
+
   uint64_t timestamp = args[1].GetAs<uint64_t>();
   type::Value result;
 

--- a/src/function/timestamp_functions.cpp
+++ b/src/function/timestamp_functions.cpp
@@ -23,9 +23,12 @@
 namespace peloton {
 namespace function {
 
-uint64_t TimestampFunctions::DateTrunc(uint32_t date_part_type,
+uint64_t TimestampFunctions::DateTrunc(const char *date_part_type,
                                        uint64_t value) {
-  DatePartType date_part = static_cast<DatePartType>(date_part_type);
+  PL_ASSERT(date_part_type != nullptr);
+
+  std::string date_part_string(date_part_type);
+  DatePartType date_part = StringToDatePartType(date_part_string);
 
   uint64_t timestamp = value;
   uint64_t result = 0;
@@ -141,7 +144,7 @@ uint64_t TimestampFunctions::DateTrunc(uint32_t date_part_type,
 
 type::Value TimestampFunctions::_DateTrunc(
     const std::vector<type::Value> &args) {
-  uint32_t date_part = args[0].GetAs<uint32_t>();
+  char *date_part = args[0].GetAs<char *>();
   uint64_t timestamp = args[1].GetAs<uint64_t>();
   type::Value result;
 

--- a/src/function/timestamp_functions.cpp
+++ b/src/function/timestamp_functions.cpp
@@ -62,20 +62,23 @@ uint64_t TimestampFunctions::DateTrunc(uint32_t date_part_type,
 
   switch (date_part) {
     case DatePartType::CENTURY: {
-      result = ((32 + 1) * 27 * 10000 + year - year % 100) * 100000 * 1000000;
+      result = (((uint64_t)32 + 1) * 27 * 10000 + year - year % 100) * 100000 *
+               1000000;
       break;
     }
     case DatePartType::DAY: {
-      result = ((month * 32 + day) * 27 * 10000 + year) * 100000 * 1000000;
+      result =
+          (((uint64_t)month * 32 + day) * 27 * 10000 + year) * 100000 * 1000000;
       break;
     }
     case DatePartType::DECADE: {
-      result = ((32 + 1) * 27 * 10000 + year - year % 10) * 100000 * 1000000;
+      result = (((uint64_t)32 + 1) * 27 * 10000 + year - year % 10) * 100000 *
+               1000000;
       break;
     }
     case DatePartType::HOUR: {
-      result = (((month * 32 + day) * 27 * 10000 + year - year % 100) * 100000 +
-                hour * 86400) *
+      result = ((((uint64_t)month * 32 + day) * 27 * 10000 + year) * 100000 +
+                hour * 3600) *
                1000000;
       break;
     }
@@ -84,7 +87,8 @@ uint64_t TimestampFunctions::DateTrunc(uint32_t date_part_type,
       break;
     }
     case DatePartType::MILLENNIUM: {
-      result = ((32 + 1) * 27 * 10000 + year - year % 1000) * 100000 * 1000000;
+      result = (((uint64_t)32 + 1) * 27 * 10000 + year - year % 1000) * 100000 *
+               1000000;
       break;
     }
     case DatePartType::MILLISECOND: {
@@ -96,12 +100,14 @@ uint64_t TimestampFunctions::DateTrunc(uint32_t date_part_type,
       break;
     }
     case DatePartType::MONTH: {
-      result = ((month * 32 + 1) * 27 * 10000 + year) * 100000 * 1000000;
+      result =
+          (((uint64_t)month * 32 + 1) * 27 * 10000 + year) * 100000 * 1000000;
       break;
     }
     case DatePartType::QUARTER: {
-      result = ((((quarter - 1) * 3 + 1) * 32 + 1) * 27 * 10000 + year) *
-               100000 * 1000000;
+      result =
+          (((((uint64_t)quarter - 1) * 3 + 1) * 32 + 1) * 27 * 10000 + year) *
+          100000 * 1000000;
       break;
     }
     case DatePartType::SECOND: {
@@ -109,12 +115,14 @@ uint64_t TimestampFunctions::DateTrunc(uint32_t date_part_type,
       break;
     }
     case DatePartType::WEEK: {
-      result =
-          ((month * 32 + day - dow) * 27 * 10000 + year) * 100000 * 1000000;
+      result = (((uint64_t)month * 32 + day - (dow == 0 ? 6 : (dow - 1))) * 27 *
+                    10000 +
+                year) *
+               100000 * 1000000;
       break;
     }
     case DatePartType::YEAR: {
-      result = ((32 + 1) * 27 * 10000 + year) * 100000 * 1000000;
+      result = (((uint64_t)32 + 1) * 27 * 10000 + year) * 100000 * 1000000;
       break;
     }
     default: { result = type::PELOTON_TIMESTAMP_NULL; }

--- a/src/include/codegen/proxy/timestamp_functions_proxy.h
+++ b/src/include/codegen/proxy/timestamp_functions_proxy.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// timestamp_functions_proxy.h
+//
+// Identification: src/include/codegen/proxy/timestamp_functions_proxy.h
+//
+// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "codegen/proxy/proxy.h"
+
+namespace peloton {
+namespace codegen {
+
+PROXY(TimestampFunctions) {
+  // Proxy everything in function::DateFunctions
+  DECLARE_METHOD(DateTrunc);
+};
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/include/function/functions.h
+++ b/src/include/function/functions.h
@@ -32,12 +32,24 @@ struct BuiltInFuncType {
 
 class BuiltInFunctions {
  private:
-  static std::unordered_map<std::string, BuiltInFuncType> kFuncMap;
+  // Map the function name in C++ source (should be unique) to the actual
+  // function implementation
+  static std::unordered_map<std::string, BuiltInFuncType> kSourceNameFuncMap;
+
+  // Map the function name used in SQL to the actual function implementation.
+  // Different SQL names can map to the same function implementation(alias).
+  static std::unordered_map<std::string, BuiltInFuncType> kSQLNameFuncMap;
 
  public:
-  static void AddFunction(const std::string &func_name, BuiltInFuncType func);
+  static void AddFunction(const std::string &sql_func_name,
+                          const std::string &source_func_name,
+                          BuiltInFuncType func);
 
-  static BuiltInFuncType GetFuncByName(const std::string &func_name);
+  // Get the function from the name in C++ source code
+  static BuiltInFuncType GetFuncBySourceName(const std::string &func_name);
+
+  // Get the function from the name used in SQL
+  static BuiltInFuncType GetFuncBySQLName(const std::string &func_name);
 };
 
 }  // namespace function

--- a/src/include/function/functions.h
+++ b/src/include/function/functions.h
@@ -34,22 +34,13 @@ class BuiltInFunctions {
  private:
   // Map the function name in C++ source (should be unique) to the actual
   // function implementation
-  static std::unordered_map<std::string, BuiltInFuncType> kSourceNameFuncMap;
-
-  // Map the function name used in SQL to the actual function implementation.
-  // Different SQL names can map to the same function implementation(alias).
-  static std::unordered_map<std::string, BuiltInFuncType> kSQLNameFuncMap;
+  static std::unordered_map<std::string, BuiltInFuncType> kFuncMap;
 
  public:
-  static void AddFunction(const std::string &sql_func_name,
-                          const std::string &source_func_name,
-                          BuiltInFuncType func);
+  static void AddFunction(const std::string &func_name, BuiltInFuncType func);
 
   // Get the function from the name in C++ source code
-  static BuiltInFuncType GetFuncBySourceName(const std::string &func_name);
-
-  // Get the function from the name used in SQL
-  static BuiltInFuncType GetFuncBySQLName(const std::string &func_name);
+  static BuiltInFuncType GetFuncByName(const std::string &func_name);
 };
 
 }  // namespace function

--- a/src/include/function/timestamp_functions.h
+++ b/src/include/function/timestamp_functions.h
@@ -15,7 +15,6 @@
 #include <string>
 #include <vector>
 
-#include "common/logger.h"
 #include "type/types.h"
 #include "type/value.h"
 

--- a/src/include/function/timestamp_functions.h
+++ b/src/include/function/timestamp_functions.h
@@ -41,6 +41,7 @@ class TimestampFunctions {
   // support explicit type casts. For example:
   // SELECT date_trunc('hour', TIMESTAMP '2001-02-16 20:38:40');
   static uint64_t DateTrunc(uint32_t date_part_type, uint64_t value);
+  static type::Value _DateTrunc(const std::vector<type::Value> &args);
 };
 
 }  // namespace function

--- a/src/include/function/timestamp_functions.h
+++ b/src/include/function/timestamp_functions.h
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// timestamp_functions.h
+//
+// Identification: src/include/function/timestamp_functions.h
+//
+// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "common/logger.h"
+#include "type/types.h"
+#include "type/value.h"
+
+namespace peloton {
+namespace function {
+
+class TimestampFunctions {
+ public:
+  // Truncate a timestamp to specified precision
+  // (1) The first argument selects to which precision to truncate the input
+  // value
+  // (2) The second argument is the length of the precision value (used to
+  // evaluate whether the value is NULL)
+  // (3) The third argument is the value expression of type timestamp
+  // (4) The fourth argument is the length of the timestamp value (used to
+  // evaluate whether the value is NULL)
+  // @return The Value returned is the value of type timestamp with
+  // all fields that are less significant than the selected one set to zero (or
+  // one, for day and month).
+  // TODO(lma): We do not support directly using date_trunc with a constant
+  // value from the SQL string. We don't need to change the implementation in
+  // this function here to support that, but we need the parser/binder to
+  // support explicit type casts. For example:
+  // SELECT date_trunc('hour', TIMESTAMP '2001-02-16 20:38:40');
+  static uint64_t DateTrunc(uint32_t date_part_type, uint64_t value);
+};
+
+}  // namespace function
+}  // namespace peloton

--- a/src/include/function/timestamp_functions.h
+++ b/src/include/function/timestamp_functions.h
@@ -26,11 +26,7 @@ class TimestampFunctions {
   // Truncate a timestamp to specified precision
   // (1) The first argument selects to which precision to truncate the input
   // value
-  // (2) The second argument is the length of the precision value (used to
-  // evaluate whether the value is NULL)
-  // (3) The third argument is the value expression of type timestamp
-  // (4) The fourth argument is the length of the timestamp value (used to
-  // evaluate whether the value is NULL)
+  // (2) The second argument is the value of the timestamp expression
   // @return The Value returned is the value of type timestamp with
   // all fields that are less significant than the selected one set to zero (or
   // one, for day and month).
@@ -39,7 +35,7 @@ class TimestampFunctions {
   // this function here to support that, but we need the parser/binder to
   // support explicit type casts. For example:
   // SELECT date_trunc('hour', TIMESTAMP '2001-02-16 20:38:40');
-  static uint64_t DateTrunc(uint32_t date_part_type, uint64_t value);
+  static uint64_t DateTrunc(const char *date_part_type, uint64_t value);
   static type::Value _DateTrunc(const std::vector<type::Value> &args);
 };
 

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -262,7 +262,7 @@ ExpressionType ParserExpressionNameToExpressionType(const std::string &str);
 
 // Note that we have some duplicate DatePartTypes with the 's' suffix
 // They have to have the same value in order for it to work.
-enum class DatePartType {
+enum class DatePartType : uint32_t {
   INVALID = INVALID_TYPE_ID,
   CENTURY = 1,
   DAY = 2,

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -1042,6 +1042,7 @@ enum class OperatorId : uint32_t {
   Sqrt,
   Extract,
   Floor,
+  DateTrunc,
 
   // Add more operators here, before the last "Invalid" entry
   Like,

--- a/src/type/types.cpp
+++ b/src/type/types.cpp
@@ -285,7 +285,7 @@ type::TypeId StringToTypeId(const std::string& str) {
   return type::TypeId::INVALID;
 }
 
-std::string TypeIdArrayToString(const std::vector<type::TypeId> &types) {
+std::string TypeIdArrayToString(const std::vector<type::TypeId>& types) {
   std::string result = "";
   for (auto type : types) {
     if (result != "") result.append(",");
@@ -296,7 +296,7 @@ std::string TypeIdArrayToString(const std::vector<type::TypeId> &types) {
 
 // Get argument type vector from its string representation
 // e.g. "integer,boolean" --> vector{TypeId::INTEGER, TypeId::BOOLEAN}
-std::vector<type::TypeId> StringToTypeArray(const std::string &types) {
+std::vector<type::TypeId> StringToTypeArray(const std::string& types) {
   std::vector<type::TypeId> result;
   std::istringstream stream(types);
   std::string type;
@@ -331,9 +331,9 @@ std::string CreateTypeToString(CreateType type) {
       return "TRIGGER";
     }
     default: {
-      throw ConversionException(StringUtil::Format(
-          "No string conversion for CreateType value '%d'",
-          static_cast<int>(type)));
+      throw ConversionException(
+          StringUtil::Format("No string conversion for CreateType value '%d'",
+                             static_cast<int>(type)));
     }
   }
   return "INVALID";
@@ -385,9 +385,9 @@ std::string DropTypeToString(DropType type) {
       return "TRIGGER";
     }
     default: {
-      throw ConversionException(StringUtil::Format(
-          "No string conversion for DropType value '%d'",
-          static_cast<int>(type)));
+      throw ConversionException(
+          StringUtil::Format("No string conversion for DropType value '%d'",
+                             static_cast<int>(type)));
     }
   }
   return "INVALID";
@@ -710,7 +710,7 @@ ExpressionType StringToExpressionType(const std::string& str) {
     return ExpressionType::OPERATOR_DIVIDE;
   } else if (upper_str == "OPERATOR_CONCAT" || upper_str == "||") {
     return ExpressionType::OPERATOR_CONCAT;
-  } else if (upper_str == "OPERATOR_MOD" || upper_str == "%" ) {
+  } else if (upper_str == "OPERATOR_MOD" || upper_str == "%") {
     return ExpressionType::OPERATOR_MOD;
   } else if (upper_str == "OPERATOR_CAST") {
     return ExpressionType::OPERATOR_CAST;
@@ -724,8 +724,8 @@ ExpressionType StringToExpressionType(const std::string& str) {
     return ExpressionType::OPERATOR_UNARY_MINUS;
   } else if (upper_str == "COMPARE_EQUAL" || upper_str == "=") {
     return ExpressionType::COMPARE_EQUAL;
-  } else if (upper_str == "COMPARE_NOTEQUAL"
-      || upper_str == "!=" || upper_str == "<>") {
+  } else if (upper_str == "COMPARE_NOTEQUAL" || upper_str == "!=" ||
+             upper_str == "<>") {
     return ExpressionType::COMPARE_NOTEQUAL;
   } else if (upper_str == "COMPARE_LESSTHAN" || upper_str == "<") {
     return ExpressionType::COMPARE_LESSTHAN;
@@ -1323,7 +1323,7 @@ std::string AggregateTypeToString(AggregateType type) {
   return "INVALID";
 }
 
-AggregateType StringToAggregateType(const std::string &str) {
+AggregateType StringToAggregateType(const std::string& str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return AggregateType::INVALID;
@@ -1334,14 +1334,13 @@ AggregateType StringToAggregateType(const std::string &str) {
   } else if (upper_str == "PLAIN") {
     return AggregateType::PLAIN;
   } else {
-    throw ConversionException(
-        StringUtil::Format("No AggregateType conversion from string '%s'",
-                           upper_str.c_str()));
+    throw ConversionException(StringUtil::Format(
+        "No AggregateType conversion from string '%s'", upper_str.c_str()));
   }
   return AggregateType::INVALID;
 }
 
-std::ostream &operator<<(std::ostream &os, const AggregateType &type) {
+std::ostream& operator<<(std::ostream& os, const AggregateType& type) {
   os << AggregateTypeToString(type);
   return os;
 }
@@ -1379,9 +1378,8 @@ QuantifierType StringToQuantifierType(const std::string& str) {
   } else if (upper_str == "ALL") {
     return QuantifierType::ALL;
   } else {
-    throw ConversionException(
-        StringUtil::Format("No QuantifierType conversion from string '%s'",
-                           upper_str.c_str()));
+    throw ConversionException(StringUtil::Format(
+        "No QuantifierType conversion from string '%s'", upper_str.c_str()));
   }
   return QuantifierType::NONE;
 }
@@ -1462,15 +1460,15 @@ std::string InsertTypeToString(InsertType type) {
       return "SELECT";
     }
     default: {
-      throw ConversionException(StringUtil::Format(
-          "No string conversion for InsertType value '%d'",
-          static_cast<int>(type)));
+      throw ConversionException(
+          StringUtil::Format("No string conversion for InsertType value '%d'",
+                             static_cast<int>(type)));
     }
   }
   return "INVALID";
 }
 
-InsertType StringToInsertType(const std::string &str) {
+InsertType StringToInsertType(const std::string& str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return InsertType::INVALID;
@@ -1479,14 +1477,13 @@ InsertType StringToInsertType(const std::string &str) {
   } else if (upper_str == "SELECT") {
     return InsertType::SELECT;
   } else {
-    throw ConversionException(
-        StringUtil::Format("No InsertType conversion from string '%s'",
-                           upper_str.c_str()));
+    throw ConversionException(StringUtil::Format(
+        "No InsertType conversion from string '%s'", upper_str.c_str()));
   }
   return InsertType::INVALID;
 }
 
-std::ostream &operator<<(std::ostream &os, const InsertType &type) {
+std::ostream& operator<<(std::ostream& os, const InsertType& type) {
   os << InsertTypeToString(type);
   return os;
 }
@@ -1516,15 +1513,15 @@ std::string CopyTypeToString(CopyType type) {
       return "EXPORT_OTHER";
     }
     default: {
-      throw ConversionException(StringUtil::Format(
-          "No string conversion for CopyType value '%d'",
-          static_cast<int>(type)));
+      throw ConversionException(
+          StringUtil::Format("No string conversion for CopyType value '%d'",
+                             static_cast<int>(type)));
     }
   }
   return "INVALID";
 }
 
-CopyType StringToCopyType(const std::string &str) {
+CopyType StringToCopyType(const std::string& str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return CopyType::INVALID;
@@ -1539,14 +1536,13 @@ CopyType StringToCopyType(const std::string &str) {
   } else if (upper_str == "EXPORT_OTHER") {
     return CopyType::EXPORT_OTHER;
   } else {
-    throw ConversionException(
-        StringUtil::Format("No CopyType conversion from string '%s'",
-                           upper_str.c_str()));
+    throw ConversionException(StringUtil::Format(
+        "No CopyType conversion from string '%s'", upper_str.c_str()));
   }
   return CopyType::INVALID;
 }
 
-std::ostream &operator<<(std::ostream &os, const CopyType &type) {
+std::ostream& operator<<(std::ostream& os, const CopyType& type) {
   os << CopyTypeToString(type);
   return os;
 }
@@ -1578,7 +1574,7 @@ std::string PayloadTypeToString(PayloadType type) {
   return "INVALID";
 }
 
-PayloadType StringToPayloadType(const std::string &str) {
+PayloadType StringToPayloadType(const std::string& str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return PayloadType::INVALID;
@@ -1595,7 +1591,7 @@ PayloadType StringToPayloadType(const std::string &str) {
   return PayloadType::INVALID;
 }
 
-std::ostream &operator<<(std::ostream &os, const PayloadType &type) {
+std::ostream& operator<<(std::ostream& os, const PayloadType& type) {
   os << PayloadTypeToString(type);
   return os;
 }
@@ -1638,9 +1634,8 @@ TaskPriorityType StringToTaskPriorityType(const std::string& str) {
   } else if (upper_str == "HIGH") {
     return TaskPriorityType::HIGH;
   } else {
-    throw ConversionException(
-        StringUtil::Format("No TaskPriorityType conversion from string '%s'",
-                           upper_str.c_str()));
+    throw ConversionException(StringUtil::Format(
+        "No TaskPriorityType conversion from string '%s'", upper_str.c_str()));
   }
   return TaskPriorityType::INVALID;
 }
@@ -1783,7 +1778,7 @@ ConstraintType StringToConstraintType(const std::string& str) {
   return ConstraintType::INVALID;
 }
 
-std::ostream &operator<<(std::ostream &os, const ConstraintType &type) {
+std::ostream& operator<<(std::ostream& os, const ConstraintType& type) {
   os << ConstraintTypeToString(type);
   return os;
 }
@@ -1810,9 +1805,9 @@ std::string SetOpTypeToString(SetOpType type) {
       return "EXCEPT_ALL";
     }
     default: {
-      throw ConversionException(StringUtil::Format(
-          "No string conversion for SetOpType value '%d'",
-          static_cast<int>(type)));
+      throw ConversionException(
+          StringUtil::Format("No string conversion for SetOpType value '%d'",
+                             static_cast<int>(type)));
     }
   }
   return "INVALID";
@@ -1831,9 +1826,8 @@ SetOpType StringToSetOpType(const std::string& str) {
   } else if (upper_str == "EXCEPT_ALL") {
     return SetOpType::EXCEPT_ALL;
   } else {
-    throw ConversionException(
-        StringUtil::Format("No SetOpType conversion from string '%s'",
-                           upper_str.c_str()));
+    throw ConversionException(StringUtil::Format(
+        "No SetOpType conversion from string '%s'", upper_str.c_str()));
   }
   return SetOpType::INVALID;
 }
@@ -1842,7 +1836,6 @@ std::ostream& operator<<(std::ostream& os, const SetOpType& type) {
   os << SetOpTypeToString(type);
   return os;
 }
-
 
 //===--------------------------------------------------------------------===//
 // Concurrency Control Types
@@ -1865,7 +1858,7 @@ std::string ProtocolTypeToString(ProtocolType type) {
   return "INVALID";
 }
 
-ProtocolType StringToProtocolType(const std::string &str) {
+ProtocolType StringToProtocolType(const std::string& str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return ProtocolType::INVALID;
@@ -1878,7 +1871,7 @@ ProtocolType StringToProtocolType(const std::string &str) {
   return ProtocolType::INVALID;
 }
 
-std::ostream &operator<<(std::ostream &os, const ProtocolType &type) {
+std::ostream& operator<<(std::ostream& os, const ProtocolType& type) {
   os << ProtocolTypeToString(type);
   return os;
 }
@@ -1904,7 +1897,7 @@ std::string EpochTypeToString(EpochType type) {
   return "INVALID";
 }
 
-EpochType StringToEpochType(const std::string &str) {
+EpochType StringToEpochType(const std::string& str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return EpochType::INVALID;
@@ -1917,7 +1910,7 @@ EpochType StringToEpochType(const std::string &str) {
   return EpochType::INVALID;
 }
 
-std::ostream &operator<<(std::ostream &os, const EpochType &type) {
+std::ostream& operator<<(std::ostream& os, const EpochType& type) {
   os << EpochTypeToString(type);
   return os;
 }
@@ -1937,15 +1930,15 @@ std::string TimestampTypeToString(TimestampType type) {
       return "COMMIT";
     }
     default: {
-      throw ConversionException(
-          StringUtil::Format("No string conversion for TimestampType value '%d'",
-                             static_cast<int>(type)));
+      throw ConversionException(StringUtil::Format(
+          "No string conversion for TimestampType value '%d'",
+          static_cast<int>(type)));
     }
   }
   return "INVALID";
 }
 
-TimestampType StringToTimestampType(const std::string &str) {
+TimestampType StringToTimestampType(const std::string& str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return TimestampType::INVALID;
@@ -1962,7 +1955,7 @@ TimestampType StringToTimestampType(const std::string &str) {
   return TimestampType::INVALID;
 }
 
-std::ostream &operator<<(std::ostream &os, const TimestampType &type) {
+std::ostream& operator<<(std::ostream& os, const TimestampType& type) {
   os << TimestampTypeToString(type);
   return os;
 }
@@ -1986,15 +1979,15 @@ std::string VisibilityTypeToString(VisibilityType type) {
       return "OK";
     }
     default: {
-      throw ConversionException(
-          StringUtil::Format("No string conversion for VisibilityType value '%d'",
-                             static_cast<int>(type)));
+      throw ConversionException(StringUtil::Format(
+          "No string conversion for VisibilityType value '%d'",
+          static_cast<int>(type)));
     }
   }
   return "INVALID";
 }
 
-VisibilityType StringToVisibilityType(const std::string &str) {
+VisibilityType StringToVisibilityType(const std::string& str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return VisibilityType::INVALID;
@@ -2011,11 +2004,10 @@ VisibilityType StringToVisibilityType(const std::string &str) {
   return VisibilityType::INVALID;
 }
 
-std::ostream &operator<<(std::ostream &os, const VisibilityType &type) {
+std::ostream& operator<<(std::ostream& os, const VisibilityType& type) {
   os << VisibilityTypeToString(type);
   return os;
 }
-
 
 std::string VisibilityIdTypeToString(VisibilityIdType type) {
   switch (type) {
@@ -2029,15 +2021,15 @@ std::string VisibilityIdTypeToString(VisibilityIdType type) {
       return "COMMIT_ID";
     }
     default: {
-      throw ConversionException(
-          StringUtil::Format("No string conversion for VisibilityIdType value '%d'",
-                             static_cast<int>(type)));
+      throw ConversionException(StringUtil::Format(
+          "No string conversion for VisibilityIdType value '%d'",
+          static_cast<int>(type)));
     }
   }
   return "INVALID";
 }
 
-VisibilityIdType StringToVisibilityIdType(const std::string &str) {
+VisibilityIdType StringToVisibilityIdType(const std::string& str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return VisibilityIdType::INVALID;
@@ -2052,7 +2044,7 @@ VisibilityIdType StringToVisibilityIdType(const std::string &str) {
   return VisibilityIdType::INVALID;
 }
 
-std::ostream &operator<<(std::ostream &os, const VisibilityIdType &type) {
+std::ostream& operator<<(std::ostream& os, const VisibilityIdType& type) {
   os << VisibilityIdTypeToString(type);
   return os;
 }
@@ -2082,15 +2074,15 @@ std::string IsolationLevelTypeToString(IsolationLevelType type) {
       return "READ_ONLY";
     }
     default: {
-      throw ConversionException(
-          StringUtil::Format("No string conversion for IsolationLevelType value '%d'",
-                             static_cast<int>(type)));
+      throw ConversionException(StringUtil::Format(
+          "No string conversion for IsolationLevelType value '%d'",
+          static_cast<int>(type)));
     }
   }
   return "INVALID";
 }
 
-IsolationLevelType StringToIsolationLevelType(const std::string &str) {
+IsolationLevelType StringToIsolationLevelType(const std::string& str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return IsolationLevelType::INVALID;
@@ -2104,19 +2096,18 @@ IsolationLevelType StringToIsolationLevelType(const std::string &str) {
     return IsolationLevelType::READ_COMMITTED;
   } else if (upper_str == "READ_ONLY") {
     return IsolationLevelType::READ_ONLY;
-  }
-  else {
-    throw ConversionException(StringUtil::Format(
-        "No IsolationLevelType conversion from string '%s'", upper_str.c_str()));
+  } else {
+    throw ConversionException(
+        StringUtil::Format("No IsolationLevelType conversion from string '%s'",
+                           upper_str.c_str()));
   }
   return IsolationLevelType::INVALID;
 }
 
-std::ostream &operator<<(std::ostream &os, const IsolationLevelType &type) {
+std::ostream& operator<<(std::ostream& os, const IsolationLevelType& type) {
   os << IsolationLevelTypeToString(type);
   return os;
 }
-
 
 //===--------------------------------------------------------------------===//
 // Conflict Avoidance types
@@ -2134,15 +2125,15 @@ std::string ConflictAvoidanceTypeToString(ConflictAvoidanceType type) {
       return "ABORT";
     }
     default: {
-      throw ConversionException(
-          StringUtil::Format("No string conversion for ConflictAvoidanceType value '%d'",
-                             static_cast<int>(type)));
+      throw ConversionException(StringUtil::Format(
+          "No string conversion for ConflictAvoidanceType value '%d'",
+          static_cast<int>(type)));
     }
   }
   return "INVALID";
 }
 
-ConflictAvoidanceType StringToConflictAvoidanceType(const std::string &str) {
+ConflictAvoidanceType StringToConflictAvoidanceType(const std::string& str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return ConflictAvoidanceType::INVALID;
@@ -2152,12 +2143,13 @@ ConflictAvoidanceType StringToConflictAvoidanceType(const std::string &str) {
     return ConflictAvoidanceType::ABORT;
   } else {
     throw ConversionException(StringUtil::Format(
-        "No ConflictAvoidanceType conversion from string '%s'", upper_str.c_str()));
+        "No ConflictAvoidanceType conversion from string '%s'",
+        upper_str.c_str()));
   }
   return ConflictAvoidanceType::INVALID;
 }
 
-std::ostream &operator<<(std::ostream &os, const ConflictAvoidanceType &type) {
+std::ostream& operator<<(std::ostream& os, const ConflictAvoidanceType& type) {
   os << ConflictAvoidanceTypeToString(type);
   return os;
 }
@@ -2178,15 +2170,15 @@ std::string GarbageCollectionTypeToString(GarbageCollectionType type) {
       return "ON";
     }
     default: {
-      throw ConversionException(
-          StringUtil::Format("No string conversion for GarbageCollectionType value '%d'",
-                             static_cast<int>(type)));
+      throw ConversionException(StringUtil::Format(
+          "No string conversion for GarbageCollectionType value '%d'",
+          static_cast<int>(type)));
     }
   }
   return "INVALID";
 }
 
-GarbageCollectionType StringToGarbageCollectionType(const std::string &str) {
+GarbageCollectionType StringToGarbageCollectionType(const std::string& str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return GarbageCollectionType::INVALID;
@@ -2196,7 +2188,8 @@ GarbageCollectionType StringToGarbageCollectionType(const std::string &str) {
     return GarbageCollectionType::ON;
   } else {
     throw ConversionException(StringUtil::Format(
-        "No GarbageCollectionType conversion from string '%s'", upper_str.c_str()));
+        "No GarbageCollectionType conversion from string '%s'",
+        upper_str.c_str()));
   }
   return GarbageCollectionType::INVALID;
 }
@@ -2250,7 +2243,6 @@ std::ostream& operator<<(std::ostream& os, const LoggingType& type) {
   return os;
 }
 
-
 std::string LogRecordTypeToString(LogRecordType type) {
   switch (type) {
     case LogRecordType::INVALID: {
@@ -2278,9 +2270,9 @@ std::string LogRecordTypeToString(LogRecordType type) {
       return "EPOCH_END";
     }
     default: {
-      throw ConversionException(
-          StringUtil::Format("No string conversion for LogRecordType value '%d'",
-                             static_cast<int>(type)));
+      throw ConversionException(StringUtil::Format(
+          "No string conversion for LogRecordType value '%d'",
+          static_cast<int>(type)));
     }
   }
   return "INVALID";
@@ -2316,7 +2308,6 @@ std::ostream& operator<<(std::ostream& os, const LogRecordType& type) {
   return os;
 }
 
-
 //===--------------------------------------------------------------------===//
 // CheckpointingType - String Utilities
 //===--------------------------------------------------------------------===//
@@ -2349,11 +2340,9 @@ CheckpointingType StringToCheckpointingType(const std::string& str) {
     return CheckpointingType::OFF;
   } else if (upper_str == "ON") {
     return CheckpointingType::ON;
-  }
-  else {
-    throw ConversionException(
-        StringUtil::Format("No CheckpointingType conversion from string '%s'",
-                           upper_str.c_str()));
+  } else {
+    throw ConversionException(StringUtil::Format(
+        "No CheckpointingType conversion from string '%s'", upper_str.c_str()));
   }
   return CheckpointingType::INVALID;
 }
@@ -2362,8 +2351,6 @@ std::ostream& operator<<(std::ostream& os, const CheckpointingType& type) {
   os << CheckpointingTypeToString(type);
   return os;
 }
-
-
 
 type::TypeId PostgresValueTypeToPelotonValueType(PostgresValueType type) {
   switch (type) {
@@ -2474,9 +2461,9 @@ std::string EntityTypeToString(EntityType type) {
       return "PREPARED_STATEMENT";
     }
     default: {
-      throw ConversionException(StringUtil::Format(
-          "No string conversion for EntityType value '%d'",
-          static_cast<int>(type)));
+      throw ConversionException(
+          StringUtil::Format("No string conversion for EntityType value '%d'",
+                             static_cast<int>(type)));
     }
   }
   return "INVALID";
@@ -2497,9 +2484,8 @@ EntityType StringToEntityType(const std::string& str) {
   } else if (upper_str == "PREPARED_STATEMENT") {
     return EntityType::PREPARED_STATEMENT;
   } else {
-    throw ConversionException(
-        StringUtil::Format("No EntityType conversion from string '%s'",
-                           upper_str.c_str()));
+    throw ConversionException(StringUtil::Format(
+        "No EntityType conversion from string '%s'", upper_str.c_str()));
   }
   return EntityType::INVALID;
 }
@@ -2537,9 +2523,9 @@ std::string RWTypeToString(RWType type) {
       return "INS_DEL";
     }
     default: {
-      throw ConversionException(StringUtil::Format(
-          "No string conversion for RWType value '%d'",
-          static_cast<int>(type)));
+      throw ConversionException(
+          StringUtil::Format("No string conversion for RWType value '%d'",
+                             static_cast<int>(type)));
     }
   }
   return "INVALID";
@@ -2562,9 +2548,8 @@ RWType StringToRWType(const std::string& str) {
   } else if (upper_str == "INS_DEL") {
     return RWType::INS_DEL;
   } else {
-    throw ConversionException(
-        StringUtil::Format("No RWType conversion from string '%s'",
-                           upper_str.c_str()));
+    throw ConversionException(StringUtil::Format(
+        "No RWType conversion from string '%s'", upper_str.c_str()));
   }
   return RWType::INVALID;
 }
@@ -2573,7 +2558,6 @@ std::ostream& operator<<(std::ostream& os, const RWType& type) {
   os << RWTypeToString(type);
   return os;
 }
-
 
 //===--------------------------------------------------------------------===//
 // GCVersionType - String Utilities
@@ -2633,9 +2617,8 @@ GCVersionType StringToGCVersionType(const std::string& str) {
   } else if (upper_str == "ABORT_INS_DEL") {
     return GCVersionType::ABORT_INS_DEL;
   } else {
-    throw ConversionException(
-        StringUtil::Format("No GCVersionType conversion from string '%s'",
-                           upper_str.c_str()));
+    throw ConversionException(StringUtil::Format(
+        "No GCVersionType conversion from string '%s'", upper_str.c_str()));
   }
   return GCVersionType::INVALID;
 }
@@ -2644,7 +2627,6 @@ std::ostream& operator<<(std::ostream& os, const GCVersionType& type) {
   os << GCVersionTypeToString(type);
   return os;
 }
-
 
 //===--------------------------------------------------------------------===//
 // Optimizer
@@ -2671,9 +2653,9 @@ std::string PropertyTypeToString(PropertyType type) {
       return "LIMIT";
     }
     default: {
-      throw ConversionException(StringUtil::Format(
-          "No string conversion for PropertyType value '%d'",
-          static_cast<int>(type)));
+      throw ConversionException(
+          StringUtil::Format("No string conversion for PropertyType value '%d'",
+                             static_cast<int>(type)));
     }
   }
   return "INVALID";
@@ -2694,9 +2676,8 @@ PropertyType StringToPropertyType(const std::string& str) {
   } else if (upper_str == "LIMIT") {
     return PropertyType::LIMIT;
   } else {
-    throw ConversionException(
-        StringUtil::Format("No PropertyType conversion from string '%s'",
-                           upper_str.c_str()));
+    throw ConversionException(StringUtil::Format(
+        "No PropertyType conversion from string '%s'", upper_str.c_str()));
   }
   return PropertyType::INVALID;
 }
@@ -2738,6 +2719,8 @@ std::string OperatorIdToString(OperatorId op_id) {
       return "LogicalAnd";
     case OperatorId::LogicalOr:
       return "LogicalOr";
+    case OperatorId::DateTrunc:
+      return "DateTrunc";
     default: {
       throw Exception{StringUtil::Format("Invalid operator ID: %u", op_id)};
     }

--- a/src/type/types.cpp
+++ b/src/type/types.cpp
@@ -90,7 +90,7 @@ std::string DatePartTypeToString(DatePartType type) {
   return ("INVALID");
 }
 
-DatePartType StringToDatePartType(const std::string& str) {
+DatePartType StringToDatePartType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return DatePartType::INVALID;
@@ -152,7 +152,7 @@ DatePartType StringToDatePartType(const std::string& str) {
   }
 }
 
-std::ostream& operator<<(std::ostream& os, const DatePartType& type) {
+std::ostream &operator<<(std::ostream &os, const DatePartType &type) {
   os << DatePartTypeToString(type);
   return os;
 }
@@ -182,7 +182,7 @@ std::string BackendTypeToString(BackendType type) {
   return ("INVALID");
 }
 
-BackendType StringToBackendType(const std::string& str) {
+BackendType StringToBackendType(const std::string &str) {
   if (str == "INVALID") {
     return BackendType::INVALID;
   } else if (str == "MM") {
@@ -200,7 +200,7 @@ BackendType StringToBackendType(const std::string& str) {
   return BackendType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const BackendType& type) {
+std::ostream &operator<<(std::ostream &os, const BackendType &type) {
   os << BackendTypeToString(type);
   return os;
 }
@@ -248,7 +248,7 @@ std::string TypeIdToString(type::TypeId type) {
   }
 }
 
-type::TypeId StringToTypeId(const std::string& str) {
+type::TypeId StringToTypeId(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return type::TypeId::INVALID;
@@ -285,7 +285,7 @@ type::TypeId StringToTypeId(const std::string& str) {
   return type::TypeId::INVALID;
 }
 
-std::string TypeIdArrayToString(const std::vector<type::TypeId>& types) {
+std::string TypeIdArrayToString(const std::vector<type::TypeId> &types) {
   std::string result = "";
   for (auto type : types) {
     if (result != "") result.append(",");
@@ -296,7 +296,7 @@ std::string TypeIdArrayToString(const std::vector<type::TypeId>& types) {
 
 // Get argument type vector from its string representation
 // e.g. "integer,boolean" --> vector{TypeId::INTEGER, TypeId::BOOLEAN}
-std::vector<type::TypeId> StringToTypeArray(const std::string& types) {
+std::vector<type::TypeId> StringToTypeArray(const std::string &types) {
   std::vector<type::TypeId> result;
   std::istringstream stream(types);
   std::string type;
@@ -339,7 +339,7 @@ std::string CreateTypeToString(CreateType type) {
   return "INVALID";
 }
 
-CreateType StringToCreateType(const std::string& str) {
+CreateType StringToCreateType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return CreateType::INVALID;
@@ -359,7 +359,7 @@ CreateType StringToCreateType(const std::string& str) {
   }
   return CreateType::INVALID;
 }
-std::ostream& operator<<(std::ostream& os, const CreateType& type) {
+std::ostream &operator<<(std::ostream &os, const CreateType &type) {
   os << CreateTypeToString(type);
   return os;
 }
@@ -393,7 +393,7 @@ std::string DropTypeToString(DropType type) {
   return "INVALID";
 }
 
-DropType StringToDropType(const std::string& str) {
+DropType StringToDropType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return DropType::INVALID;
@@ -413,7 +413,7 @@ DropType StringToDropType(const std::string& str) {
   }
   return DropType::INVALID;
 }
-std::ostream& operator<<(std::ostream& os, const DropType& type) {
+std::ostream &operator<<(std::ostream &os, const DropType &type) {
   os << DropTypeToString(type);
   return os;
 }
@@ -475,7 +475,7 @@ std::string StatementTypeToString(StatementType type) {
   return "INVALID";
 }
 
-StatementType StringToStatementType(const std::string& str) {
+StatementType StringToStatementType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return StatementType::INVALID;
@@ -511,7 +511,7 @@ StatementType StringToStatementType(const std::string& str) {
   }
   return StatementType::INVALID;
 }
-std::ostream& operator<<(std::ostream& os, const StatementType& type) {
+std::ostream &operator<<(std::ostream &os, const StatementType &type) {
   os << StatementTypeToString(type);
   return os;
 }
@@ -678,7 +678,7 @@ std::string ExpressionTypeToString(ExpressionType type, bool short_str) {
   return "INVALID";
 }
 
-ExpressionType ParserExpressionNameToExpressionType(const std::string& str) {
+ExpressionType ParserExpressionNameToExpressionType(const std::string &str) {
   std::string lower_str = str;
   std::transform(lower_str.begin(), lower_str.end(), lower_str.begin(),
                  ::tolower);
@@ -696,7 +696,7 @@ ExpressionType ParserExpressionNameToExpressionType(const std::string& str) {
   return ExpressionType::INVALID;
 }
 
-ExpressionType StringToExpressionType(const std::string& str) {
+ExpressionType StringToExpressionType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return ExpressionType::INVALID;
@@ -804,7 +804,7 @@ ExpressionType StringToExpressionType(const std::string& str) {
   return ExpressionType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const ExpressionType& type) {
+std::ostream &operator<<(std::ostream &os, const ExpressionType &type) {
   os << ExpressionTypeToString(type);
   return os;
 }
@@ -836,7 +836,7 @@ std::string IndexTypeToString(IndexType type) {
   return "INVALID";
 }
 
-IndexType StringToIndexType(const std::string& str) {
+IndexType StringToIndexType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return IndexType::INVALID;
@@ -853,7 +853,7 @@ IndexType StringToIndexType(const std::string& str) {
   return IndexType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const IndexType& type) {
+std::ostream &operator<<(std::ostream &os, const IndexType &type) {
   os << IndexTypeToString(type);
   return os;
 }
@@ -885,7 +885,7 @@ std::string IndexConstraintTypeToString(IndexConstraintType type) {
   return "INVALID";
 }
 
-IndexConstraintType StringToIndexConstraintType(const std::string& str) {
+IndexConstraintType StringToIndexConstraintType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return IndexConstraintType::INVALID;
@@ -903,7 +903,7 @@ IndexConstraintType StringToIndexConstraintType(const std::string& str) {
   return IndexConstraintType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const IndexConstraintType& type) {
+std::ostream &operator<<(std::ostream &os, const IndexConstraintType &type) {
   os << IndexConstraintTypeToString(type);
   return os;
 }
@@ -935,7 +935,7 @@ std::string HybridScanTypeToString(HybridScanType type) {
   return "INVALID";
 }
 
-HybridScanType StringToHybridScanType(const std::string& str) {
+HybridScanType StringToHybridScanType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return HybridScanType::INVALID;
@@ -952,7 +952,7 @@ HybridScanType StringToHybridScanType(const std::string& str) {
   return HybridScanType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const HybridScanType& type) {
+std::ostream &operator<<(std::ostream &os, const HybridScanType &type) {
   os << HybridScanTypeToString(type);
   return os;
 }
@@ -1068,7 +1068,7 @@ std::string PlanNodeTypeToString(PlanNodeType type) {
   return "INVALID";
 }
 
-PlanNodeType StringToPlanNodeType(const std::string& str) {
+PlanNodeType StringToPlanNodeType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return PlanNodeType::INVALID;
@@ -1139,7 +1139,7 @@ PlanNodeType StringToPlanNodeType(const std::string& str) {
   return PlanNodeType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const PlanNodeType& type) {
+std::ostream &operator<<(std::ostream &os, const PlanNodeType &type) {
   os << PlanNodeTypeToString(type);
   return os;
 }
@@ -1198,7 +1198,7 @@ std::string ParseNodeTypeToString(ParseNodeType type) {
   return "INVALID";
 }
 
-ParseNodeType StringToParseNodeType(const std::string& str) {
+ParseNodeType StringToParseNodeType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return ParseNodeType::INVALID;
@@ -1233,7 +1233,7 @@ ParseNodeType StringToParseNodeType(const std::string& str) {
   return ParseNodeType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const ParseNodeType& type) {
+std::ostream &operator<<(std::ostream &os, const ParseNodeType &type) {
   os << ParseNodeTypeToString(type);
   return os;
 }
@@ -1271,7 +1271,7 @@ std::string JoinTypeToString(JoinType type) {
   return "INVALID";
 }
 
-JoinType StringToJoinType(const std::string& str) {
+JoinType StringToJoinType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return JoinType::INVALID;
@@ -1292,7 +1292,7 @@ JoinType StringToJoinType(const std::string& str) {
   return JoinType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const JoinType& type) {
+std::ostream &operator<<(std::ostream &os, const JoinType &type) {
   os << JoinTypeToString(type);
   return os;
 }
@@ -1323,7 +1323,7 @@ std::string AggregateTypeToString(AggregateType type) {
   return "INVALID";
 }
 
-AggregateType StringToAggregateType(const std::string& str) {
+AggregateType StringToAggregateType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return AggregateType::INVALID;
@@ -1340,7 +1340,7 @@ AggregateType StringToAggregateType(const std::string& str) {
   return AggregateType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const AggregateType& type) {
+std::ostream &operator<<(std::ostream &os, const AggregateType &type) {
   os << AggregateTypeToString(type);
   return os;
 }
@@ -1369,7 +1369,7 @@ std::string QuantifierTypeToString(QuantifierType type) {
   return "NONE";
 }
 
-QuantifierType StringToQuantifierType(const std::string& str) {
+QuantifierType StringToQuantifierType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "NONE") {
     return QuantifierType::NONE;
@@ -1384,7 +1384,7 @@ QuantifierType StringToQuantifierType(const std::string& str) {
   return QuantifierType::NONE;
 }
 
-std::ostream& operator<<(std::ostream& os, const QuantifierType& type) {
+std::ostream &operator<<(std::ostream &os, const QuantifierType &type) {
   os << QuantifierTypeToString(type);
   return os;
 }
@@ -1419,7 +1419,7 @@ std::string TableReferenceTypeToString(TableReferenceType type) {
   return "INVALID";
 }
 
-TableReferenceType StringToTableReferenceType(const std::string& str) {
+TableReferenceType StringToTableReferenceType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return TableReferenceType::INVALID;
@@ -1439,7 +1439,7 @@ TableReferenceType StringToTableReferenceType(const std::string& str) {
   return TableReferenceType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const TableReferenceType& type) {
+std::ostream &operator<<(std::ostream &os, const TableReferenceType &type) {
   os << TableReferenceTypeToString(type);
   return os;
 }
@@ -1468,7 +1468,7 @@ std::string InsertTypeToString(InsertType type) {
   return "INVALID";
 }
 
-InsertType StringToInsertType(const std::string& str) {
+InsertType StringToInsertType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return InsertType::INVALID;
@@ -1483,7 +1483,7 @@ InsertType StringToInsertType(const std::string& str) {
   return InsertType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const InsertType& type) {
+std::ostream &operator<<(std::ostream &os, const InsertType &type) {
   os << InsertTypeToString(type);
   return os;
 }
@@ -1521,7 +1521,7 @@ std::string CopyTypeToString(CopyType type) {
   return "INVALID";
 }
 
-CopyType StringToCopyType(const std::string& str) {
+CopyType StringToCopyType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return CopyType::INVALID;
@@ -1542,7 +1542,7 @@ CopyType StringToCopyType(const std::string& str) {
   return CopyType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const CopyType& type) {
+std::ostream &operator<<(std::ostream &os, const CopyType &type) {
   os << CopyTypeToString(type);
   return os;
 }
@@ -1574,7 +1574,7 @@ std::string PayloadTypeToString(PayloadType type) {
   return "INVALID";
 }
 
-PayloadType StringToPayloadType(const std::string& str) {
+PayloadType StringToPayloadType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return PayloadType::INVALID;
@@ -1591,7 +1591,7 @@ PayloadType StringToPayloadType(const std::string& str) {
   return PayloadType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const PayloadType& type) {
+std::ostream &operator<<(std::ostream &os, const PayloadType &type) {
   os << PayloadTypeToString(type);
   return os;
 }
@@ -1623,7 +1623,7 @@ std::string TaskPriorityTypeToString(TaskPriorityType type) {
   return "INVALID";
 }
 
-TaskPriorityType StringToTaskPriorityType(const std::string& str) {
+TaskPriorityType StringToTaskPriorityType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return TaskPriorityType::INVALID;
@@ -1640,7 +1640,7 @@ TaskPriorityType StringToTaskPriorityType(const std::string& str) {
   return TaskPriorityType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const TaskPriorityType& type) {
+std::ostream &operator<<(std::ostream &os, const TaskPriorityType &type) {
   os << TaskPriorityTypeToString(type);
   return os;
 }
@@ -1681,7 +1681,7 @@ std::string ResultTypeToString(ResultType type) {
   return "INVALID";
 }
 
-ResultType StringToResultType(const std::string& str) {
+ResultType StringToResultType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return ResultType::INVALID;
@@ -1704,7 +1704,7 @@ ResultType StringToResultType(const std::string& str) {
   return ResultType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const ResultType& type) {
+std::ostream &operator<<(std::ostream &os, const ResultType &type) {
   os << ResultTypeToString(type);
   return os;
 }
@@ -1751,7 +1751,7 @@ std::string ConstraintTypeToString(ConstraintType type) {
   return "INVALID";
 }
 
-ConstraintType StringToConstraintType(const std::string& str) {
+ConstraintType StringToConstraintType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return ConstraintType::INVALID;
@@ -1778,7 +1778,7 @@ ConstraintType StringToConstraintType(const std::string& str) {
   return ConstraintType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const ConstraintType& type) {
+std::ostream &operator<<(std::ostream &os, const ConstraintType &type) {
   os << ConstraintTypeToString(type);
   return os;
 }
@@ -1813,7 +1813,7 @@ std::string SetOpTypeToString(SetOpType type) {
   return "INVALID";
 }
 
-SetOpType StringToSetOpType(const std::string& str) {
+SetOpType StringToSetOpType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return SetOpType::INVALID;
@@ -1832,7 +1832,7 @@ SetOpType StringToSetOpType(const std::string& str) {
   return SetOpType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const SetOpType& type) {
+std::ostream &operator<<(std::ostream &os, const SetOpType &type) {
   os << SetOpTypeToString(type);
   return os;
 }
@@ -1858,7 +1858,7 @@ std::string ProtocolTypeToString(ProtocolType type) {
   return "INVALID";
 }
 
-ProtocolType StringToProtocolType(const std::string& str) {
+ProtocolType StringToProtocolType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return ProtocolType::INVALID;
@@ -1871,7 +1871,7 @@ ProtocolType StringToProtocolType(const std::string& str) {
   return ProtocolType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const ProtocolType& type) {
+std::ostream &operator<<(std::ostream &os, const ProtocolType &type) {
   os << ProtocolTypeToString(type);
   return os;
 }
@@ -1897,7 +1897,7 @@ std::string EpochTypeToString(EpochType type) {
   return "INVALID";
 }
 
-EpochType StringToEpochType(const std::string& str) {
+EpochType StringToEpochType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return EpochType::INVALID;
@@ -1910,7 +1910,7 @@ EpochType StringToEpochType(const std::string& str) {
   return EpochType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const EpochType& type) {
+std::ostream &operator<<(std::ostream &os, const EpochType &type) {
   os << EpochTypeToString(type);
   return os;
 }
@@ -1938,7 +1938,7 @@ std::string TimestampTypeToString(TimestampType type) {
   return "INVALID";
 }
 
-TimestampType StringToTimestampType(const std::string& str) {
+TimestampType StringToTimestampType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return TimestampType::INVALID;
@@ -1955,7 +1955,7 @@ TimestampType StringToTimestampType(const std::string& str) {
   return TimestampType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const TimestampType& type) {
+std::ostream &operator<<(std::ostream &os, const TimestampType &type) {
   os << TimestampTypeToString(type);
   return os;
 }
@@ -1987,7 +1987,7 @@ std::string VisibilityTypeToString(VisibilityType type) {
   return "INVALID";
 }
 
-VisibilityType StringToVisibilityType(const std::string& str) {
+VisibilityType StringToVisibilityType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return VisibilityType::INVALID;
@@ -2004,7 +2004,7 @@ VisibilityType StringToVisibilityType(const std::string& str) {
   return VisibilityType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const VisibilityType& type) {
+std::ostream &operator<<(std::ostream &os, const VisibilityType &type) {
   os << VisibilityTypeToString(type);
   return os;
 }
@@ -2029,7 +2029,7 @@ std::string VisibilityIdTypeToString(VisibilityIdType type) {
   return "INVALID";
 }
 
-VisibilityIdType StringToVisibilityIdType(const std::string& str) {
+VisibilityIdType StringToVisibilityIdType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return VisibilityIdType::INVALID;
@@ -2044,7 +2044,7 @@ VisibilityIdType StringToVisibilityIdType(const std::string& str) {
   return VisibilityIdType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const VisibilityIdType& type) {
+std::ostream &operator<<(std::ostream &os, const VisibilityIdType &type) {
   os << VisibilityIdTypeToString(type);
   return os;
 }
@@ -2082,7 +2082,7 @@ std::string IsolationLevelTypeToString(IsolationLevelType type) {
   return "INVALID";
 }
 
-IsolationLevelType StringToIsolationLevelType(const std::string& str) {
+IsolationLevelType StringToIsolationLevelType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return IsolationLevelType::INVALID;
@@ -2104,7 +2104,7 @@ IsolationLevelType StringToIsolationLevelType(const std::string& str) {
   return IsolationLevelType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const IsolationLevelType& type) {
+std::ostream &operator<<(std::ostream &os, const IsolationLevelType &type) {
   os << IsolationLevelTypeToString(type);
   return os;
 }
@@ -2133,7 +2133,7 @@ std::string ConflictAvoidanceTypeToString(ConflictAvoidanceType type) {
   return "INVALID";
 }
 
-ConflictAvoidanceType StringToConflictAvoidanceType(const std::string& str) {
+ConflictAvoidanceType StringToConflictAvoidanceType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return ConflictAvoidanceType::INVALID;
@@ -2149,7 +2149,7 @@ ConflictAvoidanceType StringToConflictAvoidanceType(const std::string& str) {
   return ConflictAvoidanceType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const ConflictAvoidanceType& type) {
+std::ostream &operator<<(std::ostream &os, const ConflictAvoidanceType &type) {
   os << ConflictAvoidanceTypeToString(type);
   return os;
 }
@@ -2178,7 +2178,7 @@ std::string GarbageCollectionTypeToString(GarbageCollectionType type) {
   return "INVALID";
 }
 
-GarbageCollectionType StringToGarbageCollectionType(const std::string& str) {
+GarbageCollectionType StringToGarbageCollectionType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return GarbageCollectionType::INVALID;
@@ -2194,7 +2194,7 @@ GarbageCollectionType StringToGarbageCollectionType(const std::string& str) {
   return GarbageCollectionType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const GarbageCollectionType& type) {
+std::ostream &operator<<(std::ostream &os, const GarbageCollectionType &type) {
   os << GarbageCollectionTypeToString(type);
   return os;
 }
@@ -2223,7 +2223,7 @@ std::string LoggingTypeToString(LoggingType type) {
   return "INVALID";
 }
 
-LoggingType StringToLoggingType(const std::string& str) {
+LoggingType StringToLoggingType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return LoggingType::INVALID;
@@ -2238,7 +2238,7 @@ LoggingType StringToLoggingType(const std::string& str) {
   return LoggingType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const LoggingType& type) {
+std::ostream &operator<<(std::ostream &os, const LoggingType &type) {
   os << LoggingTypeToString(type);
   return os;
 }
@@ -2278,7 +2278,7 @@ std::string LogRecordTypeToString(LogRecordType type) {
   return "INVALID";
 }
 
-LogRecordType StringToLogRecordType(const std::string& str) {
+LogRecordType StringToLogRecordType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return LogRecordType::INVALID;
@@ -2303,7 +2303,7 @@ LogRecordType StringToLogRecordType(const std::string& str) {
   return LogRecordType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const LogRecordType& type) {
+std::ostream &operator<<(std::ostream &os, const LogRecordType &type) {
   os << LogRecordTypeToString(type);
   return os;
 }
@@ -2332,7 +2332,7 @@ std::string CheckpointingTypeToString(CheckpointingType type) {
   return "INVALID";
 }
 
-CheckpointingType StringToCheckpointingType(const std::string& str) {
+CheckpointingType StringToCheckpointingType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return CheckpointingType::INVALID;
@@ -2347,7 +2347,7 @@ CheckpointingType StringToCheckpointingType(const std::string& str) {
   return CheckpointingType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const CheckpointingType& type) {
+std::ostream &operator<<(std::ostream &os, const CheckpointingType &type) {
   os << CheckpointingTypeToString(type);
   return os;
 }
@@ -2469,7 +2469,7 @@ std::string EntityTypeToString(EntityType type) {
   return "INVALID";
 }
 
-EntityType StringToEntityType(const std::string& str) {
+EntityType StringToEntityType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return EntityType::INVALID;
@@ -2490,7 +2490,7 @@ EntityType StringToEntityType(const std::string& str) {
   return EntityType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const EntityType& type) {
+std::ostream &operator<<(std::ostream &os, const EntityType &type) {
   os << EntityTypeToString(type);
   return os;
 }
@@ -2531,7 +2531,7 @@ std::string RWTypeToString(RWType type) {
   return "INVALID";
 }
 
-RWType StringToRWType(const std::string& str) {
+RWType StringToRWType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return RWType::INVALID;
@@ -2554,7 +2554,7 @@ RWType StringToRWType(const std::string& str) {
   return RWType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const RWType& type) {
+std::ostream &operator<<(std::ostream &os, const RWType &type) {
   os << RWTypeToString(type);
   return os;
 }
@@ -2598,7 +2598,7 @@ std::string GCVersionTypeToString(GCVersionType type) {
   return "INVALID";
 }
 
-GCVersionType StringToGCVersionType(const std::string& str) {
+GCVersionType StringToGCVersionType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return GCVersionType::INVALID;
@@ -2623,7 +2623,7 @@ GCVersionType StringToGCVersionType(const std::string& str) {
   return GCVersionType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const GCVersionType& type) {
+std::ostream &operator<<(std::ostream &os, const GCVersionType &type) {
   os << GCVersionTypeToString(type);
   return os;
 }
@@ -2661,7 +2661,7 @@ std::string PropertyTypeToString(PropertyType type) {
   return "INVALID";
 }
 
-PropertyType StringToPropertyType(const std::string& str) {
+PropertyType StringToPropertyType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return PropertyType::INVALID;
@@ -2682,7 +2682,7 @@ PropertyType StringToPropertyType(const std::string& str) {
   return PropertyType::INVALID;
 }
 
-std::ostream& operator<<(std::ostream& os, const PropertyType& type) {
+std::ostream &operator<<(std::ostream &os, const PropertyType &type) {
   os << PropertyTypeToString(type);
   return os;
 }

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -289,8 +289,7 @@ Value::Value(TypeId type, float f) : Value(type) {
 }
 
 // VARCHAR and VARBINARY
-Value::Value(TypeId type, const char *data, uint32_t len,
-             bool manage_data)
+Value::Value(TypeId type, const char *data, uint32_t len, bool manage_data)
     : Value(type) {
   switch (type) {
     case TypeId::VARCHAR:
@@ -379,8 +378,9 @@ bool Value::CheckComparable(const Value &o) const {
         case TypeId::BOOLEAN:
         case TypeId::VARCHAR:
           return (true);
-        default:break;
-      } // SWITCH
+        default:
+          break;
+      }  // SWITCH
       break;
     case TypeId::TINYINT:
     case TypeId::SMALLINT:
@@ -397,7 +397,7 @@ bool Value::CheckComparable(const Value &o) const {
           return true;
         default:
           break;
-      } // SWITCH
+      }  // SWITCH
       break;
     case TypeId::VARCHAR:
       // Anything can be cast to a string!
@@ -414,7 +414,7 @@ bool Value::CheckComparable(const Value &o) const {
       break;
     default:
       break;
-  } // SWITCH
+  }  // SWITCH
   return false;
 }
 

--- a/test/function/timestamp_functions_test.cpp
+++ b/test/function/timestamp_functions_test.cpp
@@ -39,21 +39,22 @@ class TimestampFunctionsTests : public PelotonTest {};
  */
 void DateTruncTestHelper(DatePartType part, std::string &date,
                          std::string &expected) {
-  // The first argument is an IntegerValue of the DatePartType
+  // The first argument is an VarcharValue of the DatePartType
   // The second argument is a TimestampValue of the date
-  uint32_t int_date_part = *reinterpret_cast<const uint32_t *>(&part);
-  uint64_t int_date = type::ValueFactory::CastAsTimestamp(
-                          type::ValueFactory::GetVarcharValue(date))
-                          .GetAs<uint64_t>();
+  std::string string_date_part = DatePartTypeToString(part);
+  const char *char_date_part = string_date_part.c_str();
+  uint64_t int_date =
+      type::ValueFactory::CastAsTimestamp(
+          type::ValueFactory::GetVarcharValue(date)).GetAs<uint64_t>();
 
   // The expected return value
-  uint64_t int_expected = type::ValueFactory::CastAsTimestamp(
-                              type::ValueFactory::GetVarcharValue(expected))
-                              .GetAs<uint64_t>();
+  uint64_t int_expected =
+      type::ValueFactory::CastAsTimestamp(
+          type::ValueFactory::GetVarcharValue(expected)).GetAs<uint64_t>();
 
   // Invoke the DateTrunc method and get back the result
   auto result =
-      function::TimestampFunctions::DateTrunc(int_date_part, int_date);
+      function::TimestampFunctions::DateTrunc(char_date_part, int_date);
 
   // <PART> <EXPECTED>
   // You can generate the expected value in postgres using this SQL:
@@ -70,8 +71,8 @@ void DateTruncTestHelper(DatePartType part, std::string &date,
 
 // Invoke TimestampFunctions::DateTrunc(NULL)
 TEST_F(TimestampFunctionsTests, NullDateTruncTest) {
-  auto result =
-      function::TimestampFunctions::DateTrunc(3, type::PELOTON_TIMESTAMP_NULL);
+  auto result = function::TimestampFunctions::DateTrunc(
+      "hour", type::PELOTON_TIMESTAMP_NULL);
   EXPECT_EQ(result, type::PELOTON_TIMESTAMP_NULL);
 }
 

--- a/test/function/timestamp_functions_test.cpp
+++ b/test/function/timestamp_functions_test.cpp
@@ -1,0 +1,170 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// timestamp_functions_test.cpp
+//
+// Identification: test/expression/timestamp_functions_test.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/harness.h"
+
+#include "function/timestamp_functions.h"
+#include "type/types.h"
+#include "type/value.h"
+#include "type/value_factory.h"
+
+using ::testing::NotNull;
+using ::testing::Return;
+
+namespace peloton {
+
+namespace test {
+
+class TimestampFunctionsTests : public PelotonTest {};
+
+/**
+ * Helper method for TimestampFunctions::DateTrunc
+ * It packages up the inputs into the right format
+ * and checks whether we get the correct result.
+ */
+void DateTruncTestHelper(DatePartType part, std::string &date,
+                         std::string &expected) {
+  // The first argument is an IntegerValue of the DatePartType
+  // The second argument is a TimestampValue of the date
+  uint32_t int_date_part = *reinterpret_cast<const uint32_t *>(&part);
+  uint64_t int_date = type::ValueFactory::CastAsTimestamp(
+                          type::ValueFactory::GetVarcharValue(date))
+                          .GetAs<uint64_t>();
+
+  // The expected return value
+  uint64_t int_expected = type::ValueFactory::CastAsTimestamp(
+                              type::ValueFactory::GetVarcharValue(expected))
+                              .GetAs<uint64_t>();
+
+  // Invoke the DateTrunc method and get back the result
+  auto result =
+      function::TimestampFunctions::DateTrunc(int_date_part, int_date);
+
+  // <PART> <EXPECTED>
+  // You can generate the expected value in postgres using this SQL:
+  // SELECT date_trunc('day', TIMESTAMP '2016-12-07 13:26:02.123456-05') at
+  // time zone 'est';
+
+  // Check that result is *not* null
+  EXPECT_NE(result, type::PELOTON_TIMESTAMP_NULL);
+  // Then check that it equals our expected value
+  LOG_TRACE("COMPARE: %s = %s\n", expected.ToString().c_str(),
+            result.ToString().c_str());
+  EXPECT_EQ(result, int_expected);
+}
+
+// Invoke TimestampFunctions::DateTrunc(NULL)
+TEST_F(TimestampFunctionsTests, NullDateTruncTest) {
+  auto result =
+      function::TimestampFunctions::DateTrunc(3, type::PELOTON_TIMESTAMP_NULL);
+  EXPECT_EQ(result, type::PELOTON_TIMESTAMP_NULL);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncCenturyTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2001-01-01 00:00:00-05";
+
+  DateTruncTestHelper(DatePartType::CENTURY, date, expected);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncMillenniumTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2001-01-01 00:00:00.000000-05";
+
+  DateTruncTestHelper(DatePartType::MILLENNIUM, date, expected);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncDayTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2016-12-07 00:00:00-05";
+
+  DateTruncTestHelper(DatePartType::DAY, date, expected);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncDecadeTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2010-01-01 00:00:00-05";
+
+  DateTruncTestHelper(DatePartType::DECADE, date, expected);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncHourTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2016-12-07 13:00:00-05";
+
+  DateTruncTestHelper(DatePartType::HOUR, date, expected);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncMicrosecondTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2016-12-07 13:26:02.123456-05";
+
+  DateTruncTestHelper(DatePartType::MICROSECOND, date, expected);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncMillisecondTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2016-12-07 13:26:02.123000-05";
+
+  DateTruncTestHelper(DatePartType::MILLISECOND, date, expected);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncMinuteTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2016-12-07 13:26:00-05";
+
+  DateTruncTestHelper(DatePartType::MINUTE, date, expected);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncMonthTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2016-12-01 00:00:00-05";
+
+  DateTruncTestHelper(DatePartType::MONTH, date, expected);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncQuarterTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2016-10-01 00:00:00-05";
+
+  DateTruncTestHelper(DatePartType::QUARTER, date, expected);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncSecondTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2016-12-07 13:26:02-05";
+
+  DateTruncTestHelper(DatePartType::SECOND, date, expected);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncWeekTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2016-12-05 00:00:00-05";
+
+  DateTruncTestHelper(DatePartType::WEEK, date, expected);
+}
+
+TEST_F(TimestampFunctionsTests, DateTruncYearTest) {
+  std::string date = "2016-12-07 13:26:02.123456-05";
+  std::string expected = "2016-01-01 00:00:00-05";
+
+  DateTruncTestHelper(DatePartType::YEAR, date, expected);
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/sql/timestamp_functions_sql_test.cpp
+++ b/test/sql/timestamp_functions_sql_test.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// timestamp_functions_sql_test.cpp
+//
+// Identification: test/sql/timestamp_functions_sql_test.cpp
+//
+// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <memory>
+
+#include "catalog/catalog.h"
+#include "common/harness.h"
+#include "concurrency/transaction_manager_factory.h"
+#include "sql/testing_sql_util.h"
+
+namespace peloton {
+namespace test {
+
+class TimestampFunctionsSQLTest : public PelotonTest {};
+
+TEST_F(TimestampFunctionsSQLTest, DateTruncTest) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
+  catalog::Catalog::GetInstance()->Bootstrap();
+  txn_manager.CommitTransaction(txn);
+  // Create a t
+  txn = txn_manager.BeginTransaction();
+
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE foo(id integer, value timestamp);");
+  // Add in a testing timestamp
+  TestingSQLUtil::ExecuteSQLQuery(
+      "insert into foo values(3, '2016-12-07 13:26:02.123456-05');");
+
+  txn_manager.CommitTransaction(txn);
+
+  // Fetch values from the table
+  std::vector<StatementResult> result;
+  std::vector<FieldInfo> tuple_descriptor;
+  std::string error_message;
+  int rows_affected;
+
+  // TODO(lma): We cannot properly test it until the binder supports checking
+  // the string value of the DatePartType in the function and replace it with
+  // its id. Right now we can only directly pass the id through the function.
+  std::string test_query = "select date_trunc(13, value) from foo;";
+  std::string expected = "2016-12-07 13:26:00.000000-05";
+  TestingSQLUtil::ExecuteSQLQuery(test_query.c_str(), result, tuple_descriptor,
+                                  rows_affected, error_message);
+  auto query_result = TestingSQLUtil::GetResultValueAsString(result, 0);
+  EXPECT_EQ(query_result, expected);
+
+  // free the database just created
+  txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/sql/timestamp_functions_sql_test.cpp
+++ b/test/sql/timestamp_functions_sql_test.cpp
@@ -45,14 +45,39 @@ TEST_F(TimestampFunctionsSQLTest, DateTruncTest) {
   std::string error_message;
   int rows_affected;
 
-  // TODO(lma): We cannot properly test it until the binder supports checking
-  // the string value of the DatePartType in the function and replace it with
-  // its id. Right now we can only directly pass the id through the function.
-  std::string test_query = "select date_trunc(13, value) from foo;";
+  // wrong argument type
+  std::string test_query = "select date_trunc(123, value) from foo;";
+  TestingSQLUtil::ExecuteSQLQuery(test_query.c_str(), result, tuple_descriptor,
+                                  rows_affected, error_message);
+  EXPECT_EQ(result.size(), 0);
+
+  // wrong DatePartType
+  test_query = "select date_trunc('abc', value) from foo;";
+  TestingSQLUtil::ExecuteSQLQuery(test_query.c_str(), result, tuple_descriptor,
+                                  rows_affected, error_message);
+  EXPECT_EQ(result.size(), 0);
+
+  // Test a few end-to-end DatePartType strings. The correctness of the function
+  // is already tested in the unit tests.
+  test_query = "select date_trunc('minute', value) from foo;";
   std::string expected = "2016-12-07 13:26:00.000000-05";
   TestingSQLUtil::ExecuteSQLQuery(test_query.c_str(), result, tuple_descriptor,
                                   rows_affected, error_message);
   auto query_result = TestingSQLUtil::GetResultValueAsString(result, 0);
+  EXPECT_EQ(query_result, expected);
+
+  test_query = "select date_trunc('DAY', value) from foo;";
+  expected = "2016-12-07 00:00:00.000000-05";
+  TestingSQLUtil::ExecuteSQLQuery(test_query.c_str(), result, tuple_descriptor,
+                                  rows_affected, error_message);
+  query_result = TestingSQLUtil::GetResultValueAsString(result, 0);
+  EXPECT_EQ(query_result, expected);
+
+  test_query = "select date_trunc('CenTuRy', value) from foo;";
+  expected = "2001-01-01 00:00:00.000000-05";
+  TestingSQLUtil::ExecuteSQLQuery(test_query.c_str(), result, tuple_descriptor,
+                                  rows_affected, error_message);
+  query_result = TestingSQLUtil::GetResultValueAsString(result, 0);
   EXPECT_EQ(query_result, expected);
 
   // free the database just created


### PR DESCRIPTION
This PR implements the date_trunc SQL function. ~~It contains a SQL test, however I cannot do the real appropriate SQL test without adding the logic in the binder to check the DatePartType of the date_trunc function and replace the type string with its real type ID. That requires some fixes in #886.~~