### PR TITLE
[WIP] Morsel-Based Parallel LLVM Checkpoint: TableScan

### DIFF
--- a/src/codegen/buffering_consumer.cpp
+++ b/src/codegen/buffering_consumer.cpp
@@ -53,10 +53,10 @@ DEFINE_METHOD(peloton::codegen, BufferingConsumer, BufferTuple);
 // BUFFERING CONSUMER
 //===----------------------------------------------------------------------===//
 
+// TODO(zhixunt): Very important! Don't fix Vector::kDefaultVectorSize!
 BufferingConsumer::BufferingConsumer(const std::vector<oid_t> &cols,
                                      planner::BindingContext &context)
-    : state(&output_chunks_) {
-  output_chunks_.emplace_back();
+    : output_chunks_(Vector::kDefaultVectorSize), state(&output_chunks_) {
   for (oid_t col_id : cols) {
     output_ais_.push_back(context.Find(col_id));
   }

--- a/src/codegen/buffering_consumer.cpp
+++ b/src/codegen/buffering_consumer.cpp
@@ -138,7 +138,6 @@ void BufferingConsumer::ConsumeResult(ConsumerContext &ctx,
   }
 
   llvm::Value *task_id = ctx.GetTaskId();
-  codegen.CallPrintf("[BufferingConsumer] My task id = %d\n", {task_id});
 
   // Append the tuple to the output buffer (by calling BufferTuple(...))
   auto *consumer_state = GetStateValue(ctx, consumer_state_id_);

--- a/src/codegen/buffering_consumer.cpp
+++ b/src/codegen/buffering_consumer.cpp
@@ -57,10 +57,9 @@ DEFINE_METHOD(peloton::codegen, BufferingConsumer, BufferTuple);
 // BUFFERING CONSUMER
 //===----------------------------------------------------------------------===//
 
-// TODO(zhixunt): Very important! Don't fix Vector::kDefaultVectorSize!
 BufferingConsumer::BufferingConsumer(const std::vector<oid_t> &cols,
                                      planner::BindingContext &context)
-    : output_chunks_(), state(&output_chunks_) {
+    : output_chunks_(1), state(&output_chunks_) {
   for (oid_t col_id : cols) {
     output_ais_.push_back(context.Find(col_id));
   }

--- a/src/codegen/compilation_context.cpp
+++ b/src/codegen/compilation_context.cpp
@@ -13,6 +13,7 @@
 #include "codegen/compilation_context.h"
 
 #include "codegen/function_builder.h"
+#include "codegen/multi_thread/multithread_supported.h"
 #include "codegen/proxy/catalog_proxy.h"
 #include "codegen/proxy/transaction_proxy.h"
 #include "codegen/proxy/executor_context_proxy.h"
@@ -25,7 +26,8 @@ namespace codegen {
 // Constructor
 CompilationContext::CompilationContext(Query &query,
                                        QueryResultConsumer &result_consumer)
-    : query_(query),
+    : multithread_on_(MultithreadSupported(query.GetPlan())),
+      query_(query),
       result_consumer_(result_consumer),
       codegen_(query_.GetCodeContext()) {
   // Allocate a catalog and transaction instance in the runtime state

--- a/src/codegen/compilation_context.cpp
+++ b/src/codegen/compilation_context.cpp
@@ -183,9 +183,6 @@ llvm::Function *CompilationContext::GeneratePlanFunction(
       codegen_.VoidType(),
       {{"runtimeState", runtime_state.FinalizeType(codegen_)->getPointerTo()}}};
 
-  // Create all local state
-  runtime_state.CreateLocalState(codegen_);
-
   // Generate the primary plan logic
   Produce(root);
 

--- a/src/codegen/consumer_context.cpp
+++ b/src/codegen/consumer_context.cpp
@@ -13,6 +13,8 @@
 #include "codegen/consumer_context.h"
 
 #include "codegen/compilation_context.h"
+#include "codegen/function_builder.h"
+#include "codegen/proxy/task_info_proxy.h"
 
 namespace peloton {
 namespace codegen {
@@ -71,6 +73,18 @@ CodeGen &ConsumerContext::GetCodeGen() const {
 
 RuntimeState &ConsumerContext::GetRuntimeState() const {
   return compilation_context_.GetRuntimeState();
+}
+
+llvm::Value *ConsumerContext::GetTaskId() const {
+  auto &codegen = GetCodeGen();
+
+  if (!compilation_context_.MultithreadOn()) {
+    return codegen.Const32(0);
+  } else {
+    auto task_info_ptr =
+        codegen.GetCodeContext().GetCurrentFunction()->GetArgumentByPosition(1);
+    return codegen.Call(TaskInfoProxy::GetTaskId, {task_info_ptr});
+  }
 }
 
 }  // namespace codegen

--- a/src/codegen/multi_thread/count_down.cpp
+++ b/src/codegen/multi_thread/count_down.cpp
@@ -26,7 +26,11 @@ void CountDown::Destroy() {
 }
 
 void CountDown::Decrease() {
-  if (--count_ == 0) {
+  std::unique_lock<decltype(mutex_)> lock(mutex_);
+  int32_t new_count = --count_;
+  lock.unlock();
+
+  if (new_count == 0) {
     // If after atomic decrease, the count becomes 0, notify the waiter.
     cv_.notify_one();
   }
@@ -34,7 +38,7 @@ void CountDown::Decrease() {
 
 void CountDown::Wait() {
   std::unique_lock<decltype(mutex_)> lock(mutex_);
-  cv_.wait(lock, [&] { return count_.load() == 0; });
+  cv_.wait(lock, [&] { return count_ == 0; });
 }
 
 }  // namespace codegen

--- a/src/codegen/multi_thread/count_down.cpp
+++ b/src/codegen/multi_thread/count_down.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// count_down.cpp
+//
+// Identification: src/codegen/multi_thread/count_down.cpp
+//
+// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "codegen/multi_thread/count_down.h"
+
+namespace peloton {
+namespace codegen {
+
+void CountDown::Init(int32_t count) {
+  // Call constructor explicitly on memory buffer.
+  new (this) CountDown(count);
+}
+
+void CountDown::Destroy() {
+  // Call destructor explicitly on memory buffer.
+  this->~CountDown();
+}
+
+void CountDown::Decrease() {
+  if (--count_ == 0) {
+    // If after atomic decrease, the count becomes 0, notify the waiter.
+    cv_.notify_one();
+  }
+}
+
+void CountDown::Wait() {
+  std::unique_lock<decltype(mutex_)> lock(mutex_);
+  cv_.wait(lock, [&] { return count_.load() == 0; });
+}
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/codegen/multi_thread/executor_thread_pool.cpp
+++ b/src/codegen/multi_thread/executor_thread_pool.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// executor_thread_pool.cpp
+//
+// Identification: src/codegen/multi_thread/executor_thread_pool.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "codegen/multi_thread/executor_thread_pool.h"
+
+namespace peloton {
+namespace codegen {
+
+ExecutorThreadPool *ExecutorThreadPool::GetInstance() {
+  static ExecutorThreadPool instance;
+  return &instance;
+}
+
+int32_t ExecutorThreadPool::GetNumThreads() {
+  return std::thread::hardware_concurrency();
+}
+
+void ExecutorThreadPool::SubmitTask(char *runtime_state,
+                                    TaskInfo *task_info,
+                                    func_t func) {
+  pool_.SubmitTask(func, std::move(runtime_state), std::move(task_info));
+}
+
+ExecutorThreadPool::ExecutorThreadPool() {
+  auto num_threads = GetNumThreads();
+  auto num_dedicated_threads = 0;
+  pool_.Initialize(num_threads, num_dedicated_threads);
+}
+
+ExecutorThreadPool::~ExecutorThreadPool() {
+  pool_.Shutdown();
+}
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/codegen/multi_thread/multithread_supported.cpp
+++ b/src/codegen/multi_thread/multithread_supported.cpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// task_info.cpp
+//
+// Identification: src/codegen/multi_thread/multithread_supported.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "codegen/multi_thread/multithread_supported.h"
+
+namespace peloton {
+namespace codegen {
+
+bool MultithreadSupported(const planner::AbstractPlan &plan) {
+  switch (plan.GetPlanNodeType()) {
+    case PlanNodeType::SEQSCAN:
+      return true;
+    default:
+      return false;
+  }
+}
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/codegen/multi_thread/multithread_supported.cpp
+++ b/src/codegen/multi_thread/multithread_supported.cpp
@@ -17,8 +17,9 @@ namespace codegen {
 
 bool MultithreadSupported(const planner::AbstractPlan &plan) {
   switch (plan.GetPlanNodeType()) {
-    case PlanNodeType::SEQSCAN:
-      return true;
+// Temporarily turned off...
+//    case PlanNodeType::SEQSCAN:
+//      return true;
     default:
       return false;
   }

--- a/src/codegen/multi_thread/task_info.cpp
+++ b/src/codegen/multi_thread/task_info.cpp
@@ -15,9 +15,9 @@
 namespace peloton {
 namespace codegen {
 
-void TaskInfo::Init(int32_t thread_id, int32_t nthreads) {
+void TaskInfo::Init(int32_t task_id, int32_t ntasks) {
   // Call constructor explicitly on memory buffer.
-  new (this) TaskInfo(thread_id, nthreads);
+  new (this) TaskInfo(task_id, ntasks);
 }
 
 void TaskInfo::Destroy() {
@@ -25,17 +25,17 @@ void TaskInfo::Destroy() {
   this->~TaskInfo();
 }
 
-int32_t TaskInfo::GetThreadId() {
-  return thread_id_;
+int32_t TaskInfo::GetTaskId() {
+  return task_id_;
 }
 
-int32_t TaskInfo::GetNumThreads() {
-  return nthreads_;
+int32_t TaskInfo::GetNumTasks() {
+  return ntasks_;
 }
 
-TaskInfo::TaskInfo(int32_t thread_id, int32_t nthreads)
-    : thread_id_(thread_id), nthreads_(nthreads) {
-  PL_ASSERT(thread_id > 0 && thread_id < nthreads);
+TaskInfo::TaskInfo(int32_t task_id, int32_t ntasks)
+    : task_id_(task_id), ntasks_(ntasks) {
+  PL_ASSERT(task_id >= 0 && task_id < ntasks);
 }
 
 }  // namespace codegen

--- a/src/codegen/multi_thread/task_info.cpp
+++ b/src/codegen/multi_thread/task_info.cpp
@@ -15,9 +15,10 @@
 namespace peloton {
 namespace codegen {
 
-void TaskInfo::Init(int32_t task_id, int32_t ntasks) {
+void TaskInfo::Init(int32_t task_id, int32_t ntasks,
+                    int64_t begin, int64_t end) {
   // Call constructor explicitly on memory buffer.
-  new (this) TaskInfo(task_id, ntasks);
+  new (this) TaskInfo(task_id, ntasks, begin, end);
 }
 
 void TaskInfo::Destroy() {
@@ -33,8 +34,16 @@ int32_t TaskInfo::GetNumTasks() {
   return ntasks_;
 }
 
-TaskInfo::TaskInfo(int32_t task_id, int32_t ntasks)
-    : task_id_(task_id), ntasks_(ntasks) {
+int64_t TaskInfo::GetBegin() {
+  return begin_;
+}
+
+int64_t TaskInfo::GetEnd() {
+  return end_;
+}
+
+TaskInfo::TaskInfo(int32_t task_id, int32_t ntasks, int64_t begin, int64_t end)
+    : task_id_(task_id), ntasks_(ntasks), begin_(begin), end_(end) {
   PL_ASSERT(task_id >= 0 && task_id < ntasks);
 }
 

--- a/src/codegen/multi_thread/task_info.cpp
+++ b/src/codegen/multi_thread/task_info.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// task_info.cpp
+//
+// Identification: src/codegen/multi_thread/task_info.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "codegen/multi_thread/task_info.h"
+
+namespace peloton {
+namespace codegen {
+
+void TaskInfo::Init(int32_t thread_id, int32_t nthreads) {
+  PL_ASSERT(thread_id > 0 && thread_id < nthreads);
+  thread_id_ = thread_id;
+  nthreads_ = nthreads;
+}
+
+int32_t TaskInfo::GetThreadId() {
+  return thread_id_;
+}
+
+int32_t TaskInfo::GetNumThreads() {
+  return nthreads_;
+}
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/codegen/multi_thread/task_info.cpp
+++ b/src/codegen/multi_thread/task_info.cpp
@@ -16,9 +16,13 @@ namespace peloton {
 namespace codegen {
 
 void TaskInfo::Init(int32_t thread_id, int32_t nthreads) {
-  PL_ASSERT(thread_id > 0 && thread_id < nthreads);
-  thread_id_ = thread_id;
-  nthreads_ = nthreads;
+  // Call constructor explicitly on memory buffer.
+  new (this) TaskInfo(thread_id, nthreads);
+}
+
+void TaskInfo::Destroy() {
+  // Call destructor explicitly on memory buffer.
+  this->~TaskInfo();
 }
 
 int32_t TaskInfo::GetThreadId() {
@@ -27,6 +31,11 @@ int32_t TaskInfo::GetThreadId() {
 
 int32_t TaskInfo::GetNumThreads() {
   return nthreads_;
+}
+
+TaskInfo::TaskInfo(int32_t thread_id, int32_t nthreads)
+    : thread_id_(thread_id), nthreads_(nthreads) {
+  PL_ASSERT(thread_id > 0 && thread_id < nthreads);
 }
 
 }  // namespace codegen

--- a/src/codegen/operator/table_scan_translator.cpp
+++ b/src/codegen/operator/table_scan_translator.cpp
@@ -96,7 +96,6 @@ void TableScanTranslator::Produce() const {
   auto &codegen = GetCodeGen();
   auto &compilation_context = GetCompilationContext();
   auto &runtime_state = compilation_context.GetRuntimeState();
-  auto &table = GetTable();
 
   LOG_TRACE("TableScan on [%u] starting to produce tuples ...", table.GetOid());
 
@@ -173,10 +172,14 @@ void TableScanTranslator::Produce() const {
     });
 
     codegen.Call(CountDownProxy::Wait, {count_down_ptr});
+
     codegen.Call(CountDownProxy::Destroy, {count_down_ptr});
+
+    codegen.Call(TaskInfoProxy::Destroy, {task_info_ptr});
   }
 
-  LOG_DEBUG("TableScan on [%u] finished producing tuples ...", table.GetOid());
+  LOG_DEBUG("TableScan on [%u] finished producing tuples ...",
+            GetTable().GetOid());
 }
 
 // Get the stringified name of this scan

--- a/src/codegen/operator/table_scan_translator.cpp
+++ b/src/codegen/operator/table_scan_translator.cpp
@@ -70,6 +70,27 @@ TableScanTranslator::TableScanTranslator(const planner::SeqScanPlan &scan,
   LOG_DEBUG("Finished constructing TableScanTranslator ...");
 }
 
+void TableScanTranslator::TaskProduce() const {
+  auto &codegen = GetCodeGen();
+  auto &table = GetTable();
+
+  // Get the table instance from the database
+  llvm::Value* catalog_ptr = GetCatalogPtr();
+  llvm::Value* db_oid = codegen.Const32(table.GetDatabaseOid());
+  llvm::Value* table_oid = codegen.Const32(table.GetOid());
+  llvm::Value* table_ptr = codegen.Call(StorageManagerProxy::GetTableWithOid,
+                                        {catalog_ptr, db_oid, table_oid});
+
+  // The selection vector for the scan
+  Vector sel_vec{LoadStateValue(selection_vector_id_),
+                 Vector::kDefaultVectorSize, codegen.Int32Type()};
+
+  // Generate the scan
+  ScanConsumer scan_consumer{*this, sel_vec};
+  table_.GenerateScan(codegen, table_ptr, sel_vec.GetCapacity(),
+                      scan_consumer);
+}
+
 // Produce!
 void TableScanTranslator::Produce() const {
   auto &codegen = GetCodeGen();
@@ -79,90 +100,83 @@ void TableScanTranslator::Produce() const {
 
   LOG_TRACE("TableScan on [%u] starting to produce tuples ...", table.GetOid());
 
-  codegen::FunctionBuilder task(
-      codegen.GetCodeContext(),
-      "task",
-      codegen.VoidType(),
-      {
-          {"runtime_state", codegen.GetState()->getType()},
-          {"task_info", TaskInfoProxy::GetType(codegen)->getPointerTo()}
-      }
-  );
-  {
-    auto task_info_ptr = task.GetArgumentByPosition(1);
-    auto task_id = codegen.Call(TaskInfoProxy::GetTaskId, {task_info_ptr});
-    codegen.CallPrintf("I am task %d!\n", {task_id});
+  if (!compilation_context.MultithreadOn()) {
+    TaskProduce();
 
-    // Get the table instance from the database
-    llvm::Value* catalog_ptr = GetCatalogPtr();
-    llvm::Value* db_oid = codegen.Const32(table.GetDatabaseOid());
-    llvm::Value* table_oid = codegen.Const32(table.GetOid());
-    llvm::Value* table_ptr = codegen.Call(StorageManagerProxy::GetTableWithOid,
-                                          {catalog_ptr, db_oid, table_oid});
+  } else {
+    // Multithread On!
+    codegen::FunctionBuilder task(
+        codegen.GetCodeContext(),
+        "task",
+        codegen.VoidType(),
+        {
+            {"runtime_state", codegen.GetState()->getType()},
+            {"task_info",     TaskInfoProxy::GetType(codegen)->getPointerTo()}
+        }
+    );
+    {
+      auto task_info_ptr = task.GetArgumentByPosition(1);
+      auto task_id = codegen.Call(TaskInfoProxy::GetTaskId, {task_info_ptr});
+      codegen.CallPrintf("I am task %d!\n", {task_id});
 
-    // The selection vector for the scan
-    Vector sel_vec{LoadStateValue(selection_vector_id_),
-                   Vector::kDefaultVectorSize, codegen.Int32Type()};
+      TaskProduce();
 
-    // Generate the scan
-    ScanConsumer scan_consumer{*this, sel_vec};
-    table_.GenerateScan(codegen, table_ptr, sel_vec.GetCapacity(),
-                        scan_consumer);
+      auto count_down_ptr = runtime_state.LoadStatePtr(codegen, count_down_id_);
+      codegen.Call(CountDownProxy::Decrease, {count_down_ptr});
+
+      task.ReturnAndFinish();
+    }
+
+    auto task_func = task.GetFunction();
 
     auto count_down_ptr = runtime_state.LoadStatePtr(codegen, count_down_id_);
-    codegen.Call(CountDownProxy::Decrease, {count_down_ptr});
+    codegen.Call(CountDownProxy::Init, {count_down_ptr, codegen.Const32(1)});
 
-    task.ReturnAndFinish();
+    Vector task_info_vec{LoadStateValue(task_info_vector_id_),
+                         Vector::kDefaultVectorSize,
+                         TaskInfoProxy::GetType(codegen)};
+
+    auto task_info_ptr = task_info_vec.GetPtrToValue(codegen,
+                                                     codegen.Const32(0));
+
+    codegen.Call(TaskInfoProxy::Init, {
+        task_info_ptr,
+        /*task_id=*/codegen.Const32(0),
+        /*ntasks=*/codegen.Const32(1)
+    });
+
+    // auto thread_pool = codegen::ExecutorThreadPool::GetInstance();
+    auto thread_pool_ptr = codegen.Call(
+        ExecutorThreadPoolProxy::GetInstance, {}
+    );
+
+    // using task_type = void (*)(char *ptr, TaskInfo *);
+    auto task_info_type = TaskInfoProxy::GetType(codegen);
+    auto task_func_type = llvm::FunctionType::get(
+        codegen.VoidType(), {
+            codegen.CharPtrType(),
+            task_info_type->getPointerTo()
+        },
+        false
+    )->getPointerTo();
+
+    // thread_pool->SubmitTask(
+    //   (char *)runtime_state,
+    //   task_info,
+    //   (task_type)task
+    // );
+    codegen.Call(codegen::ExecutorThreadPoolProxy::SubmitTask, {
+        thread_pool_ptr,
+        codegen->CreatePointerCast(codegen.GetState(), codegen.CharPtrType()),
+        task_info_ptr,
+        codegen->CreatePointerCast(task_func, task_func_type)
+    });
+
+    codegen.Call(CountDownProxy::Wait, {count_down_ptr});
+    codegen.Call(CountDownProxy::Destroy, {count_down_ptr});
   }
 
-  auto task_func = task.GetFunction();
-
-  auto count_down_ptr = runtime_state.LoadStatePtr(codegen, count_down_id_);
-  codegen.Call(CountDownProxy::Init, {count_down_ptr, codegen.Const32(1)});
-
-  Vector task_info_vec{LoadStateValue(task_info_vector_id_),
-                       Vector::kDefaultVectorSize,
-                       TaskInfoProxy::GetType(codegen)};
-
-  auto task_info_ptr = task_info_vec.GetPtrToValue(codegen, codegen.Const32(0));
-
-  codegen.Call(TaskInfoProxy::Init, {
-      task_info_ptr,
-      /*task_id=*/codegen.Const32(0),
-      /*ntasks=*/codegen.Const32(1)
-  });
-
-  // auto thread_pool = codegen::ExecutorThreadPool::GetInstance();
-  auto thread_pool_ptr = codegen.Call(
-      ExecutorThreadPoolProxy::GetInstance, {}
-  );
-
-  // using task_type = void (*)(char *ptr, TaskInfo *);
-  auto task_info_type = TaskInfoProxy::GetType(codegen);
-  auto task_func_type = llvm::FunctionType::get(
-      codegen.VoidType(), {
-          codegen.CharPtrType(),
-          task_info_type->getPointerTo()
-      },
-      false
-  )->getPointerTo();
-
-  // thread_pool->SubmitTask(
-  //   (char *)runtime_state,
-  //   task_info,
-  //   (task_type)task
-  // );
-  codegen.Call(codegen::ExecutorThreadPoolProxy::SubmitTask, {
-      thread_pool_ptr,
-      codegen->CreatePointerCast(codegen.GetState(), codegen.CharPtrType()),
-      task_info_ptr,
-      codegen->CreatePointerCast(task_func, task_func_type)
-  });
-
-  codegen.Call(CountDownProxy::Wait, {count_down_ptr});
-  codegen.Call(CountDownProxy::Destroy, {count_down_ptr});
-
-  LOG_TRACE("TableScan on [%u] finished producing tuples ...", table.GetOid());
+  LOG_DEBUG("TableScan on [%u] finished producing tuples ...", table.GetOid());
 }
 
 // Get the stringified name of this scan

--- a/src/codegen/proxy/count_down_proxy.cpp
+++ b/src/codegen/proxy/count_down_proxy.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// count_down_proxy.cpp
+//
+// Identification: src/codegen/proxy/count_down_proxy.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "codegen/proxy/count_down_proxy.h"
+
+namespace peloton {
+namespace codegen {
+
+DEFINE_TYPE(CountDown, "codegen::CountDown", MEMBER(opaque));
+
+DEFINE_METHOD(peloton::codegen, CountDown, Init);
+DEFINE_METHOD(peloton::codegen, CountDown, Destroy);
+DEFINE_METHOD(peloton::codegen, CountDown, Decrease);
+DEFINE_METHOD(peloton::codegen, CountDown, Wait);
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/codegen/proxy/executor_thread_pool_proxy.cpp
+++ b/src/codegen/proxy/executor_thread_pool_proxy.cpp
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// executor_thread_pool_proxy.cpp
+//
+// Identification: src/codegen/proxy/executor_thread_pool_proxy.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "codegen/proxy/executor_thread_pool_proxy.h"
+#include "codegen/proxy/proxy.h"
+#include "codegen/proxy/type_builder.h"
+
+namespace peloton {
+namespace codegen {
+
+DEFINE_TYPE(ExecutorThreadPool, "codegen::ExecutorThreadPool", MEMBER(opaque));
+
+DEFINE_METHOD(peloton::codegen, ExecutorThreadPool, GetInstance);
+
+DEFINE_METHOD(peloton::codegen, ExecutorThreadPool, GetNumThreads);
+
+DEFINE_METHOD(peloton::codegen, ExecutorThreadPool, SubmitTask);
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/codegen/proxy/runtime_functions_proxy.cpp
+++ b/src/codegen/proxy/runtime_functions_proxy.cpp
@@ -26,6 +26,8 @@ DEFINE_METHOD(peloton::codegen, RuntimeFunctions, GetTileGroup);
 DEFINE_METHOD(peloton::codegen, RuntimeFunctions, GetTileGroupLayout);
 DEFINE_METHOD(peloton::codegen, RuntimeFunctions, ThrowDivideByZeroException);
 DEFINE_METHOD(peloton::codegen, RuntimeFunctions, ThrowOverflowException);
+DEFINE_METHOD(peloton::codegen, RuntimeFunctions, NewTaskInfos);
+DEFINE_METHOD(peloton::codegen, RuntimeFunctions, DeleteTaskInfos);
 
 }  // namespace codegen
 }  // namespace peloton

--- a/src/codegen/proxy/task_info_proxy.cpp
+++ b/src/codegen/proxy/task_info_proxy.cpp
@@ -18,8 +18,8 @@ namespace codegen {
 DEFINE_TYPE(TaskInfo, "codegen::TaskInfo", MEMBER(opaque));
 
 DEFINE_METHOD(peloton::codegen, TaskInfo, Init);
-DEFINE_METHOD(peloton::codegen, TaskInfo, GetThreadId);
-DEFINE_METHOD(peloton::codegen, TaskInfo, GetNumThreads);
+DEFINE_METHOD(peloton::codegen, TaskInfo, GetTaskId);
+DEFINE_METHOD(peloton::codegen, TaskInfo, GetNumTasks);
 
 }  // namespace codegen
 }  // namespace peloton

--- a/src/codegen/proxy/task_info_proxy.cpp
+++ b/src/codegen/proxy/task_info_proxy.cpp
@@ -18,6 +18,7 @@ namespace codegen {
 DEFINE_TYPE(TaskInfo, "codegen::TaskInfo", MEMBER(opaque));
 
 DEFINE_METHOD(peloton::codegen, TaskInfo, Init);
+DEFINE_METHOD(peloton::codegen, TaskInfo, Destroy);
 DEFINE_METHOD(peloton::codegen, TaskInfo, GetTaskId);
 DEFINE_METHOD(peloton::codegen, TaskInfo, GetNumTasks);
 

--- a/src/codegen/proxy/task_info_proxy.cpp
+++ b/src/codegen/proxy/task_info_proxy.cpp
@@ -21,6 +21,8 @@ DEFINE_METHOD(peloton::codegen, TaskInfo, Init);
 DEFINE_METHOD(peloton::codegen, TaskInfo, Destroy);
 DEFINE_METHOD(peloton::codegen, TaskInfo, GetTaskId);
 DEFINE_METHOD(peloton::codegen, TaskInfo, GetNumTasks);
+DEFINE_METHOD(peloton::codegen, TaskInfo, GetBegin);
+DEFINE_METHOD(peloton::codegen, TaskInfo, GetEnd);
 
 }  // namespace codegen
 }  // namespace peloton

--- a/src/codegen/proxy/task_info_proxy.cpp
+++ b/src/codegen/proxy/task_info_proxy.cpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// task_info_proxy.cpp
+//
+// Identification: src/codegen/proxy/task_info_proxy.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "codegen/proxy/task_info_proxy.h"
+
+namespace peloton {
+namespace codegen {
+
+DEFINE_TYPE(TaskInfo, "codegen::TaskInfo", MEMBER(opaque));
+
+DEFINE_METHOD(peloton::codegen, TaskInfo, Init);
+DEFINE_METHOD(peloton::codegen, TaskInfo, GetThreadId);
+DEFINE_METHOD(peloton::codegen, TaskInfo, GetNumThreads);
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/codegen/runtime_functions.cpp
+++ b/src/codegen/runtime_functions.cpp
@@ -102,5 +102,25 @@ void RuntimeFunctions::ThrowOverflowException() {
   throw std::overflow_error("ERROR: overflow");
 }
 
+int32_t RuntimeFunctions::NewTaskInfos(int64_t task_size, int64_t total_size,
+                                       TaskInfo **task_infos) {
+  auto ntasks = static_cast<int32_t>((total_size + task_size - 1) / task_size);
+  size_t nbytes = ntasks * sizeof(TaskInfo);
+  *task_infos = reinterpret_cast<TaskInfo *>(new char[nbytes]);
+  for (int32_t task_id = 0; task_id < ntasks; ++task_id) {
+    int64_t begin = task_id * task_size;
+    int64_t end = (task_id + 1 == ntasks) ? total_size : (begin + task_size);
+    (*task_infos)[task_id].Init(task_id, ntasks, begin, end);
+  }
+  return ntasks;
+}
+
+void RuntimeFunctions::DeleteTaskInfos(TaskInfo *task_infos, int32_t ntasks) {
+  for (int32_t task_id = 0; task_id < ntasks; ++task_id) {
+    task_infos[task_id].Destroy();
+  }
+  delete[] reinterpret_cast<char *>(task_infos);
+}
+
 }  // namespace codegen
 }  // namespace peloton

--- a/src/codegen/runtime_state.cpp
+++ b/src/codegen/runtime_state.cpp
@@ -124,33 +124,5 @@ llvm::Type *RuntimeState::FinalizeType(CodeGen &codegen) {
   return constructed_type_;
 }
 
-void RuntimeState::CreateLocalState(CodeGen &codegen) {
-  for (auto &state_info : state_slots_) {
-    if (state_info.local) {
-      (void)codegen;
-//      if (auto *arr_type = llvm::dyn_cast<llvm::ArrayType>(state_info.type)) {
-//        // Do the stack allocation of the array
-//        llvm::AllocaInst *arr = codegen->CreateAlloca(
-//            arr_type->getArrayElementType(),
-//            codegen.Const32(arr_type->getArrayNumElements()));
-//
-//        // Set the alignment
-//        arr->setAlignment(Vector::kDefaultVectorAlignment);
-//
-//        // Zero-out the allocated space
-//        uint64_t sz = codegen.SizeOf(state_info.type);
-//        codegen->CreateMemSet(arr, codegen.Const8(0), sz, arr->getAlignment());
-//
-//        state_info.val = arr;
-//      } else {
-//        state_info.val = codegen->CreateAlloca(state_info.type);
-//      }
-//
-//      // Set the name of the local state to what the client wants
-//      state_info.val->setName(state_info.name);
-    }
-  }
-}
-
 }  // namespace codegen
 }  // namespace peloton

--- a/src/codegen/transaction_runtime.cpp
+++ b/src/codegen/transaction_runtime.cpp
@@ -56,8 +56,8 @@ uint32_t TransactionRuntime::PerformVectorizedRead(
     ItemPointer location{tile_group_idx, selection_vector[idx]};
 
     // Perform the read
-//    bool can_read = txn_manager.PerformRead(&txn, location);
-    bool can_read = true;
+    bool can_read = txn_manager.PerformRead(&txn, location);
+//    bool can_read = true;
 
     // Update the selection vector and output position
     selection_vector[out_idx] = selection_vector[idx];

--- a/src/codegen/transaction_runtime.cpp
+++ b/src/codegen/transaction_runtime.cpp
@@ -56,7 +56,8 @@ uint32_t TransactionRuntime::PerformVectorizedRead(
     ItemPointer location{tile_group_idx, selection_vector[idx]};
 
     // Perform the read
-    bool can_read = txn_manager.PerformRead(&txn, location);
+//    bool can_read = txn_manager.PerformRead(&txn, location);
+    bool can_read = true;
 
     // Update the selection vector and output position
     selection_vector[out_idx] = selection_vector[idx];

--- a/src/concurrency/transaction.cpp
+++ b/src/concurrency/transaction.cpp
@@ -90,6 +90,8 @@ void Transaction::Init(const size_t thread_id,
 }
 
 RWType Transaction::GetRWType(const ItemPointer &location) {
+  std::lock_guard<std::mutex> lock(mu_);
+
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
   auto itr = rw_set_.find(tile_group_id);
@@ -106,6 +108,8 @@ RWType Transaction::GetRWType(const ItemPointer &location) {
 }
 
 void Transaction::RecordRead(const ItemPointer &location) {
+  std::lock_guard<std::mutex> lock(mu_);
+
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
 
@@ -119,6 +123,8 @@ void Transaction::RecordRead(const ItemPointer &location) {
 }
 
 void Transaction::RecordReadOwn(const ItemPointer &location) {
+  std::lock_guard<std::mutex> lock(mu_);
+
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
 
@@ -136,6 +142,8 @@ void Transaction::RecordReadOwn(const ItemPointer &location) {
 }
 
 void Transaction::RecordUpdate(const ItemPointer &location) {
+  std::lock_guard<std::mutex> lock(mu_);
+
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
 
@@ -166,6 +174,8 @@ void Transaction::RecordUpdate(const ItemPointer &location) {
 }
 
 void Transaction::RecordInsert(const ItemPointer &location) {
+  std::lock_guard<std::mutex> lock(mu_);
+
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
 
@@ -178,6 +188,8 @@ void Transaction::RecordInsert(const ItemPointer &location) {
 }
 
 bool Transaction::RecordDelete(const ItemPointer &location) {
+  std::lock_guard<std::mutex> lock(mu_);
+
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
 

--- a/src/include/codegen/buffering_consumer.h
+++ b/src/include/codegen/buffering_consumer.h
@@ -52,7 +52,7 @@ class WrappedTuple
 class BufferingConsumer : public QueryResultConsumer {
  public:
   struct BufferingState {
-    BufferingState(std::vector<std::vector<WrappedTuple>> *output)
+    explicit BufferingState(std::vector<std::vector<WrappedTuple>> *output)
         : output(output) {}
     std::vector<std::vector<WrappedTuple>> *output;
   };

--- a/src/include/codegen/buffering_consumer.h
+++ b/src/include/codegen/buffering_consumer.h
@@ -73,7 +73,7 @@ class BufferingConsumer : public QueryResultConsumer {
   }
 
   // Called from compiled query code to buffer the tuple
-  static void BufferTuple(char *state, char *tuple, uint32_t num_cols);
+  static void BufferTuple(char *state, char *tuple, int32_t task_id, uint32_t num_cols);
 
   //===--------------------------------------------------------------------===//
   // ACCESSORS

--- a/src/include/codegen/buffering_consumer.h
+++ b/src/include/codegen/buffering_consumer.h
@@ -52,7 +52,9 @@ class WrappedTuple
 class BufferingConsumer : public QueryResultConsumer {
  public:
   struct BufferingState {
-    std::vector<WrappedTuple> *output;
+    BufferingState(std::vector<std::vector<WrappedTuple>> *output)
+        : output(output) {}
+    std::vector<std::vector<WrappedTuple>> *output;
   };
 
   // Constructor
@@ -79,14 +81,18 @@ class BufferingConsumer : public QueryResultConsumer {
 
   BufferingState *GetState() { return &state; }
 
-  const std::vector<WrappedTuple> &GetOutputTuples() const { return tuples_; }
+  const std::vector<WrappedTuple> &GetOutputTuples() const;
 
  private:
   // The attributes we want to output
   std::vector<const planner::AttributeInfo *> output_ais_;
 
-  // Buffered output tuples
-  std::vector<WrappedTuple> tuples_;
+  // Output target for all tasks.
+  std::vector<std::vector<WrappedTuple>> output_chunks_;
+
+  // Merged output.
+  mutable bool merged = false;
+  mutable std::vector<WrappedTuple> tuples_;
 
   // Running buffering state
   BufferingState state;

--- a/src/include/codegen/buffering_consumer.h
+++ b/src/include/codegen/buffering_consumer.h
@@ -63,6 +63,8 @@ class BufferingConsumer : public QueryResultConsumer {
 
   void Prepare(CompilationContext &compilation_context) override;
   void InitializeState(CompilationContext &) override {}
+  void InitializeParallelState(CompilationContext &compilation_context,
+                               llvm::Value *ntasks) override;
   void TearDownState(CompilationContext &) override {}
   void ConsumeResult(ConsumerContext &ctx, RowBatch::Row &row) const override;
 
@@ -71,6 +73,9 @@ class BufferingConsumer : public QueryResultConsumer {
     auto &runtime_state = ctx.GetRuntimeState();
     return runtime_state.LoadStateValue(ctx.GetCodeGen(), id);
   }
+
+  // Setup after acknowleding number of tasks.
+  static void SetNumTasks(char *state, int32_t ntasks);
 
   // Called from compiled query code to buffer the tuple
   static void BufferTuple(char *state, char *tuple, int32_t task_id, uint32_t num_cols);

--- a/src/include/codegen/code_context.h
+++ b/src/include/codegen/code_context.h
@@ -44,6 +44,7 @@ class CodeContext {
   friend class CodeGen;
   friend class FunctionBuilder;
   friend class PelotonMM;
+  friend class ConsumerContext;
 
  public:
   using FuncPtr = void *;

--- a/src/include/codegen/compilation_context.h
+++ b/src/include/codegen/compilation_context.h
@@ -63,6 +63,8 @@ class CompilationContext {
   // the plan and prepare the provided query statement.
   void GeneratePlan(QueryCompiler::CompileStats *stats);
 
+  bool MultithreadOn() const { return multithread_on_; }
+
   //===--------------------------------------------------------------------===//
   // ACCESSORS
   //===--------------------------------------------------------------------===//
@@ -103,6 +105,9 @@ class CompilationContext {
   OperatorTranslator *GetTranslator(const planner::AbstractPlan &op) const;
 
  private:
+  // Multithread turned on
+  bool multithread_on_;
+
   // The query we'll compile
   Query &query_;
 

--- a/src/include/codegen/compilation_context.h
+++ b/src/include/codegen/compilation_context.h
@@ -65,6 +65,21 @@ class CompilationContext {
 
   bool MultithreadOn() const { return multithread_on_; }
 
+  // Add a callback to be invoked when the number of tasks is determined in the
+  // main plan function. This is used for consumer initialization for parallel
+  // execution.
+  void PushParallelInitCallback(std::function<void(llvm::Value*)> callback);
+
+  std::vector<std::function<void(llvm::Value *)>> PopParallelInitCallbacks();
+
+  void ParallelInit(llvm::Value* ntasks);
+
+  void PushParallelDestroyCallback(std::function<void(llvm::Value *)> callback);
+
+  std::vector<std::function<void(llvm::Value *)>> PopParallelDestroyCallbacks();
+
+  void ParallelDestroy(llvm::Value* ntasks);
+
   //===--------------------------------------------------------------------===//
   // ACCESSORS
   //===--------------------------------------------------------------------===//
@@ -135,6 +150,10 @@ class CompilationContext {
   // The mapping of an expression somewhere in the tree to its translator
   std::unordered_map<const expression::AbstractExpression *,
                      std::unique_ptr<ExpressionTranslator>> exp_translators_;
+
+  // Callback functions intended to be called around submitting tasks.
+  std::vector<std::function<void(llvm::Value *)>> parallal_init_callbacks_;
+  std::vector<std::function<void(llvm::Value *)>> parallel_destroy_callbacks_;
 };
 
 }  // namespace codegen

--- a/src/include/codegen/consumer_context.h
+++ b/src/include/codegen/consumer_context.h
@@ -51,6 +51,8 @@ class ConsumerContext {
   // Get the pipeline
   const Pipeline &GetPipeline() const { return pipeline_; }
 
+  llvm::Value *GetTaskId() const;
+
  private:
   // The compilation context
   CompilationContext &compilation_context_;

--- a/src/include/codegen/counting_consumer.h
+++ b/src/include/codegen/counting_consumer.h
@@ -24,6 +24,7 @@ class CountingConsumer : public codegen::QueryResultConsumer {
  public:
   void Prepare(codegen::CompilationContext &compilation_context) override;
   void InitializeState(codegen::CompilationContext &context) override;
+  void InitializeParallelState(CompilationContext &, llvm::Value *) override {}
   void ConsumeResult(codegen::ConsumerContext &context,
                      codegen::RowBatch::Row &row) const override;
   void TearDownState(codegen::CompilationContext &) override {}

--- a/src/include/codegen/multi_thread/count_down.h
+++ b/src/include/codegen/multi_thread/count_down.h
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// count_down.h
+//
+// Identification: src/include/codegen/multi_thread/count_down.h
+//
+// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "codegen/codegen.h"
+
+#include <condition_variable>
+
+namespace peloton {
+namespace codegen {
+
+class CountDown {
+ public:
+  // "Constructor".
+  void Init(int32_t count);
+
+  // "Destructor".
+  void Destroy();
+
+  // Decrement the count by 1.
+  void Decrease();
+
+  // Wait until the count becomes 0.
+  void Wait();
+
+ private:
+  // Use Init and Destroy on allocated memory instead.
+  explicit CountDown(int32_t count) : count_(count) {}
+  ~CountDown() = default;
+
+  std::atomic_int32_t count_;
+  std::mutex mutex_;
+  std::condition_variable cv_;
+};
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/include/codegen/multi_thread/count_down.h
+++ b/src/include/codegen/multi_thread/count_down.h
@@ -14,6 +14,7 @@
 
 #include "codegen/codegen.h"
 
+#include <mutex>
 #include <condition_variable>
 
 namespace peloton {
@@ -38,7 +39,7 @@ class CountDown {
   explicit CountDown(int32_t count) : count_(count) {}
   ~CountDown() = default;
 
-  std::atomic_int32_t count_;
+  std::int32_t count_;
   std::mutex mutex_;
   std::condition_variable cv_;
 };

--- a/src/include/codegen/multi_thread/executor_thread_pool.h
+++ b/src/include/codegen/multi_thread/executor_thread_pool.h
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// executor_thread_pool.h
+//
+// Identification: src/include/codegen/multi_thread/executor_thread_pool.h
+//
+// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "common/thread_pool.h"
+#include "codegen/codegen.h"
+#include "codegen/runtime_state.h"
+#include "codegen/multi_thread/task_info.h"
+
+namespace peloton {
+namespace codegen {
+
+// A singleton thread pool for the executor.
+// Used by the compiled code.
+class ExecutorThreadPool {
+ public:
+  // Get the singleton instance.
+  static ExecutorThreadPool *GetInstance();
+
+  // Number of threads available in the pool.
+  static int32_t GetNumThreads();
+
+  using func_t = void (*)(char *, TaskInfo *);
+
+  // Submit a task to be run by a worker thread.
+  void SubmitTask(char *runtime_state,
+                  TaskInfo *task_info,
+                  func_t func);
+
+ private:
+  ExecutorThreadPool();
+
+  ~ExecutorThreadPool();
+
+  ThreadPool pool_;
+};
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/include/codegen/multi_thread/multithread_supported.h
+++ b/src/include/codegen/multi_thread/multithread_supported.h
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// multithread_supported.h
+//
+// Identification: src/include/codegen/multi_thread/multithread_supported.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "planner/abstract_plan.h"
+
+namespace peloton {
+namespace codegen {
+
+bool MultithreadSupported(const planner::AbstractPlan &plan);
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/include/codegen/multi_thread/task_info.h
+++ b/src/include/codegen/multi_thread/task_info.h
@@ -23,23 +23,27 @@ namespace codegen {
 class TaskInfo {
  public:
   // "Constructor"
-  void Init(int32_t thread_id, int32_t nthreads);
+  void Init(int32_t task_id, int32_t ntasks, int64_t begin, int64_t end);
 
   // "Destructor"
   void Destroy();
 
-  // TODO(zhixunt): Change this to task-related property.
   int32_t GetTaskId();
 
-  // TODO(zhixunt): Change this to task-related property.
   int32_t GetNumTasks();
+
+  int64_t GetBegin();
+
+  int64_t GetEnd();
 
  private:
   // Use Init and Destroy on allocated memory instead.
-  TaskInfo(int32_t task_id, int32_t ntasks);
+  TaskInfo(int32_t task_id, int32_t ntasks, int64_t begin, int64_t end);
 
   int32_t task_id_;
   int32_t ntasks_;
+  int64_t begin_;
+  int64_t end_;
 };
 
 }  // namespace codegen

--- a/src/include/codegen/multi_thread/task_info.h
+++ b/src/include/codegen/multi_thread/task_info.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "codegen/codegen.h"
+#include "common/logger.h"
 
 namespace peloton {
 namespace codegen {
@@ -28,18 +29,17 @@ class TaskInfo {
   void Destroy();
 
   // TODO(zhixunt): Change this to task-related property.
-  int32_t GetThreadId();
+  int32_t GetTaskId();
 
   // TODO(zhixunt): Change this to task-related property.
-  int32_t GetNumThreads();
+  int32_t GetNumTasks();
 
  private:
   // Use Init and Destroy on allocated memory instead.
-  TaskInfo(int32_t thread_id, int32_t nthreads);
-  ~TaskInfo() = default;
+  TaskInfo(int32_t task_id, int32_t ntasks);
 
-  int32_t thread_id_;
-  int32_t nthreads_;
+  int32_t task_id_;
+  int32_t ntasks_;
 };
 
 }  // namespace codegen

--- a/src/include/codegen/multi_thread/task_info.h
+++ b/src/include/codegen/multi_thread/task_info.h
@@ -21,15 +21,22 @@ namespace codegen {
 // thread information stored in RuntimeState.
 class TaskInfo {
  public:
+  // "Constructor"
   void Init(int32_t thread_id, int32_t nthreads);
 
+  // "Destructor"
+  void Destroy();
+
+  // TODO(zhixunt): Change this to task-related property.
   int32_t GetThreadId();
 
+  // TODO(zhixunt): Change this to task-related property.
   int32_t GetNumThreads();
 
  private:
-  // Can't construct
-  TaskInfo() = default;
+  // Use Init and Destroy on allocated memory instead.
+  TaskInfo(int32_t thread_id, int32_t nthreads);
+  ~TaskInfo() = default;
 
   int32_t thread_id_;
   int32_t nthreads_;

--- a/src/include/codegen/multi_thread/task_info.h
+++ b/src/include/codegen/multi_thread/task_info.h
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// task_info.h
+//
+// Identification: src/include/codegen/multi_thread/task_info.h
+//
+// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "codegen/codegen.h"
+
+namespace peloton {
+namespace codegen {
+
+// This class stores the per-thread information of a query, as opposed to cross-
+// thread information stored in RuntimeState.
+class TaskInfo {
+ public:
+  void Init(int32_t thread_id, int32_t nthreads);
+
+  int32_t GetThreadId();
+
+  int32_t GetNumThreads();
+
+ private:
+  // Can't construct
+  TaskInfo() = default;
+
+  int32_t thread_id_;
+  int32_t nthreads_;
+};
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/include/codegen/operator/table_scan_translator.h
+++ b/src/include/codegen/operator/table_scan_translator.h
@@ -47,7 +47,8 @@ class TableScanTranslator : public OperatorTranslator {
   // The method that produces new tuples
   void Produce() const override;
 
-  void TaskProduce() const;
+  void TaskProduce(llvm::Value *tile_group_begin,
+                   llvm::Value *tile_group_end) const;
 
   // Scans are leaves in the query plan and, hence, do not consume tuples
   void Consume(ConsumerContext &, RowBatch &) const override {}

--- a/src/include/codegen/operator/table_scan_translator.h
+++ b/src/include/codegen/operator/table_scan_translator.h
@@ -152,6 +152,10 @@ class TableScanTranslator : public OperatorTranslator {
   // The ID of the selection vector in runtime state
   RuntimeState::StateID selection_vector_id_;
 
+  RuntimeState::StateID task_info_vector_id_;
+
+  RuntimeState::StateID count_down_id_;
+
   // The code-generating table instance
   codegen::Table table_;
 };

--- a/src/include/codegen/operator/table_scan_translator.h
+++ b/src/include/codegen/operator/table_scan_translator.h
@@ -47,6 +47,8 @@ class TableScanTranslator : public OperatorTranslator {
   // The method that produces new tuples
   void Produce() const override;
 
+  void TaskProduce() const;
+
   // Scans are leaves in the query plan and, hence, do not consume tuples
   void Consume(ConsumerContext &, RowBatch &) const override {}
   void Consume(ConsumerContext &, RowBatch::Row &) const override {}

--- a/src/include/codegen/operator/table_scan_translator.h
+++ b/src/include/codegen/operator/table_scan_translator.h
@@ -155,7 +155,7 @@ class TableScanTranslator : public OperatorTranslator {
   // The ID of the selection vector in runtime state
   RuntimeState::StateID selection_vector_id_;
 
-  RuntimeState::StateID task_info_vector_id_;
+  RuntimeState::StateID task_infos_id_;
 
   RuntimeState::StateID count_down_id_;
 

--- a/src/include/codegen/proxy/count_down_proxy.h
+++ b/src/include/codegen/proxy/count_down_proxy.h
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// count_down_proxy.h
+//
+// Identification: src/include/codegen/proxy/count_down_proxy.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "codegen/multi_thread/count_down.h"
+#include "codegen/proxy/task_info_proxy.h"
+#include "codegen/proxy/proxy.h"
+#include "codegen/proxy/type_builder.h"
+
+namespace peloton {
+namespace codegen {
+
+PROXY(CountDown) {
+  DECLARE_MEMBER(0, char[sizeof(CountDown)], opaque);
+  DECLARE_TYPE;
+
+  DECLARE_METHOD(Init);
+  DECLARE_METHOD(Destroy);
+  DECLARE_METHOD(Decrease);
+  DECLARE_METHOD(Wait);
+};
+
+TYPE_BUILDER(CountDown, codegen::CountDown);
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/include/codegen/proxy/executor_thread_pool_proxy.h
+++ b/src/include/codegen/proxy/executor_thread_pool_proxy.h
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// executor_thread_pool_proxy.h
+//
+// Identification: src/include/codegen/proxy/executor_thread_pool_proxy.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "codegen/multi_thread/executor_thread_pool.h"
+#include "codegen/proxy/task_info_proxy.h"
+#include "codegen/proxy/proxy.h"
+#include "codegen/proxy/type_builder.h"
+
+namespace peloton {
+namespace codegen {
+
+PROXY(ExecutorThreadPool) {
+  DECLARE_MEMBER(0, char[sizeof(ExecutorThreadPool)], opaque);
+  DECLARE_TYPE;
+
+  DECLARE_METHOD(GetInstance);
+  DECLARE_METHOD(GetNumThreads);
+  DECLARE_METHOD(SubmitTask);
+};
+
+TYPE_BUILDER(ExecutorThreadPool, codegen::ExecutorThreadPool);
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/include/codegen/proxy/runtime_functions_proxy.h
+++ b/src/include/codegen/proxy/runtime_functions_proxy.h
@@ -14,6 +14,7 @@
 
 #include "codegen/proxy/proxy.h"
 #include "codegen/proxy/type_builder.h"
+#include "codegen/proxy/task_info_proxy.h"
 #include "codegen/runtime_functions.h"
 
 namespace peloton {
@@ -32,6 +33,8 @@ PROXY(RuntimeFunctions) {
   DECLARE_METHOD(GetTileGroupLayout);
   DECLARE_METHOD(ThrowDivideByZeroException);
   DECLARE_METHOD(ThrowOverflowException);
+  DECLARE_METHOD(NewTaskInfos);
+  DECLARE_METHOD(DeleteTaskInfos);
 };
 
 TYPE_BUILDER(ColumnLayoutInfo, codegen::RuntimeFunctions::ColumnLayoutInfo);

--- a/src/include/codegen/proxy/task_info_proxy.h
+++ b/src/include/codegen/proxy/task_info_proxy.h
@@ -24,8 +24,8 @@ PROXY(TaskInfo) {
   DECLARE_TYPE;
 
   DECLARE_METHOD(Init);
-  DECLARE_METHOD(GetThreadId);
-  DECLARE_METHOD(GetNumThreads);
+  DECLARE_METHOD(GetTaskId);
+  DECLARE_METHOD(GetNumTasks);
 };
 
 TYPE_BUILDER(TaskInfo, codegen::TaskInfo);

--- a/src/include/codegen/proxy/task_info_proxy.h
+++ b/src/include/codegen/proxy/task_info_proxy.h
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// task_info_proxy.h
+//
+// Identification: src/include/codegen/proxy/task_info_proxy.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "codegen/multi_thread/task_info.h"
+#include "codegen/proxy/proxy.h"
+#include "codegen/proxy/type_builder.h"
+
+namespace peloton {
+namespace codegen {
+
+PROXY(TaskInfo) {
+  DECLARE_MEMBER(0, char[sizeof(TaskInfo)], opaque);
+  DECLARE_TYPE;
+
+  DECLARE_METHOD(Init);
+  DECLARE_METHOD(GetThreadId);
+  DECLARE_METHOD(GetNumThreads);
+};
+
+TYPE_BUILDER(TaskInfo, codegen::TaskInfo);
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/include/codegen/proxy/task_info_proxy.h
+++ b/src/include/codegen/proxy/task_info_proxy.h
@@ -27,6 +27,8 @@ PROXY(TaskInfo) {
   DECLARE_METHOD(Destroy);
   DECLARE_METHOD(GetTaskId);
   DECLARE_METHOD(GetNumTasks);
+  DECLARE_METHOD(GetBegin);
+  DECLARE_METHOD(GetEnd);
 };
 
 TYPE_BUILDER(TaskInfo, codegen::TaskInfo);

--- a/src/include/codegen/proxy/task_info_proxy.h
+++ b/src/include/codegen/proxy/task_info_proxy.h
@@ -24,6 +24,7 @@ PROXY(TaskInfo) {
   DECLARE_TYPE;
 
   DECLARE_METHOD(Init);
+  DECLARE_METHOD(Destroy);
   DECLARE_METHOD(GetTaskId);
   DECLARE_METHOD(GetNumTasks);
 };

--- a/src/include/codegen/query_result_consumer.h
+++ b/src/include/codegen/query_result_consumer.h
@@ -31,6 +31,9 @@ class QueryResultConsumer {
   // Called to generate any initialization code the consumer needs
   virtual void InitializeState(CompilationContext &compilation_context) = 0;
 
+  virtual void InitializeParallelState(CompilationContext &compilation_context,
+                                       llvm::Value *ntasks) = 0;
+
   // Called during plan-generation to consume the results of the query
   virtual void ConsumeResult(ConsumerContext &context,
                              RowBatch::Row &row) const = 0;

--- a/src/include/codegen/runtime_functions.h
+++ b/src/include/codegen/runtime_functions.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 
 #include "type/types.h"
+#include "multi_thread/task_info.h"
 
 namespace peloton {
 
@@ -63,6 +64,11 @@ class RuntimeFunctions {
   static void ThrowDivideByZeroException();
 
   static void ThrowOverflowException();
+
+  static int32_t NewTaskInfos(int64_t task_size, int64_t total_size,
+                              TaskInfo **task_infos);
+
+  static void DeleteTaskInfos(TaskInfo *task_infos, int32_t ntasks);
 };
 
 }  // namespace codegen

--- a/src/include/codegen/runtime_state.h
+++ b/src/include/codegen/runtime_state.h
@@ -68,9 +68,6 @@ class RuntimeState {
   // Construct the equivalent LLVM type that represents this runtime state
   llvm::Type *FinalizeType(CodeGen &codegen);
 
-  // Create/initialize all registered state that is stack-local
-  void CreateLocalState(CodeGen &codegen);
-
  private:
   // Little struct to track information of elements in the runtime state
   struct StateInfo {

--- a/src/include/codegen/runtime_state.h
+++ b/src/include/codegen/runtime_state.h
@@ -90,7 +90,7 @@ class RuntimeState {
 
  private:
   // All the states we've allocated
-  std::vector<RuntimeState::StateInfo> state_slots_;
+  mutable std::vector<RuntimeState::StateInfo> state_slots_;
 
   // The LLVM type of this runtime state. This type is cached for re-use.
   llvm::Type *constructed_type_;

--- a/src/include/codegen/table.h
+++ b/src/include/codegen/table.h
@@ -40,6 +40,7 @@ class Table {
   // is provided as the second argument. The scan consumer (third argument)
   // should be notified when ready to generate the scan loop body.
   void GenerateScan(CodeGen &codegen, llvm::Value *table_ptr,
+                    llvm::Value *tile_group_begin, llvm::Value *tile_group_end,
                     uint32_t batch_size, ScanCallback &consumer) const;
 
   // Given a table instance, return the number of tile groups in the table.

--- a/src/include/concurrency/transaction.h
+++ b/src/include/concurrency/transaction.h
@@ -76,11 +76,13 @@ class Transaction : public Printable {
   inline void SetCommitId(const cid_t commit_id) { commit_id_ = commit_id; }
 
   void RecordCreate(oid_t database_oid, oid_t table_oid, oid_t index_oid) {
+    std::lock_guard<std::mutex> lock(mu_);
     rw_object_set_.emplace_back(database_oid, table_oid, index_oid,
                                 DDLType::CREATE);
   }
 
   void RecordDrop(oid_t database_oid, oid_t table_oid, oid_t index_oid) {
+    std::lock_guard<std::mutex> lock(mu_);
     rw_object_set_.emplace_back(database_oid, table_oid, index_oid,
                                 DDLType::DROP);
   }
@@ -188,6 +190,10 @@ class Transaction : public Printable {
   IsolationLevelType isolation_level_;
 
   std::unique_ptr<trigger::TriggerSet> on_commit_triggers_;
+
+  // TODO(zhixunt): The key is to make the class Transaction concurrent!
+  // A mutex isn't necessarily the best way!
+  std::mutex mu_;
 };
 
 }  // namespace concurrency

--- a/test/codegen/executor_thread_pool_test.cpp
+++ b/test/codegen/executor_thread_pool_test.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// thread_pool_test.cpp
+//
+// Identification: test/codegen/thread_pool_test.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "codegen/multi_thread/executor_thread_pool.h"
+#include "codegen/codegen.h"
+#include "codegen/function_builder.h"
+#include "codegen/proxy/runtime_functions_proxy.h"
+#include "common/harness.h"
+
+#include <condition_variable>
+
+namespace peloton {
+namespace test {
+
+class ExecutorThreadPoolTest : public PelotonTest {};
+
+// This test case shows how to use ExecutorThreadPool.
+TEST_F(ExecutorThreadPoolTest, UseThreadPoolTest) {
+  struct TestRuntimeState {
+    int ans = 0;
+    bool finished = false;
+    std::mutex mutex;
+    std::condition_variable cv;
+  };
+  TestRuntimeState runtime_state;
+
+  auto pool = codegen::ExecutorThreadPool::GetInstance();
+  pool->SubmitTask(
+      reinterpret_cast<char *>(&runtime_state),
+      nullptr,
+      [](char *ptr, codegen::TaskInfo *task_info) {
+        auto test_runtime_state = reinterpret_cast<TestRuntimeState *>(ptr);
+
+        std::unique_lock<std::mutex> lock(test_runtime_state->mutex);
+        test_runtime_state->ans = 1;
+        test_runtime_state->finished = true;
+        lock.unlock();
+        test_runtime_state->cv.notify_one();
+      }
+  );
+
+  // Main thread: wait for finished flag.
+  std::unique_lock<std::mutex> lock(runtime_state.mutex);
+  runtime_state.cv.wait(lock, [&] {
+    return runtime_state.finished;
+  });
+
+  EXPECT_EQ(runtime_state.ans, 1);
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/codegen/executor_thread_pool_test.cpp
+++ b/test/codegen/executor_thread_pool_test.cpp
@@ -10,31 +10,86 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <tuple>
 #include "codegen/function_builder.h"
 #include "codegen/multi_thread/executor_thread_pool.h"
 #include "codegen/multi_thread/count_down.h"
+#include "codegen/proxy/executor_thread_pool_proxy.h"
 #include "codegen/proxy/runtime_functions_proxy.h"
+#include "codegen/proxy/count_down_proxy.h"
 #include "common/harness.h"
 
 namespace peloton {
 namespace test {
 
-class ExecutorThreadPoolTest : public PelotonTest {};
-
-// This test case shows how to use ExecutorThreadPool.
-TEST_F(ExecutorThreadPoolTest, UseThreadPoolTest) {
+class ExecutorThreadPoolTest : public PelotonTest {
+ public:
   struct TestRuntimeState {
     int ans = 0;
 
     // This is what codegen will generate.
     char count_down[sizeof(codegen::CountDown)] = {0};
   };
-  TestRuntimeState test_runtime_state;
 
-  auto count_down = reinterpret_cast<codegen::CountDown *>(
-      &test_runtime_state.count_down
-  );
-  count_down->Init(1);
+  codegen::CountDown *GetCountDown(TestRuntimeState *runtime_state) {
+    return reinterpret_cast<codegen::CountDown *>(&runtime_state->count_down);
+  }
+
+  void InitTestRuntimeState(TestRuntimeState *runtime_state) {
+    auto count_down = GetCountDown(runtime_state);
+    count_down->Init(1);
+  }
+
+  std::tuple<codegen::RuntimeState::StateID, codegen::RuntimeState::StateID>
+  SetupRuntimeState(codegen::CodeGen &cgen,
+                    codegen::RuntimeState &runtime_state) {
+    auto count_down_type = codegen::CountDownProxy::GetType(cgen);
+
+    auto ans_state_id = runtime_state.RegisterState("ans", cgen.Int32Type());
+    auto count_down_state_id = runtime_state.RegisterState(
+        "count_down", count_down_type);
+
+    runtime_state.FinalizeType(cgen);
+
+    return std::make_tuple(ans_state_id, count_down_state_id);
+  }
+
+  llvm::Function *BuildTaskFunc(
+      codegen::CodeGen &cgen,
+      codegen::RuntimeState &runtime_state,
+      codegen::RuntimeState::StateID ans_id,
+      codegen::RuntimeState::StateID count_down_id) {
+    auto &code_context = cgen.GetCodeContext();
+    auto runtime_state_type = runtime_state.FinalizeType(cgen);
+    auto task_info_type = codegen::TaskInfoProxy::GetType(cgen);
+
+    // void task(RuntimeState *runtime_state, TaskInfo *task_info) {
+    //   runtime_state->ans = 1;
+    //   runtime_state->count_down.Wait();
+    // }
+    codegen::FunctionBuilder task(code_context, "task", cgen.VoidType(), {
+        {"runtime_state", runtime_state_type->getPointerTo()},
+        {"task_info", task_info_type->getPointerTo()}
+    });
+    {
+      auto ans_ptr = runtime_state.LoadStatePtr(cgen, ans_id);
+      cgen->CreateStore(cgen.Const32(1), ans_ptr);
+
+      auto count_down_ptr = runtime_state.LoadStatePtr(cgen, count_down_id);
+      cgen.Call(codegen::CountDownProxy::Decrease, {count_down_ptr});
+
+      task.ReturnAndFinish();
+    }
+
+    return task.GetFunction();
+  }
+};
+
+// This test case shows how to use ExecutorThreadPool.
+TEST_F(ExecutorThreadPoolTest, UseThreadPoolTest) {
+  TestRuntimeState test_runtime_state;
+  InitTestRuntimeState(&test_runtime_state);
+  auto count_down = GetCountDown(&test_runtime_state);
 
   auto pool = codegen::ExecutorThreadPool::GetInstance();
   pool->SubmitTask(
@@ -57,6 +112,113 @@ TEST_F(ExecutorThreadPoolTest, UseThreadPoolTest) {
   EXPECT_EQ(test_runtime_state.ans, 1);
 
   count_down->Destroy();
+}
+
+TEST_F(ExecutorThreadPoolTest, CodeGenTaskTest) {
+  codegen::CodeContext code_context;
+  codegen::CodeGen cgen(code_context);
+
+  // Create the runtime state type in module.
+  codegen::RuntimeState runtime_state;
+  codegen::RuntimeState::StateID ans_id, count_down_id;
+  std::tie(ans_id, count_down_id) =
+      SetupRuntimeState(cgen, runtime_state);
+
+  // Build task function.
+  auto task_func = BuildTaskFunc(cgen, runtime_state, ans_id, count_down_id);
+
+  // Compile the module.
+  EXPECT_TRUE(code_context.Compile());
+
+  // Prepare runtime state.
+  TestRuntimeState test_runtime_state;
+  InitTestRuntimeState(&test_runtime_state);
+
+  // Submit task.
+  auto pool = codegen::ExecutorThreadPool::GetInstance();
+  auto fn = reinterpret_cast<codegen::ExecutorThreadPool::func_t>(
+      code_context.GetRawFunctionPointer(task_func)
+  );
+  pool->SubmitTask(reinterpret_cast<char *>(&test_runtime_state), nullptr, fn);
+  auto count_down = GetCountDown(&test_runtime_state);
+  count_down->Wait();
+
+  EXPECT_EQ(test_runtime_state.ans, 1);
+
+  count_down->Destroy();
+}
+
+// This test case shows how to generate code that uses ExecutorThreadPool.
+TEST_F(ExecutorThreadPoolTest, CodeGenThreadPoolTest) {
+  codegen::CodeContext code_context;
+  codegen::CodeGen cgen(code_context);
+  auto task_info_type = codegen::TaskInfoProxy::GetType(cgen);
+
+  // Create the runtime state type in module.
+  // Create the runtime state type in module.
+  codegen::RuntimeState runtime_state;
+  codegen::RuntimeState::StateID ans_id, count_down_id;
+  std::tie(ans_id, count_down_id) =
+      SetupRuntimeState(cgen, runtime_state);
+
+  // Build task function.
+  auto task_func = BuildTaskFunc(cgen, runtime_state, ans_id, count_down_id);
+
+  // void func(RuntimeState *runtime_state);
+  codegen::FunctionBuilder func(code_context, "func", cgen.VoidType(), {
+      {"runtime_state", runtime_state.FinalizeType(cgen)->getPointerTo()}
+  });
+  {
+    // auto count_down = runtime_state->count_down;
+    auto count_down_ptr = runtime_state.LoadStatePtr(cgen, count_down_id);
+
+    // count_down->Init(1);
+    cgen.Call(codegen::CountDownProxy::Init, {count_down_ptr, cgen.Const32(1)});
+
+    // auto thread_pool = codegen::ExecutorThreadPool::GetInstance();
+    auto thread_pool_ptr = cgen.Call(
+        codegen::ExecutorThreadPoolProxy::GetInstance, {}
+    );
+
+    // using task_type = void (*)(char *ptr, TaskInfo *);
+    auto task_type = llvm::FunctionType::get(
+        cgen.VoidType(), {
+            cgen.CharPtrType(),
+            task_info_type->getPointerTo()
+        },
+        false
+    )->getPointerTo();
+
+    // thread_pool->SubmitTask(
+    //   (char *)runtime_state,
+    //   (TaskInfo *)NULL,
+    //   (task_type)task
+    // );
+    cgen.Call(codegen::ExecutorThreadPoolProxy::SubmitTask, {
+        thread_pool_ptr,
+        cgen->CreatePointerCast(cgen.GetState(), cgen.CharPtrType()),
+        cgen.NullPtr(task_info_type->getPointerTo()),
+        cgen->CreatePointerCast(task_func, task_type)
+    });
+
+    // count_down->Wait();
+    cgen.Call(codegen::CountDownProxy::Wait, {count_down_ptr});
+
+    // count_down->Destroy();
+    cgen.Call(codegen::CountDownProxy::Destroy, {count_down_ptr});
+
+    func.ReturnAndFinish();
+  }
+
+  EXPECT_TRUE(code_context.Compile());
+
+  TestRuntimeState test_runtime_state;
+  auto fn = reinterpret_cast<void (*)(char *)>(
+      code_context.GetRawFunctionPointer(func.GetFunction())
+  );
+  fn(reinterpret_cast<char *>(&test_runtime_state));
+
+  EXPECT_EQ(test_runtime_state.ans, 1);
 }
 
 }  // namespace test

--- a/test/codegen/executor_thread_pool_test.cpp
+++ b/test/codegen/executor_thread_pool_test.cpp
@@ -114,6 +114,7 @@ TEST_F(ExecutorThreadPoolTest, UseThreadPoolTest) {
   count_down->Destroy();
 }
 
+// This test case shows how to generate code for the task function.
 TEST_F(ExecutorThreadPoolTest, CodeGenTaskTest) {
   codegen::CodeContext code_context;
   codegen::CodeGen cgen(code_context);

--- a/test/codegen/executor_thread_pool_test.cpp
+++ b/test/codegen/executor_thread_pool_test.cpp
@@ -40,7 +40,7 @@ TEST_F(ExecutorThreadPoolTest, UseThreadPoolTest) {
   pool->SubmitTask(
       reinterpret_cast<char *>(&test_runtime_state),
       nullptr,
-      [](char *ptr, codegen::TaskInfo *task_info) {
+      [](char *ptr, UNUSED_ATTRIBUTE codegen::TaskInfo *task_info) {
         auto test_runtime_state = reinterpret_cast<TestRuntimeState *>(ptr);
 
         test_runtime_state->ans = 1;

--- a/test/codegen/scan_benchmark_test.cpp
+++ b/test/codegen/scan_benchmark_test.cpp
@@ -1,0 +1,308 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// scan_benchmark_test.cpp
+//
+// Identification: test/codegen/scan_benchmark_test.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/harness.h"
+
+#include "catalog/catalog.h"
+#include "catalog/column.h"
+#include "catalog/schema.h"
+#include "codegen/buffering_consumer.h"
+#include "codegen/query_compiler.h"
+#include "common/timer.h"
+#include "common/container_tuple.h"
+#include "concurrency/transaction_manager_factory.h"
+#include "executor/seq_scan_executor.h"
+#include "executor/executor_context.h"
+#include "expression/comparison_expression.h"
+#include "expression/conjunction_expression.h"
+#include "logging/log_manager.h"
+#include "planner/seq_scan_plan.h"
+#include "storage/table_factory.h"
+#include "type/types.h"
+
+#include "codegen/testing_codegen_util.h"
+
+namespace peloton {
+namespace test {
+
+enum ScanComplexity { SIMPLE, MODERATE, COMPLEX };
+
+struct TestConfig {
+  uint32_t scale_factor = 10;
+  ScanComplexity scan_complexity = MODERATE;
+  double selectivity;
+};
+
+class BenchmarkScanTest : public PelotonCodeGenTest {
+ public:
+  BenchmarkScanTest() : PelotonCodeGenTest() {
+    // Load test table
+    LoadTestTable(TestTableId(), num_rows_to_insert);
+  }
+
+  // uint32_t NumRowsInTestTable() const { return num_rows_to_insert; }
+
+  uint32_t TestTableId() { return test_table_oids[0]; }
+
+  expression::AbstractExpression *ConstructSimplePredicate(TestConfig &config) {
+    // Setup the predicate of the form a >= ? such that the selectivity
+    // is equal to that in the configuration
+    double param = (1 - config.selectivity) *
+        num_rows_to_insert * config.scale_factor;
+    auto *a_col_exp =
+        new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 0);
+    auto *const_exp = new expression::ConstantValueExpression(
+        type::ValueFactory::GetIntegerValue(param));
+    return new expression::ComparisonExpression(
+        ExpressionType::COMPARE_GREATERTHANOREQUALTO, a_col_exp, const_exp);
+  }
+
+  expression::AbstractExpression *ConstructModeratePredicate(
+      TestConfig &config) {
+    // Setup the predicate a >= ? and b >= a such that the predicate has
+    // the selectivity as configured for the experiment
+
+    double param = (1 - config.selectivity) *
+        num_rows_to_insert * config.scale_factor;
+    auto *a_col_exp =
+        new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 0);
+    auto *const_exp = new expression::ConstantValueExpression(
+        type::ValueFactory::GetIntegerValue(param));
+    auto *a_gte_param = new expression::ComparisonExpression(
+        ExpressionType::COMPARE_GREATERTHANOREQUALTO, a_col_exp, const_exp);
+
+    auto *b_col_exp =
+        new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 1);
+    auto *a_col_exp2 =
+        new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 0);
+    auto *b_gte_a = new expression::ComparisonExpression(
+        ExpressionType::COMPARE_GREATERTHANOREQUALTO, b_col_exp, a_col_exp2);
+
+    return new expression::ConjunctionExpression(
+        ExpressionType::CONJUNCTION_AND, a_gte_param, b_gte_a);
+  }
+
+  expression::AbstractExpression *ConstructComplexPredicate(
+      __attribute((unused)) TestConfig &config) {
+    // Setup the predicate a >= ? and b >= a and c >= b
+    double param = (1 - config.selectivity) *
+        num_rows_to_insert * config.scale_factor;
+    auto *a_col_exp =
+        new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 0);
+    auto *const_exp = new expression::ConstantValueExpression(
+        type::ValueFactory::GetIntegerValue(param));
+    auto *a_gte_param = new expression::ComparisonExpression(
+        ExpressionType::COMPARE_GREATERTHANOREQUALTO, a_col_exp, const_exp);
+
+    auto *b_col_exp =
+        new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 1);
+    auto *a_col_exp2 =
+        new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 0);
+    auto *b_gte_a = new expression::ComparisonExpression(
+        ExpressionType::COMPARE_GREATERTHANOREQUALTO, b_col_exp, a_col_exp2);
+
+    auto *c_col_exp =
+        new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 2);
+    auto *b_col_exp2 =
+        new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 1);
+    auto *c_gte_b = new expression::ComparisonExpression(
+        ExpressionType::COMPARE_LESSTHANOREQUALTO, c_col_exp, b_col_exp2);
+
+    auto *b_gte_a_gte_param =
+        new expression::ConjunctionExpression(
+            ExpressionType::CONJUNCTION_AND, a_gte_param, b_gte_a);
+    return new expression::ConjunctionExpression(
+        ExpressionType::CONJUNCTION_AND, b_gte_a_gte_param, c_gte_b);
+  }
+
+  std::unique_ptr<planner::SeqScanPlan> ConstructScanPlan(TestConfig &config) {
+    expression::AbstractExpression *predicate = nullptr;
+    switch (config.scan_complexity) {
+      case ScanComplexity::SIMPLE:
+        predicate = ConstructSimplePredicate(config);
+        break;
+      case ScanComplexity::MODERATE:
+        predicate = ConstructModeratePredicate(config);
+        break;
+      case ScanComplexity::COMPLEX:
+        predicate = ConstructComplexPredicate(config);
+        break;
+      default: { throw Exception{"nope"}; }
+    }
+
+    // Setup the scan plan node
+    return std::unique_ptr<planner::SeqScanPlan>{
+        new planner::SeqScanPlan(&GetTestTable(TestTableId()), predicate, {0, 1, 2})};
+  }
+
+  Stats RunCompiledExperiment(TestConfig &config, uint32_t num_runs = 5) {
+    // Keep one copy of compile and runtime stats
+    Stats stats;
+
+    for (uint32_t i = 0; i < num_runs; i++) {
+      auto scan = ConstructScanPlan(config);
+
+      // Do binding
+      planner::BindingContext context;
+      scan->PerformBinding(context);
+
+      // We collect the results of the query into an in-memory buffer
+      codegen::BufferingConsumer buffer{{0}, context};
+
+      // COMPILE and execute
+      codegen::Query::RuntimeStats runtime_stats;
+      codegen::QueryCompiler::CompileStats compile_stats = CompileAndExecute(
+          *scan, buffer, reinterpret_cast<char*>(buffer.GetState()));
+
+      stats.Merge(compile_stats, runtime_stats,
+          buffer.GetOutputTuples().size());
+    }
+
+    stats.Finalize();
+    return stats;
+  }
+
+  Stats RunInterpretedExperiment(TestConfig &config, uint32_t num_runs = 5) {
+    // Keep one copy of compile and runtime stats
+    Stats stats;
+
+    for (uint32_t i = 0; i < num_runs; i++) {
+      auto scan = ConstructScanPlan(config);
+      std::vector<std::vector<type::Value>> vals;
+
+      codegen::QueryCompiler::CompileStats compile_stats;
+      codegen::Query::RuntimeStats runtime_stats;
+
+      auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+      auto txn = txn_manager.BeginTransaction();
+
+      executor::ExecutorContext ctx{txn};
+      executor::SeqScanExecutor executor{scan.get(), &ctx};
+
+      Timer<std::ratio<1, 1000>> timer;
+      timer.Start();
+      executor.Init();
+      timer.Stop();
+      runtime_stats.init_ms = timer.GetDuration();
+      timer.Reset();
+
+      timer.Start();
+      while (executor.Execute()) {
+        auto tile = executor.GetOutput();
+        for (oid_t tuple_id : *tile) {
+          const ContainerTuple<executor::LogicalTile> tuple{
+              tile, tuple_id};
+          std::vector<type::Value> tv;
+          for (oid_t col_id : scan->GetColumnIds()) {
+            tv.push_back(tuple.GetValue(col_id));
+          }
+          vals.push_back(std::move(tv));
+        }
+      }
+      timer.Stop();
+      runtime_stats.plan_ms = timer.GetDuration();
+
+      stats.Merge(compile_stats, runtime_stats, vals.size());
+
+      txn_manager.CommitTransaction(txn);
+    }
+
+    stats.Finalize();
+    return stats;
+  }
+
+ private:
+  uint32_t num_rows_to_insert = 10000;
+};
+
+void PrintName(std::string test_name) {
+  std::cerr << "NAME:\n===============\n" << test_name << std::endl;
+}
+
+void PrintConfig(TestConfig &config) {
+    fprintf(stderr, "CONFIGURATION:\n===============\n");
+    fprintf(stderr,
+            "Scan complexity: %d, Selectivity: %.2f\n",
+            config.scan_complexity, config.selectivity);
+  }
+
+// TEST_F(BenchmarkScanTest, ScanTestWithCompilation) {
+//   PrintName("SCAN: COMPILATION");
+//   auto stats = RunCompiledExperiment();
+//   stats.PrintStats();
+// }
+
+// TEST_F(BenchmarkScanTest, ScanTestWithInterpretation) {
+//   PrintName("SCAN: INTERPRETATION");
+//   auto stats = RunInterpretedExperiment();
+//   stats.PrintStats();
+// }
+
+TEST_F(BenchmarkScanTest, SelectivityTestWithCompilation) {
+  double selectivities[] = {0.0, 0.25, 0.5, 0.75, 1.0};
+
+  PrintName("SCAN_SELECTIVITY: COMPILATION");
+  for (double selectivity : selectivities) {
+    TestConfig config;
+    config.selectivity = selectivity;
+
+    auto stats = RunCompiledExperiment(config);
+    PrintConfig(config);
+    stats.PrintStats();
+  }
+}
+
+TEST_F(BenchmarkScanTest, SelectivityTestWithInterpretation) {
+  double selectivities[] = {0.0, 0.25, 0.5, 0.75, 1.0};
+
+  PrintName("SCAN_SELECTIVITY: INTERPRETATION");
+  for (double selectivity : selectivities) {
+    TestConfig config;
+    config.selectivity = selectivity;
+
+    auto stats = RunInterpretedExperiment(config);
+    PrintConfig(config);
+    stats.PrintStats();
+  }
+}
+
+TEST_F(BenchmarkScanTest, PredicateComplexityTestWithCompilation) {
+ ScanComplexity complexities[] = { SIMPLE, MODERATE };
+
+ PrintName("SCAN_COMPLEXITY: COMPILATION");
+ for (ScanComplexity complexity : complexities) {
+   TestConfig config;
+   config.selectivity = 0.5;
+   config.scan_complexity = complexity;
+
+   auto stats = RunCompiledExperiment(config);
+   PrintConfig(config);
+   stats.PrintStats();
+ }
+}
+
+TEST_F(BenchmarkScanTest, PredicateComplexityTestWithInterpretation) {
+ ScanComplexity complexities[] = { SIMPLE, MODERATE };
+
+ PrintName("SCAN_COMPLEXITY: INTERPRETATION");
+ for (ScanComplexity complexity : complexities) {
+   TestConfig config;
+   config.scan_complexity = complexity;
+
+   auto stats = RunInterpretedExperiment(config);
+   PrintConfig(config);
+   stats.PrintStats();
+ }
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/include/codegen/testing_codegen_util.h
+++ b/test/include/codegen/testing_codegen_util.h
@@ -159,5 +159,63 @@ class CountingConsumer : public codegen::QueryResultConsumer {
   codegen::RuntimeState::StateID counter_state_id_;
 };
 
+struct Stats {
+  // NOTE: for g++ > 4.8
+  // codegen::QueryCompiler::CompileStats compile_stats{0.0, 0.0, 0.0};
+  // codegen::Query::RuntimeStats runtime_stats{0.0, 0.0, 0.0};
+
+  // NOTE: for g++ 4.8
+  codegen::QueryCompiler::CompileStats compile_stats;
+  codegen::Query::RuntimeStats runtime_stats;
+
+  double num_samples = 0.0;
+  int32_t tuple_result_size = -1;
+
+  void Merge(codegen::QueryCompiler::CompileStats &o_compile_stats,
+             codegen::Query::RuntimeStats &o_runtime_stats,
+             int32_t o_tuple_result_size) {
+    compile_stats.ir_gen_ms += o_compile_stats.ir_gen_ms;
+    compile_stats.jit_ms += o_compile_stats.jit_ms;
+    compile_stats.setup_ms += o_compile_stats.setup_ms;
+
+    runtime_stats.init_ms += o_runtime_stats.init_ms;
+    runtime_stats.plan_ms += o_runtime_stats.plan_ms;
+    runtime_stats.tear_down_ms += o_runtime_stats.tear_down_ms;
+
+    if (tuple_result_size < 0) {
+      tuple_result_size = o_tuple_result_size;
+    } else if (tuple_result_size != o_tuple_result_size) {
+      throw Exception{
+          "ERROR: tuple result size should not"
+          " vary for the same test!"};
+    }
+
+    num_samples++;
+  }
+
+  void Finalize() {
+    compile_stats.ir_gen_ms /= num_samples;
+    compile_stats.jit_ms /= num_samples;
+    compile_stats.setup_ms /= num_samples;
+
+    runtime_stats.init_ms /= num_samples;
+    runtime_stats.plan_ms /= num_samples;
+    runtime_stats.tear_down_ms /= num_samples;
+  }
+
+  void PrintStats() {
+    fprintf(
+        stderr,
+        "Setup time: %.2f ms, IR Gen time: %.2f ms, Compile time: %.2f ms\n",
+        compile_stats.setup_ms, compile_stats.ir_gen_ms, compile_stats.jit_ms);
+    fprintf(stderr,
+            "Initialization time: %.2f ms, execution time: %.2f ms, Tear down "
+            "time: %.2f ms\n",
+            runtime_stats.init_ms, runtime_stats.plan_ms,
+            runtime_stats.tear_down_ms);
+    fprintf(stderr, "Tuple result size: %d\n", tuple_result_size);
+  }
+};
+
 }  // namespace test
 }  // namespace peloton

--- a/test/include/codegen/testing_codegen_util.h
+++ b/test/include/codegen/testing_codegen_util.h
@@ -121,6 +121,8 @@ class Printer : public codegen::QueryResultConsumer {
   // None of these are used, except ConsumeResult()
   void Prepare(codegen::CompilationContext &) override {}
   void InitializeState(codegen::CompilationContext &) override {}
+  void InitializeParallelState(codegen::CompilationContext &,
+                               llvm::Value *) override {}
   void TearDownState(codegen::CompilationContext &) override {}
   // Use
   void ConsumeResult(codegen::ConsumerContext &ctx,
@@ -137,6 +139,8 @@ class CountingConsumer : public codegen::QueryResultConsumer {
  public:
   void Prepare(codegen::CompilationContext &compilation_context) override;
   void InitializeState(codegen::CompilationContext &context) override;
+  void InitializeParallelState(codegen::CompilationContext &,
+                               llvm::Value *) override {}
   void ConsumeResult(codegen::ConsumerContext &context,
                      codegen::RowBatch::Row &row) const override;
   void TearDownState(codegen::CompilationContext &) override {}


### PR DESCRIPTION
This work is in progress. I want to get the design out early so that people can check whether this is a reasonable design.

Currently I've implemented the supporting infrastructure for the parallel LLVM engine.

- `codegen::ExecutorThreadPool`: Wrapper around common/thread_pool.h.

  Each task must have the function prototype:
  ```C
  // runtime_state: per-query, i.e. shared among all tasks.
  // task_info: per-task.
  void task(char *runtime_state, TaskInfo *task_info);
  ```

- `CountDown`: After submitting tasks, the main thread waits for a counter to get to 0. Each task decreases the counter by 1 on finish. This is similar to last semester's `Barrier`, but uses a condition variable instead of polling so that we don't waste cycles in the master thread waiting for tasks to complete.

I have written 3 test cases to show how to use this infrastructure.

- Test Case 1: From C++, use `codegen::ExecutorThreadPool` to submit tasks and wait for all to finish.

- Test Case 2: Use LLVM to generate the task function. From C++, submit tasks to `codegen::ExecutorThreadPool`.

- Test Case 3: Use LLVM to generate both the task function and the code to submit tasks. The parallel LLVM engine will generate code that look exactly like this.

## Design of Parallel LLVM Engine

The main idea is to generate LLVM IR that submits tasks to a thread pool.
Each task decreases a counter on finish. The main thread waits until the counter reaches 0.

Each task is responsible for a portion of the table(s) or intermediate table(s). We only exploit in-query parallelism by splitting the table(s).

Hash join and other plans that introduce pipeline breakers are tricky to deal with. The key is that **we only generate the task submission part of the code alongside table or intermediate table traversal**. This means we only need to change the structure of the generated code in `TableScan.Produce` and the second half of `Aggregate.Produce`. The reason is that `#(pipeline breakers) = #(traversals) - 1 = #(stages) - 1`.

In this way we are not committed to a certain number of tasks in the beginning of the query. We can have different numbers of tasks for different stages.

One key observation is that every time when `Produce` gets called, we are in the context of the main plan function; every time when `Consume` gets called, we are in the context of a task function.

Let's show the design through examples.

For simplicity, suppose our DB supports these kinds of plans:
```scala
Plan ::= TableScan(table : Table)
       | Filter(child : Plan, pred : Expr)
       | HashJoin(lhs : Plan, rhs : Plan, key : Attrib)
       | Count(child : Plan, key : Attrib)
```

### Example 1

AST:
```scala
Filter(
  child = TableScan(table1),
  pred  = Less(Attrib('x'), Const(1)) // tuple.x < 1
)
```

Single Threaded:
```scala
// Filter.Produce {
  // TableScan.Produce {
    for t in table1:
      // Filter.Consume {
        if t.x < 1:
          // Consume {
            output(t)
          // } Consume
      // } Filter.Consume
  // } TableScan.Produce
// } Filter.Produce
```

Multithreaded:
```scala
// Filter.Produce {
  // TableScan.Produce {
    c = CountDown()
    for tid in range(ntasks(table1)): // We can determine how to split the table at runtime.
      pool.submit({ // Note that now we are in the task function.
        for t in table1.range(tid):
          // Filter.Consume {
            if t.x < 1:
              // Consume {
                output(t)
              // } Consume
          // } Filter.Consume
        c.Decrease()
      })
  // } TableScan.Produce
  c.Wait()
// } Filter.Produce
```

### Example 2

AST:
```scala
HashJoin(
  lhs = Filter(
    child = TableScan(table1)
    pred  = Less(Attrib('x'), Const(1))
  ),
  rhs = TableScan(table2),
  key = "key"
)
```

Single Threaded:
```scala
// HashJoin.Produce {
  h = HashTable()

  // Filter.Produce {
    // TableScan1.Produce {
      for t1 in table1:
        // Filter.Consume {
          if t1.x < 1:
          // HashJoin.ConsumeLeft {
            h.insert(t1.key, t1)
          // } HashJoin.ConsumeLeft
        // } Filter.Consume
    // } TableScan1.Produce
  // } Filter.Produce

  // TableScan2.Produce {
    for t2 in table2:
    // HashJoin.ConsumeRight {
      if (t1 = h.probe(t2.key)) != null:
        t = combine(t1, t2)
          // Consume {
            output(t)
          // } Consume
    // } HashJoinConsumeRight
  // } TableScan2.Produce

// } HashJoinProduce
```

Multithreaded:
```scala
// HashJoin.Produce {
  h = HashTable()

  // Filter.Produce {
    // TableScan1.Produce {
      c1 = CountDown()
      for tid in range(ntasks(table1)):
        pool.submit({
          for t1 in table1.range(tid):
            // Filter.Consume {
              if t1.x < 1:
                // HashJoin.ConsumeLeft {
                  h.insert(t1.key, t1)
                // } HashJoin.ConsumeLeft
            // } Filter.Consume
        c.Decrease()
      })
      c1.Wait()
    // } TableScan1.Produce
  // } Filter.Produce

  // TableScan2.Produce {
    c2 = CountDown()
    for tid in range(ntasks(table2)):
      pool.submit({
        for t2 in table2.range(tid):
          // HashJoin.ConsumeRight {
            if (t1 = h.probe(t2.key)) != null:
              t = combine(t1, t2)
              // Consume {
                output(t)
              // } Consume
          // } HashJoin.ConsumeRight
    })
    c2.Wait()
  // } TableScan2.Produce

// } HashJoin.Produce
```

### Example 3

AST:

```scala
Count(
  child = TableScan(table1)
  key = "key"
)
```

Single Threaded:

```scala
// Count.Produce {
  h = HashTable()

  // TableScan.Produce {
  for t in table1:
    // Count.Consume {
      h[t.key] += 1
    // } Count.Consume

  for entry in h:
    // Consume {
      output(entry)
    // } Consume

// } Count.Produce
```

Multithreaded:

```scala
// Count.Produce {
  h = HashTable()

  // TableScan.Produce {
    c1 = CountDown()
    for tid in range(ntasks(table1)):
      pool.submit({
        for t1 in table1.range(tid):
          // Count.Consume {
            h[t.key] += 1
          // } Count.Consume
        c1.Decrease()
      })
    c1.Wait()
  // } TableScan.Produce

  c2 = CountDown()
  for tid in range(ntasks(h)):
    pool.submit({
      for entry in h.range(tid):
        // Consume {
          output(entry)
        // } Consume
      c2.Decrease()
    })

// } Count.Produce
```