### PR TITLE
Fix INSERT SELECT by filtering out the tuples inserted in the same execution

### DIFF
--- a/src/codegen/operator/insert_translator.cpp
+++ b/src/codegen/operator/insert_translator.cpp
@@ -83,17 +83,13 @@ void InsertTranslator::Consume(ConsumerContext &, RowBatch::Row &row) const {
   auto &codegen = GetCodeGen();
   auto *inserter = LoadStatePtr(inserter_state_id_);
 
-  auto *scan =
-      static_cast<const planner::AbstractScan *>(insert_plan_.GetChild(0));
-  std::vector<const planner::AttributeInfo *> ais;
-  scan->GetAttributes(ais);
-
   auto *tuple_ptr = codegen.Call(InserterProxy::ReserveTupleStorage,
                                  {inserter});
   auto *pool = codegen.Call(InserterProxy::GetPool, {inserter});
 
   // Generate/Materialize tuple data from row and attribute information
   std::vector<codegen::Value> values;
+  auto &ais = insert_plan_.GetAttributeInfos();
   for (const auto *ai : ais) {
     codegen::Value v = row.DeriveValue(codegen, ai);
     values.push_back(v);

--- a/src/codegen/proxy/inserter_proxy.cpp
+++ b/src/codegen/proxy/inserter_proxy.cpp
@@ -24,10 +24,13 @@ namespace codegen {
 DEFINE_TYPE(Inserter, "codegen::Inserter", MEMBER(opaque));
 
 DEFINE_METHOD(peloton::codegen, Inserter, Init);
+DEFINE_METHOD(peloton::codegen, Inserter, CreateFilter);
+DEFINE_METHOD(peloton::codegen, Inserter, IsEligible);
 DEFINE_METHOD(peloton::codegen, Inserter, ReserveTupleStorage);
 DEFINE_METHOD(peloton::codegen, Inserter, GetPool);
 DEFINE_METHOD(peloton::codegen, Inserter, InsertReserved);
 DEFINE_METHOD(peloton::codegen, Inserter, Insert);
+DEFINE_METHOD(peloton::codegen, Inserter, TearDown);
 
 }  // namespace codegen
 }  // namespace peloton

--- a/src/include/codegen/operator/insert_translator.h
+++ b/src/include/codegen/operator/insert_translator.h
@@ -62,7 +62,7 @@ class InsertTranslator : public OperatorTranslator {
   void Consume(ConsumerContext &context, RowBatch::Row &row) const override;
 
   // Codegen any cleanup work
-  void TearDownState() override {}
+  void TearDownState() override;
 
   // Get the name of this trnslator
   std::string GetName() const override { return "Insert"; }

--- a/src/include/codegen/operator/update_translator.h
+++ b/src/include/codegen/operator/update_translator.h
@@ -41,7 +41,7 @@ class UpdateTranslator : public OperatorTranslator {
   // Consume : No Cosume() override for Batch
   void Consume(ConsumerContext &context, RowBatch::Row &row) const override;
 
-  // No state finalization
+  // State finalization
   void TearDownState() override;
 
   // Get the stringified name of this translator

--- a/src/include/codegen/proxy/inserter_proxy.h
+++ b/src/include/codegen/proxy/inserter_proxy.h
@@ -25,10 +25,13 @@ PROXY(Inserter) {
   DECLARE_TYPE;
 
   DECLARE_METHOD(Init);
+  DECLARE_METHOD(CreateFilter);
+  DECLARE_METHOD(IsEligible);
   DECLARE_METHOD(ReserveTupleStorage);
   DECLARE_METHOD(GetPool);
   DECLARE_METHOD(InsertReserved);
   DECLARE_METHOD(Insert);
+  DECLARE_METHOD(TearDown);
 };
 
 TYPE_BUILDER(Inserter, codegen::Inserter);

--- a/src/include/common/item_pointer.h
+++ b/src/include/common/item_pointer.h
@@ -54,7 +54,7 @@ class ItemPointerComparator {
     return (p1->block == p2->block) && (p1->offset == p2->offset);
   }
 
-  bool operator()(const ItemPointer &p1, ItemPointer &p2) const {
+  bool operator()(const ItemPointer &p1, const ItemPointer &p2) const {
     return (p1.block == p2.block) && (p1.offset == p2.offset);
   }
 

--- a/src/include/common/item_pointer.h
+++ b/src/include/common/item_pointer.h
@@ -54,6 +54,10 @@ class ItemPointerComparator {
     return (p1->block == p2->block) && (p1->offset == p2->offset);
   }
 
+  bool operator()(const ItemPointer &p1, ItemPointer &p2) const {
+    return (p1.block == p2.block) && (p1.offset == p2.offset);
+  }
+
   ItemPointerComparator(const ItemPointerComparator &) {}
   ItemPointerComparator() {}
 };

--- a/src/planner/insert_plan.cpp
+++ b/src/planner/insert_plan.cpp
@@ -156,5 +156,20 @@ void InsertPlan::SetParameterValues(std::vector<type::Value> *values) {
   }
 }
 
+void InsertPlan::PerformBinding(BindingContext &binding_context) {
+  const auto &children = GetChildren();
+
+  if (children.size() == 1) {
+    children[0]->PerformBinding(binding_context);
+
+    auto *scan = static_cast<planner::AbstractScan *>(children[0].get());
+    auto &col_ids = scan->GetColumnIds();
+    for (oid_t col_id = 0; col_id < col_ids.size(); col_id++) {
+      ais_.push_back(binding_context.Find(col_id));
+    }
+  }
+  // Binding is not required if there is no child
+}
+
 }  // namespace planner
 }  // namespace peloton

--- a/src/planner/update_plan.cpp
+++ b/src/planner/update_plan.cpp
@@ -53,7 +53,10 @@ void UpdatePlan::PerformBinding(BindingContext &binding_context) {
   children[0]->PerformBinding(input_context);
 
   auto *scan = static_cast<planner::AbstractScan *>(children[0].get());
-  scan->GetAttributes(ais_);
+  auto &col_ids = scan->GetColumnIds();
+  for (oid_t col_id = 0; col_id < col_ids.size(); col_id++) {
+    ais_.push_back(input_context.Find(col_id));
+  }
 
   // Do projection (if one exists)
   if (GetProjectInfo() != nullptr) {

--- a/test/codegen/insert_translator_test.cpp
+++ b/test/codegen/insert_translator_test.cpp
@@ -243,5 +243,73 @@ TEST_F(InsertTranslatorTest, InsertScanTranslatorWithNull) {
                                 type::ValueFactory::GetVarcharValue("93")));
 }
 
+// Insert a tuple from table2 with column order changed, into table1.
+TEST_F(InsertTranslatorTest, InsertScanColumnTranslator) {
+  auto table1 = &GetTestTable(TestTableId1());
+  auto table2 = &GetTestTable(TestTableId2());
+
+  LoadTestTable(TestTableId2(), 10);
+
+  // Insert plan for table1
+  std::unique_ptr<planner::InsertPlan> insert_plan(
+      new planner::InsertPlan(table1));
+
+  // Scan plan for table2
+  std::unique_ptr<planner::SeqScanPlan> seq_scan_plan(
+      new planner::SeqScanPlan(table2, nullptr, {1, 0, 2, 3}));
+
+  insert_plan->AddChild(std::move(seq_scan_plan));
+
+  // Do binding
+  planner::BindingContext context;
+  insert_plan->PerformBinding(context);
+
+  // Collect the results of the query into an in-memory buffer
+  codegen::BufferingConsumer buffer{{0, 1}, context};
+
+  // COMPILE and execute
+  CompileAndExecute(*insert_plan, buffer,
+                    reinterpret_cast<char *>(buffer.GetState()));
+  auto &results = buffer.GetOutputTuples();
+  (void)results;
+
+  EXPECT_EQ(table1->GetTupleCount(), table2->GetTupleCount());
+
+  // Setup the scan plan node
+  std::unique_ptr<planner::SeqScanPlan> seq_scan_plan_table1(
+      new planner::SeqScanPlan(table1, nullptr, {0, 1, 2, 3}));
+
+  // Do binding
+  planner::BindingContext context1;
+  seq_scan_plan_table1->PerformBinding(context1);
+
+  // Printing consumer
+  codegen::BufferingConsumer buffer_table1{{0, 1, 2, 3}, context1};
+
+  // COMPILE and execute
+  CompileAndExecute(*seq_scan_plan_table1, buffer_table1,
+                    reinterpret_cast<char*>(buffer_table1.GetState()));
+
+  // Check that we got all the results
+  auto &results_table1 = buffer_table1.GetOutputTuples();
+
+  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(0).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(1).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(0)));
+  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(2).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(2)));
+  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(3).CompareEquals(
+                                type::ValueFactory::GetVarcharValue("3")));
+  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(0).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(91)));
+  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(1).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(90)));
+  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(2).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(92)));
+  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(3).CompareEquals(
+                                type::ValueFactory::GetVarcharValue("93")));
+}
+
 }  // namespace test
 }  // namespace peloton

--- a/test/codegen/update_translator_test.cpp
+++ b/test/codegen/update_translator_test.cpp
@@ -92,10 +92,46 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstant) {
                     reinterpret_cast<char *>(buffer.GetState()));
 
   LOG_DEBUG("Table has %zu tuples", table->GetTupleCount());
-  LOG_INFO("%s", table->GetInfo().c_str());
+  LOG_DEBUG("%s", table->GetInfo().c_str());
 
   // Post-condition: The table will have twice many, since it also has old ones
   EXPECT_EQ(NumRowsInTestTable()*2, table->GetTupleCount());
+
+  // Setup the scan plan node
+  std::unique_ptr<planner::SeqScanPlan> scan_plan_1(
+      new planner::SeqScanPlan(
+          &GetTestTable(TestTableId1()), nullptr, {0, 1, 2, 3}));
+
+  // Do binding
+  planner::BindingContext context_1;
+  scan_plan_1->PerformBinding(context_1);
+
+  // Printing consumer
+  codegen::BufferingConsumer buffer_1{{0, 1, 2, 3}, context_1};
+
+  // COMPILE and execute
+  CompileAndExecute(*scan_plan_1, buffer_1,
+                    reinterpret_cast<char*>(buffer_1.GetState()));
+
+  // Check that we got all the results
+  auto &results_1 = buffer_1.GetOutputTuples();
+
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(2)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+                                type::ValueFactory::GetVarcharValue("3")));
+  EXPECT_EQ(type::CMP_TRUE, results_1[9].GetValue(0).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[9].GetValue(1).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(91)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[9].GetValue(2).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(92)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[9].GetValue(3).CompareEquals(
+                                type::ValueFactory::GetVarcharValue("93")));
 }
 
 TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantAndPredicate) {
@@ -148,11 +184,244 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantAndPredicate) {
                     reinterpret_cast<char *>(buffer.GetState()));
 
   LOG_DEBUG("Table has %zu tuples", table->GetTupleCount());
-  LOG_INFO("%s", table->GetInfo().c_str());
+  LOG_DEBUG("%s", table->GetInfo().c_str());
 
   // Post-condition: The table will have twice many, since it also has old ones
   EXPECT_EQ(NumRowsInTestTable()+1, table->GetTupleCount());
+
+  // Setup the scan plan node
+  std::unique_ptr<expression::AbstractExpression> b_eq_49 =
+      CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 1), ConstIntExpr(49));
+  std::unique_ptr<planner::SeqScanPlan> scan_plan_2(
+      new planner::SeqScanPlan(
+          &GetTestTable(TestTableId2()), b_eq_49.release(), {0, 1, 2, 3}));
+
+  // Do binding
+  planner::BindingContext context_1;
+  scan_plan_2->PerformBinding(context_1);
+
+  // Printing consumer
+  codegen::BufferingConsumer buffer_1{{0, 1, 2, 3}, context_1};
+
+  // COMPILE and execute
+  CompileAndExecute(*scan_plan_2, buffer_1,
+                    reinterpret_cast<char*>(buffer_1.GetState()));
+
+  // Check that we got all the results
+  auto &results_1 = buffer_1.GetOutputTuples();
+
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(40)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(49)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(42)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+                                type::ValueFactory::GetVarcharValue("43")));
+
 }
+
+TEST_F(UpdateTranslatorTest, UpdateColumnsWithAnOperatorExpression) {
+  LoadTestTable(TestTableId2(), NumRowsInTestTable());
+
+  // SET a = 1;
+  storage::DataTable *table = &this->GetTestTable(this->TestTableId2());
+  LOG_DEBUG("Table has %zu tuples", table->GetTupleCount());
+  LOG_DEBUG("%s", table->GetInfo().c_str());
+
+  // Pre-condition
+  EXPECT_EQ(NumRowsInTestTable(), table->GetTupleCount());
+
+  std::unique_ptr<expression::AbstractExpression> b_eq_41 =
+      CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 1), ConstIntExpr(41));
+
+  // Get the scan plan without a predicate with four columns
+  std::unique_ptr<planner::SeqScanPlan> scan_plan(new planner::SeqScanPlan(
+      &GetTestTable(TestTableId2()), b_eq_41.release(), {0, 1, 2, 3}));
+
+  // Transform using a projection
+  // Column 0 of the updated tuple will have constant value 1
+  auto c_val_9 = new expression::ConstantValueExpression(
+      type::ValueFactory::GetIntegerValue(9));
+  auto tuple_val_expr =
+      expression::ExpressionUtil::TupleValueFactory(type::TypeId::INTEGER, 0, 0);
+  expression::AbstractExpression *op_expr =
+      expression::ExpressionUtil::OperatorFactory(ExpressionType::OPERATOR_PLUS,
+                                                  type::TypeId::INTEGER,
+                                                  tuple_val_expr, c_val_9);
+  std::unique_ptr<const planner::ProjectInfo> project_info(
+      new planner::ProjectInfo(
+          // Target List : [(oid_t, planner::DerivedAttribute)]
+          // Specify columns that are transformed.
+          {{1, planner::DerivedAttribute{op_expr}}},
+                   //expression::ExpressionUtil::ConstantValueFactory(
+                    //   type::ValueFactory::GetIntegerValue(49))}}},
+          // Direct Map List : [(oid_t, (oid_t, oid_t))]
+          // Specify columns that are directly pulled from the original tuple.
+          {{0, {0, 0}}, {2, {0, 2}}, {3, {0, 3}}}));
+
+  // Embed the transformation to build up an update plan.
+  std::unique_ptr<planner::UpdatePlan> update_plan(new planner::UpdatePlan(
+      &GetTestTable(TestTableId2()), std::move(project_info)));
+
+  // Add the scan to the update plan
+  update_plan->AddChild(std::move(scan_plan));
+
+  // Do binding
+  planner::BindingContext context;
+  update_plan->PerformBinding(context);
+
+  // We collect the results of the query into an in-memory buffer
+  codegen::BufferingConsumer buffer{{}, context};
+
+  // COMPILE and execute
+  CompileAndExecute(*update_plan, buffer,
+                    reinterpret_cast<char *>(buffer.GetState()));
+
+  LOG_DEBUG("Table has %zu tuples", table->GetTupleCount());
+  LOG_DEBUG("%s", table->GetInfo().c_str());
+
+  // Post-condition: The table will have twice many, since it also has old ones
+  EXPECT_EQ(NumRowsInTestTable()+1, table->GetTupleCount());
+
+  // Setup the scan plan node
+  std::unique_ptr<expression::AbstractExpression> b_eq_49 =
+      CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 1), ConstIntExpr(49));
+  std::unique_ptr<planner::SeqScanPlan> scan_plan_2(
+      new planner::SeqScanPlan(
+          &GetTestTable(TestTableId2()), b_eq_49.release(), {0, 1, 2, 3}));
+
+  // Do binding
+  planner::BindingContext context_1;
+  scan_plan_2->PerformBinding(context_1);
+
+  // Printing consumer
+  codegen::BufferingConsumer buffer_1{{0, 1, 2, 3}, context_1};
+
+  // COMPILE and execute
+  CompileAndExecute(*scan_plan_2, buffer_1,
+                    reinterpret_cast<char*>(buffer_1.GetState()));
+
+  // Check that we got all the results
+  auto &results_1 = buffer_1.GetOutputTuples();
+
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(40)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(49)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(42)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+                                type::ValueFactory::GetVarcharValue("43")));
+
+}
+
+TEST_F(UpdateTranslatorTest, UpdateColumnsWithAnOperatorExpressionComplex) {
+  LoadTestTable(TestTableId2(), NumRowsInTestTable());
+
+  // SET a = 1;
+  storage::DataTable *table = &this->GetTestTable(this->TestTableId2());
+  LOG_DEBUG("Table has %zu tuples", table->GetTupleCount());
+  LOG_DEBUG("%s", table->GetInfo().c_str());
+
+  // Pre-condition
+  EXPECT_EQ(NumRowsInTestTable(), table->GetTupleCount());
+
+  std::unique_ptr<expression::AbstractExpression> b_eq_41 =
+      CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 1), ConstIntExpr(41));
+
+  // Get the scan plan without a predicate with four columns
+  std::unique_ptr<planner::SeqScanPlan> scan_plan(new planner::SeqScanPlan(
+      &GetTestTable(TestTableId2()), b_eq_41.release(), {0, 1, 2, 3}));
+
+  // Transform using a projection
+  auto c_val_1 = new expression::ConstantValueExpression(
+      type::ValueFactory::GetIntegerValue(1));
+  auto tuple_val_expr =
+      expression::ExpressionUtil::TupleValueFactory(type::TypeId::INTEGER, 0, 0);
+  expression::AbstractExpression *op_expr =
+      expression::ExpressionUtil::OperatorFactory(ExpressionType::OPERATOR_PLUS,
+                                                  type::TypeId::INTEGER,
+                                                  tuple_val_expr, c_val_1);
+
+  auto tuple_val_expr_1 =
+      expression::ExpressionUtil::TupleValueFactory(type::TypeId::INTEGER, 0, 0);
+  auto tuple_val_expr_2 =
+      expression::ExpressionUtil::TupleValueFactory(type::TypeId::INTEGER, 0, 1);
+  expression::AbstractExpression *op_expr_2 =
+      expression::ExpressionUtil::OperatorFactory(ExpressionType::OPERATOR_PLUS,
+                                                  type::TypeId::INTEGER,
+                                                  tuple_val_expr_1,
+                                                  tuple_val_expr_2);
+
+  std::unique_ptr<const planner::ProjectInfo> project_info(
+      new planner::ProjectInfo(
+          // Target List : [(oid_t, planner::DerivedAttribute)]
+          // Specify columns that are transformed.
+          {{0, planner::DerivedAttribute{op_expr}},
+           {1, planner::DerivedAttribute{op_expr_2}}},
+                   //expression::ExpressionUtil::ConstantValueFactory(
+                    //   type::ValueFactory::GetIntegerValue(49))}}},
+          // Direct Map List : [(oid_t, (oid_t, oid_t))]
+          // Specify columns that are directly pulled from the original tuple.
+          {{2, {0, 2}}, {3, {0, 3}}}));
+
+  // Embed the transformation to build up an update plan.
+  std::unique_ptr<planner::UpdatePlan> update_plan(new planner::UpdatePlan(
+      &GetTestTable(TestTableId2()), std::move(project_info)));
+
+  // Add the scan to the update plan
+  update_plan->AddChild(std::move(scan_plan));
+
+  // Do binding
+  planner::BindingContext context;
+  update_plan->PerformBinding(context);
+
+  // We collect the results of the query into an in-memory buffer
+  codegen::BufferingConsumer buffer{{}, context};
+
+  // COMPILE and execute
+  CompileAndExecute(*update_plan, buffer,
+                    reinterpret_cast<char *>(buffer.GetState()));
+
+  LOG_DEBUG("Table has %zu tuples", table->GetTupleCount());
+  LOG_DEBUG("%s", table->GetInfo().c_str());
+
+  // Post-condition: The table will have twice many, since it also has old ones
+  EXPECT_EQ(NumRowsInTestTable()+1, table->GetTupleCount());
+
+  // Setup the scan plan node
+  std::unique_ptr<expression::AbstractExpression> a_eq_41 =
+      CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(41));
+  std::unique_ptr<planner::SeqScanPlan> scan_plan_2(
+      new planner::SeqScanPlan(
+          &GetTestTable(TestTableId2()), a_eq_41.release(), {0, 1, 2, 3}));
+
+  // Do binding
+  planner::BindingContext context_1;
+  scan_plan_2->PerformBinding(context_1);
+
+  // Printing consumer
+  codegen::BufferingConsumer buffer_1{{0, 1, 2, 3}, context_1};
+
+  // COMPILE and execute
+  CompileAndExecute(*scan_plan_2, buffer_1,
+                    reinterpret_cast<char*>(buffer_1.GetState()));
+
+  // Check that we got all the results
+  auto &results_1 = buffer_1.GetOutputTuples();
+
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(41)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(81)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(42)));
+  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+                                type::ValueFactory::GetVarcharValue("43")));
+
+}
+
 
 TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantPrimary) {
   LoadTestTable(TestTableId5(), NumRowsInTestTable());
@@ -165,12 +434,12 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantPrimary) {
   // Pre-condition
   EXPECT_EQ(NumRowsInTestTable(), table->GetTupleCount());
 
-  std::unique_ptr<expression::AbstractExpression> b_eq_40 =
+  std::unique_ptr<expression::AbstractExpression> a_eq_10 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(10));
 
   // Get the scan plan without a predicate with four columns
   std::unique_ptr<planner::SeqScanPlan> scan_plan(new planner::SeqScanPlan(
-      &GetTestTable(TestTableId5()), b_eq_40.release(), {0, 1, 2, 3}));
+      &GetTestTable(TestTableId5()), a_eq_10.release(), {0, 1, 2, 3}));
 
   // Transform using a projection
   // Column 0 of the updated tuple will have constant value 1
@@ -204,12 +473,41 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantPrimary) {
                     reinterpret_cast<char *>(buffer.GetState()));
 
   LOG_DEBUG("Table has %zu tuples", table->GetTupleCount());
-  LOG_INFO("%s", table->GetInfo().c_str());
+  LOG_DEBUG("%s", table->GetInfo().c_str());
 
   // Post-condition: The table will have twice many, since it also has old ones
   EXPECT_EQ(NumRowsInTestTable()+2, table->GetTupleCount());
-}
 
+  // Setup the scan plan node
+  std::unique_ptr<expression::AbstractExpression> a_eq_1 =
+      CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(1));
+  std::unique_ptr<planner::SeqScanPlan> scan_plan_5(
+      new planner::SeqScanPlan(
+          &GetTestTable(TestTableId5()), a_eq_1.release(), {0, 1, 2, 3}));
+
+  // Do binding
+  planner::BindingContext context_1;
+  scan_plan_5->PerformBinding(context_1);
+
+  // Printing consumer
+  codegen::BufferingConsumer buffer_5{{0, 1, 2, 3}, context_1};
+
+  // COMPILE and execute
+  CompileAndExecute(*scan_plan_5, buffer_5,
+                    reinterpret_cast<char*>(buffer_5.GetState()));
+
+  // Check that we got all the results
+  auto &results_5 = buffer_5.GetOutputTuples();
+
+  EXPECT_EQ(type::CMP_TRUE, results_5[0].GetValue(0).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(type::CMP_TRUE, results_5[0].GetValue(1).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(11)));
+  EXPECT_EQ(type::CMP_TRUE, results_5[0].GetValue(2).CompareEquals(
+                                type::ValueFactory::GetIntegerValue(12)));
+  EXPECT_EQ(type::CMP_TRUE, results_5[0].GetValue(3).CompareEquals(
+                                type::ValueFactory::GetVarcharValue("13")));
+}
 
 }  // namespace test
 }  // namespace peloton


### PR DESCRIPTION
Edited: One of the problems that the original PR solved is not in #934.

Without this PR, inserting tuples with SELECT may insert more tuples than required, e.g. `INSERT INTO foo1 SELECT a, b FROM foo1;` will insert more than the number of tuples already there in `foo1`.

This problem was there because the tuples inserted were scanned again by the table scanner depending on the tile group selection.  This is fixed by keeping  a separate filter in INSERT to filter out those.  It could also implemented in other ways, e.g. the modules underneath the INSERT logic may take a sort of filter. It may be more efficient, but more complex, so for the moment, we do this at INSERT.