### PR TITLE
Fix for 'select * ' hanging

### DIFF
--- a/src/include/network/protocol_handler.h
+++ b/src/include/network/protocol_handler.h
@@ -43,8 +43,12 @@ class ProtocolHandler {
 
   virtual void GetResult();
 
+  void SetFlushFlag(bool flush) {force_flush_ = flush;}
+
+  bool GetFlushFlag() {return force_flush_;}
+
   // Should we send the buffered packets right away?
-  bool force_flush = false;
+  bool force_flush_ = false;
 
   // TODO declare a response buffer pool so that we can reuse the responses
   // so that we don't have to new packet each time

--- a/src/include/network/protocol_handler.h
+++ b/src/include/network/protocol_handler.h
@@ -47,7 +47,6 @@ class ProtocolHandler {
 
   bool GetFlushFlag() {return force_flush_;}
 
-  // Should we send the buffered packets right away?
   bool force_flush_ = false;
 
   // TODO declare a response buffer pool so that we can reuse the responses

--- a/src/network/network_connection.cpp
+++ b/src/network/network_connection.cpp
@@ -141,6 +141,10 @@ WriteState NetworkConnection::WritePackets() {
   if (protocol_handler_->force_flush == true) {
     return FlushWriteBuffer();
   }
+
+  // we have flushed, disable force flush now
+  protocol_handler_->force_flush = false;
+
   return WriteState::WRITE_COMPLETE;
 }
 
@@ -335,9 +339,6 @@ WriteState NetworkConnection::FlushWriteBuffer() {
 
   // buffer is empty
   wbuf_.Reset();
-
-  // we have flushed, disable force flush now
-  protocol_handler_->force_flush = false;
 
   // we are ok
   return WriteState::WRITE_COMPLETE;

--- a/src/network/network_connection.cpp
+++ b/src/network/network_connection.cpp
@@ -138,12 +138,12 @@ WriteState NetworkConnection::WritePackets() {
   protocol_handler_->responses.clear();
   next_response_ = 0;
 
-  if (protocol_handler_->force_flush == true) {
+  if (protocol_handler_->GetFlushFlag()) {
     return FlushWriteBuffer();
   }
 
   // we have flushed, disable force flush now
-  protocol_handler_->force_flush = false;
+  protocol_handler_->SetFlushFlag(false);
 
   return WriteState::WRITE_COMPLETE;
 }
@@ -441,7 +441,7 @@ bool NetworkConnection::ProcessSSLRequestPacket(InputPacket *pkt) {
   // TODO: consider more about a proper response
   response->msg_type = NetworkMessageType::SSL_YES;
   protocol_handler_->responses.push_back(std::move(response));
-  protocol_handler_->force_flush = true;
+  protocol_handler_->SetFlushFlag(true);
   ssl_sent_ = true;
   return true;
 }

--- a/src/network/postgres_protocol_handler.cpp
+++ b/src/network/postgres_protocol_handler.cpp
@@ -100,7 +100,7 @@ void PostgresProtocolHandler::SendInitialResponse() {
   SendReadyForQuery(NetworkTransactionStateType::IDLE);
 
   // we need to send the response right away
-  force_flush = true;
+  SetFlushFlag(true);
 }
 
 void PostgresProtocolHandler::MakeHardcodedParameterStatus(
@@ -1094,7 +1094,7 @@ ProcessResult PostgresProtocolHandler::ProcessPacket(InputPacket *pkt, const siz
   switch (pkt->msg_type) {
     case NetworkMessageType::SIMPLE_QUERY_COMMAND: {
       LOG_TRACE("SIMPLE_QUERY_COMMAND");
-      force_flush = true;
+      SetFlushFlag(true);
       return ExecQueryMessage(pkt, thread_id);
     }
     case NetworkMessageType::PARSE_COMMAND: {
@@ -1116,7 +1116,7 @@ ProcessResult PostgresProtocolHandler::ProcessPacket(InputPacket *pkt, const siz
     case NetworkMessageType::SYNC_COMMAND: {
       LOG_TRACE("SYNC_COMMAND");
       SendReadyForQuery(txn_state_);
-      force_flush = true;
+      SetFlushFlag(true);
     } break;
     case NetworkMessageType::CLOSE_COMMAND: {
       LOG_TRACE("CLOSE_COMMAND");
@@ -1124,12 +1124,12 @@ ProcessResult PostgresProtocolHandler::ProcessPacket(InputPacket *pkt, const siz
     } break;
     case NetworkMessageType::TERMINATE_COMMAND: {
       LOG_TRACE("TERMINATE_COMMAND");
-      force_flush = true;
+      SetFlushFlag(true);
       return ProcessResult::TERMINATE;
     }
     case NetworkMessageType::NULL_COMMAND: {
       LOG_TRACE("NULL");
-      force_flush = true;
+      SetFlushFlag(true);
       return ProcessResult::TERMINATE;
     }
     default: {

--- a/src/network/protocol_handler.cpp
+++ b/src/network/protocol_handler.cpp
@@ -34,7 +34,7 @@ namespace network {
   }
 
   void ProtocolHandler::Reset() {
-    force_flush = false;
+    SetFlushFlag(false);
     responses.clear();
     request.Reset();
   }

--- a/test/network/select_all_test.cpp
+++ b/test/network/select_all_test.cpp
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// select_all_test.cpp
+//
+// Identification: test/network/select_all_test.cpp
+//
+// Copyright (c) 2016-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/harness.h"
+#include "gtest/gtest.h"
+#include "common/logger.h"
+#include "network/network_manager.h"
+#include "network/protocol_handler_factory.h"
+#include "util/string_util.h"
+#include <pqxx/pqxx> /* libpqxx is used to instantiate C++ client */
+#include <include/network/postgres_protocol_handler.h>
+
+#define NUM_THREADS 1
+
+namespace peloton {
+namespace test {
+
+//===--------------------------------------------------------------------===//
+// Select All Tests
+//===--------------------------------------------------------------------===//
+
+class SelectAllTests : public PelotonTest {};
+
+static void *LaunchServer(peloton::network::NetworkManager network_manager,
+                          int port) {
+  try {
+    network_manager.SetPort(port);
+    network_manager.StartServer();
+  } catch (peloton::ConnectionException &exception) {
+    LOG_INFO("[LaunchServer] exception in thread");
+  }
+  return NULL;
+}
+
+/**
+ * Select All Test
+ * In this test, peloton will return the result that exceeds the 8192 bytes limits.
+ * The response will be put into multiple packets and be sent back to clients.
+ */
+void *SelectAllTest(int port) {
+  try {
+    // forcing the factory to generate psql protocol handler
+    pqxx::connection C(StringUtil::Format(
+        "host=127.0.0.1 port=%d user=postgres sslmode=disable application_name=psql", port));
+    pqxx::work txn1(C);
+
+    peloton::network::NetworkConnection *conn =
+        peloton::network::NetworkManager::GetConnection(
+            peloton::network::NetworkManager::recent_connfd);
+
+    network::PostgresProtocolHandler *handler =
+        dynamic_cast<network::PostgresProtocolHandler *>(conn->protocol_handler_.get());
+    EXPECT_NE(handler, nullptr);
+
+    // create table and insert some data
+    txn1.exec("DROP TABLE IF EXISTS template;");
+    txn1.exec("CREATE TABLE template(id INT);");
+    txn1.commit();
+
+    pqxx::work txn2(C);
+    for (int i = 0; i < 2000; i++) {
+      std::string s = "INSERT INTO template VALUES (" + std::to_string(i) + ")";
+      txn2.exec(s);
+    }
+
+    pqxx::result R = txn2.exec("SELECT * from template;");
+    txn2.commit();
+
+    EXPECT_EQ(R.size(), 2000);
+  } catch (const std::exception &e) {
+    LOG_INFO("[SelectAllTest] Exception occurred: %s", e.what());
+    EXPECT_TRUE(false);
+  }
+
+  LOG_INFO("[SelectAllTest] Client has closed");
+  return NULL;
+}
+
+TEST_F(SelectAllTests, SelectAllTest) {
+  peloton::PelotonInit::Initialize();
+  LOG_INFO("Server initialized");
+  peloton::network::NetworkManager network_manager;
+
+  int port = 15721;
+  std::thread serverThread(LaunchServer, network_manager, port);
+  while (!network_manager.GetIsStarted()) {
+    sleep(1);
+  }
+
+  // server & client running correctly
+  SelectAllTest(port);
+
+  network_manager.CloseServer();
+  serverThread.join();
+  LOG_INFO("Peloton is shutting down");
+  peloton::PelotonInit::Shutdown();
+  LOG_INFO("Peloton has shut down");
+}
+
+} // namespace test
+} // namespace peloton


### PR DESCRIPTION
It's the same PR as #908 

Fix for #878
The issue is due to that the server does not flush out all the packets. The client does not get the complete result so it looks like hanging.
The server should flush out all the packets before resetting the force_flush flag.

Previous PR doesn't run the check. Just to check if it can run check after changing the source repository.