### PR TITLE
Fix for 'select * ' hanging

### DIFF
--- a/src/network/network_connection.cpp
+++ b/src/network/network_connection.cpp
@@ -141,6 +141,10 @@ WriteState NetworkConnection::WritePackets() {
   if (protocol_handler_->force_flush == true) {
     return FlushWriteBuffer();
   }
+
+  // we have flushed, disable force flush now
+  protocol_handler_->force_flush = false;
+
   return WriteState::WRITE_COMPLETE;
 }
 
@@ -335,9 +339,6 @@ WriteState NetworkConnection::FlushWriteBuffer() {
 
   // buffer is empty
   wbuf_.Reset();
-
-  // we have flushed, disable force flush now
-  protocol_handler_->force_flush = false;
 
   // we are ok
   return WriteState::WRITE_COMPLETE;

--- a/test/network/select_all_test.cpp
+++ b/test/network/select_all_test.cpp
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// select_all_test.cpp
+//
+// Identification: test/network/select_all_test.cpp
+//
+// Copyright (c) 2016-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/harness.h"
+#include "gtest/gtest.h"
+#include "common/logger.h"
+#include "network/network_manager.h"
+#include "network/protocol_handler_factory.h"
+#include "util/string_util.h"
+#include <pqxx/pqxx> /* libpqxx is used to instantiate C++ client */
+#include <include/network/postgres_protocol_handler.h>
+
+#define NUM_THREADS 1
+
+namespace peloton {
+namespace test {
+
+//===--------------------------------------------------------------------===//
+// Select All Tests
+//===--------------------------------------------------------------------===//
+
+class SelectAllTests : public PelotonTest {};
+
+static void *LaunchServer(peloton::network::NetworkManager network_manager,
+                          int port) {
+  try {
+    network_manager.SetPort(port);
+    network_manager.StartServer();
+  } catch (peloton::ConnectionException &exception) {
+    LOG_INFO("[LaunchServer] exception in thread");
+  }
+  return NULL;
+}
+
+/**
+ * Select All Test
+ * In this test, peloton will return the result that exceeds the 8192 bytes limits.
+ * The response will be put into multiple packets and be sent back to clients.
+ */
+void *SelectAllTest(int port) {
+  try {
+    // forcing the factory to generate psql protocol handler
+    pqxx::connection C(StringUtil::Format(
+        "host=127.0.0.1 port=%d user=postgres sslmode=disable application_name=psql", port));
+    pqxx::work txn1(C);
+
+    peloton::network::NetworkConnection *conn =
+        peloton::network::NetworkManager::GetConnection(
+            peloton::network::NetworkManager::recent_connfd);
+
+    network::PostgresProtocolHandler *handler =
+        dynamic_cast<network::PostgresProtocolHandler *>(conn->protocol_handler_.get());
+    EXPECT_NE(handler, nullptr);
+
+    // create table and insert some data
+    txn1.exec("DROP TABLE IF EXISTS template;");
+    txn1.exec("CREATE TABLE template(id INT);");
+    txn1.commit();
+
+    pqxx::work txn2(C);
+    for (int i = 0; i < 2000; i++) {
+      std::string s = "INSERT INTO template VALUES (" + std::to_string(i) + ")";
+      txn2.exec(s);
+    }
+
+    pqxx::result R = txn2.exec("SELECT * from template;");
+    txn2.commit();
+
+    EXPECT_EQ(R.size(), 2000);
+  } catch (const std::exception &e) {
+    LOG_INFO("[SelectAllTest] Exception occurred: %s", e.what());
+    EXPECT_TRUE(false);
+  }
+
+  LOG_INFO("[SelectAllTest] Client has closed");
+  return NULL;
+}
+
+TEST_F(SelectAllTests, SelectAllTest) {
+  peloton::PelotonInit::Initialize();
+  LOG_INFO("Server initialized");
+  peloton::network::NetworkManager network_manager;
+
+  int port = 15721;
+  std::thread serverThread(LaunchServer, network_manager, port);
+  while (!network_manager.GetIsStarted()) {
+    sleep(1);
+  }
+
+  // server & client running correctly
+  SelectAllTest(port);
+
+  network_manager.CloseServer();
+  serverThread.join();
+  LOG_INFO("Peloton is shutting down");
+  peloton::PelotonInit::Shutdown();
+  LOG_INFO("Peloton has shut down");
+}
+
+} // namespace test
+} // namespace peloton


### PR DESCRIPTION
Fix for #878
The issue is due to that the server does not flush out all the packets. The client does not get the complete result so it looks like hanging.
The server should flush out all the packets before resetting the force_flush flag.