### PR TITLE
[Cleanup] Change cmake to build libpg_query in build folder

### DIFF
--- a/cmake/ConfigGen.cmake
+++ b/cmake/ConfigGen.cmake
@@ -55,7 +55,7 @@ function(peloton_generate_export_configs)
   configure_file("cmake/Templates/PelotonConfig.cmake.in" "${PROJECT_BINARY_DIR}/PelotonConfig.cmake" @ONLY)
 
   # Add targets to the build-tree export set
-  export(TARGETS peloton peloton-proto FILE "${PROJECT_BINARY_DIR}/PelotonTargets.cmake")
+  export(TARGETS peloton peloton-proto pg_query FILE "${PROJECT_BINARY_DIR}/PelotonTargets.cmake")
   if (TARGET peloton-capnp)
     export(TARGETS peloton-capnp APPEND FILE "${PROJECT_BINARY_DIR}/PelotonTargets.cmake")
   endif()

--- a/cmake/Modules/CoverallsGenerateGcov.cmake
+++ b/cmake/Modules/CoverallsGenerateGcov.cmake
@@ -252,22 +252,27 @@ foreach (GCOV_FILE ${ALL_GCOV_FILES})
 	# ->
 	# /path/to/project/root/subdir/the_file.c
 	get_source_path_from_gcov_filename(GCOV_SRC_PATH ${GCOV_FILE})
-	file(RELATIVE_PATH GCOV_SRC_REL_PATH "${PROJECT_ROOT}" "${GCOV_SRC_PATH}")
 
-	# Is this in the list of source files?
-	# TODO: We want to match against relative path filenames from the source file root...
-	list(FIND COVERAGE_SRCS ${GCOV_SRC_PATH} WAS_FOUND)
+	# skip if full path is not present
+	# can happen if files are generated for external libraries
+	if(IS_ABSOLUTE ${GCOV_SRC_PATH})
+		file(RELATIVE_PATH GCOV_SRC_REL_PATH "${PROJECT_ROOT}" "${GCOV_SRC_PATH}")
 
-	if (NOT WAS_FOUND EQUAL -1)
-		message("YES: ${GCOV_FILE}")
-		list(APPEND GCOV_FILES ${GCOV_FILE})
+		# Is this in the list of source files?
+		# TODO: We want to match against relative path filenames from the source file root...
+		list(FIND COVERAGE_SRCS ${GCOV_SRC_PATH} WAS_FOUND)
 
-		# We remove it from the list, so we don't bother searching for it again.
-		# Also files left in COVERAGE_SRCS_REMAINING after this loop ends should
-		# have coverage data generated from them (no lines are covered).
-		list(REMOVE_ITEM COVERAGE_SRCS_REMAINING ${GCOV_SRC_PATH})
-	else()
-		message("NO:  ${GCOV_FILE}")
+		if (NOT WAS_FOUND EQUAL -1)
+			message("YES: ${GCOV_FILE}")
+			list(APPEND GCOV_FILES ${GCOV_FILE})
+
+			# We remove it from the list, so we don't bother searching for it again.
+			# Also files left in COVERAGE_SRCS_REMAINING after this loop ends should
+			# have coverage data generated from them (no lines are covered).
+			list(REMOVE_ITEM COVERAGE_SRCS_REMAINING ${GCOV_SRC_PATH})
+		else()
+			message("NO:  ${GCOV_FILE}")
+		endif()
 	endif()
 endforeach()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,10 +32,7 @@ peloton_default_properties(peloton-proto)
 
 # --[ Libpg_query library
 
-add_custom_target(libpg_query ALL
-                  COMMAND ${CMAKE_MAKE_PROGRAM}
-                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/third_party/libpg_query/
-                  COMMENT "Original libpg makefile target")
+add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/libpg_query/ libpg_query.a)
 
 
 ##################################################################################
@@ -46,9 +43,8 @@ add_custom_target(libpg_query ALL
 peloton_pickup_peloton_sources(${PROJECT_SOURCE_DIR})
 
 add_library(peloton SHARED ${srcs})
-add_dependencies(peloton libpg_query)
-target_link_libraries(peloton ${Peloton_LINKER_LIBS}
-    ${PROJECT_SOURCE_DIR}/third_party/libpg_query/libpg_query.a)
+
+target_link_libraries(peloton PUBLIC ${Peloton_LINKER_LIBS} peloton-proto PRIVATE pg_query)
 
 peloton_default_properties(peloton)
 set_target_properties(peloton PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,7 @@ peloton_pickup_peloton_sources(${PROJECT_SOURCE_DIR})
 
 add_library(peloton SHARED ${srcs})
 
-target_link_libraries(peloton PUBLIC ${Peloton_LINKER_LIBS} peloton-proto PRIVATE pg_query)
+target_link_libraries(peloton PUBLIC ${Peloton_LINKER_LIBS} peloton-proto pg_query)
 
 peloton_default_properties(peloton)
 set_target_properties(peloton PROPERTIES

--- a/third_party/libpg_query/CMakeLists.txt
+++ b/third_party/libpg_query/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 2.8.7)
+
+# ---[ Peloton project
+project(pg_query CXX C)
+
+# this code imitates the Makefile in /third_party/libpg_query/
+file(GLOB_RECURSE pg_query_srcs ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c)
+list(REMOVE_ITEM pg_query_srcs
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/pg_query_fingerprint_defs.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/pg_query_fingerprint_conds.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/pg_query_json_defs.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/pg_query_json_conds.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/postgres/guc-file.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/postgres/scan.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/pg_query_json_helper.c")
+
+include_directories(.)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/postgres/include)
+
+add_library(pg_query STATIC ${pg_query_srcs})
+
+set_target_properties(pg_query PROPERTIES LINKER_LANGUAGE C)
+set_target_properties(pg_query PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
This PR changes the cmake build system to build libpg_query manually in the build folder using cmake instead of calling the provided Makefile. 

This works, but cmake spits out a warning I don't understand:
```
CMake Warning (dev) in src/CMakeLists.txt:
  Policy CMP0022 is not set: INTERFACE_LINK_LIBRARIES defines the link
  interface.  Run "cmake --help-policy CMP0022" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  Target "peloton" has an INTERFACE_LINK_LIBRARIES property which differs
  from its LINK_INTERFACE_LIBRARIES_DEBUG properties.

  INTERFACE_LINK_LIBRARIES:

    peloton-proto;/usr/lib/x86_64-linux-gnu/libboost_system.so;/usr/lib/x86_64-linux-gnu/libboost_filesystem.so;/usr/lib/x86_64-linux-gnu/libboost_thread.so;/usr/lib/x86_64-linux-gnu/libboost_chrono.so;/usr/lib/x86_64-linux-gnu/libboost_date_time.so;/usr/lib/x86_64-linux-gnu/libboost_atomic.so;/usr/lib/x86_64-linux-gnu/libpthread.so;-lpthread;/usr/lib/x86_64-linux-gnu/libgflags.so;$<$<NOT:$<CONFIG:DEBUG>>:/usr/lib/x86_64-linux-gnu/libprotobuf.so>;$<$<CONFIG:DEBUG>:/usr/lib/x86_64-linux-gnu/libprotobuf.so>;-lpthread;/usr/lib/x86_64-linux-gnu/libevent.so;/usr/lib/x86_64-linux-gnu/libevent_pthreads.so;/usr/lib/x86_64-linux-gnu/libpqxx.so;/usr/lib/x86_64-linux-gnu/libpq.so;-lssl;LLVMCore;LLVMMCJIT;LLVMX86CodeGen;LLVMX86Desc;LLVMX86Info;LLVMX86CodeGen;LLVMX86AsmPrinter;LLVMX86AsmParser;LLVMX86Desc;LLVMX86Info;LLVMX86Disassembler;peloton-proto

  LINK_INTERFACE_LIBRARIES_DEBUG:

    peloton-proto;/usr/lib/x86_64-linux-gnu/libboost_system.so;/usr/lib/x86_64-linux-gnu/libboost_filesystem.so;/usr/lib/x86_64-linux-gnu/libboost_thread.so;/usr/lib/x86_64-linux-gnu/libboost_chrono.so;/usr/lib/x86_64-linux-gnu/libboost_date_time.so;/usr/lib/x86_64-linux-gnu/libboost_atomic.so;/usr/lib/x86_64-linux-gnu/libpthread.so;-lpthread;/usr/lib/x86_64-linux-gnu/libgflags.so;/usr/lib/x86_64-linux-gnu/libprotobuf.so;-lpthread;/usr/lib/x86_64-linux-gnu/libevent.so;/usr/lib/x86_64-linux-gnu/libevent_pthreads.so;/usr/lib/x86_64-linux-gnu/libpqxx.so;/usr/lib/x86_64-linux-gnu/libpq.so;-lssl;LLVMCore;LLVMMCJIT;LLVMX86CodeGen;LLVMX86Desc;LLVMX86Info;LLVMX86CodeGen;LLVMX86AsmPrinter;LLVMX86AsmParser;LLVMX86Desc;LLVMX86Info;LLVMX86Disassembler;peloton-proto

This warning is for project developers.  Use -Wno-dev to suppress it.

```