### PR TITLE
Statement Cache

### DIFF
--- a/src/common/container/cuckoo_map.cpp
+++ b/src/common/container/cuckoo_map.cpp
@@ -31,6 +31,8 @@ class BackendStatsContext;
 class IndexMetric;
 }  // namespace stats
 
+class StatementCache;
+
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
 CUCKOO_MAP_TYPE::CuckooMap() {}
 

--- a/src/common/container/cuckoo_map.cpp
+++ b/src/common/container/cuckoo_map.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include <functional>
 #include <iostream>
 
@@ -18,6 +17,8 @@
 #include "common/logger.h"
 #include "common/macros.h"
 #include "common/internal_types.h"
+#include "container/cuckoo_map.h"
+#include "type/types.h"
 
 namespace peloton {
 
@@ -28,32 +29,29 @@ class TileGroup;
 namespace stats {
 class BackendStatsContext;
 class IndexMetric;
-}
+}  // namespace stats
 
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
-CUCKOO_MAP_TYPE::CuckooMap(){
-}
+CUCKOO_MAP_TYPE::CuckooMap() {}
 
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
-CUCKOO_MAP_TYPE::~CuckooMap(){
-}
+CUCKOO_MAP_TYPE::~CuckooMap() {}
 
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
-bool CUCKOO_MAP_TYPE::Insert(const KeyType &key, ValueType value){
+bool CUCKOO_MAP_TYPE::Insert(const KeyType &key, ValueType value) {
   auto status = cuckoo_map.insert(key, value);
   LOG_TRACE("insert status : %d", status);
   return status;
 }
 
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
-bool CUCKOO_MAP_TYPE::Update(const KeyType &key, ValueType value){
-  auto status =  cuckoo_map.update(key, value);
+bool CUCKOO_MAP_TYPE::Update(const KeyType &key, ValueType value) {
+  auto status = cuckoo_map.update(key, value);
   return status;
 }
 
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
-bool CUCKOO_MAP_TYPE::Erase(const KeyType &key){
-
+bool CUCKOO_MAP_TYPE::Erase(const KeyType &key) {
   auto status = cuckoo_map.erase(key);
   LOG_TRACE("erase status : %d", status);
 
@@ -62,37 +60,28 @@ bool CUCKOO_MAP_TYPE::Erase(const KeyType &key){
 
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
 bool CUCKOO_MAP_TYPE::Find(const KeyType &key, ValueType &value) const {
-
   auto status = cuckoo_map.find(key, value);
   LOG_TRACE("find status : %d", status);
   return status;
 }
 
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
-bool CUCKOO_MAP_TYPE::Contains(const KeyType &key){
+bool CUCKOO_MAP_TYPE::Contains(const KeyType &key) {
   return cuckoo_map.contains(key);
 }
 
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
-void CUCKOO_MAP_TYPE::Clear(){
-  cuckoo_map.clear();
-}
+void CUCKOO_MAP_TYPE::Clear() { cuckoo_map.clear(); }
 
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
-size_t CUCKOO_MAP_TYPE::GetSize() const{
-  return cuckoo_map.size();
-}
+size_t CUCKOO_MAP_TYPE::GetSize() const { return cuckoo_map.size(); }
 
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
-bool CUCKOO_MAP_TYPE::IsEmpty() const{
-  return cuckoo_map.empty();
-}
+bool CUCKOO_MAP_TYPE::IsEmpty() const { return cuckoo_map.empty(); }
 
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
 CUCKOO_MAP_ITERATOR_TYPE
-CUCKOO_MAP_TYPE::GetIterator() {
-  return cuckoo_map.lock_table();
-}
+CUCKOO_MAP_TYPE::GetIterator() { return cuckoo_map.lock_table(); }
 
 // Explicit template instantiation
 template class CuckooMap<uint32_t, uint32_t>;
@@ -109,5 +98,9 @@ template class CuckooMap<oid_t, std::shared_ptr<stats::IndexMetric>>;
 
 // Used in SharedPointerKeyTest
 template class CuckooMap<std::shared_ptr<oid_t>, std::shared_ptr<oid_t>>;
+
+// Used in StatementCacheManager
+template class CuckooMap<std::shared_ptr<StatementCache>,
+                         std::shared_ptr<StatementCache>>;
 
 }  // namespace peloton

--- a/src/common/container/cuckoo_map.cpp
+++ b/src/common/container/cuckoo_map.cpp
@@ -14,11 +14,10 @@
 #include <iostream>
 
 #include "common/container/cuckoo_map.h"
+#include "common/internal_types.h"
 #include "common/logger.h"
 #include "common/macros.h"
-#include "common/internal_types.h"
 #include "container/cuckoo_map.h"
-#include "type/types.h"
 
 namespace peloton {
 
@@ -102,6 +101,6 @@ template class CuckooMap<oid_t, std::shared_ptr<stats::IndexMetric>>;
 template class CuckooMap<std::shared_ptr<oid_t>, std::shared_ptr<oid_t>>;
 
 // Used in StatementCacheManager
-template class CuckooMap<StatementCache*, StatementCache*>;
+template class CuckooMap<StatementCache *, StatementCache *>;
 
 }  // namespace peloton

--- a/src/common/container/cuckoo_map.cpp
+++ b/src/common/container/cuckoo_map.cpp
@@ -88,16 +88,26 @@ bool CUCKOO_MAP_TYPE::IsEmpty() const{
   return cuckoo_map.empty();
 }
 
+CUCKOO_MAP_TEMPLATE_ARGUMENTS
+CUCKOO_MAP_ITERATOR_TYPE
+CUCKOO_MAP_TYPE::GetIterator() {
+  return cuckoo_map.lock_table();
+}
+
 // Explicit template instantiation
 template class CuckooMap<uint32_t, uint32_t>;
 
 template class CuckooMap<oid_t, std::shared_ptr<storage::TileGroup>>;
 
+// Used in Shared Pointer test and iterator test
 template class CuckooMap<oid_t, std::shared_ptr<oid_t>>;
 
 template class CuckooMap<std::thread::id,
                          std::shared_ptr<stats::BackendStatsContext>>;
 
 template class CuckooMap<oid_t, std::shared_ptr<stats::IndexMetric>>;
+
+// Used in SharedPointerKeyTest
+template class CuckooMap<std::shared_ptr<oid_t>, std::shared_ptr<oid_t>>;
 
 }  // namespace peloton

--- a/src/common/container/cuckoo_map.cpp
+++ b/src/common/container/cuckoo_map.cpp
@@ -17,7 +17,6 @@
 #include "common/internal_types.h"
 #include "common/logger.h"
 #include "common/macros.h"
-#include "container/cuckoo_map.h"
 
 namespace peloton {
 

--- a/src/common/container/cuckoo_map.cpp
+++ b/src/common/container/cuckoo_map.cpp
@@ -102,7 +102,6 @@ template class CuckooMap<oid_t, std::shared_ptr<stats::IndexMetric>>;
 template class CuckooMap<std::shared_ptr<oid_t>, std::shared_ptr<oid_t>>;
 
 // Used in StatementCacheManager
-template class CuckooMap<std::shared_ptr<StatementCache>,
-                         std::shared_ptr<StatementCache>>;
+template class CuckooMap<StatementCache*, StatementCache*>;
 
 }  // namespace peloton

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -19,6 +19,7 @@
 #include "brain/layout_tuner.h"
 #include "catalog/catalog.h"
 #include "common/thread_pool.h"
+#include "common/statement_cache_manager.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "gc/gc_manager_factory.h"
 #include "settings/settings_manager.h"
@@ -79,6 +80,9 @@ void PelotonInit::Initialize() {
   pg_catalog->CreateDatabase(DEFAULT_DB_NAME, txn);
 
   txn_manager.CommitTransaction(txn);
+
+  // Initialize the Statement Cache Manager
+  StatementCacheManager::Init();
 }
 
 void PelotonInit::Shutdown() {

--- a/src/common/statement_cache.cpp
+++ b/src/common/statement_cache.cpp
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// statement.h
+//
+// Identification: src/include/common/statement_cache.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <unordered_set>
+
+#include "common/statement_cache.h"
+
+namespace peloton {
+// Add a statement to the cache
+void 
+StatementCache::AddStatement(std::shared_ptr<Statement> stmt) {
+  UpdateFromInvalidTableQueue();
+  statement_map_[stmt->GetStatementName()] = stmt;
+  for (auto table_id : stmt->GetReferencedTables()) {
+    table_ref_[table_id].push_back(stmt);
+  }
+}
+
+// Get the statement by its name;
+std::shared_ptr<Statement> 
+StatementCache::GetStatement(std::string name) {
+  UpdateFromInvalidTableQueue();
+  return statement_map_[name];
+}
+
+// Notify the Statement Cache a table id that is invalidated
+void 
+StatementCache::NotifyInvalidTable(oid_t table_id) {
+  invalid_table_queue_.Enqueue(table_id);
+}
+
+void StatementCache::UpdateFromInvalidTableQueue() {
+  std::unordered_set<oid_t> invalid_set;
+  oid_t invalid_oid;
+  while(invalid_table_queue_.Dequeue(invalid_oid)) {
+    if (table_ref_.count(invalid_oid))
+      invalid_set.insert(invalid_oid);
+  }
+
+  if (invalid_set.size()) {
+    for (oid_t id : invalid_set) 
+      for (auto &statement : table_ref_[id]) 
+        statement->SetNeedsPlan(true);
+  }
+}
+
+}

--- a/src/common/statement_cache.cpp
+++ b/src/common/statement_cache.cpp
@@ -63,7 +63,7 @@ void StatementCache::UpdateFromInvalidTableQueue() {
 void StatementCache::Clear() {
   statement_map_.clear();
   table_ref_.clear();
-  while (invalid_table_queue_.IsEmpty()) {
+  while (!invalid_table_queue_.IsEmpty()) {
     oid_t dummy;
     invalid_table_queue_.Dequeue(dummy);
   }

--- a/src/common/statement_cache.cpp
+++ b/src/common/statement_cache.cpp
@@ -2,7 +2,7 @@
 //
 //                         Peloton
 //
-// statement.h
+// statement_cache.cpp
 //
 // Identification: src/include/common/statement_cache.cpp
 //

--- a/src/common/statement_cache.cpp
+++ b/src/common/statement_cache.cpp
@@ -16,8 +16,7 @@
 
 namespace peloton {
 // Add a statement to the cache
-void 
-StatementCache::AddStatement(std::shared_ptr<Statement> stmt) {
+void StatementCache::AddStatement(std::shared_ptr<Statement> stmt) {
   UpdateFromInvalidTableQueue();
   statement_map_[stmt->GetStatementName()] = stmt;
   for (auto table_id : stmt->GetReferencedTables()) {
@@ -26,31 +25,27 @@ StatementCache::AddStatement(std::shared_ptr<Statement> stmt) {
 }
 
 // Get the statement by its name;
-std::shared_ptr<Statement> 
-StatementCache::GetStatement(std::string name) {
+std::shared_ptr<Statement> StatementCache::GetStatement(std::string name) {
   UpdateFromInvalidTableQueue();
   return statement_map_[name];
 }
 
 // Notify the Statement Cache a table id that is invalidated
-void 
-StatementCache::NotifyInvalidTable(oid_t table_id) {
+void StatementCache::NotifyInvalidTable(oid_t table_id) {
   invalid_table_queue_.Enqueue(table_id);
 }
 
 void StatementCache::UpdateFromInvalidTableQueue() {
   std::unordered_set<oid_t> invalid_set;
   oid_t invalid_oid;
-  while(invalid_table_queue_.Dequeue(invalid_oid)) {
-    if (table_ref_.count(invalid_oid))
-      invalid_set.insert(invalid_oid);
+  while (invalid_table_queue_.Dequeue(invalid_oid)) {
+    if (table_ref_.count(invalid_oid)) invalid_set.insert(invalid_oid);
   }
 
   if (invalid_set.size()) {
-    for (oid_t id : invalid_set) 
-      for (auto &statement : table_ref_[id]) 
-        statement->SetNeedsPlan(true);
+    for (oid_t id : invalid_set)
+      for (auto &statement : table_ref_[id]) statement->SetNeedsPlan(true);
   }
 }
 
-}
+}  // namespace peloton

--- a/src/common/statement_cache.cpp
+++ b/src/common/statement_cache.cpp
@@ -56,7 +56,7 @@ void StatementCache::UpdateFromInvalidTableQueue() {
 
   if (invalid_set.size()) {
     for (oid_t id : invalid_set)
-      for (auto &statement : table_ref_[id]) statement->SetNeedsPlan(true);
+      for (auto &statement : table_ref_[id]) statement->SetNeedsReplan(true);
   }
 }
 

--- a/src/common/statement_cache.cpp
+++ b/src/common/statement_cache.cpp
@@ -20,7 +20,7 @@ void StatementCache::AddStatement(std::shared_ptr<Statement> stmt) {
   UpdateFromInvalidTableQueue();
   statement_map_[stmt->GetStatementName()] = stmt;
   for (auto table_id : stmt->GetReferencedTables()) {
-    table_ref_[table_id].push_back(stmt);
+    table_ref_[table_id].insert(stmt);
   }
 }
 
@@ -28,6 +28,18 @@ void StatementCache::AddStatement(std::shared_ptr<Statement> stmt) {
 std::shared_ptr<Statement> StatementCache::GetStatement(std::string name) {
   UpdateFromInvalidTableQueue();
   return statement_map_[name];
+}
+
+  // Delete the statement
+void StatementCache::DeleteStatement(std::string name) {
+  if (!statement_map_.count(name)) {
+    return;
+  }
+  auto to_delete = statement_map_[name];
+  for (auto table_id : to_delete->GetReferencedTables()) {
+    table_ref_[table_id].erase(to_delete);
+  }
+  statement_map_.erase(name);
 }
 
 // Notify the Statement Cache a table id that is invalidated
@@ -45,6 +57,15 @@ void StatementCache::UpdateFromInvalidTableQueue() {
   if (invalid_set.size()) {
     for (oid_t id : invalid_set)
       for (auto &statement : table_ref_[id]) statement->SetNeedsPlan(true);
+  }
+}
+
+void StatementCache::Clear() {
+  statement_map_.clear();
+  table_ref_.clear();
+  while (invalid_table_queue_.IsEmpty()) {
+    oid_t dummy;
+    invalid_table_queue_.Dequeue(dummy);
   }
 }
 

--- a/src/common/statement_cache_manager.cpp
+++ b/src/common/statement_cache_manager.cpp
@@ -26,6 +26,7 @@ void StatementCacheManager::InvalidateTableOid(oid_t table_id) {
   // Lock the table by grabing the iterator
   auto iterator = statement_caches_.GetIterator();
 
+  // Iterate each plan cache
   for (auto &iter : iterator) {
     iter.first->NotifyInvalidTable(table_id);
   }

--- a/src/common/statement_cache_manager.cpp
+++ b/src/common/statement_cache_manager.cpp
@@ -14,11 +14,11 @@
 
 namespace peloton {
 
-void StatementCacheManager::RegisterStatementCache(StmtCachePtr stmt_cache) {
+void StatementCacheManager::RegisterStatementCache(StatementCache *stmt_cache) {
   statement_caches_.Insert(stmt_cache, stmt_cache);
 }
 
-void StatementCacheManager::UnRegisterStatementCache(StmtCachePtr stmt_cache) {
+void StatementCacheManager::UnRegisterStatementCache(StatementCache *stmt_cache) {
   statement_caches_.Erase(stmt_cache);
 }
 

--- a/src/common/statement_cache_manager.cpp
+++ b/src/common/statement_cache_manager.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// statement.h
+//
+// Identification: src/include/common/statement_cache_manager.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/statement_cache_manager.h"
+
+namespace peloton {
+
+void StatementCacheManager::RegisterStatementCache(StmtCachePtr stmt_cache) {
+  statement_caches_.Insert(stmt_cache, stmt_cache);
+}
+
+void StatementCacheManager::UnRegisterStatementCache(StmtCachePtr stmt_cache) {
+  statement_caches_.Erase(stmt_cache);
+}
+
+void StatementCacheManager::InvalidateTableOid(oid_t table_id) {
+  // Lock the table by grabing the iterator
+  auto iterator = statement_caches_.GetIterator();
+
+  for (auto &iter : iterator) {
+    iter.first->NotifyInvalidTable(table_id);
+  }
+  // Automatically release the table;
+}
+}
+ 

--- a/src/common/statement_cache_manager.cpp
+++ b/src/common/statement_cache_manager.cpp
@@ -23,9 +23,13 @@ void StatementCacheManager::UnRegisterStatementCache(StatementCache *stmt_cache)
 }
 
 void StatementCacheManager::InvalidateTableOid(oid_t table_id) {
-  // Lock the table by grabing the iterator
-  auto iterator = statement_caches_.GetIterator();
 
+  if (statement_caches_.IsEmpty()) 
+    return;
+
+  // Lock the table by grabing the iterator
+  LOG_TRACE("Locking the table to get the iterator");
+  auto iterator = statement_caches_.GetIterator();
   // Iterate each plan cache
   for (auto &iter : iterator) {
     iter.first->NotifyInvalidTable(table_id);
@@ -38,6 +42,7 @@ void StatementCacheManager::InvalidateTableOids(std::set<oid_t> &table_ids) {
     return;
 
   // Lock the table by grabing the iterator
+  LOG_TRACE("Locking the table to get the iterator");
   auto iterator = statement_caches_.GetIterator();
 
   // Iterate each plan cache

--- a/src/common/statement_cache_manager.cpp
+++ b/src/common/statement_cache_manager.cpp
@@ -2,7 +2,7 @@
 //
 //                         Peloton
 //
-// statement.h
+// statement_cache_manager.cpp
 //
 // Identification: src/include/common/statement_cache_manager.cpp
 //
@@ -29,6 +29,21 @@ void StatementCacheManager::InvalidateTableOid(oid_t table_id) {
   // Iterate each plan cache
   for (auto &iter : iterator) {
     iter.first->NotifyInvalidTable(table_id);
+  }
+  // Automatically release the table;
+}
+
+void StatementCacheManager::InvalidateTableOids(std::set<oid_t> &table_ids) {
+  if (table_ids.empty())
+    return;
+
+  // Lock the table by grabing the iterator
+  auto iterator = statement_caches_.GetIterator();
+
+  // Iterate each plan cache
+  for (auto &iter : iterator) {
+    for (auto &table_id : table_ids)
+      iter.first->NotifyInvalidTable(table_id);
   }
   // Automatically release the table;
 }

--- a/src/common/statement_cache_manager.cpp
+++ b/src/common/statement_cache_manager.cpp
@@ -23,13 +23,13 @@ void StatementCacheManager::UnRegisterStatementCache(StatementCache *stmt_cache)
 }
 
 void StatementCacheManager::InvalidateTableOid(oid_t table_id) {
-
   if (statement_caches_.IsEmpty()) 
     return;
 
-  // Lock the table by grabing the iterator
+  // Lock the table by grabbing the iterator
   LOG_TRACE("Locking the table to get the iterator");
   auto iterator = statement_caches_.GetIterator();
+
   // Iterate each plan cache
   for (auto &iter : iterator) {
     iter.first->NotifyInvalidTable(table_id);
@@ -38,14 +38,14 @@ void StatementCacheManager::InvalidateTableOid(oid_t table_id) {
 }
 
 void StatementCacheManager::InvalidateTableOids(std::set<oid_t> &table_ids) {
-  if (table_ids.empty())
+  if (table_ids.empty() || statement_caches_.IsEmpty())
     return;
 
-  // Lock the table by grabing the iterator
+  // Lock the table by grabbing the iterator
   LOG_TRACE("Locking the table to get the iterator");
   auto iterator = statement_caches_.GetIterator();
 
-  // Iterate each plan cache
+  // Iterate each plan cache and notify every table id
   for (auto &iter : iterator) {
     for (auto &table_id : table_ids)
       iter.first->NotifyInvalidTable(table_id);

--- a/src/executor/drop_executor.cpp
+++ b/src/executor/drop_executor.cpp
@@ -12,10 +12,14 @@
 
 #include "executor/drop_executor.h"
 
-#include "catalog/index_catalog.h"
 #include "catalog/catalog.h"
+#include "catalog/index_catalog.h"
 #include "catalog/trigger_catalog.h"
+#include "catalog/database_catalog.h"
+#include "catalog/table_catalog.h"
+#include "catalog/index_catalog.h"
 #include "common/logger.h"
+#include "common/statement_cache_manager.h"
 #include "executor/executor_context.h"
 
 namespace peloton {
@@ -72,6 +76,7 @@ bool DropExecutor::DExecute() {
 bool DropExecutor::DropDatabase(const planner::DropPlan &node,
                                 concurrency::TransactionContext *txn) {
   auto database_name = node.GetDatabaseName();
+
   if (node.IsMissing()) {
     try {
       auto database_object = catalog::Catalog::GetInstance()->GetDatabaseObject(
@@ -82,12 +87,21 @@ bool DropExecutor::DropDatabase(const planner::DropPlan &node,
     }
   }
 
+  auto database_object =
+      catalog::Catalog::GetInstance()->GetDatabaseObject(database_name, txn);
+  std::set<oid_t> table_ids;
+  auto table_objects = database_object->GetTableObjects(false);
+  for (auto it : table_objects) {
+    table_ids.insert(it.second->GetTableOid());
+  }
+
   ResultType result =
       catalog::Catalog::GetInstance()->DropDatabaseWithName(database_name, txn);
   txn->SetResult(result);
 
   if (txn->GetResult() == ResultType::SUCCESS) {
     LOG_TRACE("Dropping database succeeded!");
+    // StatementCacheManager::GetStmtCacheManager()->InvalidateTableOids(table_ids);
   } else {
     LOG_TRACE("Result is: %s", ResultTypeToString(txn->GetResult()).c_str());
   }
@@ -109,12 +123,17 @@ bool DropExecutor::DropTable(const planner::DropPlan &node,
     }
   }
 
+  oid_t table_id = catalog::Catalog::GetInstance()
+                       ->GetTableObject(database_name, table_name, txn)
+                       ->GetTableOid();
+
   ResultType result = catalog::Catalog::GetInstance()->DropTable(
       database_name, table_name, txn);
   txn->SetResult(result);
 
   if (txn->GetResult() == ResultType::SUCCESS) {
     LOG_TRACE("Dropping table succeeded!");
+    StatementCacheManager::GetStmtCacheManager()->InvalidateTableOid(table_id);
   } else {
     LOG_TRACE("Result is: %s", ResultTypeToString(txn->GetResult()).c_str());
   }
@@ -125,14 +144,21 @@ bool DropExecutor::DropTrigger(const planner::DropPlan &node,
                                concurrency::TransactionContext *txn) {
   auto database_name = node.GetDatabaseName();
   std::string table_name = node.GetTableName();
+  LOG_DEBUG("database name: %s", database_name.c_str());
+  LOG_DEBUG("table name: %s", table_name.c_str());
   std::string trigger_name = node.GetTriggerName();
 
+  oid_t table_id = catalog::Catalog::GetInstance()
+                       ->GetTableObject(database_name, table_name, txn)
+                       ->GetTableOid();
+  LOG_DEBUG("%d", table_id);
   ResultType result = catalog::TriggerCatalog::GetInstance().DropTrigger(
       database_name, table_name, trigger_name, txn);
   txn->SetResult(result);
 
   if (txn->GetResult() == ResultType::SUCCESS) {
     LOG_TRACE("Dropping trigger succeeded!");
+    StatementCacheManager::GetStmtCacheManager()->InvalidateTableOid(table_id);
   } else if (txn->GetResult() == ResultType::FAILURE && node.IsMissing()) {
     txn->SetResult(ResultType::SUCCESS);
     LOG_TRACE("Dropping trigger Succeeded!");
@@ -149,10 +175,14 @@ bool DropExecutor::DropIndex(const planner::DropPlan &node,
   std::string index_name = node.GetIndexName();
   auto index_object =
       catalog::IndexCatalog::GetInstance()->GetIndexObject(index_name, txn);
+
   ResultType result = catalog::Catalog::GetInstance()->DropIndex(
       index_object->GetIndexOid(), txn);
   txn->SetResult(result);
+
   if (txn->GetResult() == ResultType::SUCCESS) {
+    oid_t table_id = index_object->GetTableOid();
+    StatementCacheManager::GetStmtCacheManager()->InvalidateTableOid(table_id);
     LOG_TRACE("Dropping Index Succeeded! Index oid: %d",
               index_object->GetIndexOid());
   } else {

--- a/src/include/common/container/cuckoo_map.h
+++ b/src/include/common/container/cuckoo_map.h
@@ -28,6 +28,10 @@ namespace peloton {
 // CUCKOO_MAP_TYPE
 #define CUCKOO_MAP_TYPE CuckooMap<KeyType, ValueType>
 
+// Iterator type
+#define CUCKOO_MAP_ITERATOR_TYPE \
+typename cuckoohash_map<KeyType, ValueType>::locked_table
+
 CUCKOO_MAP_TEMPLATE_ARGUMENTS
 class CuckooMap {
  public:
@@ -58,6 +62,12 @@ class CuckooMap {
 
   // Checks if the cuckoo_map is empty
   bool IsEmpty() const;
+
+  // Lock the table and get iterator
+  // The table would be unlock when the iterator
+  // is out of scope
+  CUCKOO_MAP_ITERATOR_TYPE
+  GetIterator();
 
  private:
 

--- a/src/include/common/statement.h
+++ b/src/include/common/statement.h
@@ -81,9 +81,9 @@ class Statement : public Printable {
 
   std::unique_ptr<parser::SQLStatementList> PassStmtParseTreeList() {return std::move(sql_stmt_list_);}
 
-  inline bool GetNeedsPlan() const { return (needs_replan_); }
+  inline bool GetNeedsReplan() const { return (needs_replan_); }
 
-  inline void SetNeedsPlan(bool replan) { needs_replan_ = replan; }
+  inline void SetNeedsReplan(bool replan) { needs_replan_ = replan; }
 
   // Get a string representation for debugging
   const std::string GetInfo() const;

--- a/src/include/common/statement_cache.h
+++ b/src/include/common/statement_cache.h
@@ -27,7 +27,8 @@ namespace peloton {
 class StatementCache {
   typedef std::shared_ptr<Statement> StatementPtr;
   typedef std::unordered_map<std::string, StatementPtr> NameMap;
-  typedef std::unordered_map<oid_t, std::vector<StatementPtr>> TableRef;
+  typedef std::unordered_map<oid_t, std::unordered_set<StatementPtr>> TableRef;
+
 
   // Private members
 
@@ -54,8 +55,14 @@ class StatementCache {
   // Get the statement by its name;
   std::shared_ptr<Statement> GetStatement(std::string name);
 
+  // Delete the statement
+  void DeleteStatement(std::string name);
+
   // Notify the Statement Cache a table id that is invalidated
   void NotifyInvalidTable(oid_t table_id);
+
+  // Clear the cache
+  void Clear();
 
  private:
   void UpdateFromInvalidTableQueue();

--- a/src/include/common/statement_cache.h
+++ b/src/include/common/statement_cache.h
@@ -2,7 +2,7 @@
 //
 //                         Peloton
 //
-// statement.h
+// statement_cache.h
 //
 // Identification: src/include/common/statement_cache.h
 //

--- a/src/include/common/statement_cache.h
+++ b/src/include/common/statement_cache.h
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// statement.h
+//
+// Identification: src/include/common/statement_cache.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <unordered_map>
+
+#include "cache.h"
+#include "type/types.h"
+
+namespace peloton {
+// The statement cache that caches statement.
+// It would pop out statements when the cache hits limit
+// It would also replan the statement7
+class StatementCache {
+ public:
+  // Add a statement to the cache
+  void AddStatement(std::shared_ptr<Statement> stmt);
+
+  // Get the statement by its name;
+  std::shared_ptr<Statement> GetStatement(std::string name);
+
+  // Notify the Statement Cache a table id that is invalidated
+  void NotifyInvalidTable(oid_t table_id);
+
+ private:
+  // Private members
+  
+  // StatementName -> Statement
+  Cache<std::string, Statement> statement_cache_;
+  
+  // TableOid -> Statements
+  std::unordered_map<oid_t, std::unordered_set<Statement *>> table_statement_cache_;
+
+  // Queue to receive invalid table oids from executor
+  LockFreeQueue<oid_t> invalid_table_queue_;
+
+
+  // Private functions
+
+  // Fetch the invalid table queue and mark all related plans in this cache
+  // to be invalid, also clear the queue.
+  void UpdateFromInvalidTableQueue();
+  
+};
+}  // namespace peloton

--- a/src/include/common/statement_cache.h
+++ b/src/include/common/statement_cache.h
@@ -14,9 +14,9 @@
 
 #include <unordered_map>
 
+#include "common/internal_types.h"
 #include "container/lock_free_queue.h"
 #include "statement.h"
-#include "type/types.h"
 
 namespace peloton {
 
@@ -28,7 +28,6 @@ class StatementCache {
   typedef std::shared_ptr<Statement> StatementPtr;
   typedef std::unordered_map<std::string, StatementPtr> NameMap;
   typedef std::unordered_map<oid_t, std::unordered_set<StatementPtr>> TableRef;
-
 
   // Private members
 
@@ -46,8 +45,7 @@ class StatementCache {
 
  public:
   StatementCache()
-      : invalid_table_queue_(DEFAULT_STATEMENT_CACHE_INVALID_QUEUE_SIZE)
-      {}
+      : invalid_table_queue_(DEFAULT_STATEMENT_CACHE_INVALID_QUEUE_SIZE) {}
 
   // Add a statement to the cache
   void AddStatement(std::shared_ptr<Statement> stmt);

--- a/src/include/common/statement_cache_manager.h
+++ b/src/include/common/statement_cache_manager.h
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// statement.h
+//
+// Identification: src/include/common/statement_cache_manager.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "container/cuckoo_map.h"
+#include "statement_cache.h"
+
+namespace peloton {
+class StatementCacheManager {
+ public:
+  // Register a statement cache to this statement manager
+  // Called by protocol handler when building up a connection
+  void RegisterStatementCache(StatementCache &stmt_cache);
+
+  // Remove the statement cache from this statement manager
+  // Called by protocol handler when tearing down a connection
+  void UnRegisterStatementCache(StatementCache &stmt_cache);
+
+  // Notify the manager that the table schema or index 
+  // is changed now.
+  // Called in executor
+  // WARNING: 
+  // Be conservative to call this function as it would block
+  // the whole statement caches map and prevent them from register
+  // and unregister to the manager. It eould therefore block new 
+  // connections coming in and old connection tearing down. 
+  // However, current connection can still retrieve updated plans from their plan cache.
+  void InvalidateTableOid(oid_t table_id);
+
+private:
+  // A lock free hash map
+  CuckooMap<StatementCache, nullptr> statement_caches;
+}
+}  // namespace peloton

--- a/src/include/common/statement_cache_manager.h
+++ b/src/include/common/statement_cache_manager.h
@@ -13,18 +13,19 @@
 #pragma once
 
 #include "container/cuckoo_map.h"
-#include "statement_cache.h"
+#include "common/statement_cache.h"
 
 namespace peloton {
 class StatementCacheManager {
+  typedef std::shared_ptr<StatementCache> StmtCachePtr;
  public:
   // Register a statement cache to this statement manager
   // Called by protocol handler when building up a connection
-  void RegisterStatementCache(StatementCache &stmt_cache);
+  void RegisterStatementCache(StmtCachePtr stmt_cache);
 
   // Remove the statement cache from this statement manager
   // Called by protocol handler when tearing down a connection
-  void UnRegisterStatementCache(StatementCache &stmt_cache);
+  void UnRegisterStatementCache(StmtCachePtr stmt_cache);
 
   // Notify the manager that the table schema or index 
   // is changed now.
@@ -32,13 +33,13 @@ class StatementCacheManager {
   // WARNING: 
   // Be conservative to call this function as it would block
   // the whole statement caches map and prevent them from register
-  // and unregister to the manager. It eould therefore block new 
+  // and unregister to the manager. It would therefore block new 
   // connections coming in and old connection tearing down. 
-  // However, current connection can still retrieve updated plans from their plan cache.
+  // However, current connections can still retrieve updated plans from their plan cache.
   void InvalidateTableOid(oid_t table_id);
 
 private:
   // A lock free hash map
-  CuckooMap<StatementCache, nullptr> statement_caches;
-}
+  CuckooMap<StmtCachePtr, StmtCachePtr> statement_caches_;
+};
 }  // namespace peloton

--- a/src/include/common/statement_cache_manager.h
+++ b/src/include/common/statement_cache_manager.h
@@ -16,16 +16,21 @@
 #include "common/statement_cache.h"
 
 namespace peloton {
+
+class StatementCacheManager;
+
+static std::shared_ptr<StatementCacheManager> statement_cache_manager;
+
 class StatementCacheManager {
-  typedef std::shared_ptr<StatementCache> StmtCachePtr;
+
  public:
   // Register a statement cache to this statement manager
   // Called by protocol handler when building up a connection
-  void RegisterStatementCache(StmtCachePtr stmt_cache);
+  void RegisterStatementCache(StatementCache *stmt_cache);
 
   // Remove the statement cache from this statement manager
   // Called by protocol handler when tearing down a connection
-  void UnRegisterStatementCache(StmtCachePtr stmt_cache);
+  void UnRegisterStatementCache(StatementCache *stmt_cache);
 
   // Notify the manager that the table schema or index 
   // is changed now.
@@ -38,8 +43,22 @@ class StatementCacheManager {
   // However, current connections can still retrieve updated plans from their plan cache.
   void InvalidateTableOid(oid_t table_id);
 
+  // TODO (Tianyi) : remove this singloton to peloton instance
+  // Initialize an statement cache manager instance
+  inline static void Init(){
+    statement_cache_manager = std::make_shared<StatementCacheManager>();
+  }
+
+  // Get the instance of statement cache manager
+  inline static std::shared_ptr<StatementCacheManager> GetStmtCacheManager() {
+    return statement_cache_manager;
+  }
+
 private:
   // A lock free hash map
-  CuckooMap<StmtCachePtr, StmtCachePtr> statement_caches_;
+  CuckooMap<StatementCache*, StatementCache*> statement_caches_;
+
+  // Instance of statement cache manager
 };
+
 }  // namespace peloton

--- a/src/include/network/postgres_protocol_handler.h
+++ b/src/include/network/postgres_protocol_handler.h
@@ -21,6 +21,7 @@
 #include "common/cache.h"
 #include "common/portal.h"
 #include "common/statement.h"
+#include "common/statement_cache.h"
 #include "traffic_cop/traffic_cop.h"
 #include "protocol_handler.h"
 #include "common/internal_types.h"
@@ -184,13 +185,7 @@ class PostgresProtocolHandler: public ProtocolHandler {
   QueryType skipped_query_type_;
 
   // Statement cache
-  // StatementName -> Statement
-  Cache<std::string, Statement> statement_cache_;
-  // TableOid -> Statements
-  // FIXME: This table statement cache is not in sync with the other cache.
-  // That means if something gets thrown out of the statement cache it is not
-  // automatically evicted from this cache.
-  std::unordered_map<oid_t, std::vector<Statement*>> table_statement_cache_;
+  std::shared_ptr<StatementCache> statement_cache_;
 
   //  Portals
   std::unordered_map<std::string, std::shared_ptr<Portal>> portals_;

--- a/src/include/network/postgres_protocol_handler.h
+++ b/src/include/network/postgres_protocol_handler.h
@@ -53,10 +53,6 @@ class PostgresProtocolHandler: public ProtocolHandler {
   void SendInitialResponse();
   void Reset();
 
-
-  // Ugh... this should not be here but we have no choice...
-  void ReplanPreparedStatement(Statement* statement);
-
   void GetResult();
 
   //===--------------------------------------------------------------------===//

--- a/src/include/network/postgres_protocol_handler.h
+++ b/src/include/network/postgres_protocol_handler.h
@@ -57,14 +57,6 @@ class PostgresProtocolHandler: public ProtocolHandler {
   // Ugh... this should not be here but we have no choice...
   void ReplanPreparedStatement(Statement* statement);
 
-  // Check existence of statement in cache by name
-  // Return true if exists
-  bool ExistCachedStatement(std::string statement_name) {
-    auto statement_cache_itr = statement_cache_.find(statement_name);
-    return statement_cache_itr != statement_cache_.end();
-  }
-
-
   void GetResult();
 
   //===--------------------------------------------------------------------===//
@@ -171,7 +163,6 @@ class PostgresProtocolHandler: public ProtocolHandler {
   NetworkProtocolType protocol_type_;
 
   // Manage standalone queries
-  std::shared_ptr<Statement> unnamed_statement_;
 
   // The result-column format code
   std::vector<int> result_format_;
@@ -185,7 +176,7 @@ class PostgresProtocolHandler: public ProtocolHandler {
   QueryType skipped_query_type_;
 
   // Statement cache
-  std::shared_ptr<StatementCache> statement_cache_;
+  StatementCache statement_cache_;
 
   //  Portals
   std::unordered_map<std::string, std::shared_ptr<Portal>> portals_;

--- a/src/network/postgres_protocol_handler.cpp
+++ b/src/network/postgres_protocol_handler.cpp
@@ -19,7 +19,6 @@
 #include "common/macros.h"
 #include "common/portal.h"
 #include "expression/expression_util.h"
-#include "include/traffic_cop/traffic_cop.h"
 #include "network/marshal.h"
 #include "network/postgres_protocol_handler.h"
 #include "parser/postgresparser.h"

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -565,12 +565,13 @@ ResultType TrafficCop::ExecuteStatement(
       default:
         // The statement may be out of date
         // It needs to be replan
-        if (statement->GetNeedsPlan()) {
+        if (statement->GetNeedsReplan()) {
           // TODO(Tianyi) Move Statement Replan into Statement's method
           // to increase coherence
           auto plan =
               optimizer_->BuildPelotonPlanTree(statement->GetStmtParseTreeList(), default_database_name_, tcop_txn_state_.top().first);
           statement->SetPlanTree(plan);
+          statement->SetNeedsReplan(true);
         }
         
         ExecuteHelper(statement->GetPlanTree(), params, result,

--- a/test/common/cuckoo_map_test.cpp
+++ b/test/common/cuckoo_map_test.cpp
@@ -26,9 +26,8 @@ class CuckooMapTests : public PelotonTest {};
 
 // Test basic functionality
 TEST_F(CuckooMapTests, BasicTest) {
-
-  typedef uint32_t  key_type;
-  typedef uint32_t  value_type;
+  typedef uint32_t key_type;
+  typedef uint32_t value_type;
 
   {
     CuckooMap<key_type, value_type> map;
@@ -36,7 +35,7 @@ TEST_F(CuckooMapTests, BasicTest) {
     EXPECT_TRUE(map.IsEmpty());
 
     size_t const element_count = 3;
-    for (size_t element = 0; element < element_count; ++element ) {
+    for (size_t element = 0; element < element_count; ++element) {
       value_type val(element);
       auto status = map.Insert(element, val);
       EXPECT_TRUE(status);
@@ -44,7 +43,7 @@ TEST_F(CuckooMapTests, BasicTest) {
       EXPECT_FALSE(status);
     }
 
-    for (size_t element = 0; element < element_count; ++element ) {
+    for (size_t element = 0; element < element_count; ++element) {
       value_type value;
       auto status = map.Find(element, value);
       EXPECT_TRUE(status);
@@ -54,13 +53,11 @@ TEST_F(CuckooMapTests, BasicTest) {
     auto map_size = map.GetSize();
     EXPECT_EQ(map_size, element_count);
   }
-
 }
 
 // Test shared pointers
 TEST_F(CuckooMapTests, SharedPointerTest) {
-
-  typedef oid_t  key_type;
+  typedef oid_t key_type;
   typedef std::shared_ptr<oid_t> value_type;
 
   {
@@ -69,7 +66,7 @@ TEST_F(CuckooMapTests, SharedPointerTest) {
     EXPECT_TRUE(map.IsEmpty());
 
     size_t const element_count = 3;
-    for (size_t element = 0; element < element_count; ++element ) {
+    for (size_t element = 0; element < element_count; ++element) {
       value_type val = std::make_shared<oid_t>(element);
       auto status = map.Insert(element, val);
       EXPECT_TRUE(status);
@@ -80,7 +77,7 @@ TEST_F(CuckooMapTests, SharedPointerTest) {
       EXPECT_TRUE(update_status);
     }
 
-    for (size_t element = 0; element < element_count; ++element ) {
+    for (size_t element = 0; element < element_count; ++element) {
       value_type value;
       auto status = map.Find(element, value);
       EXPECT_TRUE(status);
@@ -90,7 +87,65 @@ TEST_F(CuckooMapTests, SharedPointerTest) {
     auto map_size = map.GetSize();
     EXPECT_EQ(map_size, element_count);
   }
+}
 
+// Test Iterator
+TEST_F(CuckooMapTests, IteratorTest) {
+  typedef oid_t key_type;
+  typedef std::shared_ptr<oid_t> value_type;
+
+  CuckooMap<key_type, value_type> map;
+  
+  {
+    size_t const element_count = 3;
+    for (size_t element = 0; element < element_count; ++element) {
+      value_type val = std::make_shared<oid_t>(element);
+      auto status = map.Insert(element, val);
+      EXPECT_TRUE(status);
+      status = map.Insert(element, val);
+      EXPECT_FALSE(status);
+    }
+
+    auto iterator = map.GetIterator();
+    for (auto &iter : iterator) {
+      EXPECT_EQ(iter.first, *(iter.second));
+    }
+  }
+
+  // It's out of the scope of iterator, the map is unlocked now.
+  // Otherwise it would be blocked.
+  EXPECT_TRUE(map.Contains(1));
+}
+
+// Test if we can use a shared pointer as the key
+TEST_F(CuckooMapTests, SharedPointerKeyTest) {
+  typedef std::shared_ptr<oid_t> key_type;
+  {
+    CuckooMap<key_type, key_type> map;
+    size_t const element_count = 3;
+    std::vector<key_type> ptr_vec;
+    for (size_t element = 0; element < element_count; ++element) {
+      key_type val = std::make_shared<oid_t>(element);
+      auto status = map.Insert(val, val);
+      EXPECT_TRUE(status);
+      status = map.Insert(val, val);
+      EXPECT_FALSE(status);
+      ptr_vec.push_back(val);
+    }
+
+    for (size_t element = 0; element < element_count; ++element) {
+      key_type key = std::make_shared<oid_t>(element);
+      key_type val;
+      auto status = map.Find(key, val);
+      EXPECT_FALSE(status);
+    }
+
+    for (auto &key : ptr_vec) {
+      key_type val;
+      auto status = map.Find(key, val);
+      EXPECT_TRUE(status);
+    }
+  }
 }
 
 }  // namespace test

--- a/test/common/statement_cache_manager_test.cpp
+++ b/test/common/statement_cache_manager_test.cpp
@@ -11,48 +11,78 @@
 //===----------------------------------------------------------------------===//
 
 #include "common/statement_cache_manager.h"
-#include "common/statement_cache.h"
 #include "common/statement.h"
+#include "common/statement_cache.h"
 
 #include "common/harness.h"
-
 
 namespace peloton {
 namespace test {
 // Tests for both statement cache
 class StatementCacheTests : public PelotonTest {};
-  
-  TEST_F(StatementCacheTests, CorrectnessTest) {
-    // Register the statement cache to the statement cache manager
-    StatementCacheManager::Init();
-    auto statement_cache_manager = StatementCacheManager::GetStmtCacheManager();
-    StatementCache statement_cache;
-    statement_cache_manager->RegisterStatementCache(&statement_cache);
-    std::set<oid_t> ref_table = {0};
 
-    std::string string_name = "foo";
+TEST_F(StatementCacheTests, InvalidateOneTest) {
+  // Register the statement cache to the statement cache manager
+  StatementCacheManager::Init();
+  auto statement_cache_manager = StatementCacheManager::GetStmtCacheManager();
+  StatementCache statement_cache;
+  statement_cache_manager->RegisterStatementCache(&statement_cache);
+  std::set<oid_t> ref_table = {0};
+
+  std::string string_name = "foo";
+  std::string query = "SELECT * FROM TEST";
+  auto statement = std::make_shared<Statement>(string_name, query);
+  statement->SetReferencedTables(ref_table);
+
+  EXPECT_TRUE(!statement->GetNeedsPlan());
+  statement_cache.AddStatement(statement);
+
+  // Invalidate table oid 0
+  statement_cache_manager->InvalidateTableOid(0);
+
+  // The plan need to replan now
+  statement = statement_cache.GetStatement(string_name);
+  EXPECT_TRUE(statement->GetNeedsPlan());
+
+  // Unregister the statement cache and invalidate again
+  statement->SetNeedsPlan(false);
+  statement_cache_manager->UnRegisterStatementCache(&statement_cache);
+  statement_cache_manager->InvalidateTableOids(ref_table);
+  statement = statement_cache.GetStatement(string_name);
+  // This one should not be affected, since the cache is already un-registered
+  EXPECT_TRUE(!statement->GetNeedsPlan());
+}
+
+TEST_F(StatementCacheTests, InvalidateManyTest) {
+  // Register the statement cache to the statement cache manager
+  StatementCacheManager::Init();
+  auto statement_cache_manager = StatementCacheManager::GetStmtCacheManager();
+  StatementCache statement_cache;
+  statement_cache_manager->RegisterStatementCache(&statement_cache);
+  std::set<oid_t> ref_table = {0, 1};
+
+  for (auto oid : ref_table) {
+    std::string string_name = "foo" + oid;
     std::string query = "SELECT * FROM TEST";
     auto statement = std::make_shared<Statement>(string_name, query);
-    statement->SetReferencedTables(ref_table);
+    std::set<oid_t> cur_ref_table;
+    cur_ref_table.insert(oid);
+    statement->SetReferencedTables(cur_ref_table);
 
     EXPECT_TRUE(!statement->GetNeedsPlan());
     statement_cache.AddStatement(statement);
-
-    // Invalidate table oid 0
-    statement_cache_manager->InvalidateTableOids(ref_table);
-
-    // The plan need to replan now
-    statement = statement_cache.GetStatement(string_name);
-    EXPECT_TRUE(statement->GetNeedsPlan());
-
-    // Unregister the statement cache and invalidate again
-    statement->SetNeedsPlan(false);
-    statement_cache_manager->UnRegisterStatementCache(&statement_cache);
-    statement_cache_manager->InvalidateTableOids(ref_table);
-    statement = statement_cache.GetStatement(string_name);
-    // This one should not be affected, since the cache is already un-registered
-    EXPECT_TRUE(!statement->GetNeedsPlan());
   }
 
+  // Invalidate table oid 0, 1
+  statement_cache_manager->InvalidateTableOids(ref_table);
+
+  // Both plans need to replan now
+  for (auto oid : ref_table) {
+    std::string string_name = "foo" + oid;
+    auto statement = statement_cache.GetStatement(string_name);
+
+    EXPECT_TRUE(statement->GetNeedsPlan());
+  }
 }
-}
+}  // namespace test
+}  // namespace peloton

--- a/test/common/statement_cache_manager_test.cpp
+++ b/test/common/statement_cache_manager_test.cpp
@@ -22,5 +22,36 @@ namespace test {
 // Tests for both statement cache
 class StatementCacheTests : public PelotonTest {};
   
+  TEST_F(StatementCacheTests, CorrectnessTest) {
+    // Register the statement cache to the statement cache manager
+    auto statement_cache_manager = std::make_shared<StatementCacheManager>();
+    auto statement_cache = std::make_shared<StatementCache>();
+    statement_cache_manager->RegisterStatementCache(statement_cache);
+    std::set<oid_t> ref_table = {0};
+
+    std::string string_name = "foo";
+    std::string query = "bar";
+    auto statement = std::make_shared<Statement>(string_name, query);
+    statement->SetReferencedTables(ref_table);
+
+    EXPECT_TRUE(!statement->GetNeedsPlan());
+    statement_cache->AddStatement(statement);
+
+    // Invalidate table oid 0
+    statement_cache_manager->InvalidateTableOid(0);
+
+    // The plan need to replan now
+    statement = statement_cache->GetStatement(string_name);
+    EXPECT_TRUE(statement->GetNeedsPlan());
+
+    // Unregister the statement cache and invalidate again
+    statement->SetNeedsPlan(false);
+    statement_cache_manager->UnRegisterStatementCache(statement_cache);
+    statement_cache_manager->InvalidateTableOid(0);
+    statement = statement_cache->GetStatement(string_name);
+    // This one should not be affected, since the cache is already un-registered
+    EXPECT_TRUE(!statement->GetNeedsPlan());
+  }
+
 }
 }

--- a/test/common/statement_cache_manager_test.cpp
+++ b/test/common/statement_cache_manager_test.cpp
@@ -2,7 +2,7 @@
 //
 //                         Peloton
 //
-// statement_cache_test.cpp
+// statement_cache_manager_test.cpp
 //
 // Identification: test/common/statement_cache_manager_test.cpp
 //
@@ -39,7 +39,7 @@ class StatementCacheTests : public PelotonTest {};
     statement_cache.AddStatement(statement);
 
     // Invalidate table oid 0
-    statement_cache_manager->InvalidateTableOid(0);
+    statement_cache_manager->InvalidateTableOids(ref_table);
 
     // The plan need to replan now
     statement = statement_cache.GetStatement(string_name);
@@ -48,7 +48,7 @@ class StatementCacheTests : public PelotonTest {};
     // Unregister the statement cache and invalidate again
     statement->SetNeedsPlan(false);
     statement_cache_manager->UnRegisterStatementCache(&statement_cache);
-    statement_cache_manager->InvalidateTableOid(0);
+    statement_cache_manager->InvalidateTableOids(ref_table);
     statement = statement_cache.GetStatement(string_name);
     // This one should not be affected, since the cache is already un-registered
     EXPECT_TRUE(!statement->GetNeedsPlan());

--- a/test/common/statement_cache_manager_test.cpp
+++ b/test/common/statement_cache_manager_test.cpp
@@ -34,7 +34,7 @@ TEST_F(StatementCacheTests, InvalidateOneTest) {
   auto statement = std::make_shared<Statement>(string_name, query);
   statement->SetReferencedTables(ref_table);
 
-  EXPECT_TRUE(!statement->GetNeedsPlan());
+  EXPECT_TRUE(!statement->GetNeedsReplan());
   statement_cache.AddStatement(statement);
 
   // Invalidate table oid 0
@@ -42,15 +42,15 @@ TEST_F(StatementCacheTests, InvalidateOneTest) {
 
   // The plan need to replan now
   statement = statement_cache.GetStatement(string_name);
-  EXPECT_TRUE(statement->GetNeedsPlan());
+  EXPECT_TRUE(statement->GetNeedsReplan());
 
   // Unregister the statement cache and invalidate again
-  statement->SetNeedsPlan(false);
+  statement->SetNeedsReplan(false);
   statement_cache_manager->UnRegisterStatementCache(&statement_cache);
   statement_cache_manager->InvalidateTableOids(ref_table);
   statement = statement_cache.GetStatement(string_name);
   // This one should not be affected, since the cache is already un-registered
-  EXPECT_TRUE(!statement->GetNeedsPlan());
+  EXPECT_TRUE(!statement->GetNeedsReplan());
 }
 
 TEST_F(StatementCacheTests, InvalidateManyTest) {
@@ -69,7 +69,7 @@ TEST_F(StatementCacheTests, InvalidateManyTest) {
     cur_ref_table.insert(oid);
     statement->SetReferencedTables(cur_ref_table);
 
-    EXPECT_TRUE(!statement->GetNeedsPlan());
+    EXPECT_TRUE(!statement->GetNeedsReplan());
     statement_cache.AddStatement(statement);
   }
 
@@ -81,7 +81,7 @@ TEST_F(StatementCacheTests, InvalidateManyTest) {
     std::string string_name = "foo" + oid;
     auto statement = statement_cache.GetStatement(string_name);
 
-    EXPECT_TRUE(statement->GetNeedsPlan());
+    EXPECT_TRUE(statement->GetNeedsReplan());
   }
 }
 }  // namespace test

--- a/test/common/statement_cache_manager_test.cpp
+++ b/test/common/statement_cache_manager_test.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// statement_cache_test.cpp
+//
+// Identification: test/common/statement_cache_manager_test.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/statement_cache_manager.h"
+#include "common/statement_cache.h"
+#include "common/statement.h"
+
+#include "common/harness.h"
+
+
+namespace peloton {
+namespace test {
+// Tests for both statement cache
+class StatementCacheTests : public PelotonTest {};
+  
+}
+}

--- a/test/common/statement_cache_manager_test.cpp
+++ b/test/common/statement_cache_manager_test.cpp
@@ -31,7 +31,7 @@ class StatementCacheTests : public PelotonTest {};
     std::set<oid_t> ref_table = {0};
 
     std::string string_name = "foo";
-    std::string query = "bar";
+    std::string query = "SELECT * FROM TEST";
     auto statement = std::make_shared<Statement>(string_name, query);
     statement->SetReferencedTables(ref_table);
 

--- a/test/common/statement_cache_test.cpp
+++ b/test/common/statement_cache_test.cpp
@@ -12,13 +12,12 @@
 
 #include "common/statement_cache.h"
 #include "common/statement.h"
-#include "common/statement_cache_manager.h"
 
 #include "common/harness.h"
 
 namespace peloton {
 namespace test {
-// Tests for both statement cache and statement cache manager
+// Tests for both statement cache
 class StatementCacheTests : public PelotonTest {};
 
 // Test statementCache add and get statement

--- a/test/common/statement_cache_test.cpp
+++ b/test/common/statement_cache_test.cpp
@@ -23,7 +23,7 @@ class StatementCacheTests : public PelotonTest {};
 // Test statementCache add and get statement
 TEST_F(StatementCacheTests, AddGetTest) {
   std::string string_name = "foo";
-  std::string query = "bar";
+  std::string query = "SELECT * FROM TEST";
   auto statement = std::make_shared<Statement>(string_name, query);
   EXPECT_EQ(string_name, statement->GetStatementName());
   EXPECT_EQ(query, statement->GetQueryString());
@@ -39,7 +39,7 @@ TEST_F(StatementCacheTests, AddGetTest) {
 TEST_F(StatementCacheTests, UnnamedStatementTest) {
   // An empty string for name of unnamed statement
   std::string unname;
-  std::string query = "bar";
+  std::string query = "SELECT * FROM TEST";
   auto statement = std::make_shared<Statement>(unname, query);
 
   auto statement_cache = std::make_shared<StatementCache>();
@@ -55,7 +55,7 @@ TEST_F(StatementCacheTests, DisableTableTest) {
 
   std::vector<std::shared_ptr<Statement>> statements;
   std::set<oid_t> ref_table = {0, 1, 2, 3};
-  std::string query = "foo";
+  std::string query = "SELECT * FROM TEST";
   // Prepare the 4 statements
   for (size_t i = 0; i < 4; i++) {
     std::string name("" + i);

--- a/test/common/statement_cache_test.cpp
+++ b/test/common/statement_cache_test.cpp
@@ -14,16 +14,7 @@
 #include "common/statement.h"
 #include "common/statement_cache_manager.h"
 
-#include "binder/bind_node_visitor.h"
-#include "catalog/catalog.h"
 #include "common/harness.h"
-#include "common/statement.h"
-#include "concurrency/transaction_manager_factory.h"
-#include "expression/function_expression.h"
-#include "expression/tuple_value_expression.h"
-#include "include/traffic_cop/traffic_cop.h"
-#include "optimizer/optimizer.h"
-#include "parser/postgresparser.h"
 
 namespace peloton {
 namespace test {

--- a/test/common/statement_cache_test.cpp
+++ b/test/common/statement_cache_test.cpp
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// statement_cache_test.cpp
+//
+// Identification: test/common/statement_cache_test.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/statement_cache.h"
+#include "common/statement.h"
+#include "common/statement_cache_manager.h"
+
+#include "binder/bind_node_visitor.h"
+#include "catalog/catalog.h"
+#include "common/harness.h"
+#include "common/statement.h"
+#include "concurrency/transaction_manager_factory.h"
+#include "expression/function_expression.h"
+#include "expression/tuple_value_expression.h"
+#include "include/traffic_cop/traffic_cop.h"
+#include "optimizer/optimizer.h"
+#include "parser/postgresparser.h"
+
+namespace peloton {
+namespace test {
+// Tests for both statement cache and statement cache manager
+class StatementCacheTests : public PelotonTest {};
+
+// Test statementCache add and get statement
+TEST_F(StatementCacheTests, AddGetTest) {
+  std::string string_name = "foo";
+  std::string query = "bar";
+  auto statement = std::make_shared<Statement>(string_name, query);
+  EXPECT_EQ(string_name, statement->GetStatementName());
+  EXPECT_EQ(query, statement->GetQueryString());
+  EXPECT_TRUE(!statement->GetNeedsPlan());
+
+  auto statement_cache = std::make_shared<StatementCache>();
+  statement_cache->AddStatement(statement);
+  auto got_statement = statement_cache->GetStatement(string_name);
+  EXPECT_EQ(statement, got_statement);
+}
+
+// Test add and get unnamed statement
+TEST_F(StatementCacheTests, UnnamedStatementTest) {
+  // An empty string for name of unnamed statement
+  std::string unname;
+  std::string query = "bar";
+  auto statement = std::make_shared<Statement>(unname, query);
+
+  auto statement_cache = std::make_shared<StatementCache>();
+  statement_cache->AddStatement(statement);
+  auto got_statement = statement_cache->GetStatement(unname);
+  EXPECT_EQ(statement, got_statement);
+}
+
+// Test the NotifyInvalidTable() method works
+TEST_F(StatementCacheTests, DisableTableTest) {
+  // Statement vector
+  std::shared_ptr<StatementCache> cache = std::make_shared<StatementCache>();
+
+  std::vector<std::shared_ptr<Statement>> statements;
+  std::set<oid_t> ref_table = {0, 1, 2, 3};
+  std::string query = "foo";
+  // Prepare the 4 statements
+  for (size_t i = 0; i < 4; i++) {
+    std::string name("" + i);
+    ref_table.erase(i);
+    auto stmt = std::make_shared<Statement>(name, query);
+    stmt->SetReferencedTables(ref_table);
+    statements.push_back(stmt);
+    ref_table.insert(i);
+  }
+
+  oid_t table = 0;
+  // Insert statements in to the table
+  for (auto &stmt : statements) {
+    EXPECT_EQ(3, stmt->GetReferencedTables().size());
+    EXPECT_EQ(0, stmt->GetReferencedTables().count(table));
+    for (oid_t t_i = 0; t_i < 4; t_i++) {
+      // Reference table should contain all of 0 - 3 except itself
+      EXPECT_EQ(t_i != table, stmt->GetReferencedTables().count(t_i));
+    }
+    table++;
+    EXPECT_TRUE(!stmt->GetNeedsPlan());
+
+    cache->AddStatement(stmt);
+  }
+
+  // Disable the cache
+  cache->NotifyInvalidTable(2);
+
+  // plan 0 1 3 need to replan while 2 do not
+  for (oid_t i = 0; i < 4; i++) {
+    std::string name = "" + i;
+    auto stmt = cache->GetStatement(name);
+    EXPECT_NE(nullptr, stmt);
+    if (i != 2) {
+      EXPECT_TRUE(stmt->GetNeedsPlan());
+    } else {
+      EXPECT_FALSE(stmt->GetNeedsPlan());
+    }
+  }
+}
+
+
+}  // namespace test
+}  // namespace peloton

--- a/test/common/statement_cache_test.cpp
+++ b/test/common/statement_cache_test.cpp
@@ -27,7 +27,7 @@ TEST_F(StatementCacheTests, AddGetTest) {
   auto statement = std::make_shared<Statement>(string_name, query);
   EXPECT_EQ(string_name, statement->GetStatementName());
   EXPECT_EQ(query, statement->GetQueryString());
-  EXPECT_TRUE(!statement->GetNeedsPlan());
+  EXPECT_TRUE(!statement->GetNeedsReplan());
 
   auto statement_cache = std::make_shared<StatementCache>();
   statement_cache->AddStatement(statement);
@@ -76,7 +76,7 @@ TEST_F(StatementCacheTests, DisableTableTest) {
       EXPECT_EQ(t_i != table, stmt->GetReferencedTables().count(t_i));
     }
     table++;
-    EXPECT_TRUE(!stmt->GetNeedsPlan());
+    EXPECT_TRUE(!stmt->GetNeedsReplan());
 
     cache->AddStatement(stmt);
   }
@@ -90,9 +90,9 @@ TEST_F(StatementCacheTests, DisableTableTest) {
     auto stmt = cache->GetStatement(name);
     EXPECT_NE(nullptr, stmt);
     if (i != 2) {
-      EXPECT_TRUE(stmt->GetNeedsPlan());
+      EXPECT_TRUE(stmt->GetNeedsReplan());
     } else {
-      EXPECT_FALSE(stmt->GetNeedsPlan());
+      EXPECT_FALSE(stmt->GetNeedsReplan());
     }
   }
 }

--- a/test/common/statement_cache_test.cpp
+++ b/test/common/statement_cache_test.cpp
@@ -56,9 +56,11 @@ TEST_F(StatementCacheTests, DisableTableTest) {
   std::vector<std::shared_ptr<Statement>> statements;
   std::set<oid_t> ref_table = {0, 1, 2, 3};
   std::string query = "SELECT * FROM TEST";
+
+  LOG_INFO("Pareparing statements");
   // Prepare the 4 statements
   for (size_t i = 0; i < 4; i++) {
-    std::string name("" + i);
+    std::string name = std::to_string(i);
     ref_table.erase(i);
     auto stmt = std::make_shared<Statement>(name, query);
     stmt->SetReferencedTables(ref_table);
@@ -67,7 +69,8 @@ TEST_F(StatementCacheTests, DisableTableTest) {
   }
 
   oid_t table = 0;
-  // Insert statements in to the table
+  LOG_INFO("Putting statements into cache");
+  // Insert statements in to the cache
   for (auto &stmt : statements) {
     EXPECT_EQ(3, stmt->GetReferencedTables().size());
     EXPECT_EQ(0, stmt->GetReferencedTables().count(table));
@@ -81,12 +84,13 @@ TEST_F(StatementCacheTests, DisableTableTest) {
     cache->AddStatement(stmt);
   }
 
+  LOG_INFO("Notify cache the disabled table oid 2");
   // Disable the cache
   cache->NotifyInvalidTable(2);
 
   // plan 0 1 3 need to replan while 2 do not
   for (oid_t i = 0; i < 4; i++) {
-    std::string name = "" + i;
+    std::string name = std::to_string(i);
     auto stmt = cache->GetStatement(name);
     EXPECT_NE(nullptr, stmt);
     if (i != 2) {

--- a/test/executor/drop_test.cpp
+++ b/test/executor/drop_test.cpp
@@ -110,7 +110,7 @@ TEST_F(DropTests, DroppingTable) {
       (int)catalog->GetDatabaseObject(TEST_DB_NAME, txn)->GetTableObjects().size(),
       2);
 
-  // Now dropping the table using the executer
+  // Now dropping the table using the executor
   catalog->DropTable(TEST_DB_NAME, "department_table", txn);
   EXPECT_EQ(
       (int)catalog->GetDatabaseObject(TEST_DB_NAME, txn)->GetTableObjects().size(),

--- a/test/network/prepare_stmt_test.cpp
+++ b/test/network/prepare_stmt_test.cpp
@@ -84,8 +84,6 @@ void *PrepareStatementTest(int port) {
     // %d",conn->protocol_handler_.ExistCachedStatement("searchstmt"));
     EXPECT_EQ(R.size(), 1);
 
-    EXPECT_TRUE(handler->ExistCachedStatement("searchstmt"));
-
   } catch (const std::exception &e) {
     LOG_INFO("[PrepareStatementTest] Exception occurred: %s", e.what());
     EXPECT_TRUE(false);
@@ -104,11 +102,11 @@ TEST_F(PrepareStmtTests, PrepareStatementTest) {
   }
 
   PrepareStatementTest(port);
-
+  LOG_DEBUG("Server Closing");
   network_manager.CloseServer();
   serverThread.join();
   peloton::PelotonInit::Shutdown();
-  LOG_INFO("Peloton has shut down");
+  LOG_DEBUG("Peloton has shut down");
 }
 
 }  // namespace test


### PR DESCRIPTION
This is the plan cache that is used by Postgres protocol handler to support Prepare or extended protocol.

It would be updated when schema or index changes. The assumption is that the table schema or index rarely changes and the plan cache is not going to last for a very long time (drop when the connection tears down).