### PR TITLE
Simplify NULL handling in type system

### DIFF
--- a/src/codegen/expression/comparison_translator.cpp
+++ b/src/codegen/expression/comparison_translator.cpp
@@ -48,14 +48,7 @@ codegen::Value ComparisonTranslator::DeriveValue(CodeGen &codegen,
     case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
       return left.CompareGte(codegen, right);
     case ExpressionType::COMPARE_LIKE: {
-      type::Type left_type = left.GetType();
-      type::Type right_type = right.GetType();
-      auto *binary_op = type::TypeSystem::GetBinaryOperator(
-          OperatorId::Like, left_type, left_type, right_type, right_type);
-      PL_ASSERT(binary_op);
-
-      return binary_op->DoWork(codegen, left.CastTo(codegen, left_type),
-                               right.CastTo(codegen, right_type),
+      return left.CallBinaryOp(codegen, OperatorId::Like, right,
                                OnError::Exception);
     }
     default: {

--- a/src/codegen/expression/function_translator.cpp
+++ b/src/codegen/expression/function_translator.cpp
@@ -62,9 +62,9 @@ codegen::Value FunctionTranslator::DeriveValue(CodeGen &codegen,
     PL_ASSERT(binary_op);
 
     // Invoke
-    return binary_op->DoWork(codegen, args[0].CastTo(codegen, left_type),
-                             args[1].CastTo(codegen, right_type),
-                             OnError::Exception);
+    return binary_op->Eval(codegen, args[0].CastTo(codegen, left_type),
+                           args[1].CastTo(codegen, right_type),
+                           OnError::Exception);
   } else {
     // It's an N-Ary function
 
@@ -77,7 +77,7 @@ codegen::Value FunctionTranslator::DeriveValue(CodeGen &codegen,
     // Lookup the function
     auto *nary_op = type::TypeSystem::GetNaryOperator(operator_id, arg_types);
     PL_ASSERT(nary_op != nullptr);
-    return nary_op->DoWork(codegen, args, OnError::Exception);
+    return nary_op->Eval(codegen, args, OnError::Exception);
   }
 }
 

--- a/src/codegen/table_storage.cpp
+++ b/src/codegen/table_storage.cpp
@@ -23,10 +23,11 @@ namespace peloton {
 namespace codegen {
 
 void TableStorage::StoreValues(CodeGen &codegen, llvm::Value *tuple_ptr,
-    const std::vector<codegen::Value> &values, llvm::Value *pool) const {
+                               const std::vector<codegen::Value> &values,
+                               llvm::Value *pool) const {
   for (oid_t i = 0; i < schema_.GetColumnCount(); i++) {
     type::Type schema_type =
-        type::Type{schema_.GetType(i),schema_.AllowNull(i)};
+        type::Type{schema_.GetType(i), schema_.AllowNull(i)};
     auto &sql_type = schema_type.GetSqlType();
     llvm::Type *val_type, *len_type;
     sql_type.GetTypeForMaterialization(codegen, val_type, len_type);
@@ -42,8 +43,9 @@ void TableStorage::StoreValues(CodeGen &codegen, llvm::Value *tuple_ptr,
       lang::If value_is_null{codegen, value.IsNull(codegen)};
       {
         auto null_val = sql_type.GetNullValue(codegen);
-        codegen.Call(TupleRuntimeProxy::CreateVarlen,
-            {null_val.GetValue(), null_val.GetLength(), val_ptr, pool});
+        codegen->CreateStore(
+            null_val.GetValue(),
+            codegen->CreateBitCast(ptr, val_type->getPointerTo()));
       }
       value_is_null.ElseBlock();
       {

--- a/src/codegen/tuple_runtime.cpp
+++ b/src/codegen/tuple_runtime.cpp
@@ -11,20 +11,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "codegen/tuple_runtime.h"
-#include "common/macros.h"
 #include "type/abstract_pool.h"
 
 namespace peloton {
 namespace codegen {
 
 void TupleRuntime::CreateVarlen(char *data, uint32_t len, char *buf,
-                                 peloton::type::AbstractPool *pool) {
+                                peloton::type::AbstractPool *pool) {
   struct varlen_t {
     uint32_t len;
-    char data[];
+    char data[0];
   };
 
-  varlen_t *area =
+  auto *area =
       reinterpret_cast<varlen_t *>(pool->Allocate(sizeof(uint32_t) + len));
   area->len = len;
   PL_MEMCPY(area->data, data, len);

--- a/src/codegen/type/bigint_type.cpp
+++ b/src/codegen/type/bigint_type.cpp
@@ -172,7 +172,7 @@ struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
 };
 
 // Addition
-struct Add : public TypeSystem::BinaryOperator {
+struct Add : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == BigInt::Instance() &&
@@ -184,8 +184,8 @@ struct Add : public TypeSystem::BinaryOperator {
     return Type{BigInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do addition
@@ -203,7 +203,7 @@ struct Add : public TypeSystem::BinaryOperator {
 };
 
 // Subtraction
-struct Sub : public TypeSystem::BinaryOperator {
+struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == BigInt::Instance() &&
@@ -215,8 +215,8 @@ struct Sub : public TypeSystem::BinaryOperator {
     return Type{BigInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do subtraction
@@ -234,7 +234,7 @@ struct Sub : public TypeSystem::BinaryOperator {
 };
 
 // Multiplication
-struct Mul : public TypeSystem::BinaryOperator {
+struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == BigInt::Instance() &&
@@ -246,8 +246,8 @@ struct Mul : public TypeSystem::BinaryOperator {
     return Type{BigInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do multiplication
@@ -265,7 +265,7 @@ struct Mul : public TypeSystem::BinaryOperator {
 };
 
 // Division
-struct Div : public TypeSystem::BinaryOperator {
+struct Div : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == BigInt::Instance() &&
@@ -277,8 +277,8 @@ struct Div : public TypeSystem::BinaryOperator {
     return Type{BigInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
@@ -321,7 +321,7 @@ struct Div : public TypeSystem::BinaryOperator {
 };
 
 // Modulo
-struct Modulo : public TypeSystem::BinaryOperator {
+struct Modulo : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == BigInt::Instance() &&
@@ -333,8 +333,8 @@ struct Modulo : public TypeSystem::BinaryOperator {
     return Type{BigInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero

--- a/src/codegen/type/bigint_type.cpp
+++ b/src/codegen/type/bigint_type.cpp
@@ -148,7 +148,7 @@ struct CompareBigInt : public TypeSystem::SimpleNullableComparison {
 };
 
 // Negation
-struct Negate : public TypeSystem::UnaryOperator {
+struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == BigInt::Instance();
   }
@@ -157,7 +157,7 @@ struct Negate : public TypeSystem::UnaryOperator {
     return Type{BigInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &val) const override {
+  Value Impl(CodeGen &codegen, const Value &val) const override {
     PL_ASSERT(SupportsType(val.GetType()));
 
     llvm::Value *overflow_bit = nullptr;

--- a/src/codegen/type/bigint_type.cpp
+++ b/src/codegen/type/bigint_type.cpp
@@ -33,7 +33,7 @@ namespace {
 // We do BIGINT -> {INTEGRAL_TYPE, DECIMAL, VARCHAR, BOOLEAN}
 //===----------------------------------------------------------------------===//
 
-struct CastBigInt : public TypeSystem::SimpleNullableCast {
+struct CastBigInt : public TypeSystem::CastHandleNull {
   bool SupportsTypes(const Type &from_type,
                      const Type &to_type) const override {
     if (from_type.GetSqlType() != BigInt::Instance()) {
@@ -97,7 +97,7 @@ struct CastBigInt : public TypeSystem::SimpleNullableCast {
 };
 
 // Comparison
-struct CompareBigInt : public TypeSystem::SimpleNullableComparison {
+struct CompareBigInt : public TypeSystem::SimpleComparisonHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == BigInt::Instance() && left_type == right_type;

--- a/src/codegen/type/bigint_type.cpp
+++ b/src/codegen/type/bigint_type.cpp
@@ -94,50 +94,50 @@ struct CastBigInt : public TypeSystem::SimpleNullableCast {
 };
 
 // Comparison
-struct CompareBigInt : public TypeSystem::Comparison {
+struct CompareBigInt : public TypeSystem::SimpleNullableComparison {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == BigInt::Instance() && left_type == right_type;
   }
 
-  Value DoCompareLt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareLtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSLT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareLte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareLteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSLE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareEq(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareEqImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpEQ(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareNe(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareNeImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpNE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareGtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSGT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareGteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSGE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoComparisonForSort(CodeGen &codegen, const Value &left,
-                            const Value &right) const override {
+  Value CompareForSortImpl(CodeGen &codegen, const Value &left,
+                           const Value &right) const override {
     // For integer comparisons, just subtract left from right and cast the
     // result to a 32-bit value
     llvm::Value *diff = codegen->CreateSub(left.GetValue(), right.GetValue());

--- a/src/codegen/type/bigint_type.cpp
+++ b/src/codegen/type/bigint_type.cpp
@@ -52,8 +52,8 @@ struct CastBigInt : public TypeSystem::SimpleNullableCast {
     }
   }
 
-  Value CastImpl(CodeGen &codegen, const Value &value,
-                 const Type &to_type) const override {
+  Value Impl(CodeGen &codegen, const Value &value,
+             const Type &to_type) const override {
     llvm::Value *result = nullptr;
     switch (to_type.GetSqlType().TypeId()) {
       case peloton::type::TypeId::BOOLEAN: {

--- a/src/codegen/type/bigint_type.cpp
+++ b/src/codegen/type/bigint_type.cpp
@@ -88,8 +88,11 @@ struct CastBigInt : public TypeSystem::SimpleNullableCast {
       }
     }
 
+    // We could be casting this non-nullable value to a nullable type
+    llvm::Value *null = to_type.nullable ? codegen.ConstBool(false) : nullptr;
+
     // Return the result
-    return Value{to_type, result, nullptr, nullptr};
+    return Value{to_type, result, nullptr, null};
   }
 };
 

--- a/src/codegen/type/bigint_type.cpp
+++ b/src/codegen/type/bigint_type.cpp
@@ -151,7 +151,7 @@ struct CompareBigInt : public TypeSystem::SimpleComparisonHandleNull {
 };
 
 // Negation
-struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
+struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == BigInt::Instance();
   }
@@ -175,7 +175,7 @@ struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
 };
 
 // Addition
-struct Add : public TypeSystem::SimpleNullableBinaryOperator {
+struct Add : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == BigInt::Instance() &&
@@ -206,7 +206,7 @@ struct Add : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Subtraction
-struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
+struct Sub : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == BigInt::Instance() &&
@@ -237,7 +237,7 @@ struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Multiplication
-struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
+struct Mul : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == BigInt::Instance() &&
@@ -268,7 +268,7 @@ struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Division
-struct Div : public TypeSystem::SimpleNullableBinaryOperator {
+struct Div : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == BigInt::Instance() &&
@@ -324,7 +324,7 @@ struct Div : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Modulo
-struct Modulo : public TypeSystem::SimpleNullableBinaryOperator {
+struct Modulo : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == BigInt::Instance() &&

--- a/src/codegen/type/bigint_type.cpp
+++ b/src/codegen/type/bigint_type.cpp
@@ -33,7 +33,7 @@ namespace {
 // We do BIGINT -> {INTEGRAL_TYPE, DECIMAL, VARCHAR, BOOLEAN}
 //===----------------------------------------------------------------------===//
 
-struct CastBigInt : public TypeSystem::Cast {
+struct CastBigInt : public TypeSystem::SimpleNullableCast {
   bool SupportsTypes(const Type &from_type,
                      const Type &to_type) const override {
     if (from_type.GetSqlType() != BigInt::Instance()) {
@@ -52,8 +52,8 @@ struct CastBigInt : public TypeSystem::Cast {
     }
   }
 
-  Value DoCast(CodeGen &codegen, const Value &value,
-               const Type &to_type) const override {
+  Value CastImpl(CodeGen &codegen, const Value &value,
+                 const Type &to_type) const override {
     llvm::Value *result = nullptr;
     switch (to_type.GetSqlType().TypeId()) {
       case peloton::type::TypeId::BOOLEAN: {
@@ -431,8 +431,8 @@ static std::vector<TypeSystem::NaryOpInfo> kNaryOperatorTable = {};
 BigInt::BigInt()
     : SqlType(peloton::type::TypeId::BIGINT),
       type_system_(kImplicitCastingTable, kExplicitCastingTable,
-                   kComparisonTable, kUnaryOperatorTable,
-                   kBinaryOperatorTable, kNaryOperatorTable) {}
+                   kComparisonTable, kUnaryOperatorTable, kBinaryOperatorTable,
+                   kNaryOperatorTable) {}
 
 Value BigInt::GetMinValue(CodeGen &codegen) const {
   auto *raw_val = codegen.Const64(peloton::type::PELOTON_INT64_MIN);

--- a/src/codegen/type/boolean_type.cpp
+++ b/src/codegen/type/boolean_type.cpp
@@ -42,7 +42,12 @@ struct CastBooleanToInteger : public TypeSystem::SimpleNullableCast {
 
     // Any integral value requires a zero-extension
     auto *raw_val = codegen->CreateZExt(value.GetValue(), codegen.Int32Type());
-    return Value{to_type, raw_val, nullptr, nullptr};
+
+    // We could be casting this non-nullable value to a nullable type
+    llvm::Value *null = to_type.nullable ? codegen.ConstBool(false) : nullptr;
+
+    // Return the result
+    return Value{to_type, raw_val, nullptr, null};
   }
 };
 
@@ -60,7 +65,12 @@ struct CastBooleanToVarchar : public TypeSystem::SimpleNullableCast {
     // Convert this boolean (unsigned int) into a string
     llvm::Value *str_val = codegen->CreateSelect(
         value.GetValue(), codegen.ConstString("T"), codegen.ConstString("F"));
-    return Value{to_type, str_val, codegen.Const32(1)};
+
+    // We could be casting this non-nullable value to a nullable type
+    llvm::Value *null = to_type.nullable ? codegen.ConstBool(false) : nullptr;
+
+    // Return the result
+    return Value{to_type, str_val, codegen.Const32(1), null};
   }
 };
 

--- a/src/codegen/type/boolean_type.cpp
+++ b/src/codegen/type/boolean_type.cpp
@@ -36,8 +36,8 @@ struct CastBooleanToInteger : public TypeSystem::SimpleNullableCast {
            to_type.type_id == peloton::type::TypeId::INTEGER;
   }
 
-  Value CastImpl(CodeGen &codegen, const Value &value,
-                 const Type &to_type) const override {
+  Value Impl(CodeGen &codegen, const Value &value,
+             const Type &to_type) const override {
     PL_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // Any integral value requires a zero-extension
@@ -53,8 +53,8 @@ struct CastBooleanToVarchar : public TypeSystem::SimpleNullableCast {
            to_type.type_id == peloton::type::TypeId::VARCHAR;
   }
 
-  Value CastImpl(CodeGen &codegen, const Value &value,
-                 const Type &to_type) const override {
+  Value Impl(CodeGen &codegen, const Value &value,
+             const Type &to_type) const override {
     PL_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // Convert this boolean (unsigned int) into a string

--- a/src/codegen/type/boolean_type.cpp
+++ b/src/codegen/type/boolean_type.cpp
@@ -29,15 +29,15 @@ namespace {
 // CASTING OPERATIONS
 //===----------------------------------------------------------------------===//
 
-struct CastBooleanToInteger : public TypeSystem::Cast {
+struct CastBooleanToInteger : public TypeSystem::SimpleNullableCast {
   bool SupportsTypes(const Type &from_type,
                      const Type &to_type) const override {
     return from_type.type_id == peloton::type::TypeId::BOOLEAN &&
            to_type.type_id == peloton::type::TypeId::INTEGER;
   }
 
-  Value DoCast(CodeGen &codegen, const Value &value,
-               const Type &to_type) const override {
+  Value CastImpl(CodeGen &codegen, const Value &value,
+                 const Type &to_type) const override {
     PL_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // Any integral value requires a zero-extension
@@ -46,15 +46,15 @@ struct CastBooleanToInteger : public TypeSystem::Cast {
   }
 };
 
-struct CastBooleanToVarchar : public TypeSystem::Cast {
+struct CastBooleanToVarchar : public TypeSystem::SimpleNullableCast {
   bool SupportsTypes(const Type &from_type,
                      const Type &to_type) const override {
     return from_type.type_id == peloton::type::TypeId::BOOLEAN &&
            to_type.type_id == peloton::type::TypeId::VARCHAR;
   }
 
-  Value DoCast(CodeGen &codegen, const Value &value,
-               const Type &to_type) const override {
+  Value CastImpl(CodeGen &codegen, const Value &value,
+                 const Type &to_type) const override {
     PL_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // Convert this boolean (unsigned int) into a string
@@ -241,8 +241,8 @@ static std::vector<TypeSystem::NaryOpInfo> kNaryOperatorTable = {};
 Boolean::Boolean()
     : SqlType(peloton::type::TypeId::BOOLEAN),
       type_system_(kImplicitCastingTable, kExplicitCastingTable,
-                   kComparisonTable, kUnaryOperatorTable,
-                   kBinaryOperatorTable, kNaryOperatorTable) {}
+                   kComparisonTable, kUnaryOperatorTable, kBinaryOperatorTable,
+                   kNaryOperatorTable) {}
 
 Value Boolean::GetMinValue(CodeGen &codegen) const {
   auto *raw_val = codegen.ConstBool(peloton::type::PELOTON_BOOLEAN_MIN);

--- a/src/codegen/type/boolean_type.cpp
+++ b/src/codegen/type/boolean_type.cpp
@@ -29,7 +29,7 @@ namespace {
 // CASTING OPERATIONS
 //===----------------------------------------------------------------------===//
 
-struct CastBooleanToInteger : public TypeSystem::SimpleNullableCast {
+struct CastBooleanToInteger : public TypeSystem::CastHandleNull {
   bool SupportsTypes(const Type &from_type,
                      const Type &to_type) const override {
     return from_type.type_id == peloton::type::TypeId::BOOLEAN &&
@@ -51,7 +51,7 @@ struct CastBooleanToInteger : public TypeSystem::SimpleNullableCast {
   }
 };
 
-struct CastBooleanToVarchar : public TypeSystem::SimpleNullableCast {
+struct CastBooleanToVarchar : public TypeSystem::CastHandleNull {
   bool SupportsTypes(const Type &from_type,
                      const Type &to_type) const override {
     return from_type.type_id == peloton::type::TypeId::BOOLEAN &&
@@ -79,7 +79,7 @@ struct CastBooleanToVarchar : public TypeSystem::SimpleNullableCast {
 //===----------------------------------------------------------------------===//
 
 // Comparison functions
-struct CompareBoolean : public TypeSystem::SimpleNullableComparison {
+struct CompareBoolean : public TypeSystem::SimpleComparisonHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.type_id == peloton::type::TypeId::BOOLEAN &&

--- a/src/codegen/type/boolean_type.cpp
+++ b/src/codegen/type/boolean_type.cpp
@@ -176,7 +176,7 @@ struct CompareBoolean : public TypeSystem::SimpleComparisonHandleNull {
 //===----------------------------------------------------------------------===//
 
 // Logical AND
-struct LogicalAnd : public TypeSystem::SimpleNullableBinaryOperator {
+struct LogicalAnd : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Boolean::Instance() &&
@@ -196,7 +196,7 @@ struct LogicalAnd : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Logical OR
-struct LogicalOr : public TypeSystem::SimpleNullableBinaryOperator {
+struct LogicalOr : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Boolean::Instance() &&

--- a/src/codegen/type/boolean_type.cpp
+++ b/src/codegen/type/boolean_type.cpp
@@ -166,7 +166,7 @@ struct CompareBoolean : public TypeSystem::SimpleNullableComparison {
 //===----------------------------------------------------------------------===//
 
 // Logical AND
-struct LogicalAnd : public TypeSystem::BinaryOperator {
+struct LogicalAnd : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Boolean::Instance() &&
@@ -178,15 +178,15 @@ struct LogicalAnd : public TypeSystem::BinaryOperator {
     return type::Type{Boolean::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               UNUSED_ATTRIBUTE OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             UNUSED_ATTRIBUTE OnError on_error) const override {
     auto *raw_val = codegen->CreateAnd(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 };
 
 // Logical OR
-struct LogicalOr : public TypeSystem::BinaryOperator {
+struct LogicalOr : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Boolean::Instance() &&
@@ -198,8 +198,8 @@ struct LogicalOr : public TypeSystem::BinaryOperator {
     return type::Type{Boolean::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               UNUSED_ATTRIBUTE OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             UNUSED_ATTRIBUTE OnError on_error) const override {
     auto *raw_val = codegen->CreateOr(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }

--- a/src/codegen/type/boolean_type.cpp
+++ b/src/codegen/type/boolean_type.cpp
@@ -69,15 +69,15 @@ struct CastBooleanToVarchar : public TypeSystem::SimpleNullableCast {
 //===----------------------------------------------------------------------===//
 
 // Comparison functions
-struct CompareBoolean : public TypeSystem::Comparison {
+struct CompareBoolean : public TypeSystem::SimpleNullableComparison {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.type_id == peloton::type::TypeId::BOOLEAN &&
            left_type == right_type;
   }
 
-  Value DoCompareLt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareLtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do the comparison
@@ -88,8 +88,8 @@ struct CompareBoolean : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result, nullptr, nullptr};
   }
 
-  Value DoCompareLte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareLteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do the comparison
@@ -100,8 +100,8 @@ struct CompareBoolean : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result, nullptr, nullptr};
   }
 
-  Value DoCompareEq(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareEqImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do the comparison
@@ -112,8 +112,8 @@ struct CompareBoolean : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result, nullptr, nullptr};
   }
 
-  Value DoCompareNe(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareNeImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do the comparison
@@ -124,8 +124,8 @@ struct CompareBoolean : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result, nullptr, nullptr};
   }
 
-  Value DoCompareGt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareGtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do the comparison
@@ -136,8 +136,8 @@ struct CompareBoolean : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result, nullptr, nullptr};
   }
 
-  Value DoCompareGte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareGteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do the comparison
@@ -148,8 +148,8 @@ struct CompareBoolean : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result, nullptr, nullptr};
   }
 
-  Value DoComparisonForSort(CodeGen &codegen, const Value &left,
-                            const Value &right) const override {
+  Value CompareForSortImpl(CodeGen &codegen, const Value &left,
+                           const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // For boolean sorting, we convert 1-bit boolean values into a 32-bit number

--- a/src/codegen/type/date_type.cpp
+++ b/src/codegen/type/date_type.cpp
@@ -56,50 +56,50 @@ struct CastDateToTimestamp : public TypeSystem::SimpleNullableCast {
 };
 
 // Comparison
-struct CompareDate : public TypeSystem::Comparison {
+struct CompareDate : public TypeSystem::SimpleNullableComparison {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == Date::Instance() && left_type == right_type;
   }
 
-  Value DoCompareLt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareLtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSLT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareLte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareLteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSLE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareEq(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareEqImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpEQ(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareNe(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareNeImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpNE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareGtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSGT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareGteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSGE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoComparisonForSort(CodeGen &codegen, const Value &left,
-                            const Value &right) const override {
+  Value CompareForSortImpl(CodeGen &codegen, const Value &left,
+                           const Value &right) const override {
     // For integer comparisons, just subtract left from right and cast the
     // result to a 32-bit value
     llvm::Value *diff = codegen->CreateSub(left.GetValue(), right.GetValue());

--- a/src/codegen/type/date_type.cpp
+++ b/src/codegen/type/date_type.cpp
@@ -33,7 +33,7 @@ namespace {
 // We do DATE -> {TIMESTAMP, VARCHAR}
 //===----------------------------------------------------------------------===//
 
-struct CastDateToTimestamp : public TypeSystem::Cast {
+struct CastDateToTimestamp : public TypeSystem::SimpleNullableCast {
   bool SupportsTypes(const type::Type &from_type,
                      const type::Type &to_type) const override {
     return from_type.GetSqlType() == Date::Instance() &&
@@ -41,8 +41,8 @@ struct CastDateToTimestamp : public TypeSystem::Cast {
   }
 
   // Cast the given decimal value into the provided type
-  Value DoCast(CodeGen &codegen, const Value &value,
-               const type::Type &to_type) const override {
+  Value CastImpl(CodeGen &codegen, const Value &value,
+                 const type::Type &to_type) const override {
     PL_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // Date is number of days since 2000, timestamp is micros since same
@@ -134,8 +134,8 @@ static std::vector<TypeSystem::NaryOpInfo> kNaryOperatorTable = {};
 Date::Date()
     : SqlType(peloton::type::TypeId::DATE),
       type_system_(kImplicitCastingTable, kExplicitCastingTable,
-                   kComparisonTable, kUnaryOperatorTable,
-                   kBinaryOperatorTable, kNaryOperatorTable) {}
+                   kComparisonTable, kUnaryOperatorTable, kBinaryOperatorTable,
+                   kNaryOperatorTable) {}
 
 Value Date::GetMinValue(CodeGen &codegen) const {
   auto *raw_val = codegen.Const32(peloton::type::PELOTON_DATE_MIN);

--- a/src/codegen/type/date_type.cpp
+++ b/src/codegen/type/date_type.cpp
@@ -51,7 +51,10 @@ struct CastDateToTimestamp : public TypeSystem::SimpleNullableCast {
         codegen.Const64(peloton::type::TimestampType::kUsecsPerDate);
     llvm::Value *timestamp = codegen->CreateMul(date, usecs_per_date);
 
-    return Value{to_type, timestamp, nullptr, nullptr};
+    // We could be casting this non-nullable value to a nullable type
+    llvm::Value *null = to_type.nullable ? codegen.ConstBool(false) : nullptr;
+
+    return Value{to_type, timestamp, nullptr, null};
   }
 };
 

--- a/src/codegen/type/date_type.cpp
+++ b/src/codegen/type/date_type.cpp
@@ -41,8 +41,8 @@ struct CastDateToTimestamp : public TypeSystem::SimpleNullableCast {
   }
 
   // Cast the given decimal value into the provided type
-  Value CastImpl(CodeGen &codegen, const Value &value,
-                 const type::Type &to_type) const override {
+  Value Impl(CodeGen &codegen, const Value &value,
+             const type::Type &to_type) const override {
     PL_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // Date is number of days since 2000, timestamp is micros since same

--- a/src/codegen/type/date_type.cpp
+++ b/src/codegen/type/date_type.cpp
@@ -33,7 +33,7 @@ namespace {
 // We do DATE -> {TIMESTAMP, VARCHAR}
 //===----------------------------------------------------------------------===//
 
-struct CastDateToTimestamp : public TypeSystem::SimpleNullableCast {
+struct CastDateToTimestamp : public TypeSystem::CastHandleNull {
   bool SupportsTypes(const type::Type &from_type,
                      const type::Type &to_type) const override {
     return from_type.GetSqlType() == Date::Instance() &&
@@ -59,7 +59,7 @@ struct CastDateToTimestamp : public TypeSystem::SimpleNullableCast {
 };
 
 // Comparison
-struct CompareDate : public TypeSystem::SimpleNullableComparison {
+struct CompareDate : public TypeSystem::SimpleComparisonHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == Date::Instance() && left_type == right_type;

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -139,7 +139,7 @@ struct CompareDecimal : public TypeSystem::SimpleNullableComparison {
 };
 
 // Negation
-struct Negate : public TypeSystem::UnaryOperator {
+struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == Decimal::Instance();
   }
@@ -148,7 +148,7 @@ struct Negate : public TypeSystem::UnaryOperator {
     return Type{Decimal::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &val) const override {
+  Value Impl(CodeGen &codegen, const Value &val) const override {
     PL_ASSERT(SupportsType(val.GetType()));
 
     llvm::Value *overflow_bit = nullptr;
@@ -179,7 +179,7 @@ struct Floor : public TypeSystem::SimpleNullableUnaryOperator {
 };
 
 // Addition
-struct Add : public TypeSystem::BinaryOperator {
+struct Add : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Decimal::Instance() &&
@@ -191,8 +191,8 @@ struct Add : public TypeSystem::BinaryOperator {
     return Type{Decimal::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               UNUSED_ATTRIBUTE OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             UNUSED_ATTRIBUTE OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     auto *raw_val = codegen->CreateFAdd(left.GetValue(), right.GetValue());
     return Value{Decimal::Instance(), raw_val, nullptr, nullptr};
@@ -200,7 +200,7 @@ struct Add : public TypeSystem::BinaryOperator {
 };
 
 // Subtraction
-struct Sub : public TypeSystem::BinaryOperator {
+struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Decimal::Instance() &&
@@ -212,8 +212,8 @@ struct Sub : public TypeSystem::BinaryOperator {
     return Type{Decimal::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               UNUSED_ATTRIBUTE OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             UNUSED_ATTRIBUTE OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     auto *raw_val = codegen->CreateFSub(left.GetValue(), right.GetValue());
     return Value{Decimal::Instance(), raw_val, nullptr, nullptr};
@@ -221,7 +221,7 @@ struct Sub : public TypeSystem::BinaryOperator {
 };
 
 // Multiplication
-struct Mul : public TypeSystem::BinaryOperator {
+struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Decimal::Instance() &&
@@ -233,8 +233,8 @@ struct Mul : public TypeSystem::BinaryOperator {
     return Type{Decimal::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               UNUSED_ATTRIBUTE OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             UNUSED_ATTRIBUTE OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     auto *raw_val = codegen->CreateFMul(left.GetValue(), right.GetValue());
     return Value{Decimal::Instance(), raw_val, nullptr, nullptr};
@@ -242,7 +242,7 @@ struct Mul : public TypeSystem::BinaryOperator {
 };
 
 // Division
-struct Div : public TypeSystem::BinaryOperator {
+struct Div : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Decimal::Instance() &&
@@ -254,8 +254,8 @@ struct Div : public TypeSystem::BinaryOperator {
     return Type{Decimal::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
@@ -299,7 +299,7 @@ struct Div : public TypeSystem::BinaryOperator {
 };
 
 // Modulo
-struct Modulo : public TypeSystem::BinaryOperator {
+struct Modulo : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Decimal::Instance() &&
@@ -311,8 +311,8 @@ struct Modulo : public TypeSystem::BinaryOperator {
     return Type{Decimal::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -35,7 +35,7 @@ namespace {
 // We do DECIMAL -> {INTEGRAL_TYPE, VARCHAR, BOOLEAN}
 //===----------------------------------------------------------------------===//
 
-struct CastDecimal : public TypeSystem::SimpleNullableCast {
+struct CastDecimal : public TypeSystem::CastHandleNull {
   bool SupportsTypes(const type::Type &from_type,
                      const type::Type &to_type) const override {
     if (from_type.GetSqlType() != Decimal::Instance()) {
@@ -88,7 +88,7 @@ struct CastDecimal : public TypeSystem::SimpleNullableCast {
 };
 
 // Comparison
-struct CompareDecimal : public TypeSystem::SimpleNullableComparison {
+struct CompareDecimal : public TypeSystem::SimpleComparisonHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == Decimal::Instance() && left_type == right_type;

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -162,7 +162,7 @@ struct Negate : public TypeSystem::UnaryOperator {
   }
 };
 
-struct Floor : public TypeSystem::UnaryOperator {
+struct Floor : public TypeSystem::SimpleNullableUnaryOperator {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == Decimal::Instance();
   }
@@ -171,7 +171,7 @@ struct Floor : public TypeSystem::UnaryOperator {
     return Type{Decimal::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &val) const override {
+  Value Impl(CodeGen &codegen, const Value &val) const override {
     llvm::Value *raw_ret =
         codegen.Call(DecimalFunctionsProxy::Floor, {val.GetValue()});
     return Value{Integer::Instance(), raw_ret};

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -142,7 +142,7 @@ struct CompareDecimal : public TypeSystem::SimpleComparisonHandleNull {
 };
 
 // Negation
-struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
+struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == Decimal::Instance();
   }
@@ -165,7 +165,7 @@ struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
   }
 };
 
-struct Floor : public TypeSystem::SimpleNullableUnaryOperator {
+struct Floor : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == Decimal::Instance();
   }
@@ -182,7 +182,7 @@ struct Floor : public TypeSystem::SimpleNullableUnaryOperator {
 };
 
 // Addition
-struct Add : public TypeSystem::SimpleNullableBinaryOperator {
+struct Add : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Decimal::Instance() &&
@@ -203,7 +203,7 @@ struct Add : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Subtraction
-struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
+struct Sub : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Decimal::Instance() &&
@@ -224,7 +224,7 @@ struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Multiplication
-struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
+struct Mul : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Decimal::Instance() &&
@@ -245,7 +245,7 @@ struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Division
-struct Div : public TypeSystem::SimpleNullableBinaryOperator {
+struct Div : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Decimal::Instance() &&
@@ -302,7 +302,7 @@ struct Div : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Modulo
-struct Modulo : public TypeSystem::SimpleNullableBinaryOperator {
+struct Modulo : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Decimal::Instance() &&

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -35,7 +35,7 @@ namespace {
 // We do DECIMAL -> {INTEGRAL_TYPE, VARCHAR, BOOLEAN}
 //===----------------------------------------------------------------------===//
 
-struct CastDecimal : public TypeSystem::Cast {
+struct CastDecimal : public TypeSystem::SimpleNullableCast {
   bool SupportsTypes(const type::Type &from_type,
                      const type::Type &to_type) const override {
     if (from_type.GetSqlType() != Decimal::Instance()) {
@@ -54,9 +54,10 @@ struct CastDecimal : public TypeSystem::Cast {
   }
 
   // Cast the given decimal value into the provided type
-  Value DoCast(CodeGen &codegen, const Value &value,
-               const type::Type &to_type) const override {
+  Value CastImpl(CodeGen &codegen, const Value &value,
+                 const type::Type &to_type) const override {
     PL_ASSERT(SupportsTypes(value.GetType(), to_type));
+    PL_ASSERT(!to_type.nullable);
 
     llvm::Type *val_type = nullptr, *len_type = nullptr;
     to_type.GetSqlType().GetTypeForMaterialization(codegen, val_type, len_type);

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -80,7 +80,10 @@ struct CastDecimal : public TypeSystem::SimpleNullableCast {
       }
     }
 
-    return Value{to_type, result, nullptr, nullptr};
+    // We could be casting this non-nullable value to a nullable type
+    llvm::Value *null = to_type.nullable ? codegen.ConstBool(false) : nullptr;
+
+    return Value{to_type, result, nullptr, null};
   }
 };
 

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -85,50 +85,50 @@ struct CastDecimal : public TypeSystem::SimpleNullableCast {
 };
 
 // Comparison
-struct CompareDecimal : public TypeSystem::Comparison {
+struct CompareDecimal : public TypeSystem::SimpleNullableComparison {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == Decimal::Instance() && left_type == right_type;
   }
 
-  Value DoCompareLt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareLtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateFCmpULT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareLte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareLteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateFCmpULE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareEq(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareEqImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateFCmpUEQ(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareNe(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareNeImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateFCmpUNE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareGtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateFCmpUGT(left.GetValue(), right.GetValue());
     return Value{Decimal::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareGteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateFCmpUGE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoComparisonForSort(CodeGen &codegen, const Value &left,
-                            const Value &right) const override {
+  Value CompareForSortImpl(CodeGen &codegen, const Value &left,
+                           const Value &right) const override {
     // For integer comparisons, just subtract left from right and cast the
     // result to a 32-bit value
     llvm::Value *diff = codegen->CreateSub(left.GetValue(), right.GetValue());

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -165,6 +165,7 @@ struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   }
 };
 
+// Floor
 struct Floor : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == Decimal::Instance();
@@ -178,6 +179,23 @@ struct Floor : public TypeSystem::UnaryOperatorHandleNull {
     llvm::Value *raw_ret =
         codegen.Call(DecimalFunctionsProxy::Floor, {val.GetValue()});
     return Value{Integer::Instance(), raw_ret};
+  }
+};
+
+// Round
+struct Round : public TypeSystem::UnaryOperatorHandleNull {
+  bool SupportsType(const Type &type) const override {
+    return type.GetSqlType() == Decimal::Instance();
+  }
+
+  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+    return Decimal::Instance();
+  }
+
+  Value Impl(CodeGen &codegen, const Value &val) const override {
+    llvm::Value *raw_ret =
+        codegen.Call(DecimalFunctionsProxy::Round, {val.GetValue()});
+    return Value{Decimal::Instance(), raw_ret};
   }
 };
 
@@ -355,23 +373,6 @@ struct Modulo : public TypeSystem::BinaryOperatorHandleNull {
 
     // Return result
     return result;
-  }
-};
-
-// Round
-struct Round : public TypeSystem::UnaryOperator {
-  bool SupportsType(const Type &type) const override {
-    return type.GetSqlType() == Decimal::Instance();
-  }
-
-  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
-    return Decimal::Instance();
-  }
-
-  Value DoWork(CodeGen &codegen, const Value &val) const override {
-    llvm::Value *raw_ret =
-        codegen.Call(DecimalFunctionsProxy::Round, {val.GetValue()});
-    return Value{Decimal::Instance(), raw_ret};
   }
 };
 

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -54,8 +54,8 @@ struct CastDecimal : public TypeSystem::SimpleNullableCast {
   }
 
   // Cast the given decimal value into the provided type
-  Value CastImpl(CodeGen &codegen, const Value &value,
-                 const type::Type &to_type) const override {
+  Value Impl(CodeGen &codegen, const Value &value,
+             const type::Type &to_type) const override {
     PL_ASSERT(SupportsTypes(value.GetType(), to_type));
     PL_ASSERT(!to_type.nullable);
 

--- a/src/codegen/type/integer_type.cpp
+++ b/src/codegen/type/integer_type.cpp
@@ -88,8 +88,11 @@ struct CastInteger : public TypeSystem::SimpleNullableCast {
       }
     }
 
+    // We could be casting this non-nullable value to a nullable type
+    llvm::Value *null = to_type.nullable ? codegen.ConstBool(false) : nullptr;
+
     // Return the result
-    return Value{to_type, result, nullptr, nullptr};
+    return Value{to_type, result, nullptr, null};
   }
 };
 

--- a/src/codegen/type/integer_type.cpp
+++ b/src/codegen/type/integer_type.cpp
@@ -51,8 +51,8 @@ struct CastInteger : public TypeSystem::SimpleNullableCast {
     }
   }
 
-  Value CastImpl(CodeGen &codegen, const Value &value,
-                 const Type &to_type) const override {
+  Value Impl(CodeGen &codegen, const Value &value,
+             const Type &to_type) const override {
     llvm::Value *result = nullptr;
     switch (to_type.GetSqlType().TypeId()) {
       case peloton::type::TypeId::BOOLEAN: {

--- a/src/codegen/type/integer_type.cpp
+++ b/src/codegen/type/integer_type.cpp
@@ -146,7 +146,7 @@ struct CompareInteger : public TypeSystem::SimpleNullableComparison {
 };
 
 // Negation
-struct Negate : public TypeSystem::UnaryOperator {
+struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == Integer::Instance();
   }
@@ -155,7 +155,7 @@ struct Negate : public TypeSystem::UnaryOperator {
     return Type{Integer::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &val) const override {
+  Value Impl(CodeGen &codegen, const Value &val) const override {
     PL_ASSERT(SupportsType(val.GetType()));
 
     llvm::Value *overflow_bit = nullptr;
@@ -170,7 +170,7 @@ struct Negate : public TypeSystem::UnaryOperator {
 };
 
 // Addition
-struct Add : public TypeSystem::BinaryOperator {
+struct Add : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Integer::Instance() &&
@@ -182,8 +182,8 @@ struct Add : public TypeSystem::BinaryOperator {
     return Type{Integer::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do addition
@@ -201,7 +201,7 @@ struct Add : public TypeSystem::BinaryOperator {
 };
 
 // Subtraction
-struct Sub : public TypeSystem::BinaryOperator {
+struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Integer::Instance() &&
@@ -213,8 +213,8 @@ struct Sub : public TypeSystem::BinaryOperator {
     return Type{Integer::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do subtraction
@@ -232,7 +232,7 @@ struct Sub : public TypeSystem::BinaryOperator {
 };
 
 // Multiplication
-struct Mul : public TypeSystem::BinaryOperator {
+struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Integer::Instance() &&
@@ -244,8 +244,8 @@ struct Mul : public TypeSystem::BinaryOperator {
     return Type{Integer::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do multiplication
@@ -263,7 +263,7 @@ struct Mul : public TypeSystem::BinaryOperator {
 };
 
 // Division
-struct Div : public TypeSystem::BinaryOperator {
+struct Div : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Integer::Instance() &&
@@ -275,8 +275,8 @@ struct Div : public TypeSystem::BinaryOperator {
     return Type{Integer::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
@@ -319,7 +319,7 @@ struct Div : public TypeSystem::BinaryOperator {
 };
 
 // Modulo
-struct Modulo : public TypeSystem::BinaryOperator {
+struct Modulo : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Integer::Instance() &&
@@ -331,8 +331,8 @@ struct Modulo : public TypeSystem::BinaryOperator {
     return Type{Integer::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero

--- a/src/codegen/type/integer_type.cpp
+++ b/src/codegen/type/integer_type.cpp
@@ -149,7 +149,7 @@ struct CompareInteger : public TypeSystem::SimpleComparisonHandleNull {
 };
 
 // Negation
-struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
+struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == Integer::Instance();
   }
@@ -173,7 +173,7 @@ struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
 };
 
 // Addition
-struct Add : public TypeSystem::SimpleNullableBinaryOperator {
+struct Add : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Integer::Instance() &&
@@ -204,7 +204,7 @@ struct Add : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Subtraction
-struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
+struct Sub : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Integer::Instance() &&
@@ -235,7 +235,7 @@ struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Multiplication
-struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
+struct Mul : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Integer::Instance() &&
@@ -266,7 +266,7 @@ struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Division
-struct Div : public TypeSystem::SimpleNullableBinaryOperator {
+struct Div : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Integer::Instance() &&
@@ -322,7 +322,7 @@ struct Div : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Modulo
-struct Modulo : public TypeSystem::SimpleNullableBinaryOperator {
+struct Modulo : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Integer::Instance() &&

--- a/src/codegen/type/integer_type.cpp
+++ b/src/codegen/type/integer_type.cpp
@@ -32,7 +32,7 @@ namespace {
 // We do BIGINT -> {INTEGRAL_TYPE, DECIMAL, VARCHAR, BOOLEAN}
 //===----------------------------------------------------------------------===//
 
-struct CastInteger : public TypeSystem::SimpleNullableCast {
+struct CastInteger : public TypeSystem::CastHandleNull {
   bool SupportsTypes(const Type &from_type,
                      const Type &to_type) const override {
     if (from_type.GetSqlType() != Integer::Instance()) {
@@ -97,7 +97,7 @@ struct CastInteger : public TypeSystem::SimpleNullableCast {
 };
 
 // Comparison
-struct CompareInteger : public TypeSystem::SimpleNullableComparison {
+struct CompareInteger : public TypeSystem::SimpleComparisonHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == Integer::Instance() && left_type == right_type;

--- a/src/codegen/type/integer_type.cpp
+++ b/src/codegen/type/integer_type.cpp
@@ -32,7 +32,7 @@ namespace {
 // We do BIGINT -> {INTEGRAL_TYPE, DECIMAL, VARCHAR, BOOLEAN}
 //===----------------------------------------------------------------------===//
 
-struct CastInteger : public TypeSystem::Cast {
+struct CastInteger : public TypeSystem::SimpleNullableCast {
   bool SupportsTypes(const Type &from_type,
                      const Type &to_type) const override {
     if (from_type.GetSqlType() != Integer::Instance()) {
@@ -51,8 +51,8 @@ struct CastInteger : public TypeSystem::Cast {
     }
   }
 
-  Value DoCast(CodeGen &codegen, const Value &value,
-               const Type &to_type) const override {
+  Value CastImpl(CodeGen &codegen, const Value &value,
+                 const Type &to_type) const override {
     llvm::Value *result = nullptr;
     switch (to_type.GetSqlType().TypeId()) {
       case peloton::type::TypeId::BOOLEAN: {

--- a/src/codegen/type/integer_type.cpp
+++ b/src/codegen/type/integer_type.cpp
@@ -94,50 +94,50 @@ struct CastInteger : public TypeSystem::SimpleNullableCast {
 };
 
 // Comparison
-struct CompareInteger : public TypeSystem::Comparison {
+struct CompareInteger : public TypeSystem::SimpleNullableComparison {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == Integer::Instance() && left_type == right_type;
   }
 
-  Value DoCompareLt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareLtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSLT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareLte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareLteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSLE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareEq(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareEqImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpEQ(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareNe(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareNeImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpNE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareGtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSGT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareGteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSGE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoComparisonForSort(CodeGen &codegen, const Value &left,
-                            const Value &right) const override {
+  Value CompareForSortImpl(CodeGen &codegen, const Value &left,
+                           const Value &right) const override {
     // For integer comparisons, just subtract left from right and cast the
     // result to a 32-bit value
     llvm::Value *diff = codegen->CreateSub(left.GetValue(), right.GetValue());

--- a/src/codegen/type/smallint_type.cpp
+++ b/src/codegen/type/smallint_type.cpp
@@ -33,7 +33,7 @@ namespace {
 // We do SMALLINT -> {INTEGRAL_TYPE, DECIMAL, VARCHAR, BOOLEAN}
 //===----------------------------------------------------------------------===//
 
-struct CastSmallInt : public TypeSystem::Cast {
+struct CastSmallInt : public TypeSystem::SimpleNullableCast {
   bool SupportsTypes(const Type &from_type,
                      const Type &to_type) const override {
     if (from_type.GetSqlType() != SmallInt::Instance()) {
@@ -53,8 +53,8 @@ struct CastSmallInt : public TypeSystem::Cast {
     }
   }
 
-  Value DoCast(CodeGen &codegen, const Value &value,
-               const Type &to_type) const override {
+  Value CastImpl(CodeGen &codegen, const Value &value,
+                 const Type &to_type) const override {
     llvm::Value *result = nullptr;
     switch (to_type.GetSqlType().TypeId()) {
       case peloton::type::TypeId::BOOLEAN: {
@@ -452,8 +452,8 @@ static std::vector<TypeSystem::NaryOpInfo> kNaryOperatorTable = {};
 SmallInt::SmallInt()
     : SqlType(peloton::type::TypeId::SMALLINT),
       type_system_(kImplicitCastingTable, kExplicitCastingTable,
-                   kComparisonTable, kUnaryOperatorTable,
-                   kBinaryOperatorTable, kNaryOperatorTable) {}
+                   kComparisonTable, kUnaryOperatorTable, kBinaryOperatorTable,
+                   kNaryOperatorTable) {}
 
 Value SmallInt::GetMinValue(CodeGen &codegen) const {
   auto *raw_val = codegen.Const16(peloton::type::PELOTON_INT16_MIN);

--- a/src/codegen/type/smallint_type.cpp
+++ b/src/codegen/type/smallint_type.cpp
@@ -164,7 +164,7 @@ struct CompareSmallInt : public TypeSystem::SimpleComparisonHandleNull {
 //===----------------------------------------------------------------------===//
 
 // Negation
-struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
+struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == SmallInt::Instance();
   }
@@ -192,7 +192,7 @@ struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
 //===----------------------------------------------------------------------===//
 
 // Addition
-struct Add : public TypeSystem::SimpleNullableBinaryOperator {
+struct Add : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == SmallInt::Instance() &&
@@ -223,7 +223,7 @@ struct Add : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Subtraction
-struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
+struct Sub : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == SmallInt::Instance() &&
@@ -254,7 +254,7 @@ struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Multiplication
-struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
+struct Mul : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == SmallInt::Instance() &&
@@ -285,7 +285,7 @@ struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Division
-struct Div : public TypeSystem::SimpleNullableBinaryOperator {
+struct Div : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == SmallInt::Instance() &&
@@ -342,7 +342,7 @@ struct Div : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Modulo
-struct Modulo : public TypeSystem::SimpleNullableBinaryOperator {
+struct Modulo : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == SmallInt::Instance() &&

--- a/src/codegen/type/smallint_type.cpp
+++ b/src/codegen/type/smallint_type.cpp
@@ -93,8 +93,11 @@ struct CastSmallInt : public TypeSystem::SimpleNullableCast {
       }
     }
 
+    // We could be casting this non-nullable value to a nullable type
+    llvm::Value *null = to_type.nullable ? codegen.ConstBool(false) : nullptr;
+
     // Return the result
-    return Value{to_type, result, nullptr, nullptr};
+    return Value{to_type, result, nullptr, null};
   }
 };
 

--- a/src/codegen/type/smallint_type.cpp
+++ b/src/codegen/type/smallint_type.cpp
@@ -103,50 +103,50 @@ struct CastSmallInt : public TypeSystem::SimpleNullableCast {
 //===----------------------------------------------------------------------===//
 
 // Comparison
-struct CompareSmallInt : public TypeSystem::Comparison {
+struct CompareSmallInt : public TypeSystem::SimpleNullableComparison {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == SmallInt::Instance() && left_type == right_type;
   }
 
-  Value DoCompareLt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareLtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSLT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareLte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareLteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSLE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareEq(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareEqImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpEQ(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareNe(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareNeImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpNE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareGtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSGT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareGteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSGE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoComparisonForSort(CodeGen &codegen, const Value &left,
-                            const Value &right) const override {
+  Value CompareForSortImpl(CodeGen &codegen, const Value &left,
+                           const Value &right) const override {
     // For integer comparisons, just subtract left from right and cast the
     // result to a 32-bit value
     llvm::Value *diff = codegen->CreateSub(left.GetValue(), right.GetValue());

--- a/src/codegen/type/smallint_type.cpp
+++ b/src/codegen/type/smallint_type.cpp
@@ -161,7 +161,7 @@ struct CompareSmallInt : public TypeSystem::SimpleNullableComparison {
 //===----------------------------------------------------------------------===//
 
 // Negation
-struct Negate : public TypeSystem::UnaryOperator {
+struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == SmallInt::Instance();
   }
@@ -170,7 +170,7 @@ struct Negate : public TypeSystem::UnaryOperator {
     return Type{SmallInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &val) const override {
+  Value Impl(CodeGen &codegen, const Value &val) const override {
     PL_ASSERT(SupportsType(val.GetType()));
 
     llvm::Value *overflow_bit = nullptr;
@@ -189,7 +189,7 @@ struct Negate : public TypeSystem::UnaryOperator {
 //===----------------------------------------------------------------------===//
 
 // Addition
-struct Add : public TypeSystem::BinaryOperator {
+struct Add : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == SmallInt::Instance() &&
@@ -201,8 +201,8 @@ struct Add : public TypeSystem::BinaryOperator {
     return Type{SmallInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do addition
@@ -220,7 +220,7 @@ struct Add : public TypeSystem::BinaryOperator {
 };
 
 // Subtraction
-struct Sub : public TypeSystem::BinaryOperator {
+struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == SmallInt::Instance() &&
@@ -232,8 +232,8 @@ struct Sub : public TypeSystem::BinaryOperator {
     return Type{SmallInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do subtraction
@@ -251,7 +251,7 @@ struct Sub : public TypeSystem::BinaryOperator {
 };
 
 // Multiplication
-struct Mul : public TypeSystem::BinaryOperator {
+struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == SmallInt::Instance() &&
@@ -263,8 +263,8 @@ struct Mul : public TypeSystem::BinaryOperator {
     return Type{SmallInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do multiplication
@@ -282,7 +282,7 @@ struct Mul : public TypeSystem::BinaryOperator {
 };
 
 // Division
-struct Div : public TypeSystem::BinaryOperator {
+struct Div : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == SmallInt::Instance() &&
@@ -294,8 +294,8 @@ struct Div : public TypeSystem::BinaryOperator {
     return Type{SmallInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
@@ -339,7 +339,7 @@ struct Div : public TypeSystem::BinaryOperator {
 };
 
 // Modulo
-struct Modulo : public TypeSystem::BinaryOperator {
+struct Modulo : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == SmallInt::Instance() &&
@@ -351,8 +351,8 @@ struct Modulo : public TypeSystem::BinaryOperator {
     return Type{SmallInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero

--- a/src/codegen/type/smallint_type.cpp
+++ b/src/codegen/type/smallint_type.cpp
@@ -53,8 +53,8 @@ struct CastSmallInt : public TypeSystem::SimpleNullableCast {
     }
   }
 
-  Value CastImpl(CodeGen &codegen, const Value &value,
-                 const Type &to_type) const override {
+  Value Impl(CodeGen &codegen, const Value &value,
+             const Type &to_type) const override {
     llvm::Value *result = nullptr;
     switch (to_type.GetSqlType().TypeId()) {
       case peloton::type::TypeId::BOOLEAN: {

--- a/src/codegen/type/smallint_type.cpp
+++ b/src/codegen/type/smallint_type.cpp
@@ -33,7 +33,7 @@ namespace {
 // We do SMALLINT -> {INTEGRAL_TYPE, DECIMAL, VARCHAR, BOOLEAN}
 //===----------------------------------------------------------------------===//
 
-struct CastSmallInt : public TypeSystem::SimpleNullableCast {
+struct CastSmallInt : public TypeSystem::CastHandleNull {
   bool SupportsTypes(const Type &from_type,
                      const Type &to_type) const override {
     if (from_type.GetSqlType() != SmallInt::Instance()) {
@@ -106,7 +106,7 @@ struct CastSmallInt : public TypeSystem::SimpleNullableCast {
 //===----------------------------------------------------------------------===//
 
 // Comparison
-struct CompareSmallInt : public TypeSystem::SimpleNullableComparison {
+struct CompareSmallInt : public TypeSystem::SimpleComparisonHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == SmallInt::Instance() && left_type == right_type;

--- a/src/codegen/type/timestamp_type.cpp
+++ b/src/codegen/type/timestamp_type.cpp
@@ -53,50 +53,50 @@ struct CastTimestampToDate : public TypeSystem::SimpleNullableCast {
 };
 
 // Comparison
-struct CompareTimestamp : public TypeSystem::Comparison {
+struct CompareTimestamp : public TypeSystem::SimpleNullableComparison {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == Timestamp::Instance() && left_type == right_type;
   }
 
-  Value DoCompareLt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareLtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSLT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareLte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareLteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSLE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareEq(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareEqImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpEQ(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareNe(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareNeImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpNE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareGtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSGT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareGteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSGE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoComparisonForSort(CodeGen &codegen, const Value &left,
-                            const Value &right) const override {
+  Value CompareForSortImpl(CodeGen &codegen, const Value &left,
+                           const Value &right) const override {
     // For integer comparisons, just subtract left from right and cast the
     // result to a 32-bit value
     llvm::Value *diff = codegen->CreateSub(left.GetValue(), right.GetValue());

--- a/src/codegen/type/timestamp_type.cpp
+++ b/src/codegen/type/timestamp_type.cpp
@@ -39,8 +39,8 @@ struct CastTimestampToDate : public TypeSystem::SimpleNullableCast {
   }
 
   // Cast the given decimal value into the provided type
-  Value CastImpl(CodeGen &codegen, const Value &value,
-                 const type::Type &to_type) const override {
+  Value Impl(CodeGen &codegen, const Value &value,
+             const type::Type &to_type) const override {
     PL_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // TODO: Fix me

--- a/src/codegen/type/timestamp_type.cpp
+++ b/src/codegen/type/timestamp_type.cpp
@@ -31,7 +31,7 @@ namespace {
 // We do DATE -> {TIMESTAMP, VARCHAR}
 //===----------------------------------------------------------------------===//
 
-struct CastTimestampToDate : public TypeSystem::SimpleNullableCast {
+struct CastTimestampToDate : public TypeSystem::CastHandleNull {
   bool SupportsTypes(const type::Type &from_type,
                      const type::Type &to_type) const override {
     return from_type.GetSqlType() == Timestamp::Instance() &&
@@ -58,7 +58,7 @@ struct CastTimestampToDate : public TypeSystem::SimpleNullableCast {
 };
 
 // Comparison
-struct CompareTimestamp : public TypeSystem::SimpleNullableComparison {
+struct CompareTimestamp : public TypeSystem::SimpleComparisonHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == Timestamp::Instance() && left_type == right_type;

--- a/src/codegen/type/timestamp_type.cpp
+++ b/src/codegen/type/timestamp_type.cpp
@@ -48,7 +48,12 @@ struct CastTimestampToDate : public TypeSystem::SimpleNullableCast {
         codegen.Const64(peloton::type::TimestampType::kUsecsPerDate);
     llvm::Value *date = codegen->CreateSDiv(value.GetValue(), usecs_per_date);
     llvm::Value *result = codegen->CreateTrunc(date, codegen.Int32Type());
-    return Value{to_type, result, nullptr, nullptr};
+
+    // We could be casting this non-nullable value to a nullable type
+    llvm::Value *null = to_type.nullable ? codegen.ConstBool(false) : nullptr;
+
+    // Return the result
+    return Value{to_type, result, nullptr, null};
   }
 };
 

--- a/src/codegen/type/timestamp_type.cpp
+++ b/src/codegen/type/timestamp_type.cpp
@@ -31,7 +31,7 @@ namespace {
 // We do DATE -> {TIMESTAMP, VARCHAR}
 //===----------------------------------------------------------------------===//
 
-struct CastTimestampToDate : public TypeSystem::Cast {
+struct CastTimestampToDate : public TypeSystem::SimpleNullableCast {
   bool SupportsTypes(const type::Type &from_type,
                      const type::Type &to_type) const override {
     return from_type.GetSqlType() == Timestamp::Instance() &&
@@ -39,8 +39,8 @@ struct CastTimestampToDate : public TypeSystem::Cast {
   }
 
   // Cast the given decimal value into the provided type
-  Value DoCast(CodeGen &codegen, const Value &value,
-               const type::Type &to_type) const override {
+  Value CastImpl(CodeGen &codegen, const Value &value,
+                 const type::Type &to_type) const override {
     PL_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // TODO: Fix me

--- a/src/codegen/type/tinyint_type.cpp
+++ b/src/codegen/type/tinyint_type.cpp
@@ -89,8 +89,11 @@ struct CastTinyInt : public TypeSystem::SimpleNullableCast {
       }
     }
 
+    // We could be casting this non-nullable value to a nullable type
+    llvm::Value *null = to_type.nullable ? codegen.ConstBool(false) : nullptr;
+
     // Return the result
-    return Value{to_type, result, nullptr, nullptr};
+    return Value{to_type, result, nullptr, null};
   }
 };
 

--- a/src/codegen/type/tinyint_type.cpp
+++ b/src/codegen/type/tinyint_type.cpp
@@ -33,7 +33,7 @@ namespace {
 // We do TINYINT -> {INTEGRAL_TYPE, DECIMAL, VARCHAR, BOOLEAN}
 //===----------------------------------------------------------------------===//
 
-struct CastTinyInt : public TypeSystem::SimpleNullableCast {
+struct CastTinyInt : public TypeSystem::CastHandleNull {
   bool SupportsTypes(const Type &from_type,
                      const Type &to_type) const override {
     if (from_type.GetSqlType() != TinyInt::Instance()) {
@@ -98,7 +98,7 @@ struct CastTinyInt : public TypeSystem::SimpleNullableCast {
 };
 
 // Comparison
-struct CompareTinyInt : public TypeSystem::SimpleNullableComparison {
+struct CompareTinyInt : public TypeSystem::SimpleComparisonHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == TinyInt::Instance() && left_type == right_type;

--- a/src/codegen/type/tinyint_type.cpp
+++ b/src/codegen/type/tinyint_type.cpp
@@ -33,7 +33,7 @@ namespace {
 // We do TINYINT -> {INTEGRAL_TYPE, DECIMAL, VARCHAR, BOOLEAN}
 //===----------------------------------------------------------------------===//
 
-struct CastTinyInt : public TypeSystem::Cast {
+struct CastTinyInt : public TypeSystem::SimpleNullableCast {
   bool SupportsTypes(const Type &from_type,
                      const Type &to_type) const override {
     if (from_type.GetSqlType() != TinyInt::Instance()) {
@@ -52,8 +52,8 @@ struct CastTinyInt : public TypeSystem::Cast {
     }
   }
 
-  Value DoCast(CodeGen &codegen, const Value &value,
-               const Type &to_type) const override {
+  Value CastImpl(CodeGen &codegen, const Value &value,
+                 const Type &to_type) const override {
     llvm::Value *result = nullptr;
     switch (to_type.GetSqlType().TypeId()) {
       case peloton::type::TypeId::BOOLEAN: {
@@ -439,8 +439,8 @@ static std::vector<TypeSystem::NaryOpInfo> kNaryOperatorTable = {};
 TinyInt::TinyInt()
     : SqlType(peloton::type::TypeId::TINYINT),
       type_system_(kImplicitCastingTable, kExplicitCastingTable,
-                   kComparisonTable, kUnaryOperatorTable,
-                   kBinaryOperatorTable, kNaryOperatorTable) {}
+                   kComparisonTable, kUnaryOperatorTable, kBinaryOperatorTable,
+                   kNaryOperatorTable) {}
 
 Value TinyInt::GetMinValue(CodeGen &codegen) const {
   auto *raw_val = codegen.Const8(peloton::type::PELOTON_INT8_MIN);

--- a/src/codegen/type/tinyint_type.cpp
+++ b/src/codegen/type/tinyint_type.cpp
@@ -152,7 +152,7 @@ struct CompareTinyInt : public TypeSystem::SimpleComparisonHandleNull {
 };
 
 // Negation
-struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
+struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == TinyInt::Instance();
   }
@@ -176,7 +176,7 @@ struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
 };
 
 // Addition
-struct Add : public TypeSystem::SimpleNullableBinaryOperator {
+struct Add : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == TinyInt::Instance() &&
@@ -207,7 +207,7 @@ struct Add : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Subtraction
-struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
+struct Sub : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == TinyInt::Instance() &&
@@ -238,7 +238,7 @@ struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Multiplication
-struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
+struct Mul : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == TinyInt::Instance() &&
@@ -269,7 +269,7 @@ struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Division
-struct Div : public TypeSystem::SimpleNullableBinaryOperator {
+struct Div : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == TinyInt::Instance() &&
@@ -325,7 +325,7 @@ struct Div : public TypeSystem::SimpleNullableBinaryOperator {
 };
 
 // Modulo
-struct Modulo : public TypeSystem::SimpleNullableBinaryOperator {
+struct Modulo : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == TinyInt::Instance() &&

--- a/src/codegen/type/tinyint_type.cpp
+++ b/src/codegen/type/tinyint_type.cpp
@@ -52,8 +52,8 @@ struct CastTinyInt : public TypeSystem::SimpleNullableCast {
     }
   }
 
-  Value CastImpl(CodeGen &codegen, const Value &value,
-                 const Type &to_type) const override {
+  Value Impl(CodeGen &codegen, const Value &value,
+             const Type &to_type) const override {
     llvm::Value *result = nullptr;
     switch (to_type.GetSqlType().TypeId()) {
       case peloton::type::TypeId::BOOLEAN: {

--- a/src/codegen/type/tinyint_type.cpp
+++ b/src/codegen/type/tinyint_type.cpp
@@ -95,50 +95,50 @@ struct CastTinyInt : public TypeSystem::SimpleNullableCast {
 };
 
 // Comparison
-struct CompareTinyInt : public TypeSystem::Comparison {
+struct CompareTinyInt : public TypeSystem::SimpleNullableComparison {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type == TinyInt::Instance() && left_type == right_type;
   }
 
-  Value DoCompareLt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareLtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSLT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareLte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareLteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSLE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareEq(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareEqImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpEQ(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareNe(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareNeImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpNE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareGtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSGT(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoCompareGte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareGteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     auto *raw_val = codegen->CreateICmpSGE(left.GetValue(), right.GetValue());
     return Value{Boolean::Instance(), raw_val, nullptr, nullptr};
   }
 
-  Value DoComparisonForSort(CodeGen &codegen, const Value &left,
-                            const Value &right) const override {
+  Value CompareForSortImpl(CodeGen &codegen, const Value &left,
+                           const Value &right) const override {
     // For integer comparisons, just subtract left from right and cast the
     // result to a 32-bit value
     llvm::Value *diff = codegen->CreateSub(left.GetValue(), right.GetValue());

--- a/src/codegen/type/tinyint_type.cpp
+++ b/src/codegen/type/tinyint_type.cpp
@@ -149,7 +149,7 @@ struct CompareTinyInt : public TypeSystem::SimpleNullableComparison {
 };
 
 // Negation
-struct Negate : public TypeSystem::UnaryOperator {
+struct Negate : public TypeSystem::SimpleNullableUnaryOperator {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == TinyInt::Instance();
   }
@@ -158,7 +158,7 @@ struct Negate : public TypeSystem::UnaryOperator {
     return Type{TinyInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &val) const override {
+  Value Impl(CodeGen &codegen, const Value &val) const override {
     PL_ASSERT(SupportsType(val.GetType()));
 
     llvm::Value *overflow_bit = nullptr;
@@ -173,7 +173,7 @@ struct Negate : public TypeSystem::UnaryOperator {
 };
 
 // Addition
-struct Add : public TypeSystem::BinaryOperator {
+struct Add : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == TinyInt::Instance() &&
@@ -185,8 +185,8 @@ struct Add : public TypeSystem::BinaryOperator {
     return Type{TinyInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do addition
@@ -204,7 +204,7 @@ struct Add : public TypeSystem::BinaryOperator {
 };
 
 // Subtraction
-struct Sub : public TypeSystem::BinaryOperator {
+struct Sub : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == TinyInt::Instance() &&
@@ -216,8 +216,8 @@ struct Sub : public TypeSystem::BinaryOperator {
     return Type{TinyInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do subtraction
@@ -235,7 +235,7 @@ struct Sub : public TypeSystem::BinaryOperator {
 };
 
 // Multiplication
-struct Mul : public TypeSystem::BinaryOperator {
+struct Mul : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == TinyInt::Instance() &&
@@ -247,8 +247,8 @@ struct Mul : public TypeSystem::BinaryOperator {
     return Type{TinyInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do multiplication
@@ -266,7 +266,7 @@ struct Mul : public TypeSystem::BinaryOperator {
 };
 
 // Division
-struct Div : public TypeSystem::BinaryOperator {
+struct Div : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == TinyInt::Instance() &&
@@ -278,8 +278,8 @@ struct Div : public TypeSystem::BinaryOperator {
     return Type{TinyInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
@@ -322,7 +322,7 @@ struct Div : public TypeSystem::BinaryOperator {
 };
 
 // Modulo
-struct Modulo : public TypeSystem::BinaryOperator {
+struct Modulo : public TypeSystem::SimpleNullableBinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == TinyInt::Instance() &&
@@ -334,8 +334,8 @@ struct Modulo : public TypeSystem::BinaryOperator {
     return Type{TinyInt::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero

--- a/src/codegen/type/type_system.cpp
+++ b/src/codegen/type/type_system.cpp
@@ -27,8 +27,9 @@ namespace type {
 // SimpleNullableCast
 //
 //===----------------------------------------------------------------------===//
-Value TypeSystem::SimpleNullableCast::DoCast(
-    CodeGen &codegen, const Value &value, const Type &to_type) const {
+Value TypeSystem::SimpleNullableCast::DoCast(CodeGen &codegen,
+                                             const Value &value,
+                                             const Type &to_type) const {
   if (!value.IsNullable()) {
     // If the value isn't NULLable, avoid the NULL check and just invoke
     return CastImpl(codegen, value, to_type);

--- a/src/codegen/type/type_system.cpp
+++ b/src/codegen/type/type_system.cpp
@@ -45,7 +45,7 @@ Value TypeSystem::SimpleNullableCast::Eval(CodeGen &codegen, const Value &value,
   is_null.ElseBlock();
   {
     // If both values are not null, perform the non-null-aware operation
-    ret_val = Impl(codegen, value, to_type.AsNonNullable());
+    ret_val = Impl(codegen, value, to_type);
   }
   is_null.EndIf();
 

--- a/src/codegen/type/type_system.cpp
+++ b/src/codegen/type/type_system.cpp
@@ -229,9 +229,6 @@ Value TypeSystem::UnaryOperatorHandleNull::Eval(CodeGen &codegen,
     return Impl(codegen, val);
   }
 
-  // The input is NULLable
-  PL_ASSERT(val.IsNullable());
-
   Value null_val, ret_val;
   lang::If is_null{codegen, val.IsNull(codegen), "is_null"};
   {

--- a/src/codegen/type/type_system.cpp
+++ b/src/codegen/type/type_system.cpp
@@ -27,12 +27,11 @@ namespace type {
 // SimpleNullableCast
 //
 //===----------------------------------------------------------------------===//
-Value TypeSystem::SimpleNullableCast::DoCast(CodeGen &codegen,
-                                             const Value &value,
-                                             const Type &to_type) const {
+Value TypeSystem::SimpleNullableCast::Eval(CodeGen &codegen, const Value &value,
+                                           const Type &to_type) const {
   if (!value.IsNullable()) {
     // If the value isn't NULLable, avoid the NULL check and just invoke
-    return CastImpl(codegen, value, to_type);
+    return Impl(codegen, value, to_type);
   }
 
   // The value is NULLable, we need to perform a null check
@@ -46,7 +45,7 @@ Value TypeSystem::SimpleNullableCast::DoCast(CodeGen &codegen,
   is_null.ElseBlock();
   {
     // If both values are not null, perform the non-null-aware operation
-    ret_val = CastImpl(codegen, value, to_type.AsNonNullable());
+    ret_val = Impl(codegen, value, to_type.AsNonNullable());
   }
   is_null.EndIf();
 
@@ -78,37 +77,37 @@ Value TypeSystem::SimpleNullableCast::DoCast(CodeGen &codegen,
   /* Return the result with the computed null-bit */                       \
   return Value{result.GetType().AsNullable(), result.GetValue(), nullptr, null};
 
-Value TypeSystem::SimpleNullableComparison::DoCompareLt(
+Value TypeSystem::SimpleNullableComparison::EvalCompareLt(
     CodeGen &codegen, const Value &left, const Value &right) const {
   GEN_COMPARE(CompareLtImpl(codegen, left, right));
 }
 
-Value TypeSystem::SimpleNullableComparison::DoCompareLte(
+Value TypeSystem::SimpleNullableComparison::EvalCompareLte(
     CodeGen &codegen, const Value &left, const Value &right) const {
   GEN_COMPARE(CompareLteImpl(codegen, left, right));
 }
 
-Value TypeSystem::SimpleNullableComparison::DoCompareEq(
+Value TypeSystem::SimpleNullableComparison::EvalCompareEq(
     CodeGen &codegen, const Value &left, const Value &right) const {
   GEN_COMPARE(CompareEqImpl(codegen, left, right));
 }
 
-Value TypeSystem::SimpleNullableComparison::DoCompareNe(
+Value TypeSystem::SimpleNullableComparison::EvalCompareNe(
     CodeGen &codegen, const Value &left, const Value &right) const {
   GEN_COMPARE(CompareNeImpl(codegen, left, right));
 }
 
-Value TypeSystem::SimpleNullableComparison::DoCompareGt(
+Value TypeSystem::SimpleNullableComparison::EvalCompareGt(
     CodeGen &codegen, const Value &left, const Value &right) const {
   GEN_COMPARE(CompareGtImpl(codegen, left, right));
 }
 
-Value TypeSystem::SimpleNullableComparison::DoCompareGte(
+Value TypeSystem::SimpleNullableComparison::EvalCompareGte(
     CodeGen &codegen, const Value &left, const Value &right) const {
   GEN_COMPARE(CompareGteImpl(codegen, left, right));
 }
 
-Value TypeSystem::SimpleNullableComparison::DoCompareForSort(
+Value TypeSystem::SimpleNullableComparison::EvalCompareForSort(
     CodeGen &codegen, const Value &left, const Value &right) const {
   GEN_COMPARE(CompareForSortImpl(codegen, left, right));
 }
@@ -120,8 +119,8 @@ Value TypeSystem::SimpleNullableComparison::DoCompareForSort(
 // SimpleNullableUnaryOperator
 //
 //===----------------------------------------------------------------------===//
-Value TypeSystem::SimpleNullableUnaryOperator::DoWork(CodeGen &codegen,
-                                                      const Value &val) const {
+Value TypeSystem::SimpleNullableUnaryOperator::Eval(CodeGen &codegen,
+                                                    const Value &val) const {
   if (!val.IsNullable()) {
     // If the input is not NULLable, elide the NULL check
     return Impl(codegen, val);
@@ -151,10 +150,10 @@ Value TypeSystem::SimpleNullableUnaryOperator::DoWork(CodeGen &codegen,
 // SimpleNullableBinaryOperator
 //
 //===----------------------------------------------------------------------===//
-Value TypeSystem::SimpleNullableBinaryOperator::DoWork(CodeGen &codegen,
-                                                       const Value &left,
-                                                       const Value &right,
-                                                       OnError on_error) const {
+Value TypeSystem::SimpleNullableBinaryOperator::Eval(CodeGen &codegen,
+                                                     const Value &left,
+                                                     const Value &right,
+                                                     OnError on_error) const {
   if (!left.IsNullable() && !right.IsNullable()) {
     // Neither input is NULLable, elide the NULL check
     return Impl(codegen, left, right, on_error);

--- a/src/codegen/type/type_system.cpp
+++ b/src/codegen/type/type_system.cpp
@@ -13,9 +13,9 @@
 #include "codegen/type/type_system.h"
 
 #include "codegen/lang/if.h"
-#include "codegen/value.h"
 #include "codegen/type/boolean_type.h"
 #include "codegen/type/integer_type.h"
+#include "codegen/value.h"
 #include "common/exception.h"
 #include "util/string_util.h"
 
@@ -25,9 +25,10 @@ namespace type {
 
 //===----------------------------------------------------------------------===//
 //
-// SimpleNullableCast
+// CastHandleNull
 //
 //===----------------------------------------------------------------------===//
+
 Value TypeSystem::CastHandleNull::Eval(CodeGen &codegen, const Value &value,
                                        const Type &to_type) const {
   if (!value.IsNullable()) {
@@ -55,7 +56,7 @@ Value TypeSystem::CastHandleNull::Eval(CodeGen &codegen, const Value &value,
 
 //===----------------------------------------------------------------------===//
 //
-// SimpleNullableComparison
+// SimpleComparisonHandleNull
 //
 //===----------------------------------------------------------------------===//
 
@@ -117,7 +118,7 @@ Value TypeSystem::SimpleComparisonHandleNull::EvalCompareForSort(
 
 //===----------------------------------------------------------------------===//
 //
-// SimpleNullableComparison
+// ExpensiveComparisonHandleNull
 //
 //===----------------------------------------------------------------------===//
 
@@ -174,11 +175,11 @@ Value TypeSystem::ExpensiveComparisonHandleNull::EvalCompareForSort(
 
 //===----------------------------------------------------------------------===//
 //
-// SimpleNullableUnaryOperator
+// UnaryOperatorHandleNull
 //
 //===----------------------------------------------------------------------===//
-Value TypeSystem::SimpleNullableUnaryOperator::Eval(CodeGen &codegen,
-                                                    const Value &val) const {
+Value TypeSystem::UnaryOperatorHandleNull::Eval(CodeGen &codegen,
+                                                const Value &val) const {
   if (!val.IsNullable()) {
     // If the input is not NULLable, elide the NULL check
     return Impl(codegen, val);
@@ -205,13 +206,13 @@ Value TypeSystem::SimpleNullableUnaryOperator::Eval(CodeGen &codegen,
 
 //===----------------------------------------------------------------------===//
 //
-// SimpleNullableBinaryOperator
+// BinaryOperatorHandleNull
 //
 //===----------------------------------------------------------------------===//
-Value TypeSystem::SimpleNullableBinaryOperator::Eval(CodeGen &codegen,
-                                                     const Value &left,
-                                                     const Value &right,
-                                                     OnError on_error) const {
+Value TypeSystem::BinaryOperatorHandleNull::Eval(CodeGen &codegen,
+                                                 const Value &left,
+                                                 const Value &right,
+                                                 OnError on_error) const {
   if (!left.IsNullable() && !right.IsNullable()) {
     // Neither input is NULLable, elide the NULL check
     return Impl(codegen, left, right, on_error);

--- a/src/codegen/type/varbinary_type.cpp
+++ b/src/codegen/type/varbinary_type.cpp
@@ -35,7 +35,7 @@ namespace {
 ///===--------------------------------------------------------------------===///
 
 // Comparison
-struct CompareVarbinary : public TypeSystem::Comparison {
+struct CompareVarbinary : public TypeSystem::SimpleNullableComparison {
   bool SupportsTypes(const type::Type &left_type,
                      const type::Type &right_type) const override {
     return left_type.GetSqlType() == Varbinary::Instance() &&
@@ -53,8 +53,8 @@ struct CompareVarbinary : public TypeSystem::Comparison {
     return codegen.Call(ValuesRuntimeProxy::CompareStrings, args);
   }
 
-  Value DoCompareLt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareLtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -67,8 +67,8 @@ struct CompareVarbinary : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result};
   }
 
-  Value DoCompareLte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareLteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -81,8 +81,8 @@ struct CompareVarbinary : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result};
   }
 
-  Value DoCompareEq(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareEqImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -95,8 +95,8 @@ struct CompareVarbinary : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result};
   }
 
-  Value DoCompareNe(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareNeImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -109,8 +109,8 @@ struct CompareVarbinary : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result};
   }
 
-  Value DoCompareGt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareGtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -123,8 +123,8 @@ struct CompareVarbinary : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result};
   }
 
-  Value DoCompareGte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareGteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -137,8 +137,8 @@ struct CompareVarbinary : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result};
   }
 
-  Value DoComparisonForSort(CodeGen &codegen, const Value &left,
-                            const Value &right) const override {
+  Value CompareForSortImpl(CodeGen &codegen, const Value &left,
+                           const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -184,8 +184,8 @@ static std::vector<TypeSystem::NaryOpInfo> kNaryOperatorTable = {};
 Varbinary::Varbinary()
     : SqlType(peloton::type::TypeId::VARBINARY),
       type_system_(kImplicitCastingTable, kExplicitCastingTable,
-                   kComparisonTable, kUnaryOperatorTable,
-                   kBinaryOperatorTable, kNaryOperatorTable) {}
+                   kComparisonTable, kUnaryOperatorTable, kBinaryOperatorTable,
+                   kNaryOperatorTable) {}
 
 Value Varbinary::GetMinValue(UNUSED_ATTRIBUTE CodeGen &codegen) const {
   throw Exception{"The VARBINARY type does not have a minimum value ..."};

--- a/src/codegen/type/varbinary_type.cpp
+++ b/src/codegen/type/varbinary_type.cpp
@@ -35,7 +35,7 @@ namespace {
 ///===--------------------------------------------------------------------===///
 
 // Comparison
-struct CompareVarbinary : public TypeSystem::SimpleNullableComparison {
+struct CompareVarbinary : public TypeSystem::SimpleComparisonHandleNull {
   bool SupportsTypes(const type::Type &left_type,
                      const type::Type &right_type) const override {
     return left_type.GetSqlType() == Varbinary::Instance() &&

--- a/src/codegen/type/varchar_type.cpp
+++ b/src/codegen/type/varchar_type.cpp
@@ -109,7 +109,7 @@ struct CompareVarchar : public TypeSystem::ExpensiveComparisonHandleNull {
   }
 };
 
-struct Ascii : public TypeSystem::SimpleNullableUnaryOperator {
+struct Ascii : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == Varchar::Instance();
   }
@@ -171,7 +171,7 @@ struct Like : public TypeSystem::BinaryOperator {
   }
 };
 
-struct Length : public TypeSystem::SimpleNullableUnaryOperator {
+struct Length : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == Varchar::Instance();
   }

--- a/src/codegen/type/varchar_type.cpp
+++ b/src/codegen/type/varchar_type.cpp
@@ -171,7 +171,7 @@ struct Like : public TypeSystem::BinaryOperator {
   }
 };
 
-struct Length : public TypeSystem::UnaryOperator {
+struct Length : public TypeSystem::SimpleNullableUnaryOperator {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == Varchar::Instance();
   }
@@ -180,7 +180,7 @@ struct Length : public TypeSystem::UnaryOperator {
     return Integer::Instance();
   }
 
-  Value DoWork(CodeGen &codegen, const Value &val) const override {
+  Value Impl(CodeGen &codegen, const Value &val) const override {
     llvm::Value *raw_ret = codegen.Call(StringFunctionsProxy::Length,
                                         {val.GetValue(), val.GetLength()});
     return Value{Integer::Instance(), raw_ret};

--- a/src/codegen/type/varchar_type.cpp
+++ b/src/codegen/type/varchar_type.cpp
@@ -141,7 +141,7 @@ struct CompareVarchar : public TypeSystem::SimpleNullableComparison {
   }
 };
 
-struct Ascii : public TypeSystem::UnaryOperator {
+struct Ascii : public TypeSystem::SimpleNullableUnaryOperator {
   bool SupportsType(const Type &type) const override {
     return type.GetSqlType() == Varchar::Instance();
   }
@@ -150,7 +150,7 @@ struct Ascii : public TypeSystem::UnaryOperator {
     return Integer::Instance();
   }
 
-  Value DoWork(CodeGen &codegen, const Value &val) const override {
+  Value Impl(CodeGen &codegen, const Value &val) const override {
     llvm::Value *raw_ret = codegen.Call(StringFunctionsProxy::Ascii,
                                         {val.GetValue(), val.GetLength()});
     return Value{Integer::Instance(), raw_ret};

--- a/src/codegen/type/varchar_type.cpp
+++ b/src/codegen/type/varchar_type.cpp
@@ -190,7 +190,7 @@ struct Length : public TypeSystem::UnaryOperatorHandleNull {
 // DateTrunc
 // TODO(lma): Move this to the Timestamp type once the function lookup logic is
 // corrected.
-struct DateTrunc : public TypeSystem::BinaryOperator {
+struct DateTrunc : public TypeSystem::BinaryOperatorHandleNull {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
     return left_type.GetSqlType() == Varchar::Instance() &&
@@ -202,8 +202,8 @@ struct DateTrunc : public TypeSystem::BinaryOperator {
     return Type{Timestamp::Instance()};
   }
 
-  Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-               UNUSED_ATTRIBUTE OnError on_error) const override {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             UNUSED_ATTRIBUTE OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     llvm::Value *raw_ret = codegen.Call(TimestampFunctionsProxy::DateTrunc,

--- a/src/codegen/type/varchar_type.cpp
+++ b/src/codegen/type/varchar_type.cpp
@@ -27,7 +27,7 @@ namespace type {
 namespace {
 
 // Comparison
-struct CompareVarchar : public TypeSystem::Comparison {
+struct CompareVarchar : public TypeSystem::SimpleNullableComparison {
   bool SupportsTypes(const type::Type &left_type,
                      const type::Type &right_type) const override {
     return left_type.GetSqlType() == Varchar::Instance() &&
@@ -45,8 +45,8 @@ struct CompareVarchar : public TypeSystem::Comparison {
     return codegen.Call(ValuesRuntimeProxy::CompareStrings, args);
   }
 
-  Value DoCompareLt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareLtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -59,8 +59,8 @@ struct CompareVarchar : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result};
   }
 
-  Value DoCompareLte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareLteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -73,8 +73,8 @@ struct CompareVarchar : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result};
   }
 
-  Value DoCompareEq(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareEqImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -87,8 +87,8 @@ struct CompareVarchar : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result};
   }
 
-  Value DoCompareNe(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareNeImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -101,8 +101,8 @@ struct CompareVarchar : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result};
   }
 
-  Value DoCompareGt(CodeGen &codegen, const Value &left,
-                    const Value &right) const override {
+  Value CompareGtImpl(CodeGen &codegen, const Value &left,
+                      const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -115,8 +115,8 @@ struct CompareVarchar : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result};
   }
 
-  Value DoCompareGte(CodeGen &codegen, const Value &left,
-                     const Value &right) const override {
+  Value CompareGteImpl(CodeGen &codegen, const Value &left,
+                       const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)
@@ -129,8 +129,8 @@ struct CompareVarchar : public TypeSystem::Comparison {
     return Value{Boolean::Instance(), result};
   }
 
-  Value DoComparisonForSort(CodeGen &codegen, const Value &left,
-                            const Value &right) const override {
+  Value CompareForSortImpl(CodeGen &codegen, const Value &left,
+                           const Value &right) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Call CompareStrings(...)

--- a/src/codegen/type/varchar_type.cpp
+++ b/src/codegen/type/varchar_type.cpp
@@ -182,11 +182,12 @@ struct Like : public TypeSystem::BinaryOperator {
   Value Eval(CodeGen &codegen, const Value &left, const Value &right,
              UNUSED_ATTRIBUTE OnError on_error) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    
+    // Pre-condition: Left value is the input string; right value is the pattern
+    
     if (!left.IsNullable()) {
       return Impl(codegen, left, right);
     }
-
-    // The input string is NULLable, perform NULL check
 
     codegen::Value null_ret, not_null_ret;
     lang::If input_null{codegen, left.IsNull(codegen)};
@@ -195,7 +196,10 @@ struct Like : public TypeSystem::BinaryOperator {
       null_ret = codegen::Value{Boolean::Instance(), codegen.ConstBool(false)};
     }
     input_null.ElseBlock();
-    { not_null_ret = Impl(codegen, left, right); }
+    { 
+      // Input is not null, invoke LIKE
+      not_null_ret = Impl(codegen, left, right); 
+    }
     return input_null.BuildPHI(null_ret, not_null_ret);
   }
 };

--- a/src/codegen/type/varchar_type.cpp
+++ b/src/codegen/type/varchar_type.cpp
@@ -125,6 +125,22 @@ struct Ascii : public TypeSystem::UnaryOperatorHandleNull {
   }
 };
 
+struct Length : public TypeSystem::UnaryOperatorHandleNull {
+  bool SupportsType(const Type &type) const override {
+    return type.GetSqlType() == Varchar::Instance();
+  }
+
+  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+    return Integer::Instance();
+  }
+
+  Value Impl(CodeGen &codegen, const Value &val) const override {
+    llvm::Value *raw_ret = codegen.Call(StringFunctionsProxy::Length,
+                                        {val.GetValue(), val.GetLength()});
+    return Value{Integer::Instance(), raw_ret};
+  }
+};
+
 struct Like : public TypeSystem::BinaryOperator {
   bool SupportsTypes(const Type &left_type,
                      const Type &right_type) const override {
@@ -168,22 +184,6 @@ struct Like : public TypeSystem::BinaryOperator {
       not_null_ret = Impl(codegen, left, right);
     }
     return input_null.BuildPHI(null_ret, not_null_ret);
-  }
-};
-
-struct Length : public TypeSystem::UnaryOperatorHandleNull {
-  bool SupportsType(const Type &type) const override {
-    return type.GetSqlType() == Varchar::Instance();
-  }
-
-  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
-    return Integer::Instance();
-  }
-
-  Value Impl(CodeGen &codegen, const Value &val) const override {
-    llvm::Value *raw_ret = codegen.Call(StringFunctionsProxy::Length,
-                                        {val.GetValue(), val.GetLength()});
-    return Value{Integer::Instance(), raw_ret};
   }
 };
 

--- a/src/codegen/value.cpp
+++ b/src/codegen/value.cpp
@@ -285,20 +285,13 @@ Value Value::CallBinaryOp(CodeGen &codegen, OperatorId op_id,
   auto *binary_op = type::TypeSystem::GetBinaryOperator(
       op_id, GetType(), left_target_type, other.GetType(), right_target_type);
 
+  PL_ASSERT(binary_op != nullptr);
+
   Value casted_left = CastTo(codegen, left_target_type);
   Value casted_right = other.CastTo(codegen, right_target_type);
 
-  // Check if we need to do a NULL-aware binary operation invocation
-  if (!casted_left.IsNullable() && !casted_right.IsNullable()) {
-    // Nope
-    return binary_op->DoWork(codegen, casted_left, casted_right, on_error);
-  } else {
-    // One of the inputs are NULL
-    type::TypeSystem::BinaryOperatorWithNullPropagation null_aware_bin_op{
-        *binary_op};
-    return null_aware_bin_op.DoWork(codegen, casted_left, casted_right,
-                                    on_error);
-  }
+  // Evaluate
+  return binary_op->DoWork(codegen, casted_left, casted_right, on_error);
 }
 
 }  // namespace codegen

--- a/src/codegen/value.cpp
+++ b/src/codegen/value.cpp
@@ -58,7 +58,7 @@ Value Value::CastTo(CodeGen &codegen, const type::Type &to_type) const {
   // Lookup the cast operation and execute it
   const auto *cast_op = type::TypeSystem::GetCast(GetType(), to_type);
   PL_ASSERT(cast_op != nullptr);
-  return cast_op->DoCast(codegen, *this, to_type);
+  return cast_op->Eval(codegen, *this, to_type);
 }
 
 #define GEN_COMPARE(OP)                                     \
@@ -72,7 +72,7 @@ Value Value::CastTo(CodeGen &codegen, const type::Type &to_type) const {
   Value left = CastTo(codegen, left_cast);                  \
   Value right = other.CastTo(codegen, right_cast);          \
                                                             \
-  return comparison->Do##OP(codegen, left, right);
+  return comparison->Eval##OP(codegen, left, right);
 
 Value Value::CompareEq(CodeGen &codegen, const Value &other) const {
   GEN_COMPARE(CompareEq);
@@ -274,7 +274,7 @@ Value Value::BuildPHI(
 Value Value::CallUnaryOp(CodeGen &codegen, OperatorId op_id) const {
   auto *unary_op = type::TypeSystem::GetUnaryOperator(op_id, GetType());
   PL_ASSERT(unary_op != nullptr);
-  return unary_op->DoWork(codegen, *this);
+  return unary_op->Eval(codegen, *this);
 }
 
 Value Value::CallBinaryOp(CodeGen &codegen, OperatorId op_id,
@@ -291,7 +291,7 @@ Value Value::CallBinaryOp(CodeGen &codegen, OperatorId op_id,
   Value casted_right = other.CastTo(codegen, right_target_type);
 
   // Evaluate
-  return binary_op->DoWork(codegen, casted_left, casted_right, on_error);
+  return binary_op->Eval(codegen, casted_left, casted_right, on_error);
 }
 
 }  // namespace codegen

--- a/src/codegen/value.cpp
+++ b/src/codegen/value.cpp
@@ -61,23 +61,17 @@ Value Value::CastTo(CodeGen &codegen, const type::Type &to_type) const {
   return cast_op->DoCast(codegen, *this, to_type);
 }
 
-#define DO_COMPARE(OP)                                                     \
-  type::Type left_cast = GetType();                                        \
-  type::Type right_cast = other.GetType();                                 \
-                                                                           \
-  const auto *comparison = type::TypeSystem::GetComparison(                \
-      GetType(), left_cast, other.GetType(), right_cast);                  \
-                                                                           \
-  Value left = CastTo(codegen, left_cast);                                 \
-  Value right = other.CastTo(codegen, right_cast);                         \
-                                                                           \
-  if (!left.IsNullable() && !right.IsNullable()) {                         \
-    return comparison->Do##OP(codegen, left, right);                       \
-  } else {                                                                 \
-    type::TypeSystem::ComparisonWithNullPropagation null_aware_comparison{ \
-        *comparison};                                                      \
-    return null_aware_comparison.Do##OP(codegen, left, right);             \
-  }
+#define DO_COMPARE(OP)                                      \
+  type::Type left_cast = GetType();                         \
+  type::Type right_cast = other.GetType();                  \
+                                                            \
+  const auto *comparison = type::TypeSystem::GetComparison( \
+      GetType(), left_cast, other.GetType(), right_cast);   \
+                                                            \
+  Value left = CastTo(codegen, left_cast);                  \
+  Value right = other.CastTo(codegen, right_cast);          \
+                                                            \
+  return comparison->Do##OP(codegen, left, right);
 
 Value Value::CompareEq(CodeGen &codegen, const Value &other) const {
   DO_COMPARE(CompareEq);
@@ -104,7 +98,7 @@ Value Value::CompareGte(CodeGen &codegen, const Value &other) const {
 }
 
 Value Value::CompareForSort(CodeGen &codegen, const Value &other) const {
-  DO_COMPARE(ComparisonForSort);
+  DO_COMPARE(CompareForSort);
 }
 
 #undef DO_COMPARE

--- a/src/codegen/value.cpp
+++ b/src/codegen/value.cpp
@@ -55,18 +55,10 @@ Value Value::CastTo(CodeGen &codegen, const type::Type &to_type) const {
     return *this;
   }
 
-  // Do the explicit cast
-  const auto *cast = type::TypeSystem::GetCast(GetType(), to_type);
-
-  if (IsNullable()) {
-    // We need to handle NULL's during casting
-    type::TypeSystem::CastWithNullPropagation null_aware_cast{*cast};
-    return null_aware_cast.DoCast(codegen, *this, to_type);
-  } else {
-    // No NULL, just do the cast
-    PL_ASSERT(!to_type.nullable);
-    return cast->DoCast(codegen, *this, to_type);
-  }
+  // Lookup the cast operation and execute it
+  const auto *cast_op = type::TypeSystem::GetCast(GetType(), to_type);
+  PL_ASSERT(cast_op != nullptr);
+  return cast_op->DoCast(codegen, *this, to_type);
 }
 
 #define DO_COMPARE(OP)                                                     \

--- a/src/include/codegen/type/type_system.h
+++ b/src/include/codegen/type/type_system.h
@@ -42,7 +42,9 @@ class Type;
 class TypeSystem {
  public:
   //===--------------------------------------------------------------------===//
-  // Casting operator
+  //
+  // Casting operation
+  //
   //===--------------------------------------------------------------------===//
   class Cast {
    public:
@@ -58,21 +60,25 @@ class TypeSystem {
                          const Type &to_type) const = 0;
   };
 
-  class CastWithNullPropagation : public Cast {
+  //===--------------------------------------------------------------------===//
+  //
+  // SimpleNullableCast
+  //
+  // A abstract base class for cast operations. This class performs generic NULL
+  // checking logic that is common across most casting operations. If the input
+  // is NULLable, an if-then-else construct is generated to perform the NULL
+  // check. Subclasses implement casting logic assuming non-NULLable inputs.
+  //
+  //===--------------------------------------------------------------------===//
+  class SimpleNullableCast : public TypeSystem::Cast {
    public:
-    CastWithNullPropagation(const TypeSystem::Cast &inner_cast)
-        : inner_cast_(inner_cast) {}
-
-    // Does this cast support casting from the given type to the given type?
-    bool SupportsTypes(const Type &from_type,
-                       const Type &to_type) const override;
-
-    // Perform the cast on the given value to the provided type
     Value DoCast(CodeGen &codegen, const Value &value,
                  const Type &to_type) const override;
 
-   private:
-    const TypeSystem::Cast &inner_cast_;
+   protected:
+    // Perform the cast assuming the input is not NULLable
+    virtual Value CastImpl(CodeGen &codegen, const Value &value,
+                           const Type &to_type) const = 0;
   };
 
   struct CastInfo {
@@ -82,7 +88,9 @@ class TypeSystem {
   };
 
   //===--------------------------------------------------------------------===//
+  //
   // The generic comparison interface for all comparisons between all types
+  //
   //===--------------------------------------------------------------------===//
   class Comparison {
    public:

--- a/src/include/codegen/type/type_system.h
+++ b/src/include/codegen/type/type_system.h
@@ -184,8 +184,8 @@ class TypeSystem {
   // An abstract base class for comparison operations. This class correctly
   // computes the NULL bit, but generates a full-blown if-then-else clause
   // (hence the "expensive" part) to perform the NULL check. Thus, derived
-  // comparison implementations are assured that arguments are not NULLable.
-  // If the arguments are non-NULLable, then the NULL check is elided.
+  // comparison implementations are assured that arguments are not NULL-able.
+  // If the arguments are non-NULL-able, then the NULL check is elided.
   //
   //===--------------------------------------------------------------------===//
   class ExpensiveComparisonHandleNull : public Comparison {
@@ -249,15 +249,19 @@ class TypeSystem {
 
   //===--------------------------------------------------------------------===//
   //
-  // SimpleNullableUnaryOperator
+  // UnaryOperatorHandleNull
   //
-  // An abstract base class for NULLable unary operators. This class performs
-  // generic NULL checking logic. A NULL value is returned if the input is NULL.
-  // Otherwise, the unary function logic is executed. If the input is not
-  // NULLable, the NULL-check is entirely elided.
+  // An abstract base class for unary operators that returns NULL if the input
+  // is NULL. If the input is not NULL, derived implementations are invoked to
+  // execute the operator logic.
+  //
+  // If the input is not NULL-able, no NULL check is performed.
+  //
+  // If the input is NULL-able, an if-then-else clause is created, and derived
+  // implementations are called in the non-NULL branch.
   //
   //===--------------------------------------------------------------------===//
-  class SimpleNullableUnaryOperator : public UnaryOperator {
+  class UnaryOperatorHandleNull : public UnaryOperator {
    public:
     Value Eval(CodeGen &codegen, const Value &val) const override;
 
@@ -303,15 +307,19 @@ class TypeSystem {
 
   //===--------------------------------------------------------------------===//
   //
-  // SimpleNullableBinaryOperator
+  // BinaryOperatorHandleNull
   //
-  // An abstract base class for NULLable unary operators. This class performs
-  // generic NULL checking logic. A NULL value is returned if the input is NULL.
-  // Otherwise, the unary function logic is executed. If the input is not
-  // NULLable, the NULL-check is entirely elided.
+  // An abstract base class for binary operators that returns NULL if either
+  // input argument is NULL. If neither input is NULL, derived implementations
+  // are called (through Impl()) to execute operator logic.
+  //
+  // If the input is not NULL-able, no NULL check is performed.
+  //
+  // If the input is NULL-able, an if-then-else clause is created, and derived
+  // implementations are called in the non-NULL branch.
   //
   //===--------------------------------------------------------------------===//
-  struct SimpleNullableBinaryOperator : public BinaryOperator {
+  struct BinaryOperatorHandleNull : public BinaryOperator {
    public:
     Value Eval(CodeGen &codegen, const Value &left, const Value &right,
                OnError on_error) const override;

--- a/src/include/codegen/type/type_system.h
+++ b/src/include/codegen/type/type_system.h
@@ -106,19 +106,14 @@ class TypeSystem {
     // Main comparison operators
     virtual Value DoCompareLt(CodeGen &codegen, const Value &left,
                               const Value &right) const = 0;
-
     virtual Value DoCompareLte(CodeGen &codegen, const Value &left,
                                const Value &right) const = 0;
-
     virtual Value DoCompareEq(CodeGen &codegen, const Value &left,
                               const Value &right) const = 0;
-
     virtual Value DoCompareNe(CodeGen &codegen, const Value &left,
                               const Value &right) const = 0;
-
     virtual Value DoCompareGt(CodeGen &codegen, const Value &left,
                               const Value &right) const = 0;
-
     virtual Value DoCompareGte(CodeGen &codegen, const Value &left,
                                const Value &right) const = 0;
 
@@ -220,6 +215,9 @@ class TypeSystem {
     virtual Value Impl(CodeGen &codegen, const Value &val) const = 0;
   };
 
+  //===--------------------------------------------------------------------===//
+  // Metadata structure capturing an operator ID and an instance
+  //===--------------------------------------------------------------------===//
   struct UnaryOpInfo {
     // The ID of the operation
     OperatorId op_id;
@@ -229,7 +227,11 @@ class TypeSystem {
   };
 
   //===--------------------------------------------------------------------===//
+  //
+  // BinaryOperator
+  //
   // A binary operator (i.e., an operator that accepts two arguments)
+  //
   //===--------------------------------------------------------------------===//
   class BinaryOperator {
    public:
@@ -248,23 +250,25 @@ class TypeSystem {
                          const Value &right, OnError on_error) const = 0;
   };
 
-  class BinaryOperatorWithNullPropagation : public BinaryOperator {
+  //===--------------------------------------------------------------------===//
+  //
+  // SimpleNullableBinaryOperator
+  //
+  // An abstract base class for NULLable unary operators. This class performs
+  // generic NULL checking logic. A NULL value is returned if the input is NULL.
+  // Otherwise, the unary function logic is executed. If the input is not
+  // NULLable, the NULL-check is entirely elided.
+  //
+  //===--------------------------------------------------------------------===//
+  struct SimpleNullableBinaryOperator : public BinaryOperator {
    public:
-    BinaryOperatorWithNullPropagation(
-        const TypeSystem::BinaryOperator &inner_op)
-        : inner_op_(inner_op) {}
-
-    bool SupportsTypes(const Type &left_type,
-                       const Type &right_type) const override;
-
-    Type ResultType(const Type &left_type,
-                    const Type &right_type) const override;
-
     Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
                  OnError on_error) const override;
 
-   private:
-    const BinaryOperator &inner_op_;
+   protected:
+    // The implementation assuming non-nullable types
+    virtual Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+                       OnError on_error) const = 0;
   };
 
   struct BinaryOpInfo {

--- a/src/include/codegen/type/type_system.h
+++ b/src/include/codegen/type/type_system.h
@@ -134,10 +134,14 @@ class TypeSystem {
   // SimpleComparisonHandleNull
   //
   // An abstract base class for comparison operations. This class computes the
-  // NULL bit based on arguments, but **always** invokes the derived comparison
-  // implementation. For simple comparisons, i.e., numeric comparisons, this is
-  // safe since the values will always be valid (though potentially garbage),
-  // but the resulting boolean is masked with the NULL bit. For string
+  // NULL bit based on arguments and **always** invokes the derived
+  // implementation to perform the comparison. This means that derived classes
+  // may operate on SQL NULL values. For simple comparisons, i.e., numeric
+  // comparisons, this is safe since the values will always be valid, though
+  // potentially garbage). The resulting boolean value is still marked with the
+  // correct NULL bit, thus hiding the (potentially) garbage comparison.
+  //
+  // This class isn't safe for string comparisons since strings  For string
   // comparisons, this is not safe because the string can take on C/C++ NULL,
   // and SEGFAULT.
   //

--- a/src/include/codegen/type/type_system.h
+++ b/src/include/codegen/type/type_system.h
@@ -56,8 +56,8 @@ class TypeSystem {
                                const Type &to_type) const = 0;
 
     // Perform the cast on the given value to the provided type
-    virtual Value DoCast(CodeGen &codegen, const Value &value,
-                         const Type &to_type) const = 0;
+    virtual Value Eval(CodeGen &codegen, const Value &value,
+                       const Type &to_type) const = 0;
   };
 
   //===--------------------------------------------------------------------===//
@@ -73,13 +73,13 @@ class TypeSystem {
   //===--------------------------------------------------------------------===//
   class SimpleNullableCast : public TypeSystem::Cast {
    public:
-    Value DoCast(CodeGen &codegen, const Value &value,
-                 const Type &to_type) const override;
+    Value Eval(CodeGen &codegen, const Value &value,
+               const Type &to_type) const override;
 
    protected:
     // Perform the cast assuming the input is not NULLable
-    virtual Value CastImpl(CodeGen &codegen, const Value &value,
-                           const Type &to_type) const = 0;
+    virtual Value Impl(CodeGen &codegen, const Value &value,
+                       const Type &to_type) const = 0;
   };
 
   struct CastInfo {
@@ -104,26 +104,26 @@ class TypeSystem {
                                const Type &right_type) const = 0;
 
     // Main comparison operators
-    virtual Value DoCompareLt(CodeGen &codegen, const Value &left,
-                              const Value &right) const = 0;
-    virtual Value DoCompareLte(CodeGen &codegen, const Value &left,
-                               const Value &right) const = 0;
-    virtual Value DoCompareEq(CodeGen &codegen, const Value &left,
-                              const Value &right) const = 0;
-    virtual Value DoCompareNe(CodeGen &codegen, const Value &left,
-                              const Value &right) const = 0;
-    virtual Value DoCompareGt(CodeGen &codegen, const Value &left,
-                              const Value &right) const = 0;
-    virtual Value DoCompareGte(CodeGen &codegen, const Value &left,
-                               const Value &right) const = 0;
+    virtual Value EvalCompareLt(CodeGen &codegen, const Value &left,
+                                const Value &right) const = 0;
+    virtual Value EvalCompareLte(CodeGen &codegen, const Value &left,
+                                 const Value &right) const = 0;
+    virtual Value EvalCompareEq(CodeGen &codegen, const Value &left,
+                                const Value &right) const = 0;
+    virtual Value EvalCompareNe(CodeGen &codegen, const Value &left,
+                                const Value &right) const = 0;
+    virtual Value EvalCompareGt(CodeGen &codegen, const Value &left,
+                                const Value &right) const = 0;
+    virtual Value EvalCompareGte(CodeGen &codegen, const Value &left,
+                                 const Value &right) const = 0;
 
     // Perform a comparison used for sorting. We need a stable and transitive
     // sorting comparison operator here. The operator returns:
     //  < 0 - if the left value comes before the right value when sorted
     //  = 0 - if the left value is equivalent to the right element
     //  > 0 - if the left value comes after the right value when sorted
-    virtual Value DoCompareForSort(CodeGen &codegen, const Value &left,
-                                   const Value &right) const = 0;
+    virtual Value EvalCompareForSort(CodeGen &codegen, const Value &left,
+                                     const Value &right) const = 0;
   };
 
   //===--------------------------------------------------------------------===//
@@ -139,20 +139,20 @@ class TypeSystem {
   //===--------------------------------------------------------------------===//
   class SimpleNullableComparison : public Comparison {
    public:
-    Value DoCompareLt(CodeGen &codegen, const Value &left,
-                      const Value &right) const override;
-    Value DoCompareLte(CodeGen &codegen, const Value &left,
-                       const Value &right) const override;
-    Value DoCompareEq(CodeGen &codegen, const Value &left,
-                      const Value &right) const override;
-    Value DoCompareNe(CodeGen &codegen, const Value &left,
-                      const Value &right) const override;
-    Value DoCompareGt(CodeGen &codegen, const Value &left,
-                      const Value &right) const override;
-    Value DoCompareGte(CodeGen &codegen, const Value &left,
-                       const Value &right) const override;
-    Value DoCompareForSort(CodeGen &codegen, const Value &left,
-                           const Value &right) const override;
+    Value EvalCompareLt(CodeGen &codegen, const Value &left,
+                        const Value &right) const override;
+    Value EvalCompareLte(CodeGen &codegen, const Value &left,
+                         const Value &right) const override;
+    Value EvalCompareEq(CodeGen &codegen, const Value &left,
+                        const Value &right) const override;
+    Value EvalCompareNe(CodeGen &codegen, const Value &left,
+                        const Value &right) const override;
+    Value EvalCompareGt(CodeGen &codegen, const Value &left,
+                        const Value &right) const override;
+    Value EvalCompareGte(CodeGen &codegen, const Value &left,
+                         const Value &right) const override;
+    Value EvalCompareForSort(CodeGen &codegen, const Value &left,
+                             const Value &right) const override;
 
    protected:
     // The non-null comparison implementations
@@ -193,7 +193,7 @@ class TypeSystem {
     virtual Type ResultType(const Type &val_type) const = 0;
 
     // Apply the operator on the given value
-    virtual Value DoWork(CodeGen &codegen, const Value &val) const = 0;
+    virtual Value Eval(CodeGen &codegen, const Value &val) const = 0;
   };
 
   //===--------------------------------------------------------------------===//
@@ -208,7 +208,7 @@ class TypeSystem {
   //===--------------------------------------------------------------------===//
   class SimpleNullableUnaryOperator : public UnaryOperator {
    public:
-    Value DoWork(CodeGen &codegen, const Value &val) const override;
+    Value Eval(CodeGen &codegen, const Value &val) const override;
 
    protected:
     // The actual implementation assuming non-NULL input
@@ -246,8 +246,8 @@ class TypeSystem {
                             const Type &right_type) const = 0;
 
     // Execute the actual operator
-    virtual Value DoWork(CodeGen &codegen, const Value &left,
-                         const Value &right, OnError on_error) const = 0;
+    virtual Value Eval(CodeGen &codegen, const Value &left, const Value &right,
+                       OnError on_error) const = 0;
   };
 
   //===--------------------------------------------------------------------===//
@@ -262,8 +262,8 @@ class TypeSystem {
   //===--------------------------------------------------------------------===//
   struct SimpleNullableBinaryOperator : public BinaryOperator {
    public:
-    Value DoWork(CodeGen &codegen, const Value &left, const Value &right,
-                 OnError on_error) const override;
+    Value Eval(CodeGen &codegen, const Value &left, const Value &right,
+               OnError on_error) const override;
 
    protected:
     // The implementation assuming non-nullable types
@@ -291,8 +291,8 @@ class TypeSystem {
     virtual Type ResultType(const std::vector<Type> &arg_types) const = 0;
 
     // Execute the actual operator
-    virtual Value DoWork(CodeGen &codegen, const std::vector<Value> &input_args,
-                         OnError on_error) const = 0;
+    virtual Value Eval(CodeGen &codegen, const std::vector<Value> &input_args,
+                       OnError on_error) const = 0;
   };
 
   struct NaryOpInfo {

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -1044,9 +1044,9 @@ enum class OperatorId : uint32_t {
   Extract,
   Floor,
   DateTrunc,
+  Like,
 
   // Add more operators here, before the last "Invalid" entry
-  Like,
   Invalid
 };
 std::string OperatorIdToString(OperatorId op_id);

--- a/src/type/types.cpp
+++ b/src/type/types.cpp
@@ -2719,6 +2719,38 @@ std::string OperatorIdToString(OperatorId op_id) {
       return "LogicalAnd";
     case OperatorId::LogicalOr:
       return "LogicalOr";
+    case OperatorId::Ascii:
+      return "Ascii";
+    case OperatorId::Chr:
+      return "Chr";
+    case OperatorId::Concat:
+      return "Concat";
+    case OperatorId::Substr:
+      return "Substr";
+    case OperatorId::CharLength:
+      return "CharLength";
+    case OperatorId::OctetLength:
+      return "OctetLength";
+    case OperatorId::Length:
+      return "Length";
+    case OperatorId::Repeat:
+      return "Repeat";
+    case OperatorId::Replace:
+      return "Replace";
+    case OperatorId::LTrim:
+      return "LTrim";
+    case OperatorId::RTrim:
+      return "RTrim";
+    case OperatorId::BTrim:
+      return "BTrim";
+    case OperatorId::Sqrt:
+      return "Sqrt";
+    case OperatorId::Extract:
+      return "Extract";
+    case OperatorId::Floor:
+      return "Floor";
+    case OperatorId::Like:
+      return "Like";
     case OperatorId::DateTrunc:
       return "DateTrunc";
     default: {

--- a/test/sql/type_sql_test.cpp
+++ b/test/sql/type_sql_test.cpp
@@ -121,12 +121,15 @@ void CheckQueryResult(std::vector<StatementResult> result,
 
 TEST_F(TypeSQLTests, VarcharTest) {
   TestingSQLUtil::ExecuteSQLQuery("CREATE TABLE foo(name varchar(250));");
-  std::vector<std::string> names{"Alice", "Peter",  "Cathy",
-                                 "Bob",   "Alicia", "David"};
-  for (size_t i = 0; i < names.size(); i++) {
-    std::string sql = "INSERT INTO foo VALUES ('" + names[i] + "');";
+
+  for (const std::string &name :
+       {"Alice", "Peter", "Cathy", "Bob", "Alicia", "David"}) {
+    std::string sql = "INSERT INTO foo VALUES ('" + name + "');";
     TestingSQLUtil::ExecuteSQLQuery(sql);
   }
+
+  // NULL for good measure
+  TestingSQLUtil::ExecuteSQLQuery("INSERT INTO foo VALUES (NULL);");
 
   std::vector<StatementResult> result;
   std::vector<FieldInfo> tuple_descriptor;


### PR DESCRIPTION
**Problem**: Right now, all the operators/functions in codegen assume non-null inputs, and rely on the `codegen::Value` class to wrap operators in "null-aware" wrappers to handle NULL inputs. This was okay as long as all calls go through `codegen::Value`. But, with the introduction of function expressions, this is no longer the case as these expressions directly call into the type system. Exposing the null logic externally is a bad idea; moreover, the functions themselves know how to handle NULLs.

**Solution**: Provide base classes that perform the same NULL-handling logic, deferring to derived classes to perform non-null-aware logic. This encapsulates NULL logic to the operator, which makes a lot more sense.

**Details**: In this PR, we introduce four base classes for casting, comparison, unary, and binary operators. The base performs common NULL handling in the evaluation method, and call into derived implementations. Base classes can also elide the NULL-check if it knows the input is not null-able; but, even this can be overridden.