### PR TITLE
Add namespace check to validator script

### DIFF
--- a/script/validators/source_validator.py
+++ b/script/validators/source_validator.py
@@ -170,7 +170,10 @@ def check_namespaces(file_path):
 
 VALIDATORS = [
     check_common_patterns,
-    check_namespaces, 
+
+    # Uncomment the below validator once the namespace refactoring is done
+    #check_namespaces, 
+    
     # Uncomment the below validator when all files are clang-format-compliant
     #check_format
 ]


### PR DESCRIPTION
As requested in #491:

* checks if source and header files define namespaces consistent to the directory they live in
  * e.g. `/src/util/stringbox_util.cpp` has to define its functions in pelton::util
  * e.g. `/src/include/codegen/operator/order_by_translator.h` has to define its functions in pelton::codegen::operator
* removes early return on failures in the validator script to create a list with all violations instead of just the first violation

The current code base violates this rule many times, refactoring is necessary. The validator script is also ran in the pre-commit hook, but there only staged files are checked, so it shouldn't cause problems. 

**Edit:** I realized that the validator script also runs in travis. To be able to pass the checks on this PR, I disabled the namespace check. We can enable it once the refactoring is done. 