### PR TITLE
Remove make_unique from bloom_filter_test.cpp

### DIFF
--- a/test/codegen/bloom_filter_test.cpp
+++ b/test/codegen/bloom_filter_test.cpp
@@ -336,7 +336,8 @@ void BloomFilterCodegenTest::CreateTable(std::string table_name, int tuple_size,
   }
   auto *catalog = catalog::Catalog::GetInstance();
   catalog->CreateTable(DEFAULT_DB_NAME, table_name,
-                       std::make_unique<catalog::Schema>(cols), txn);
+                       std::unique_ptr<catalog::Schema>(new catalog::Schema(cols)),
+                       txn);
 }
 
 // Insert a tuple to specific table


### PR DESCRIPTION
This PR fixes issue #964 
`std::make_unique` is a part of c++14 so using `std::unique_ptr` instead.