### PR TITLE
Fix Issue 933 - Updating with mismatched types

### DIFF
--- a/src/codegen/operator/update_translator.cpp
+++ b/src/codegen/operator/update_translator.cpp
@@ -43,8 +43,9 @@ UpdateTranslator::UpdateTranslator(const planner::UpdatePlan &update_plan,
 
 bool IsTarget(const TargetList &target_list, uint32_t index) {
   for (const auto &target : target_list) {
-    if (target.first == index)
+    if (target.first == index) {
       return true;
+    }
   }
   return false;
 }
@@ -110,10 +111,11 @@ void UpdateTranslator::Consume(ConsumerContext &, RowBatch::Row &row) const {
   llvm::Value *tuple_ptr;
   std::vector<llvm::Value *> prep_args = {updater, row.GetTileGroupID(),
                                           row.GetTID(codegen)};
-  if (update_plan_.GetUpdatePrimaryKey() == false)
+  if (update_plan_.GetUpdatePrimaryKey() == false) {
     tuple_ptr = codegen.Call(UpdaterProxy::Prepare, prep_args);
-  else
+  } else {
     tuple_ptr = codegen.Call(UpdaterProxy::PreparePK, prep_args);
+  }
 
   // Update only when we have tuple_ptr, otherwise it is not allowed to update
   llvm::Value *prepare_cond = codegen->CreateICmpNE(
@@ -128,10 +130,11 @@ void UpdateTranslator::Consume(ConsumerContext &, RowBatch::Row &row) const {
   
     // Finally, update with help from the Updater
     std::vector<llvm::Value *> update_args = {updater};
-    if (update_plan_.GetUpdatePrimaryKey() == false)
+    if (update_plan_.GetUpdatePrimaryKey() == false) {
       codegen.Call(UpdaterProxy::Update, update_args);
-    else
+    } else {
       codegen.Call(UpdaterProxy::UpdatePK, update_args);
+    }
   }
   prepare_success.EndIf();
 }

--- a/test/sql/update_sql_test.cpp
+++ b/test/sql/update_sql_test.cpp
@@ -25,7 +25,7 @@ namespace test {
 class UpdateSQLTests : public PelotonTest {};
 
 TEST_F(UpdateSQLTests, SimpleUpdateSQLTest) {
-  LOG_INFO("Bootstrapping...");
+  LOG_DEBUG("Bootstrapping...");
 
   auto catalog = catalog::Catalog::GetInstance();
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
@@ -33,28 +33,28 @@ TEST_F(UpdateSQLTests, SimpleUpdateSQLTest) {
   catalog->CreateDatabase(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
 
-  LOG_INFO("Bootstrapping completed!");
+  LOG_DEBUG("Bootstrapping completed!");
 
   // Create a table first
-  LOG_INFO("Creating a table...");
-  LOG_INFO("Query: CREATE TABLE test(a INT PRIMARY KEY, b double)");
+  LOG_DEBUG("Creating a table...");
+  LOG_DEBUG("Query: CREATE TABLE test(a INT PRIMARY KEY, b double)");
 
   TestingSQLUtil::ExecuteSQLQuery(
       "CREATE TABLE test(a INT PRIMARY KEY, b double);");
 
-  LOG_INFO("Table created!");
+  LOG_DEBUG("Table created!");
 
   // Insert a tuple into table
-  LOG_INFO("Inserting a tuple...");
-  LOG_INFO("Query: INSERT INTO test VALUES (0, 1)");
+  LOG_DEBUG("Inserting a tuple...");
+  LOG_DEBUG("Query: INSERT INTO test VALUES (0, 1)");
 
   TestingSQLUtil::ExecuteSQLQuery("INSERT INTO test VALUES (0, 1);");
 
-  LOG_INFO("Tuple inserted!");
+  LOG_DEBUG("Tuple inserted!");
 
   // Update a tuple into table
-  LOG_INFO("Updating a tuple...");
-  LOG_INFO("Query: UPDATE test SET b = 2.0 WHERE a = 0");
+  LOG_DEBUG("Updating a tuple...");
+  LOG_DEBUG("Query: UPDATE test SET b = 2.0 WHERE a = 0");
 
   std::vector<StatementResult> result;
   std::vector<FieldInfo> tuple_descriptor;
@@ -65,7 +65,7 @@ TEST_F(UpdateSQLTests, SimpleUpdateSQLTest) {
                                   result, tuple_descriptor, rows_affected,
                                   error_message);
 
-  LOG_INFO("Tuple Updated!");
+  LOG_DEBUG("Tuple Updated!");
 
   // Check the return value
   EXPECT_EQ(1, rows_affected);
@@ -78,14 +78,14 @@ TEST_F(UpdateSQLTests, SimpleUpdateSQLTest) {
   EXPECT_EQ('2', result[0].second[0]);
 
   // Another update a tuple into table
-  LOG_INFO("Another update a tuple...");
-  LOG_INFO("Query: UPDATE test SET b = 2 WHERE a = 0");
+  LOG_DEBUG("Another update a tuple...");
+  LOG_DEBUG("Query: UPDATE test SET b = 2 WHERE a = 0");
 
   TestingSQLUtil::ExecuteSQLQuery("UPDATE test SET b = 2 WHERE a = 0;", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
 
-  LOG_INFO("Tuple Updated Again!");
+  LOG_DEBUG("Tuple Updated Again!");
 
   // Check the return value
   EXPECT_EQ(1, rows_affected);
@@ -104,7 +104,7 @@ TEST_F(UpdateSQLTests, SimpleUpdateSQLTest) {
 }
 
 TEST_F(UpdateSQLTests, ComplexUpdateSQLTest) {
-  LOG_INFO("Bootstrapping...");
+  LOG_DEBUG("Bootstrapping...");
 
   auto catalog = catalog::Catalog::GetInstance();
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
@@ -112,11 +112,11 @@ TEST_F(UpdateSQLTests, ComplexUpdateSQLTest) {
   catalog->CreateDatabase(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
 
-  LOG_INFO("Bootstrapping completed!");
+  LOG_DEBUG("Bootstrapping completed!");
 
   // Create a table first
-  LOG_INFO("Creating a table...");
-  LOG_INFO(
+  LOG_DEBUG("Creating a table...");
+  LOG_DEBUG(
       "Query: CREATE TABLE employees(e_id int primary key, salary double, "
       "bonus double)");
 
@@ -124,20 +124,20 @@ TEST_F(UpdateSQLTests, ComplexUpdateSQLTest) {
       "CREATE TABLE employees(e_id int primary key, salary double, bonus "
       "double);");
 
-  LOG_INFO("Table created!");
+  LOG_DEBUG("Table created!");
 
   // Insert a tuple into table
-  LOG_INFO("Inserting a tuple...");
-  LOG_INFO("Query: INSERT INTO employees VALUES (0, 1.1, 0.5)");
+  LOG_DEBUG("Inserting a tuple...");
+  LOG_DEBUG("Query: INSERT INTO employees VALUES (0, 1.1, 0.5)");
 
   TestingSQLUtil::ExecuteSQLQuery(
       "INSERT INTO employees VALUES (0, 1.1, 0.5);");
 
-  LOG_INFO("Tuple inserted!");
+  LOG_DEBUG("Tuple inserted!");
 
   // Update a tuple into table
-  LOG_INFO("Updating a tuple...");
-  LOG_INFO(
+  LOG_DEBUG("Updating a tuple...");
+  LOG_DEBUG(
       "Query: UPDATE employees SET "
       "salary = 2 + salary + bonus*salary + 3*(salary+1)+0.1*bonus*salary"
       " WHERE e_id = 0");
@@ -153,7 +153,7 @@ TEST_F(UpdateSQLTests, ComplexUpdateSQLTest) {
       " WHERE e_id = 0;",
       result, tuple_descriptor, rows_affected, error_message);
 
-  LOG_INFO("Tuple Updated!");
+  LOG_DEBUG("Tuple Updated!");
 
   // Check the return value
   EXPECT_EQ(rows_affected, 1);
@@ -166,8 +166,8 @@ TEST_F(UpdateSQLTests, ComplexUpdateSQLTest) {
   EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 0), "10.005");
 
   // Another update a tuple into table
-  LOG_INFO("Another update a tuple...");
-  LOG_INFO(
+  LOG_DEBUG("Another update a tuple...");
+  LOG_DEBUG(
       "Query: UPDATE employees SET "
       "salary = 10, bonus = bonus + 5 WHERE e_id = 0");
 
@@ -176,7 +176,7 @@ TEST_F(UpdateSQLTests, ComplexUpdateSQLTest) {
       "salary = 10, bonus = bonus + 5 WHERE e_id = 0;",
       result, tuple_descriptor, rows_affected, error_message);
 
-  LOG_INFO("Tuple Updated Again!");
+  LOG_DEBUG("Tuple Updated Again!");
 
   // Check the return value
   EXPECT_EQ(rows_affected, 1);
@@ -188,6 +188,89 @@ TEST_F(UpdateSQLTests, ComplexUpdateSQLTest) {
   // Check the return value
   EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 0), "10");
   EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 1), "5.5");
+
+  // free the database just created
+  txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+TEST_F(UpdateSQLTests, UpdateSQLCastTest) {
+  LOG_DEBUG("Bootstrapping...");
+
+  auto catalog = catalog::Catalog::GetInstance();
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog->CreateDatabase(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+
+  LOG_DEBUG("Bootstrapping completed!");
+
+  // Create a table first
+  LOG_DEBUG("Creating a table...");
+  LOG_DEBUG(
+      "Query: CREATE TABLE employees(e_id int primary key, salary double, "
+      "bonus double)");
+
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE employees(e_id int primary key, salary double, bonus "
+      "double);");
+
+  LOG_DEBUG("Table created!");
+
+  // Insert a tuple into table
+  LOG_DEBUG("Inserting a tuple...");
+  LOG_DEBUG("Query: INSERT INTO employees VALUES (0, 1, 0.5)");
+
+  TestingSQLUtil::ExecuteSQLQuery(
+      "INSERT INTO employees VALUES (0, 1, 0.5);");
+
+  LOG_DEBUG("Tuple inserted!");
+
+  // Update a tuple into table
+  LOG_DEBUG("Updating a tuple...");
+  LOG_DEBUG("Query: UPDATE employees SET salary = 2 WHERE e_id = 0");
+
+  std::vector<StatementResult> result;
+  std::vector<FieldInfo> tuple_descriptor;
+  std::string error_message;
+  int rows_affected;
+
+  TestingSQLUtil::ExecuteSQLQuery(
+      "UPDATE employees SET salary = 2.0 WHERE e_id = 0",
+      result, tuple_descriptor, rows_affected, error_message);
+
+  LOG_DEBUG("Tuple Updated!");
+
+  // Check the return value
+  EXPECT_EQ(rows_affected, 1);
+
+  // Check value of column salary after updating
+  TestingSQLUtil::ExecuteSQLQuery("SELECT salary from employees", result,
+                                  tuple_descriptor, rows_affected,
+                                  error_message);
+  // Check the return value
+  EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 0), "2");
+
+  // Another update a tuple into table
+  LOG_DEBUG("Another update a tuple...");
+  LOG_DEBUG("Query: UPDATE employees SET salary = 3 WHERE e_id = 0");
+
+  TestingSQLUtil::ExecuteSQLQuery(
+      "UPDATE employees SET salary = 3 WHERE e_id = 0",
+      result, tuple_descriptor, rows_affected, error_message);
+
+  LOG_DEBUG("Tuple Updated Again!");
+
+  // Check the return value
+  EXPECT_EQ(rows_affected, 1);
+
+  // Check value of column salary and bonus after updating
+  TestingSQLUtil::ExecuteSQLQuery("SELECT salary from employees", result,
+                                  tuple_descriptor, rows_affected,
+                                  error_message);
+  // Check the return value
+  EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 0), "3");
 
   // free the database just created
   txn = txn_manager.BeginTransaction();


### PR DESCRIPTION
This PR fixes #933 by casting to the value types that are defined in the schema of the table, before creating a storage space in `codegen`.  Previously this casting was missing, and #933 occurs.

Test cases are created exactly same as #933 case and added.