### PR TITLE
[Cleanup] Catalog -> StorageManager in Codegen

### DIFF
--- a/src/codegen/compilation_context.cpp
+++ b/src/codegen/compilation_context.cpp
@@ -31,15 +31,16 @@ CompilationContext::CompilationContext(Query &query,
       parameter_cache_(parameters_map_),
       result_consumer_(result_consumer),
       codegen_(query_.GetCodeContext()) {
-  // Allocate a catalog and transaction instance in the runtime state
+  // Allocate a storagand transaction instance in the runtime state
   auto &runtime_state = GetRuntimeState();
 
   auto *txn_type = TransactionProxy::GetType(codegen_)->getPointerTo();
   txn_state_id_ = runtime_state.RegisterState("transaction", txn_type);
 
-  auto *catalog_ptr_type =
+  auto *storage_manager_ptr_type =
       StorageManagerProxy::GetType(codegen_)->getPointerTo();
-  catalog_state_id_ = runtime_state.RegisterState("catalog", catalog_ptr_type);
+  storage_manager_state_id_ =
+      runtime_state.RegisterState("storageManager", storage_manager_ptr_type);
 
   auto *executor_context_type =
       ExecutorContextProxy::GetType(codegen_)->getPointerTo();
@@ -135,9 +136,9 @@ void CompilationContext::GenerateHelperFunctions() {
   }
 }
 
-// Get the catalog pointer from the runtime state
-llvm::Value *CompilationContext::GetCatalogPtr() {
-  return GetRuntimeState().LoadStateValue(codegen_, catalog_state_id_);
+// Get the storage manager pointer from the runtime state
+llvm::Value *CompilationContext::GetStorageManagerPtr() {
+  return GetRuntimeState().LoadStateValue(codegen_, storage_manager_state_id_);
 }
 
 // Get the transaction pointer from the runtime state

--- a/src/codegen/compilation_context.cpp
+++ b/src/codegen/compilation_context.cpp
@@ -13,7 +13,7 @@
 #include "codegen/compilation_context.h"
 
 #include "codegen/function_builder.h"
-#include "codegen/proxy/catalog_proxy.h"
+#include "codegen/proxy/storage_manager_proxy.h"
 #include "codegen/proxy/transaction_proxy.h"
 #include "codegen/proxy/executor_context_proxy.h"
 #include "codegen/proxy/query_parameters_proxy.h"

--- a/src/codegen/compilation_context.cpp
+++ b/src/codegen/compilation_context.cpp
@@ -31,7 +31,7 @@ CompilationContext::CompilationContext(Query &query,
       parameter_cache_(parameters_map_),
       result_consumer_(result_consumer),
       codegen_(query_.GetCodeContext()) {
-  // Allocate a storagand transaction instance in the runtime state
+  // Allocate a storage manager and transaction instance in the runtime state
   auto &runtime_state = GetRuntimeState();
 
   auto *txn_type = TransactionProxy::GetType(codegen_)->getPointerTo();

--- a/src/codegen/operator/delete_translator.cpp
+++ b/src/codegen/operator/delete_translator.cpp
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "codegen/operator/delete_translator.h"
-#include "codegen/proxy/catalog_proxy.h"
 #include "codegen/proxy/deleter_proxy.h"
+#include "codegen/proxy/storage_manager_proxy.h"
 #include "planner/delete_plan.h"
 #include "storage/data_table.h"
 

--- a/src/codegen/operator/delete_translator.cpp
+++ b/src/codegen/operator/delete_translator.cpp
@@ -40,7 +40,8 @@ void DeleteTranslator::InitializeState() {
   storage::DataTable *table = delete_plan_.GetTable();
   llvm::Value *table_ptr =
       codegen.Call(StorageManagerProxy::GetTableWithOid,
-                   {GetCatalogPtr(), codegen.Const32(table->GetDatabaseOid()),
+                   {GetStorageManagerPtr(),
+                    codegen.Const32(table->GetDatabaseOid()),
                     codegen.Const32(table->GetOid())});
 
   llvm::Value *executor_ptr = GetCompilationContext().GetExecutorContextPtr();

--- a/src/codegen/operator/insert_translator.cpp
+++ b/src/codegen/operator/insert_translator.cpp
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "codegen/proxy/catalog_proxy.h"
 #include "codegen/proxy/inserter_proxy.h"
+#include "codegen/proxy/query_parameters_proxy.h"
+#include "codegen/proxy/storage_manager_proxy.h"
 #include "codegen/proxy/transaction_runtime_proxy.h"
 #include "codegen/proxy/tuple_proxy.h"
-#include "codegen/proxy/query_parameters_proxy.h"
 #include "codegen/operator/insert_translator.h"
 #include "planner/insert_plan.h"
 #include "storage/data_table.h"

--- a/src/codegen/operator/insert_translator.cpp
+++ b/src/codegen/operator/insert_translator.cpp
@@ -45,7 +45,8 @@ void InsertTranslator::InitializeState() {
   storage::DataTable *table = insert_plan_.GetTable();
   llvm::Value *table_ptr =
       codegen.Call(StorageManagerProxy::GetTableWithOid,
-                   {GetCatalogPtr(), codegen.Const32(table->GetDatabaseOid()),
+                   {GetStorageManagerPtr(),
+                    codegen.Const32(table->GetDatabaseOid()),
                     codegen.Const32(table->GetOid())});
 
   llvm::Value *executor_ptr = context.GetExecutorContextPtr();

--- a/src/codegen/operator/operator_translator.cpp
+++ b/src/codegen/operator/operator_translator.cpp
@@ -27,8 +27,8 @@ CodeGen &OperatorTranslator::GetCodeGen() const {
   return context_.GetCodeGen();
 }
 
-llvm::Value *OperatorTranslator::GetCatalogPtr() const {
-  return context_.GetCatalogPtr();
+llvm::Value *OperatorTranslator::GetStorageManagerPtr() const {
+  return context_.GetStorageManagerPtr();
 }
 
 llvm::Value *OperatorTranslator::LoadStatePtr(

--- a/src/codegen/operator/table_scan_translator.cpp
+++ b/src/codegen/operator/table_scan_translator.cpp
@@ -13,7 +13,7 @@
 #include "codegen/operator/table_scan_translator.h"
 
 #include "codegen/lang/if.h"
-#include "codegen/proxy/catalog_proxy.h"
+#include "codegen/proxy/storage_manager_proxy.h"
 #include "codegen/proxy/transaction_runtime_proxy.h"
 #include "codegen/type/boolean_type.h"
 #include "planner/seq_scan_plan.h"

--- a/src/codegen/operator/table_scan_translator.cpp
+++ b/src/codegen/operator/table_scan_translator.cpp
@@ -65,11 +65,11 @@ void TableScanTranslator::Produce() const {
   LOG_TRACE("TableScan on [%u] starting to produce tuples ...", table.GetOid());
 
   // Get the table instance from the database
-  llvm::Value *catalog_ptr = GetCatalogPtr();
+  llvm::Value *storage_manager_ptr = GetStorageManagerPtr();
   llvm::Value *db_oid = codegen.Const32(table.GetDatabaseOid());
   llvm::Value *table_oid = codegen.Const32(table.GetOid());
   llvm::Value *table_ptr = codegen.Call(StorageManagerProxy::GetTableWithOid,
-                                        {catalog_ptr, db_oid, table_oid});
+                                        {storage_manager_ptr, db_oid, table_oid});
 
   // The selection vector for the scan
   Vector sel_vec{LoadStateValue(selection_vector_id_),

--- a/src/codegen/operator/update_translator.cpp
+++ b/src/codegen/operator/update_translator.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "codegen/lang/if.h"
-#include "codegen/proxy/catalog_proxy.h"
+#include "codegen/proxy/storage_manager_proxy.h"
 #include "codegen/proxy/target_proxy.h"
 #include "codegen/proxy/updater_proxy.h"
 #include "codegen/operator/update_translator.h"

--- a/src/codegen/operator/update_translator.cpp
+++ b/src/codegen/operator/update_translator.cpp
@@ -59,7 +59,7 @@ void UpdateTranslator::InitializeState() {
   // Get the table object pointer
   storage::DataTable *table = update_plan_.GetTable();
   llvm::Value *table_ptr = codegen.Call(StorageManagerProxy::GetTableWithOid,
-      {GetCatalogPtr(), codegen.Const32(table->GetDatabaseOid()),
+      {GetStorageManagerPtr(), codegen.Const32(table->GetDatabaseOid()),
        codegen.Const32(table->GetOid())});
 
   // Get the target list's raw vectors and their sizes

--- a/src/codegen/proxy/storage_manager_proxy.cpp
+++ b/src/codegen/proxy/storage_manager_proxy.cpp
@@ -2,15 +2,15 @@
 //
 //                         Peloton
 //
-// catalog_proxy.cpp
+// storage_manager_proxy.cpp
 //
-// Identification: src/codegen/proxy/catalog_proxy.cpp
+// Identification: src/codegen/proxy/storage_manager_proxy.cpp
 //
 // Copyright (c) 2015-2017, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
-#include "codegen/proxy/catalog_proxy.h"
+#include "codegen/proxy/storage_manager_proxy.h"
 
 #include "codegen/proxy/data_table_proxy.h"
 
@@ -20,7 +20,7 @@ namespace codegen {
 // Define the proxy type with the single opaque member field
 DEFINE_TYPE(StorageManager, "peloton::storage::StorageManager", MEMBER(opaque));
 
-// Define a method that proxies catalog::Catalog::GetTableWithOid()
+// Define a method that proxies storage::StorageManager::GetTableWithOid()
 DEFINE_METHOD(peloton::storage, StorageManager, GetTableWithOid);
 
 }  // namespace codegen

--- a/src/codegen/query.cpp
+++ b/src/codegen/query.cpp
@@ -50,7 +50,7 @@ void Query::Execute(executor::ExecutorContext &executor_context,
   // We use this handy class to avoid complex casting and pointer manipulation
   struct FunctionArguments {
     concurrency::Transaction *txn;
-    storage::StorageManager *catalog;
+    storage::StorageManager *storage_manager;
     executor::ExecutorContext *executor_context;
     QueryParameters *query_parameters;
     char *consumer_arg;
@@ -60,7 +60,7 @@ void Query::Execute(executor::ExecutorContext &executor_context,
   // Set up the function arguments
   auto *func_args = reinterpret_cast<FunctionArguments *>(param_data.get());
   func_args->txn = executor_context.GetTransaction();
-  func_args->catalog = storage::StorageManager::GetInstance();
+  func_args->storage_manager = storage::StorageManager::GetInstance();
   func_args->executor_context = &executor_context;
   func_args->query_parameters = &query_parameters;
   func_args->consumer_arg = consumer_arg;

--- a/src/include/codegen/compilation_context.h
+++ b/src/include/codegen/compilation_context.h
@@ -82,8 +82,8 @@ class CompilationContext {
 
   QueryResultConsumer &GetQueryResultConsumer() const { return result_consumer_; }
 
-  // Get a pointer to the catalog object from the runtime state
-  llvm::Value *GetCatalogPtr();
+  // Get a pointer to the storage manager object from the runtime state
+  llvm::Value *GetStorageManagerPtr();
 
   // Get a pointer to the transaction object from runtime state
   llvm::Value *GetTransactionPtr();
@@ -142,7 +142,7 @@ class CompilationContext {
 
   // The runtime state IDs
   RuntimeState::StateID txn_state_id_;
-  RuntimeState::StateID catalog_state_id_;
+  RuntimeState::StateID storage_manager_state_id_;
   RuntimeState::StateID executor_context_state_id_;
   RuntimeState::StateID query_parameters_state_id_;
 

--- a/src/include/codegen/operator/operator_translator.h
+++ b/src/include/codegen/operator/operator_translator.h
@@ -75,7 +75,7 @@ class OperatorTranslator {
   CodeGen &GetCodeGen() const;
 
   // Get the pointer to the Manager from the runtime state parameter
-  llvm::Value *GetCatalogPtr() const;
+  llvm::Value *GetStorageManagerPtr() const;
 
   // Retrieve a parameter from the runtime state
   llvm::Value *LoadStatePtr(const RuntimeState::StateID &state_id) const;

--- a/src/include/codegen/proxy/storage_manager_proxy.h
+++ b/src/include/codegen/proxy/storage_manager_proxy.h
@@ -2,9 +2,9 @@
 //
 //                         Peloton
 //
-// catalog_proxy.h
+// storage_manager_proxy.h
 //
-// Identification: src/include/codegen/proxy/catalog_proxy.h
+// Identification: src/include/codegen/proxy/storage_manager_proxy.h
 //
 // Copyright (c) 2015-2017, Carnegie Mellon University Database Group
 //

--- a/src/include/codegen/query.h
+++ b/src/include/codegen/query.h
@@ -55,7 +55,7 @@ class Query {
   // this query.
   bool Prepare(const QueryFunctions &funcs);
 
-  // Execute th e query given the storage manager and runtime/consumer state
+  // Execute the query given the storage manager and runtime/consumer state
   // that is passed along to the query execution code.
   void Execute(executor::ExecutorContext &executor_context,
                QueryParameters &parameters, char *consumer_arg,

--- a/src/include/codegen/query.h
+++ b/src/include/codegen/query.h
@@ -55,7 +55,7 @@ class Query {
   // this query.
   bool Prepare(const QueryFunctions &funcs);
 
-  // Execute th e query given the catalog manager and runtime/consumer state
+  // Execute th e query given the storage manager and runtime/consumer state
   // that is passed along to the query execution code.
   void Execute(executor::ExecutorContext &executor_context,
                QueryParameters &parameters, char *consumer_arg,


### PR DESCRIPTION
This PR is a part of the clean-up's, and modifies `catalog` to `storage_manager` in codegen, which is more correct of naming.