### PR TITLE
Changed StatementResult to ResultValue

### DIFF
--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -44,7 +44,7 @@ void CleanExecutorTree(executor::AbstractExecutor *root);
 void PlanExecutor::ExecutePlan(
     std::shared_ptr<planner::AbstractPlan> plan,
     concurrency::Transaction *txn, const std::vector<type::Value> &params,
-    std::vector<StatementResult> &result,
+    std::vector<ResultValue> &result,
     const std::vector<int> &result_format, executor::ExecuteResult &p_status) {
   PL_ASSERT(plan != nullptr && txn != nullptr);
   LOG_TRACE("PlanExecutor Start (Txn ID=%" PRId64")", txn->GetTransactionId());
@@ -81,8 +81,8 @@ void PlanExecutor::ExecutePlan(
         // Construct the returned results
         for (auto &tuple : tuples) {
           for (unsigned int i = 0; i < tile->GetColumnCount(); i++) {
-            auto res = StatementResult();
-            PlanExecutor::copyFromTo(tuple[i], res.second);
+            auto res = ResultValue();
+            PlanExecutor::copyFromTo(tuple[i], res);
             result.push_back(std::move(res));
             LOG_TRACE("column content: %s",
                       tuple[i].c_str() != nullptr ?  tuple[i].c_str() : "-emptry-");
@@ -129,10 +129,10 @@ void PlanExecutor::ExecutePlan(
   const auto &results = consumer.GetOutputTuples();
   for (const auto &tuple : results) {
     for (uint32_t i = 0; i < tuple.tuple_.size(); i++) {
-      auto res = StatementResult();
+      auto res = ResultValue();
       auto column_val = tuple.GetValue(i);
       auto str = column_val.IsNull() ? "" : column_val.ToString();
-      PlanExecutor::copyFromTo(str, res.second);
+      PlanExecutor::copyFromTo(str, res);
       LOG_TRACE("column content: [%s]", str.c_str());
       result.push_back(std::move(res));
     }

--- a/src/include/common/statement.h
+++ b/src/include/common/statement.h
@@ -25,8 +25,10 @@ namespace planner {
 class AbstractPlan;
 }
 
-// Contains the value of a coulmn in a tuple of the result set.
+// Contains the value of a column in a tuple of the result set.
 // std::string since the result is sent to the client over the network.
+// Previously it used to be StatementResult of type
+// std::pair<std::vector<unsigned char>, std::vector<unsigned char>>.
 typedef std::vector<unsigned char> ResultValue;
 
 // FIELD INFO TYPE : field name, oid (data type), size

--- a/src/include/common/statement.h
+++ b/src/include/common/statement.h
@@ -25,9 +25,9 @@ namespace planner {
 class AbstractPlan;
 }
 
-// TODO: Somebody needs to define what the hell this is???
-typedef std::pair<std::vector<unsigned char>, std::vector<unsigned char>>
-    StatementResult;
+// Contains the value of a coulmn in a tuple of the result set.
+// std::string since the result is sent to the client over the network.
+typedef std::vector<unsigned char> ResultValue;
 
 // FIELD INFO TYPE : field name, oid (data type), size
 typedef std::tuple<std::string, oid_t, size_t> FieldInfo;

--- a/src/include/executor/plan_executor.h
+++ b/src/include/executor/plan_executor.h
@@ -74,7 +74,7 @@ class PlanExecutor {
   static void ExecutePlan(std::shared_ptr<planner::AbstractPlan> plan,
                                    concurrency::Transaction* txn,
                                    const std::vector<type::Value> &params,
-                                   std::vector<StatementResult> &result,
+                                   std::vector<ResultValue> &result,
                                    const std::vector<int> &result_format,
                                    executor::ExecuteResult &p_status);
 

--- a/src/include/network/postgres_protocol_handler.h
+++ b/src/include/network/postgres_protocol_handler.h
@@ -110,7 +110,7 @@ class PostgresProtocolHandler: public ProtocolHandler {
   void PutTupleDescriptor(const std::vector<FieldInfo>& tuple_descriptor);
 
   // Send each row, one packet at a time, used by SELECT queries
-  void SendDataRows(std::vector<StatementResult>& results, int colcount);
+  void SendDataRows(std::vector<ResultValue>& results, int colcount);
 
   // Used to send a packet that indicates the completion of a query. Also has
   // txn state mgmt

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -54,7 +54,7 @@ class TrafficCop {
 
   // PortalExec - Execute query string
 //  ResultType ExecuteStatement(const std::string &query,
-//                              std::vector<StatementResult> &result,
+//                              std::vector<ResultValue> &result,
 //                              std::vector<FieldInfo> &tuple_descriptor,
 //                              int &rows_changed, std::string &error_message,
 //                              const size_t thread_id = 0);
@@ -64,7 +64,7 @@ class TrafficCop {
       const std::vector<type::Value> &params, const bool unnamed,
       std::shared_ptr<stats::QueryMetric::QueryParams> param_stats,
       const std::vector<int> &result_format,
-      std::vector<StatementResult> &result,
+      std::vector<ResultValue> &result,
       std::string &error_message, const size_t thread_id = 0);
 
   // ExecutePrepStmt - Helper to handle txn-specifics for the plan-tree of a
@@ -72,7 +72,7 @@ class TrafficCop {
   executor::ExecuteResult ExecuteHelper(
       std::shared_ptr<planner::AbstractPlan> plan,
       const std::vector<type::Value> &params,
-      std::vector<StatementResult> &result,
+      std::vector<ResultValue> &result,
       const std::vector<int> &result_format, const size_t thread_id = 0);
 
   // InitBindPrepStmt - Prepare and bind a query from a query string
@@ -126,11 +126,11 @@ class TrafficCop {
     return statement_;
   }
 
-  void SetResult(std::vector<StatementResult> result) {
+  void SetResult(std::vector<ResultValue> result) {
     result_ = result;
   }
 
-  std::vector<StatementResult>& GetResult() {
+  std::vector<ResultValue>& GetResult() {
     return result_;
   }
 
@@ -180,7 +180,7 @@ class TrafficCop {
 
   std::vector<type::Value> param_values_;
 
-  std::vector<StatementResult> results_;
+  std::vector<ResultValue> results_;
 
   // This save currnet statement in the traffic cop
   std::shared_ptr<Statement> statement_;
@@ -199,7 +199,7 @@ class TrafficCop {
   // flag of psql protocol
   // executePlan arguments
 
-  std::vector<StatementResult> result_;
+  std::vector<ResultValue> result_;
   void(* task_callback_)(void *);
   void * task_callback_arg_;
 //  IOTrigger io_trigger_;
@@ -228,7 +228,7 @@ class TrafficCop {
 //  const std::vector<type::Value> params_;
 //  UNUSED_ATTRIBUTE const bool unnamed;
 //  std::shared_ptr<stats::QueryMetric::QueryParams> param_stats_;
-//  const std::vector<int> &result_format, std::vector<StatementResult> result;
+//  const std::vector<int> &result_format, std::vector<ResultValue> result;
 //  int &rows_changed, UNUSED_ATTRIBUTE std::string error_message;
 //  const size_t thread_id UNUSED_ATTRIBUTE;
 };
@@ -240,7 +240,7 @@ struct ExecutePlanArg {
   inline ExecutePlanArg(const std::shared_ptr<planner::AbstractPlan> plan,
                         concurrency::Transaction *txn,
                         const std::vector<type::Value> &params,
-                        std::vector<StatementResult> &result,
+                        std::vector<ResultValue> &result,
                         const std::vector<int> &result_format,
                         executor::ExecuteResult &p_status) :
       plan_(plan),
@@ -256,7 +256,7 @@ struct ExecutePlanArg {
   std::shared_ptr<planner::AbstractPlan> plan_;
   concurrency::Transaction *txn_;
   const std::vector<type::Value> &params_;
-  std::vector<StatementResult> &result_;
+  std::vector<ResultValue> &result_;
   const std::vector<int> &result_format_;
   executor::ExecuteResult &p_status_;
 //  struct event* event_;

--- a/src/network/postgres_protocol_handler.cpp
+++ b/src/network/postgres_protocol_handler.cpp
@@ -139,7 +139,7 @@ void PostgresProtocolHandler::PutTupleDescriptor(
   responses.push_back(std::move(pkt));
 }
 
-void PostgresProtocolHandler::SendDataRows(std::vector<StatementResult> &results,
+void PostgresProtocolHandler::SendDataRows(std::vector<ResultValue> &results,
                                  int colcount) {
   if (results.empty() || colcount == 0) return;
 
@@ -151,7 +151,7 @@ void PostgresProtocolHandler::SendDataRows(std::vector<StatementResult> &results
     pkt->msg_type = NetworkMessageType::DATA_ROW;
     PacketPutInt(pkt.get(), colcount, 2);
     for (int j = 0; j < colcount; j++) {
-      auto content = results[i * colcount + j].second;
+      auto content = results[i * colcount + j];
       if (content.size() == 0) {
         // content is NULL
         PacketPutInt(pkt.get(), NULL_CONTENT_SIZE, 4);
@@ -255,7 +255,7 @@ ProcessResult PostgresProtocolHandler::ExecQueryMessage(InputPacket *pkt, const 
   protocol_type_ = NetworkProtocolType::POSTGRES_PSQL;
 
   if (!query.empty()) {
-    std::vector<StatementResult> result;
+    std::vector<ResultValue> result;
     std::vector<FieldInfo> tuple_descriptor;
     std::string error_message;
 

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -149,7 +149,7 @@ ResultType TrafficCop::ExecuteStatementGetResult() {
 executor::ExecuteResult TrafficCop::ExecuteHelper(
     std::shared_ptr<planner::AbstractPlan> plan,
     const std::vector<type::Value> &params,
-    std::vector<StatementResult> &result, const std::vector<int> &result_format,
+    std::vector<ResultValue> &result, const std::vector<int> &result_format,
     const size_t thread_id) {
   concurrency::Transaction *txn;
 
@@ -469,7 +469,7 @@ ResultType TrafficCop::ExecuteStatement(
     const std::shared_ptr<Statement> &statement,
     const std::vector<type::Value> &params, UNUSED_ATTRIBUTE const bool unnamed,
     std::shared_ptr<stats::QueryMetric::QueryParams> param_stats,
-    const std::vector<int> &result_format, std::vector<StatementResult> &result,
+    const std::vector<int> &result_format, std::vector<ResultValue> &result,
     UNUSED_ATTRIBUTE std::string &error_message,
     const size_t thread_id UNUSED_ATTRIBUTE) {
   if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -73,7 +73,7 @@ void SetupTables(std::string database_name) {
     traffic_cop.SetTcopTxnState(txn);
 
     vector<type::Value> params;
-    vector<StatementResult> result;
+    vector<ResultValue> result;
     vector<int> result_format;
     unique_ptr<Statement> statement(new Statement("CREATE", sql));
     auto parse_tree = parser.BuildParseTree(sql);

--- a/test/catalog/constraints_test.cpp
+++ b/test/catalog/constraints_test.cpp
@@ -138,7 +138,7 @@ TEST_F(ConstraintsTests, DEFAULTTEST) {
   TestingConstraintsUtil::CreateAndPopulateTable(constraints, multi_constraints);
 
   // Bootstrap
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
@@ -158,7 +158,6 @@ TEST_F(ConstraintsTests, DEFAULTTEST) {
   status = TestingSQLUtil::ExecuteSQLQuery(
       sql, result, tuple_descriptor, rows_affected, error_message);
   EXPECT_EQ(ResultType::SUCCESS, status);
-  // EXPECT_EQ(result[0].second[0], '1');
   std::string resultStr = TestingSQLUtil::GetResultValueAsString(result, 0);
   LOG_INFO("OUTPUT:\n%s", resultStr.c_str());
 }

--- a/test/executor/copy_test.cpp
+++ b/test/executor/copy_test.cpp
@@ -85,7 +85,7 @@ TEST_F(CopyTests, Copying) {
     auto statement = TestingStatsUtil::GetInsertStmt(12345, insert_str);
     std::vector<type::Value> params;
     std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
-    std::vector<StatementResult> result;
+    std::vector<ResultValue> result;
 
     TestingSQLUtil::counter_.store(1);
     executor::ExecuteResult status = traffic_cop.ExecuteHelper(

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -84,7 +84,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   LOG_INFO("Building plan tree completed!");
 
   std::vector<type::Value> params;
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   LOG_INFO("Executing plan...\n%s",
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -52,7 +52,7 @@ void ShowTable(std::string database_name, std::string table_name) {
   auto& peloton_parser = parser::PostgresParser::GetInstance();
   executor::ExecuteResult status;
   std::vector<type::Value> params;
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
 
   optimizer::Optimizer optimizer;
 
@@ -143,7 +143,7 @@ TEST_F(DeleteTests, VariousOperations) {
   statement->SetPlanTree(optimizer->BuildPelotonPlanTree(insert_stmt, DEFAULT_DB_NAME, txn));
   LOG_INFO("Building plan tree completed!");
   std::vector<type::Value> params;
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   LOG_INFO("Executing plan...\n%s",
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -212,7 +212,7 @@ TEST_F(UpdateTests, UpdatingOld) {
   statement->SetPlanTree(optimizer->BuildPelotonPlanTree(insert_stmt, DEFAULT_DB_NAME, txn));
   LOG_INFO("Building plan tree completed!");
   std::vector<type::Value> params;
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   LOG_INFO("Executing plan...\n%s",
            planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
 

--- a/test/function/functions_test.cpp
+++ b/test/function/functions_test.cpp
@@ -100,7 +100,7 @@ TEST_F(FunctionsTests, FuncCallTest) {
 
   TestingSQLUtil::ExecuteSQLQuery("INSERT INTO test VALUES (4.0, 'abc');");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
@@ -108,18 +108,18 @@ TEST_F(FunctionsTests, FuncCallTest) {
   TestingSQLUtil::ExecuteSQLQuery("SELECT SQRT(a), SUBSTR(s,1,2) FROM test;",
                                   result, tuple_descriptor, rows_affected,
                                   error_message);
-  EXPECT_EQ(1, result[0].second.size());
-  EXPECT_EQ('2', result[0].second[0]);
-  EXPECT_EQ(2, result[1].second.size());
-  EXPECT_EQ(result[1].second[0], 'a');
-  EXPECT_EQ(result[1].second[1], 'b');
+  EXPECT_EQ(1, result[0].size());
+  EXPECT_EQ('2', result[0][0]);
+  EXPECT_EQ(2, result[1].size());
+  EXPECT_EQ(result[1][0], 'a');
+  EXPECT_EQ(result[1][1], 'b');
 
   TestingSQLUtil::ExecuteSQLQuery("SELECT ASCII(s) FROM test;", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
-  EXPECT_EQ(2, result[0].second.size());
-  EXPECT_EQ('9', result[0].second[0]);
-  EXPECT_EQ('7', result[0].second[1]);
+  EXPECT_EQ(2, result[0].size());
+  EXPECT_EQ('9', result[0][0]);
+  EXPECT_EQ('7', result[0][1]);
 
   // free the database just created
   txn = txn_manager.BeginTransaction();

--- a/test/include/sql/testing_sql_util.h
+++ b/test/include/sql/testing_sql_util.h
@@ -40,13 +40,13 @@ class TestingSQLUtil {
 
   // Execute a SQL query end-to-end
   static ResultType ExecuteSQLQuery(const std::string query,
-                                    std::vector<StatementResult> &result,
+                                    std::vector<ResultValue> &result,
                                     std::vector<FieldInfo> &tuple_descriptor,
                                     int &rows_affected,
                                     std::string &error_message);
 
   static ResultType ExecuteSQLQuery(const std::string query,
-                                    std::vector<StatementResult> &result,
+                                    std::vector<ResultValue> &result,
                                     std::vector<FieldInfo> &tuple_descriptor,
                                     int &rows_affected);
 
@@ -56,7 +56,7 @@ class TestingSQLUtil {
   // the refactor by Siddharth
   static ResultType ExecuteSQLQueryWithOptimizer(
       std::unique_ptr<optimizer::AbstractOptimizer> &optimizer,
-      const std::string query, std::vector<StatementResult> &result,
+      const std::string query, std::vector<ResultValue> &result,
       std::vector<FieldInfo> &tuple_descriptor, int &rows_changed,
       std::string &error_message);
 
@@ -67,7 +67,7 @@ class TestingSQLUtil {
 
   // A simpler wrapper around ExecuteSQLQuery
   static ResultType ExecuteSQLQuery(const std::string query,
-                                    std::vector<StatementResult> &result);
+                                    std::vector<ResultValue> &result);
 
   // A another simpler wrapper around ExecuteSQLQuery
   static ResultType ExecuteSQLQuery(const std::string query);
@@ -84,8 +84,8 @@ class TestingSQLUtil {
   // NOTE: Result columns across different rows are unfolded into a single
   // vector (vector<ResultType>).
   static std::string GetResultValueAsString(
-      const std::vector<StatementResult> &result, size_t index) {
-    std::string value(result[index].second.begin(), result[index].second.end());
+      const std::vector<ResultValue> &result, size_t index) {
+    std::string value(result[index].begin(), result[index].end());
     return value;
   }
 

--- a/test/optimizer/old_optimizer_test.cpp
+++ b/test/optimizer/old_optimizer_test.cpp
@@ -67,7 +67,7 @@ TEST_F(OldOptimizerTests, UpdateDelWithIndexScanTest) {
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(create_stmt, DEFAULT_DB_NAME, txn));
 
   std::vector<type::Value> params;
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   LOG_TRACE("Query Plan:\n%s",
             planner::PlanUtil::GetInfo(statement->GetPlanTree().get()).c_str());
   std::vector<int> result_format;

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -60,7 +60,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
   statement->SetPlanTree(optimizer.BuildPelotonPlanTree(create_stmt, DEFAULT_DB_NAME, txn));
 
   std::vector<type::Value> params;
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<int> result_format;
   result_format =
       std::vector<int>(statement->GetTupleDescriptor().size(), 0);

--- a/test/planner/planner_equality_test.cpp
+++ b/test/planner/planner_equality_test.cpp
@@ -82,7 +82,7 @@ class PlannerEqualityTest : public PelotonTest {
 
  protected:
   std::unique_ptr<optimizer::AbstractOptimizer> optimizer;
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;

--- a/test/sql/aggregate_sql_test.cpp
+++ b/test/sql/aggregate_sql_test.cpp
@@ -36,7 +36,7 @@ TEST_F(AggregateSQLTests, EmptyTableTest) {
   TestingSQLUtil::ExecuteSQLQuery(
       "CREATE TABLE xxx(a INT PRIMARY KEY, b INT);");
   LOG_DEBUG("execute one query");
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
@@ -54,7 +54,7 @@ TEST_F(AggregateSQLTests, EmptyTableTest) {
     os << "SELECT " << nullAggregates[i] << "(b) FROM xxx";
     TestingSQLUtil::ExecuteSQLQuery(os.str(), result, tuple_descriptor,
                                     rows_affected, error_message);
-    std::string resultStr(result[0].second.begin(), result[0].second.end());
+    std::string resultStr(result[0].begin(), result[0].end());
 
     EXPECT_EQ(expected, resultStr);
   }
@@ -68,7 +68,7 @@ TEST_F(AggregateSQLTests, EmptyTableTest) {
     os << "SELECT " << zeroAggregates[i] << "(b) FROM xxx";
     TestingSQLUtil::ExecuteSQLQuery(os.str(), result, tuple_descriptor,
                                     rows_affected, error_message);
-    std::string resultStr(result[0].second.begin(), result[0].second.end());
+    std::string resultStr(result[0].begin(), result[0].end());
 
     EXPECT_EQ(expected, resultStr);
   }
@@ -98,7 +98,7 @@ TEST_F(AggregateSQLTests, MinMaxTest) {
 
   TestingSQLUtil::ShowTable(DEFAULT_DB_NAME, "test");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
@@ -109,7 +109,7 @@ TEST_F(AggregateSQLTests, MinMaxTest) {
                                   tuple_descriptor, rows_affected,
                                   error_message);
   // Check the return value
-  EXPECT_EQ(result[0].second[0], '1');
+  EXPECT_EQ(result[0][0], '1');
   // Check the return type
   // TODO: LM: Right now we cannot deduce TINYINT
   // EXPECT_EQ(PostgresValueType::TINYINT, std::get<1>(tuple_descriptor[0]));
@@ -117,7 +117,7 @@ TEST_F(AggregateSQLTests, MinMaxTest) {
   TestingSQLUtil::ExecuteSQLQuery("SELECT max(b) from test", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
-  EXPECT_EQ(result[0].second[0], '4');
+  EXPECT_EQ(result[0][0], '4');
   // EXPECT_EQ(PostgresValueType::TINYINT, std::get<1>(tuple_descriptor[0]));
 
   // test int
@@ -125,7 +125,7 @@ TEST_F(AggregateSQLTests, MinMaxTest) {
                                   tuple_descriptor, rows_affected,
                                   error_message);
   // Check the return value
-  EXPECT_EQ(result[0].second[0], '1');
+  EXPECT_EQ(result[0][0], '1');
   // Check the return type
   EXPECT_EQ(static_cast<oid_t>(PostgresValueType::INTEGER),
             std::get<1>(tuple_descriptor[0]));
@@ -133,7 +133,7 @@ TEST_F(AggregateSQLTests, MinMaxTest) {
   TestingSQLUtil::ExecuteSQLQuery("SELECT max(a) from test", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
-  EXPECT_EQ(result[0].second[0], '4');
+  EXPECT_EQ(result[0][0], '4');
   EXPECT_EQ(static_cast<oid_t>(PostgresValueType::INTEGER),
             std::get<1>(tuple_descriptor[0]));
 
@@ -141,7 +141,7 @@ TEST_F(AggregateSQLTests, MinMaxTest) {
   TestingSQLUtil::ExecuteSQLQuery("SELECT min(d) from test", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
-  EXPECT_EQ(result[0].second[0], '1');
+  EXPECT_EQ(result[0][0], '1');
   // Check the return type
   // TODO: LM: Right now we cannot deduce BIGINT
   // EXPECT_EQ(PostgresValueType::BIGINT,
@@ -150,7 +150,7 @@ TEST_F(AggregateSQLTests, MinMaxTest) {
   TestingSQLUtil::ExecuteSQLQuery("SELECT max(d) from test", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
-  EXPECT_EQ(result[0].second[0], '4');
+  EXPECT_EQ(result[0][0], '4');
   // EXPECT_EQ(PostgresValueType::BIGINT,
   //          std::get<1>(tuple_descriptor[0]));
 
@@ -158,14 +158,14 @@ TEST_F(AggregateSQLTests, MinMaxTest) {
   TestingSQLUtil::ExecuteSQLQuery("SELECT min(e) from test", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
-  EXPECT_EQ(result[0].second[0], '1');
+  EXPECT_EQ(result[0][0], '1');
   EXPECT_EQ(static_cast<oid_t>(PostgresValueType::DOUBLE),
             std::get<1>(tuple_descriptor[0]));
 
   TestingSQLUtil::ExecuteSQLQuery("SELECT max(e) from test", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
-  EXPECT_EQ(result[0].second[0], '4');
+  EXPECT_EQ(result[0][0], '4');
   EXPECT_EQ(static_cast<oid_t>(PostgresValueType::DOUBLE),
             std::get<1>(tuple_descriptor[0]));
 
@@ -173,7 +173,7 @@ TEST_F(AggregateSQLTests, MinMaxTest) {
   TestingSQLUtil::ExecuteSQLQuery("SELECT min(f) from test", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
-  EXPECT_EQ(result[0].second[0], '1');
+  EXPECT_EQ(result[0][0], '1');
   // Right now we treat all double and decimal as double
   EXPECT_EQ(static_cast<oid_t>(PostgresValueType::DOUBLE),
             std::get<1>(tuple_descriptor[0]));
@@ -181,21 +181,21 @@ TEST_F(AggregateSQLTests, MinMaxTest) {
   TestingSQLUtil::ExecuteSQLQuery("SELECT max(f) from test", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
-  EXPECT_EQ(result[0].second[0], '4');
+  EXPECT_EQ(result[0][0], '4');
   EXPECT_EQ(static_cast<oid_t>(PostgresValueType::DOUBLE),
             std::get<1>(tuple_descriptor[0]));
 
   // test varchar
   TestingSQLUtil::ExecuteSQLQuery("SELECT min(g) from test", result);
-  EXPECT_EQ(result[0].second[0], '1');
+  EXPECT_EQ(result[0][0], '1');
   TestingSQLUtil::ExecuteSQLQuery("SELECT max(g) from test", result);
-  EXPECT_EQ(result[0].second[0], '4');
+  EXPECT_EQ(result[0][0], '4');
 
   // test timestamp
   TestingSQLUtil::ExecuteSQLQuery("SELECT min(h) from test", result);
-  EXPECT_EQ(result[0].second[18], '1');
+  EXPECT_EQ(result[0][18], '1');
   TestingSQLUtil::ExecuteSQLQuery("SELECT max(h) from test", result);
-  EXPECT_EQ(result[0].second[18], '4');
+  EXPECT_EQ(result[0][18], '4');
 
   // free the database just created
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();

--- a/test/sql/case_sql_test.cpp
+++ b/test/sql/case_sql_test.cpp
@@ -48,7 +48,7 @@ TEST_F(CaseSQLTests, Simple) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -85,7 +85,7 @@ TEST_F(CaseSQLTests, SimpleWithArg) {
   txn_manager.CommitTransaction(txn);
 
   CreateAndLoadTable();
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -122,7 +122,7 @@ TEST_F(CaseSQLTests, SimpleWithArgStringResult) {
   txn_manager.CommitTransaction(txn);
 
   CreateAndLoadTable();
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -161,7 +161,7 @@ TEST_F(CaseSQLTests, SimpleMultipleWhen) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -199,7 +199,7 @@ TEST_F(CaseSQLTests, SimpleMultipleWhenWithoutElse) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;

--- a/test/sql/decimal_functions_sql_test.cpp
+++ b/test/sql/decimal_functions_sql_test.cpp
@@ -52,7 +52,7 @@ class DecimalFunctionsSQLTest : public PelotonTest {};
 
     txn_manager.CommitTransaction(txn);
     // Fetch values from the table
-    std::vector<StatementResult> result;
+    std::vector<ResultValue> result;
     std::vector<FieldInfo> tuple_descriptor;
     std::string error_message;
     int rows_affected;
@@ -107,7 +107,7 @@ class DecimalFunctionsSQLTest : public PelotonTest {};
 
     txn_manager.CommitTransaction(txn);
     // Fetch values from the table
-    std::vector<StatementResult> result;
+    std::vector<ResultValue> result;
     std::vector<FieldInfo> tuple_descriptor;
     std::string error_message;
     int rows_affected;

--- a/test/sql/distinct_aggregate_sql_test.cpp
+++ b/test/sql/distinct_aggregate_sql_test.cpp
@@ -46,7 +46,7 @@ class DistinctAggregateSQLTests : public PelotonTest {
 
   void ExecuteSQLQueryAndCheckUnorderedResult(
       std::string query, std::unordered_set<std::string> ref_result) {
-    std::vector<StatementResult> result;
+    std::vector<ResultValue> result;
     std::vector<FieldInfo> tuple_descriptor;
     std::string error_message;
     int rows_changed;

--- a/test/sql/distinct_sql_test.cpp
+++ b/test/sql/distinct_sql_test.cpp
@@ -39,7 +39,7 @@ class DistinctSQLTests : public PelotonTest {
   }
 
   void ExecuteSQLQueryAndCheckUnorderedResult(std::string query, std::unordered_set<std::string> ref_result) {
-    std::vector<StatementResult> result;
+    std::vector<ResultValue> result;
     std::vector<FieldInfo> tuple_descriptor;
     std::string error_message;
     int rows_changed;

--- a/test/sql/drop_sql_test.cpp
+++ b/test/sql/drop_sql_test.cpp
@@ -46,7 +46,7 @@ TEST_F(DropSQLTests, DropTableTest) {
   txn_manager.CommitTransaction(txn);
   EXPECT_NE(table, nullptr);
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
@@ -58,7 +58,7 @@ TEST_F(DropSQLTests, DropTableTest) {
   TestingSQLUtil::ExecuteSQLQuery("SELECT * FROM test;", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
-  EXPECT_EQ(result[0].second[0], '1');
+  EXPECT_EQ(result[0][0], '1');
 
   // Drop the table
   EXPECT_EQ(TestingSQLUtil::ExecuteSQLQuery("DROP TABLE test;"),

--- a/test/sql/index_scan_sql_test.cpp
+++ b/test/sql/index_scan_sql_test.cpp
@@ -46,7 +46,7 @@ TEST_F(IndexScanSQLTests, CreateIndexAfterInsertTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -77,7 +77,7 @@ TEST_F(IndexScanSQLTests, CreateIndexAfterInsertOnMultipleColumnsTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -115,7 +115,7 @@ TEST_F(IndexScanSQLTests, SQLTest) {
       "VARCHAR);");
   LOG_INFO("Table created!");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   // Inserting a tuple end-to-end
   LOG_INFO("Inserting a tuple...");
   TestingSQLUtil::ExecuteSQLQuery(

--- a/test/sql/insert_sql_test.cpp
+++ b/test/sql/insert_sql_test.cpp
@@ -112,7 +112,7 @@ TEST_F(InsertSQLTests, InsertOneValue) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -155,7 +155,7 @@ TEST_F(InsertSQLTests, InsertMultipleValues) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -207,7 +207,7 @@ TEST_F(InsertSQLTests, InsertSpecifyColumns) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -250,7 +250,7 @@ TEST_F(InsertSQLTests, InsertTooLargeVarchar) {
 
   CreateAndLoadTable3();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -294,7 +294,7 @@ TEST_F(InsertSQLTests, InsertIntoSelectSimple) {
   CreateAndLoadTable();
   CreateAndLoadTable2();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -369,7 +369,7 @@ TEST_F(InsertSQLTests, InsertIntoSelectSimpleAllType) {
   CreateAndLoadTable4();
   CreateAndLoadTable5();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -457,7 +457,7 @@ TEST_F(InsertSQLTests, InsertIntoSelectColumn) {
   CreateAndLoadTable6();
   CreateAndLoadTable7();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;

--- a/test/sql/is_null_sql_test.cpp
+++ b/test/sql/is_null_sql_test.cpp
@@ -65,7 +65,7 @@ TEST_F(IsNullSqlTests, InsertNullTest) {
   LOG_TRACE("Test insert null...");
   LOG_TRACE("Query: select * from a");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
@@ -98,7 +98,7 @@ TEST_F(IsNullSqlTests, IsNullWhereTest) {
   LOG_TRACE("Test is null in where clause...");
   LOG_TRACE("Query: select * from a where value is null");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
@@ -138,7 +138,7 @@ TEST_F(IsNullSqlTests, IsNotNullWhereTest) {
   LOG_TRACE("Test is not null in where clause...");
   LOG_TRACE("Query: select * from a where value is not null");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;

--- a/test/sql/optimizer_sql_test.cpp
+++ b/test/sql/optimizer_sql_test.cpp
@@ -124,7 +124,7 @@ class OptimizerSQLTests : public PelotonTest {
 
  protected:
   unique_ptr<optimizer::AbstractOptimizer> optimizer;
-  vector<StatementResult> result;
+  vector<ResultValue> result;
   vector<FieldInfo> tuple_descriptor;
   string error_message;
   int rows_changed;

--- a/test/sql/order_by_sql_test.cpp
+++ b/test/sql/order_by_sql_test.cpp
@@ -68,7 +68,7 @@ TEST_F(OrderBySQLTests, PerformanceTest) {
 
   TestingSQLUtil::ShowTable(DEFAULT_DB_NAME, "test");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
@@ -120,7 +120,7 @@ TEST_F(OrderBySQLTests, OrderByWithColumnsTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -150,7 +150,7 @@ TEST_F(OrderBySQLTests, OrderByWithColumnsDescTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -180,7 +180,7 @@ TEST_F(OrderBySQLTests, OrderByWithoutColumnsTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -210,7 +210,7 @@ TEST_F(OrderBySQLTests, OrderByWithoutColumnsDescTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -240,7 +240,7 @@ TEST_F(OrderBySQLTests, OrderByWithColumnsAndLimitTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -271,7 +271,7 @@ TEST_F(OrderBySQLTests, OrderByWithColumnsAndLimitDescTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -302,7 +302,7 @@ TEST_F(OrderBySQLTests, OrderByWithoutColumnsAndLimitTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -333,7 +333,7 @@ TEST_F(OrderBySQLTests, OrderByWithoutColumnsAndLimitDescTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -364,7 +364,7 @@ TEST_F(OrderBySQLTests, OrderByStar) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -397,7 +397,7 @@ TEST_F(OrderBySQLTests, OrderByStarDesc) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -430,7 +430,7 @@ TEST_F(OrderBySQLTests, OrderByStarWithLimit) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -462,7 +462,7 @@ TEST_F(OrderBySQLTests, OrderByStarWithLimitDesc) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -494,7 +494,7 @@ TEST_F(OrderBySQLTests, OrderByWithProjectionTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -528,7 +528,7 @@ TEST_F(OrderBySQLTests, OrderByWithProjectionDescTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -562,7 +562,7 @@ TEST_F(OrderBySQLTests, OrderByWithProjectionLimitTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;
@@ -598,7 +598,7 @@ TEST_F(OrderBySQLTests, OrderByWithProjectionLimitDescTest) {
 
   CreateAndLoadTable();
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;

--- a/test/sql/string_functions_sql_test.cpp
+++ b/test/sql/string_functions_sql_test.cpp
@@ -51,7 +51,7 @@ TEST_F(StringFunctionTest, LengthTest) {
   }
   EXPECT_EQ(i, 32);
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
 

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -52,7 +52,7 @@ void TestingSQLUtil::ShowTable(std::string database_name,
 
 // Execute a SQL query end-to-end
 ResultType TestingSQLUtil::ExecuteSQLQuery(
-    const std::string query, std::vector<StatementResult> &result,
+    const std::string query, std::vector<ResultValue> &result,
     std::vector<FieldInfo> &tuple_descriptor, int &rows_changed,
     std::string &error_message) {
   LOG_INFO("Query: %s", query.c_str());
@@ -92,7 +92,7 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(
 // Execute a SQL query end-to-end with the specific optimizer
 ResultType TestingSQLUtil::ExecuteSQLQueryWithOptimizer(
     std::unique_ptr<optimizer::AbstractOptimizer> &optimizer,
-    const std::string query, std::vector<StatementResult> &result,
+    const std::string query, std::vector<ResultValue> &result,
     std::vector<FieldInfo> &tuple_descriptor, int &rows_changed,
     std::string &error_message) {
   auto &peloton_parser = parser::PostgresParser::GetInstance();
@@ -143,7 +143,7 @@ TestingSQLUtil::GeneratePlanWithOptimizer(
 }
 
 ResultType TestingSQLUtil::ExecuteSQLQuery(
-    const std::string query, std::vector<StatementResult> &result) {
+    const std::string query, std::vector<ResultValue> &result) {
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
 
@@ -177,7 +177,7 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(
 }
 
 ResultType TestingSQLUtil::ExecuteSQLQuery(const std::string query) {
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
 
@@ -217,7 +217,7 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(const std::string query) {
 // {"1|string1", "2|strin2", "3|string3"}
 void TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
     std::string query, std::vector<std::string> ref_result, bool ordered) {
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;

--- a/test/sql/timestamp_functions_sql_test.cpp
+++ b/test/sql/timestamp_functions_sql_test.cpp
@@ -40,7 +40,7 @@ TEST_F(TimestampFunctionsSQLTest, DateTruncTest) {
   txn_manager.CommitTransaction(txn);
 
   // Fetch values from the table
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;

--- a/test/sql/type_sql_test.cpp
+++ b/test/sql/type_sql_test.cpp
@@ -105,7 +105,7 @@ TEST_F(TypeSQLTests, TypeLimitSQLTest) {
   }
 }
 
-void CheckQueryResult(std::vector<StatementResult> result,
+void CheckQueryResult(std::vector<ResultValue> result,
                       std::vector<std::string> expected,
                       size_t tuple_descriptor_size) {
   EXPECT_EQ(result.size(), expected.size());
@@ -113,7 +113,7 @@ void CheckQueryResult(std::vector<StatementResult> result,
     for (size_t j = 0; j < tuple_descriptor_size; j++) {
       int idx = i * tuple_descriptor_size + j;
       std::string s =
-          std::string(result[idx].second.begin(), result[idx].second.end());
+          std::string(result[idx].begin(), result[idx].end());
       EXPECT_EQ(s, expected[i]);
     }
   }
@@ -131,7 +131,7 @@ TEST_F(TypeSQLTests, VarcharTest) {
   // NULL for good measure
   TestingSQLUtil::ExecuteSQLQuery("INSERT INTO foo VALUES (NULL);");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_changed;

--- a/test/sql/update_primary_index_sql_test.cpp
+++ b/test/sql/update_primary_index_sql_test.cpp
@@ -41,7 +41,7 @@ TEST_F(UpdatePrimaryIndexSQLTests, UpdatePrimaryIndexTest) {
 
   TestingSQLUtil::ShowTable(DEFAULT_DB_NAME, "test");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
@@ -51,7 +51,7 @@ TEST_F(UpdatePrimaryIndexSQLTests, UpdatePrimaryIndexTest) {
                                   tuple_descriptor, rows_affected,
                                   error_message);
   // Check the return value
-  EXPECT_EQ(result[6].second[0], '3');
+  EXPECT_EQ(result[6][0], '3');
 
   // Perform primary key update
   TestingSQLUtil::ExecuteSQLQuery("UPDATE test SET a=2 WHERE c=300", result,
@@ -63,7 +63,7 @@ TEST_F(UpdatePrimaryIndexSQLTests, UpdatePrimaryIndexTest) {
                                   tuple_descriptor, rows_affected,
                                   error_message);
   // Check the return value, it should not be changed
-  EXPECT_EQ(result[6].second[0], '3');
+  EXPECT_EQ(result[6][0], '3');
 
   // Perform another primary key update
   TestingSQLUtil::ExecuteSQLQuery("UPDATE test SET a=5 WHERE c=300", result,
@@ -75,7 +75,7 @@ TEST_F(UpdatePrimaryIndexSQLTests, UpdatePrimaryIndexTest) {
                                   tuple_descriptor, rows_affected,
                                   error_message);
   // Check the return value, it should not be changed
-  EXPECT_EQ(result[6].second[0], '5');
+  EXPECT_EQ(result[6][0], '5');
 
   // Perform normal update
   TestingSQLUtil::ExecuteSQLQuery("UPDATE test SET b=2000 WHERE c=200", result,
@@ -87,7 +87,7 @@ TEST_F(UpdatePrimaryIndexSQLTests, UpdatePrimaryIndexTest) {
                                   tuple_descriptor, rows_affected,
                                   error_message);
   // Check the return value
-  EXPECT_EQ(result[0].second[0], '2');
+  EXPECT_EQ(result[0][0], '2');
 
   // free the database just created
   txn = txn_manager.BeginTransaction();

--- a/test/sql/update_secondary_index_sql_test.cpp
+++ b/test/sql/update_secondary_index_sql_test.cpp
@@ -43,7 +43,7 @@ TEST_F(UpdateSecondaryIndexSQLTests, UpdateSecondaryIndexTest) {
 
   TestingSQLUtil::ShowTable(DEFAULT_DB_NAME, "test");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
@@ -53,7 +53,7 @@ TEST_F(UpdateSecondaryIndexSQLTests, UpdateSecondaryIndexTest) {
                                   tuple_descriptor, rows_affected,
                                   error_message);
   // Check the return value
-  EXPECT_EQ(result[6].second[0], '3');
+  EXPECT_EQ(result[6][0], '3');
 
   // Perform update
   TestingSQLUtil::ExecuteSQLQuery("UPDATE test SET b=1000 WHERE c=200", result,
@@ -65,7 +65,7 @@ TEST_F(UpdateSecondaryIndexSQLTests, UpdateSecondaryIndexTest) {
                                   tuple_descriptor, rows_affected,
                                   error_message);
   // Check the return value
-  EXPECT_EQ(result[0].second[0], '2');
+  EXPECT_EQ(result[0][0], '2');
 
   // free the database just created
   txn = txn_manager.BeginTransaction();

--- a/test/sql/update_sql_test.cpp
+++ b/test/sql/update_sql_test.cpp
@@ -56,7 +56,7 @@ TEST_F(UpdateSQLTests, SimpleUpdateSQLTest) {
   LOG_DEBUG("Updating a tuple...");
   LOG_DEBUG("Query: UPDATE test SET b = 2.0 WHERE a = 0");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
@@ -75,7 +75,7 @@ TEST_F(UpdateSQLTests, SimpleUpdateSQLTest) {
                                   tuple_descriptor, rows_affected,
                                   error_message);
   // Check the return value
-  EXPECT_EQ('2', result[0].second[0]);
+  EXPECT_EQ('2', result[0][0]);
 
   // Another update a tuple into table
   LOG_DEBUG("Another update a tuple...");
@@ -95,7 +95,7 @@ TEST_F(UpdateSQLTests, SimpleUpdateSQLTest) {
                                   tuple_descriptor, rows_affected,
                                   error_message);
   // Check the return value
-  EXPECT_EQ('2', result[0].second[0]);
+  EXPECT_EQ('2', result[0][0]);
 
   // free the database just created
   txn = txn_manager.BeginTransaction();
@@ -142,7 +142,7 @@ TEST_F(UpdateSQLTests, ComplexUpdateSQLTest) {
       "salary = 2 + salary + bonus*salary + 3*(salary+1)+0.1*bonus*salary"
       " WHERE e_id = 0");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;
@@ -231,7 +231,7 @@ TEST_F(UpdateSQLTests, UpdateSQLCastTest) {
   LOG_DEBUG("Updating a tuple...");
   LOG_DEBUG("Query: UPDATE employees SET salary = 2 WHERE e_id = 0");
 
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::vector<FieldInfo> tuple_descriptor;
   std::string error_message;
   int rows_affected;

--- a/test/statistics/stats_test.cpp
+++ b/test/statistics/stats_test.cpp
@@ -391,7 +391,7 @@ TEST_F(StatsTests, MultiThreadStatsTest) {
 //
 //  // Execute insert
 //  std::vector<type::Value> params;
-//  std::vector<StatementResult> result;
+//  std::vector<ResultValue> result;
 //  std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
 //  executor::ExecuteResult status = traffic_cop.ExecuteHelper(
 //      statement->GetPlanTree().get(), params, result, result_format);

--- a/test/statistics/testing_stats_util.cpp
+++ b/test/statistics/testing_stats_util.cpp
@@ -40,7 +40,7 @@ void TestingStatsUtil::ShowTable(std::string database_name,
   auto &traffic_cop = tcop::TrafficCop::GetInstance();
 
   std::vector<type::Value> params;
-  std::vector<StatementResult> result;
+  std::vector<ResultValue> result;
   std::string sql = "SELECT * FROM " + database_name + "." + table_name;
   statement.reset(new Statement("SELECT", sql));
   // using transaction to optimize


### PR DESCRIPTION
The second element of the StatementResult type was used to store the value of a column of a tuple in a result set. The first element of the pair was **never** used. So I have changed `std::pair<std::vector<unsigned char>, std::vector<unsigned char>>` to `std::vector<unsigned char>` and everything else seems to be working as expected. I have renamed the type to `ResultValue`.

We are copying it from `std::string` to `std::vector<unsigned char>` because it is later used by `SendDataRows` function of the `PostgresProtocolHandler`. I am not sure, but I am guessing there must be a way we can avoid this conversion and hence save the copy.

This PR changes 37 files, however only 7 are a part of the engine,  the rest are tests. 