### PR TITLE
Add support for DATE type and TypeCast Transform

### DIFF
--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -55,19 +55,17 @@ struct ColumnDefinition {
 
   ColumnDefinition(DataType type) : type(type) {
     // Set varlen to TEXT_MAX_LENGTH if the data type is TEXT
-    if (type == DataType::TEXT)
-      varlen = type::PELOTON_TEXT_MAX_LEN;
+    if (type == DataType::TEXT) varlen = type::PELOTON_TEXT_MAX_LEN;
   }
 
-  ColumnDefinition(char* name, DataType type) : name(name), type(type) {
+  ColumnDefinition(char *name, DataType type) : name(name), type(type) {
     // Set varlen to TEXT_MAX_LENGTH if the data type is TEXT
-    if (type == DataType::TEXT)
-      varlen = type::PELOTON_TEXT_MAX_LEN;
+    if (type == DataType::TEXT) varlen = type::PELOTON_TEXT_MAX_LEN;
   }
 
   virtual ~ColumnDefinition() {}
 
-  static DataType StrToDataType(char* str) {
+  static DataType StrToDataType(char *str) {
     DataType data_type;
     // Transform column type
     if ((strcmp(str, "int") == 0) || (strcmp(str, "int4") == 0)) {
@@ -105,7 +103,7 @@ struct ColumnDefinition {
     return data_type;
   }
 
-  static type::TypeId StrToValueType(char* str) {
+  static type::TypeId StrToValueType(char *str) {
     type::TypeId value_type;
     // Transform column type
     if ((strcmp(str, "int") == 0) || (strcmp(str, "int4") == 0)) {
@@ -221,11 +219,11 @@ class CreateStatement : public TableRefStatement {
   CreateStatement(CreateType type)
       : TableRefStatement(StatementType::CREATE),
         type(type),
-        if_not_exists(false) {};
+        if_not_exists(false){};
 
   virtual ~CreateStatement() {}
 
-  virtual void Accept(SqlNodeVisitor* v) override { v->Visit(this); }
+  virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
   CreateType type;
   bool if_not_exists;

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -48,7 +48,9 @@ struct ColumnDefinition {
     TEXT,
 
     VARCHAR,
-    VARBINARY
+    VARBINARY,
+
+    DATE
   };
 
   ColumnDefinition(DataType type) : type(type) {
@@ -64,6 +66,77 @@ struct ColumnDefinition {
   }
 
   virtual ~ColumnDefinition() {}
+
+  static DataType StrToDataType(char* str) {
+    DataType data_type;
+    // Transform column type
+    if ((strcmp(str, "int") == 0) || (strcmp(str, "int4") == 0)) {
+      data_type = ColumnDefinition::DataType::INT;
+    } else if (strcmp(str, "varchar") == 0) {
+      data_type = ColumnDefinition::DataType::VARCHAR;
+    } else if (strcmp(str, "int8") == 0) {
+      data_type = ColumnDefinition::DataType::BIGINT;
+    } else if (strcmp(str, "int2") == 0) {
+      data_type = ColumnDefinition::DataType::SMALLINT;
+    } else if (strcmp(str, "timestamp") == 0) {
+      data_type = ColumnDefinition::DataType::TIMESTAMP;
+    } else if (strcmp(str, "bool") == 0) {
+      data_type = ColumnDefinition::DataType::BOOLEAN;
+    } else if (strcmp(str, "bpchar") == 0) {
+      data_type = ColumnDefinition::DataType::CHAR;
+    } else if ((strcmp(str, "double") == 0) || (strcmp(str, "float8") == 0)) {
+      data_type = ColumnDefinition::DataType::DOUBLE;
+    } else if ((strcmp(str, "real") == 0) || (strcmp(str, "float4") == 0)) {
+      data_type = ColumnDefinition::DataType::FLOAT;
+    } else if (strcmp(str, "numeric") == 0) {
+      data_type = ColumnDefinition::DataType::DECIMAL;
+    } else if (strcmp(str, "text") == 0) {
+      data_type = ColumnDefinition::DataType::TEXT;
+    } else if (strcmp(str, "tinyint") == 0) {
+      data_type = ColumnDefinition::DataType::TINYINT;
+    } else if (strcmp(str, "varbinary") == 0) {
+      data_type = ColumnDefinition::DataType::VARBINARY;
+    } else if (strcmp(str, "date") == 0) {
+      data_type = ColumnDefinition::DataType::DATE;
+    } else {
+      throw NotImplementedException(
+          StringUtil::Format("DataType %s not supported yet...\n", str));
+    }
+    return data_type;
+  }
+
+  static type::TypeId StrToValueType(char* str) {
+    type::TypeId value_type;
+    // Transform column type
+    if ((strcmp(str, "int") == 0) || (strcmp(str, "int4") == 0)) {
+      value_type = type::TypeId::INTEGER;
+    } else if ((strcmp(str, "varchar") == 0) || (strcmp(str, "bpchar") == 0) ||
+               (strcmp(str, "text") == 0)) {
+      value_type = type::TypeId::VARCHAR;
+    } else if (strcmp(str, "int8") == 0) {
+      value_type = type::TypeId::BIGINT;
+    } else if (strcmp(str, "int2") == 0) {
+      value_type = type::TypeId::SMALLINT;
+    } else if (strcmp(str, "timestamp") == 0) {
+      value_type = type::TypeId::TIMESTAMP;
+    } else if (strcmp(str, "bool") == 0) {
+      value_type = type::TypeId::BOOLEAN;
+    } else if ((strcmp(str, "double") == 0) || (strcmp(str, "float8") == 0) ||
+               (strcmp(str, "real") == 0) || (strcmp(str, "float4") == 0) ||
+               (strcmp(str, "numeric") == 0)) {
+      value_type = type::TypeId::DECIMAL;
+    } else if (strcmp(str, "tinyint") == 0) {
+      value_type = type::TypeId::TINYINT;
+    } else if (strcmp(str, "varbinary") == 0) {
+      value_type = type::TypeId::VARBINARY;
+    } else if (strcmp(str, "date") == 0) {
+      value_type = type::TypeId::DATE;
+    } else {
+      throw NotImplementedException(
+          StringUtil::Format("DataType %s not supported yet...\n", str));
+    }
+    return value_type;
+  }
 
   static type::TypeId GetValueType(DataType type) {
     switch (type) {
@@ -98,6 +171,9 @@ struct ColumnDefinition {
 
       case DataType::VARBINARY:
         return type::TypeId::VARBINARY;
+
+      case DataType::DATE:
+        return type::TypeId::DATE;
 
       case DataType::INVALID:
       case DataType::PRIMARY:

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -44,13 +44,12 @@ struct ColumnDefinition {
     DECIMAL,
     BOOLEAN,
     ADDRESS,
+    DATE,
     TIMESTAMP,
     TEXT,
 
     VARCHAR,
-    VARBINARY,
-
-    DATE
+    VARBINARY
   };
 
   ColumnDefinition(DataType type) : type(type) {

--- a/src/include/parser/parsenodes.h
+++ b/src/include/parser/parsenodes.h
@@ -449,6 +449,14 @@ typedef struct A_Const {
   int location; /* token location, or -1 if unknown */
 } A_Const;
 
+typedef struct TypeCast
+{
+  NodeTag   type;
+  Node     *arg;      /* the expression being casted */
+  TypeName   *typeName;   /* the target type */
+  int     location;   /* token location, or -1 if unknown */
+} TypeCast;
+
 typedef struct WindowDef {
   NodeTag type;
   char *name;            /* window's own name */

--- a/src/include/parser/parsenodes.h
+++ b/src/include/parser/parsenodes.h
@@ -34,9 +34,7 @@ typedef enum InhOption {
 
 typedef enum BoolExprType { AND_EXPR, OR_EXPR, NOT_EXPR } BoolExprType;
 
-typedef struct Expr {
-  NodeTag type;
-} Expr;
+typedef struct Expr { NodeTag type; } Expr;
 
 typedef struct BoolExpr {
   Expr xpr;
@@ -449,12 +447,11 @@ typedef struct A_Const {
   int location; /* token location, or -1 if unknown */
 } A_Const;
 
-typedef struct TypeCast
-{
-  NodeTag   type;
-  Node     *arg;      /* the expression being casted */
-  TypeName   *typeName;   /* the target type */
-  int     location;   /* token location, or -1 if unknown */
+typedef struct TypeCast {
+  NodeTag type;
+  Node *arg;          /* the expression being casted */
+  TypeName *typeName; /* the target type */
+  int location;       /* token location, or -1 if unknown */
 } TypeCast;
 
 typedef struct WindowDef {

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -145,6 +145,9 @@ class PostgresParser {
   // transform helper for constant values
   static expression::AbstractExpression* ConstTransform(A_Const* root);
 
+  // transform helper for cast expressions
+  static expression::AbstractExpression* TypeCastTransform(TypeCast* root);
+
   // transform helper for function calls
   static expression::AbstractExpression* FuncCallTransform(FuncCall* root);
 

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -44,20 +44,20 @@ class PostgresParser {
   ~PostgresParser();
 
   // Parse a given query
-  static parser::SQLStatementList* ParseSQLString(const char* sql);
-  static parser::SQLStatementList* ParseSQLString(const std::string& sql);
+  static parser::SQLStatementList *ParseSQLString(const char *sql);
+  static parser::SQLStatementList *ParseSQLString(const std::string &sql);
 
-  static PostgresParser& GetInstance();
+  static PostgresParser &GetInstance();
 
   std::unique_ptr<parser::SQLStatementList> BuildParseTree(
-      const std::string& query_string);
+      const std::string &query_string);
 
  private:
   //===--------------------------------------------------------------------===//
   // Helper Functions
   //===--------------------------------------------------------------------===//
 
-  static FKConstrActionType CharToActionType(char& type) {
+  static FKConstrActionType CharToActionType(char &type) {
     switch (type) {
       case 'a':
         return FKConstrActionType::NOACTION;
@@ -74,7 +74,7 @@ class PostgresParser {
     }
   }
 
-  static FKConstrMatchType CharToMatchType(char& type) {
+  static FKConstrMatchType CharToMatchType(char &type) {
     switch (type) {
       case 'f':
         return FKConstrMatchType::FULL;
@@ -87,7 +87,7 @@ class PostgresParser {
     }
   }
 
-  static bool IsAggregateFunction(std::string& fun_name) {
+  static bool IsAggregateFunction(std::string &fun_name) {
     if (fun_name == "min" || fun_name == "max" || fun_name == "count" ||
         fun_name == "avg" || fun_name == "sum")
       return true;
@@ -99,151 +99,151 @@ class PostgresParser {
   //===--------------------------------------------------------------------===//
 
   // transform helper for internal parse tree
-  static parser::SQLStatementList* PgQueryInternalParsetreeTransform(
+  static parser::SQLStatementList *PgQueryInternalParsetreeTransform(
       PgQueryInternalParsetreeAndError stmt);
 
   // transform helper for Alias parsenodes
-  static std::string AliasTransform(Alias* root);
+  static std::string AliasTransform(Alias *root);
 
   // transform helper for RangeVar parsenodes
-  static parser::TableRef* RangeVarTransform(RangeVar* root);
+  static parser::TableRef *RangeVarTransform(RangeVar *root);
 
   // transform helper for RangeSubselect parsenodes
-  static parser::TableRef* RangeSubselectTransform(RangeSubselect* root);
+  static parser::TableRef *RangeSubselectTransform(RangeSubselect *root);
 
   // transform helper for JoinExpr parsenodes
-  static parser::JoinDefinition* JoinTransform(JoinExpr* root);
+  static parser::JoinDefinition *JoinTransform(JoinExpr *root);
 
   // transform helper for from clauses
-  static parser::TableRef* FromTransform(SelectStmt* root);
+  static parser::TableRef *FromTransform(SelectStmt *root);
 
   // transform helper for select targets
-  static std::vector<std::unique_ptr<expression::AbstractExpression>>*
-  TargetTransform(List* root);
+  static std::vector<std::unique_ptr<expression::AbstractExpression>> *
+  TargetTransform(List *root);
 
   // transform helper for all expr nodes
-  static expression::AbstractExpression* ExprTransform(Node* root);
+  static expression::AbstractExpression *ExprTransform(Node *root);
 
   // transform helper for A_Expr nodes
-  static expression::AbstractExpression* AExprTransform(A_Expr* root);
+  static expression::AbstractExpression *AExprTransform(A_Expr *root);
 
   // transform helper for BoolExpr nodes
-  static expression::AbstractExpression* BoolExprTransform(BoolExpr* root);
+  static expression::AbstractExpression *BoolExprTransform(BoolExpr *root);
 
   // transform helper for NullTest nodes
-  static expression::AbstractExpression* NullTestTransform(NullTest* root);
+  static expression::AbstractExpression *NullTestTransform(NullTest *root);
 
   // transform helper for where clauses
-  static expression::AbstractExpression* WhereTransform(Node* root);
+  static expression::AbstractExpression *WhereTransform(Node *root);
 
   // transform helper for when clauses
-  static expression::AbstractExpression* WhenTransform(Node* root);
+  static expression::AbstractExpression *WhenTransform(Node *root);
 
   // transform helper for column refs
-  static expression::AbstractExpression* ColumnRefTransform(ColumnRef* root);
+  static expression::AbstractExpression *ColumnRefTransform(ColumnRef *root);
 
   // transform helper for constant values
-  static expression::AbstractExpression* ConstTransform(A_Const* root);
+  static expression::AbstractExpression *ConstTransform(A_Const *root);
 
   // transform helper for cast expressions
-  static expression::AbstractExpression* TypeCastTransform(TypeCast* root);
+  static expression::AbstractExpression *TypeCastTransform(TypeCast *root);
 
   // transform helper for function calls
-  static expression::AbstractExpression* FuncCallTransform(FuncCall* root);
+  static expression::AbstractExpression *FuncCallTransform(FuncCall *root);
 
   // transform helper for parameter refs
-  static expression::AbstractExpression* ParamRefTransform(ParamRef* root);
+  static expression::AbstractExpression *ParamRefTransform(ParamRef *root);
 
   // transform helper for expressions
-  static expression::AbstractExpression* ExprTransform(Expr* root);
+  static expression::AbstractExpression *ExprTransform(Expr *root);
 
   // transform helper for case expressions
-  static expression::AbstractExpression* CaseExprTransform(CaseExpr* root);
+  static expression::AbstractExpression *CaseExprTransform(CaseExpr *root);
 
   // transform helper for group by clauses
-  static parser::GroupByDescription* GroupByTransform(List* root, Node* having);
+  static parser::GroupByDescription *GroupByTransform(List *root, Node *having);
 
   // transform helper for order by clauses
-  static parser::OrderDescription* OrderByTransform(List* order);
+  static parser::OrderDescription *OrderByTransform(List *order);
 
   // transform helper for table column definitions
-  static parser::ColumnDefinition* ColumnDefTransform(ColumnDef* root);
+  static parser::ColumnDefinition *ColumnDefTransform(ColumnDef *root);
 
   // transform helper for create statements
-  static parser::SQLStatement* CreateTransform(CreateStmt* root);
+  static parser::SQLStatement *CreateTransform(CreateStmt *root);
 
   // transform helper for create index statements
-  static parser::SQLStatement* CreateIndexTransform(IndexStmt* root);
+  static parser::SQLStatement *CreateIndexTransform(IndexStmt *root);
 
   // transform helper for create trigger statements
-  static parser::SQLStatement* CreateTriggerTransform(CreateTrigStmt* root);
+  static parser::SQLStatement *CreateTriggerTransform(CreateTrigStmt *root);
 
   // transform helper for create db statement
-  static parser::SQLStatement* CreateDbTransform(CreatedbStmt* root);
+  static parser::SQLStatement *CreateDbTransform(CreatedbStmt *root);
 
   // transform helper for column name (for insert statement)
-  static std::vector<std::string>* ColumnNameTransform(List* root);
+  static std::vector<std::string> *ColumnNameTransform(List *root);
 
   // transform helper for ListsTransform (insert multiple rows)
   static std::vector<
-      std::vector<std::unique_ptr<expression::AbstractExpression>>>*
-  ValueListsTransform(List* root);
+      std::vector<std::unique_ptr<expression::AbstractExpression>>> *
+  ValueListsTransform(List *root);
 
   // transform helper for insert statements
-  static parser::SQLStatement* InsertTransform(InsertStmt* root);
+  static parser::SQLStatement *InsertTransform(InsertStmt *root);
 
   // transform helper for select statements
-  static parser::SQLStatement* SelectTransform(SelectStmt* root);
+  static parser::SQLStatement *SelectTransform(SelectStmt *root);
 
   // transform helper for delete statements
-  static parser::SQLStatement* DeleteTransform(DeleteStmt* root);
+  static parser::SQLStatement *DeleteTransform(DeleteStmt *root);
 
   // transform helper for single node in parse list
-  static parser::SQLStatement* NodeTransform(Node* stmt);
+  static parser::SQLStatement *NodeTransform(Node *stmt);
 
   // transform helper for the whole parse list
-  static parser::SQLStatementList* ListTransform(List* root);
+  static parser::SQLStatementList *ListTransform(List *root);
 
   // transform helper for update statement
-  static parser::UpdateStatement* UpdateTransform(UpdateStmt* update_stmt);
+  static parser::UpdateStatement *UpdateTransform(UpdateStmt *update_stmt);
 
   // transform helper for update statement
-  static std::vector<std::unique_ptr<parser::UpdateClause>>*
-  UpdateTargetTransform(List* root);
+  static std::vector<std::unique_ptr<parser::UpdateClause>> *
+  UpdateTargetTransform(List *root);
 
   // transform helper for drop statement
-  static parser::DropStatement* DropTransform(DropStmt* root);
+  static parser::DropStatement *DropTransform(DropStmt *root);
 
   // transform helper for drop table statement
-  static parser::DropStatement* DropTableTransform(DropStmt* root);
+  static parser::DropStatement *DropTableTransform(DropStmt *root);
 
   // transform helper for drop trigger statement
-  static parser::DropStatement* DropTriggerTransform(DropStmt* root);
+  static parser::DropStatement *DropTriggerTransform(DropStmt *root);
 
   // transform helper for truncate statement
-  static parser::DeleteStatement* TruncateTransform(TruncateStmt* root);
+  static parser::DeleteStatement *TruncateTransform(TruncateStmt *root);
 
   // transform helper for transaction statement
-  static parser::TransactionStatement* TransactionTransform(
-      TransactionStmt* root);
+  static parser::TransactionStatement *TransactionTransform(
+      TransactionStmt *root);
 
   // transform helper for execute statement
-  static parser::ExecuteStatement* ExecuteTransform(ExecuteStmt* root);
+  static parser::ExecuteStatement *ExecuteTransform(ExecuteStmt *root);
 
   // transform helper for constant values
-  static expression::AbstractExpression* ValueTransform(value val);
+  static expression::AbstractExpression *ValueTransform(value val);
 
   static std::vector<std::unique_ptr<expression::AbstractExpression>>
-  ParamListTransform(List* root);
+  ParamListTransform(List *root);
 
   // transform helper for execute statement
-  static parser::PrepareStatement* PrepareTransform(PrepareStmt* root);
+  static parser::PrepareStatement *PrepareTransform(PrepareStmt *root);
 
   // transform helper for execute statement
-  static parser::CopyStatement* CopyTransform(CopyStmt* root);
+  static parser::CopyStatement *CopyTransform(CopyStmt *root);
 
   // transform helper for analyze statement
-  static parser::AnalyzeStatement* VacuumTransform(VacuumStmt* root);
+  static parser::AnalyzeStatement *VacuumTransform(VacuumStmt *root);
 };
 
 }  // namespace parser

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -515,6 +515,28 @@ class ValueFactory {
                     " is not coercable to TIMESTAMP.");
   }
 
+  static Value CastAsDate(const Value &value) {
+    if (Type::GetInstance(TypeId::DATE)
+            ->IsCoercableFrom(value.GetTypeId())) {
+      if (value.IsNull())
+        return ValueFactory::GetDateValue(PELOTON_DATE_NULL);
+      switch (value.GetTypeId()) {
+        case TypeId::DATE:
+          return ValueFactory::GetDateValue(value.GetAs<uint32_t>());
+        case TypeId::VARCHAR: {
+          std::string str = value.ToString();
+          uint32_t res = 0;
+          // TODO: convert string according to certain formate to DATE type
+          return ValueFactory::GetDateValue(res);
+        }
+        default:
+          break;
+      }
+    }
+    throw Exception(Type::GetInstance(value.GetTypeId())->ToString() +
+                    " is not coercable to DATE.");
+  }
+
   static inline Value CastAsBoolean(const Value &value) {
     if (Type::GetInstance(TypeId::BOOLEAN)
             ->IsCoercableFrom(value.GetTypeId())) {

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -43,7 +43,7 @@ PostgresParser::~PostgresParser() {}
 
 // This function takes a Postgres Alias parsenode and extracts the name of
 // the alias and return a duplicate of the string.
-std::string PostgresParser::AliasTransform(Alias* root) {
+std::string PostgresParser::AliasTransform(Alias *root) {
   if (root == nullptr) {
     return "";
   }
@@ -53,8 +53,8 @@ std::string PostgresParser::AliasTransform(Alias* root) {
 // This function takes a Postgres JoinExpr parsenode and transfers it to a
 // Peloton JoinDefinition object. Depends on AExprTransform and
 // BoolExprTransform.
-parser::JoinDefinition* PostgresParser::JoinTransform(JoinExpr* root) {
-  parser::JoinDefinition* result = nullptr;
+parser::JoinDefinition *PostgresParser::JoinTransform(JoinExpr *root) {
+  parser::JoinDefinition *result = nullptr;
 
   // Natrual join is not supported
   if ((root->jointype > 4) || (root->isNatural)) {
@@ -93,14 +93,14 @@ parser::JoinDefinition* PostgresParser::JoinTransform(JoinExpr* root) {
   // Check the type of left arg and right arg before transform
   if (root->larg->type == T_RangeVar) {
     result->left.reset(
-        RangeVarTransform(reinterpret_cast<RangeVar*>(root->larg)));
+        RangeVarTransform(reinterpret_cast<RangeVar *>(root->larg)));
   } else if (root->larg->type == T_RangeSubselect) {
-    result->left.reset(
-        RangeSubselectTransform(reinterpret_cast<RangeSubselect*>(root->larg)));
+    result->left.reset(RangeSubselectTransform(
+        reinterpret_cast<RangeSubselect *>(root->larg)));
   } else if (root->larg->type == T_JoinExpr) {
-    TableRef* l_table_ref = new TableRef(TableReferenceType::JOIN);
+    TableRef *l_table_ref = new TableRef(TableReferenceType::JOIN);
     l_table_ref->join.reset(
-        JoinTransform(reinterpret_cast<JoinExpr*>(root->larg)));
+        JoinTransform(reinterpret_cast<JoinExpr *>(root->larg)));
     result->left.reset(l_table_ref);
   } else {
     delete result;
@@ -109,14 +109,14 @@ parser::JoinDefinition* PostgresParser::JoinTransform(JoinExpr* root) {
   }
   if (root->rarg->type == T_RangeVar) {
     result->right.reset(
-        RangeVarTransform(reinterpret_cast<RangeVar*>(root->rarg)));
+        RangeVarTransform(reinterpret_cast<RangeVar *>(root->rarg)));
   } else if (root->rarg->type == T_RangeSubselect) {
-    result->right.reset(
-        RangeSubselectTransform(reinterpret_cast<RangeSubselect*>(root->rarg)));
+    result->right.reset(RangeSubselectTransform(
+        reinterpret_cast<RangeSubselect *>(root->rarg)));
   } else if (root->rarg->type == T_JoinExpr) {
-    TableRef* r_table_ref = new TableRef(TableReferenceType::JOIN);
+    TableRef *r_table_ref = new TableRef(TableReferenceType::JOIN);
     r_table_ref->join.reset(
-        JoinTransform(reinterpret_cast<JoinExpr*>(root->rarg)));
+        JoinTransform(reinterpret_cast<JoinExpr *>(root->rarg)));
     result->right.reset(r_table_ref);
   } else {
     delete result;
@@ -129,12 +129,12 @@ parser::JoinDefinition* PostgresParser::JoinTransform(JoinExpr* root) {
   switch (root->quals->type) {
     case T_A_Expr: {
       result->condition.reset(
-          AExprTransform(reinterpret_cast<A_Expr*>(root->quals)));
+          AExprTransform(reinterpret_cast<A_Expr *>(root->quals)));
       break;
     }
     case T_BoolExpr: {
       result->condition.reset(
-          BoolExprTransform(reinterpret_cast<BoolExpr*>(root->quals)));
+          BoolExprTransform(reinterpret_cast<BoolExpr *>(root->quals)));
       break;
     }
     default: {
@@ -148,8 +148,8 @@ parser::JoinDefinition* PostgresParser::JoinTransform(JoinExpr* root) {
 
 // This function takes in a single Postgres RangeVar parsenode and transfer
 // it into a Peloton TableRef object.
-parser::TableRef* PostgresParser::RangeVarTransform(RangeVar* root) {
-  parser::TableRef* result =
+parser::TableRef *PostgresParser::RangeVarTransform(RangeVar *root) {
+  parser::TableRef *result =
       new parser::TableRef(StringToTableReferenceType("name"));
   result->table_info_.reset(new parser::TableInfo());
 
@@ -173,11 +173,11 @@ parser::TableRef* PostgresParser::RangeVarTransform(RangeVar* root) {
 
 // This function takes in a single Postgres RangeVar parsenode and transfer
 // it into a Peloton TableRef object.
-parser::TableRef* PostgresParser::RangeSubselectTransform(
-    RangeSubselect* root) {
+parser::TableRef *PostgresParser::RangeSubselectTransform(
+    RangeSubselect *root) {
   auto result = new parser::TableRef(StringToTableReferenceType("select"));
-  result->select = reinterpret_cast<parser::SelectStatement*>(
-      SelectTransform(reinterpret_cast<SelectStmt*>(root->subquery)));
+  result->select = reinterpret_cast<parser::SelectStatement *>(
+      SelectTransform(reinterpret_cast<SelectStmt *>(root->subquery)));
   result->alias = AliasTransform(root->alias);
   if (result->select == nullptr) {
     delete result;
@@ -188,11 +188,11 @@ parser::TableRef* PostgresParser::RangeSubselectTransform(
 }
 
 // Get in a target list and check if is with variables
-bool IsTargetListWithVariable(List* target_list) {
+bool IsTargetListWithVariable(List *target_list) {
   // The only valid situation of a null from list is that all targets are
   // constant
   for (auto cell = target_list->head; cell != nullptr; cell = cell->next) {
-    ResTarget* target = reinterpret_cast<ResTarget*>(cell->data.ptr_value);
+    ResTarget *target = reinterpret_cast<ResTarget *>(cell->data.ptr_value);
     LOG_TRACE("Type: %d", target->type);
 
     // Bypass the target nodes with type:
@@ -214,31 +214,31 @@ bool IsTargetListWithVariable(List* target_list) {
 // This fucntion takes in fromClause of a Postgres SelectStmt and transfers
 // into a Peloton TableRef object.
 // TODO: support select from multiple sources, nested queries, various joins
-parser::TableRef* PostgresParser::FromTransform(SelectStmt* select_root) {
+parser::TableRef *PostgresParser::FromTransform(SelectStmt *select_root) {
   // now support select from only one sources
 
-  List* root = select_root->fromClause;
+  List *root = select_root->fromClause;
   /* Statement like 'SELECT *;' cannot detect by postgres parser and would lead
    * to
    * a null list of from clause*/
   if (root == nullptr) return nullptr;
 
-  parser::TableRef* result = nullptr;
-  Node* node;
+  parser::TableRef *result = nullptr;
+  Node *node;
   if (root->length > 1) {
     result = new TableRef(StringToTableReferenceType("CROSS_PRODUCT"));
     for (auto cell = root->head; cell != nullptr; cell = cell->next) {
-      node = reinterpret_cast<Node*>(cell->data.ptr_value);
+      node = reinterpret_cast<Node *>(cell->data.ptr_value);
       switch (node->type) {
         case T_RangeVar: {
           result->list.push_back(std::unique_ptr<TableRef>(
-              RangeVarTransform(reinterpret_cast<RangeVar*>(node))));
+              RangeVarTransform(reinterpret_cast<RangeVar *>(node))));
           break;
         }
         case T_RangeSubselect: {
           result->list.push_back(
               std::unique_ptr<TableRef>(RangeSubselectTransform(
-                  reinterpret_cast<RangeSubselect*>(node))));
+                  reinterpret_cast<RangeSubselect *>(node))));
           break;
         }
         default: {
@@ -251,15 +251,15 @@ parser::TableRef* PostgresParser::FromTransform(SelectStmt* select_root) {
     return result;
   }
 
-  node = reinterpret_cast<Node*>(root->head->data.ptr_value);
+  node = reinterpret_cast<Node *>(root->head->data.ptr_value);
   switch (node->type) {
     case T_RangeVar: {
-      result = RangeVarTransform(reinterpret_cast<RangeVar*>(node));
+      result = RangeVarTransform(reinterpret_cast<RangeVar *>(node));
       break;
     }
     case T_JoinExpr: {
       result = new parser::TableRef(StringToTableReferenceType("join"));
-      result->join.reset(JoinTransform(reinterpret_cast<JoinExpr*>(node)));
+      result->join.reset(JoinTransform(reinterpret_cast<JoinExpr *>(node)));
       if (result->join == nullptr) {
         delete result;
         result = nullptr;
@@ -267,7 +267,8 @@ parser::TableRef* PostgresParser::FromTransform(SelectStmt* select_root) {
       break;
     }
     case T_RangeSubselect: {
-      result = RangeSubselectTransform(reinterpret_cast<RangeSubselect*>(node));
+      result =
+          RangeSubselectTransform(reinterpret_cast<RangeSubselect *>(node));
       break;
     }
     default: {
@@ -281,22 +282,22 @@ parser::TableRef* PostgresParser::FromTransform(SelectStmt* select_root) {
 
 // This function takes in a Postgres ColumnRef parsenode and transfer into
 // a Peloton tuple value expression.
-expression::AbstractExpression* PostgresParser::ColumnRefTransform(
-    ColumnRef* root) {
-  expression::AbstractExpression* result = nullptr;
-  List* fields = root->fields;
-  switch ((reinterpret_cast<Node*>(fields->head->data.ptr_value))->type) {
+expression::AbstractExpression *PostgresParser::ColumnRefTransform(
+    ColumnRef *root) {
+  expression::AbstractExpression *result = nullptr;
+  List *fields = root->fields;
+  switch ((reinterpret_cast<Node *>(fields->head->data.ptr_value))->type) {
     case T_String: {
       if (fields->length == 1) {
         result = new expression::TupleValueExpression(std::string(
-            (reinterpret_cast<value*>(fields->head->data.ptr_value))->val.str));
+            (reinterpret_cast<value *>(fields->head->data.ptr_value))
+                ->val.str));
       } else {
         result = new expression::TupleValueExpression(
-            std::string(
-                (reinterpret_cast<value*>(fields->head->next->data.ptr_value))
-                    ->val.str),
-            std::string((reinterpret_cast<value*>(fields->head->data.ptr_value))
-                            ->val.str));
+            std::string((reinterpret_cast<value *>(
+                             fields->head->next->data.ptr_value))->val.str),
+            std::string((reinterpret_cast<value *>(
+                             fields->head->data.ptr_value))->val.str));
       }
       break;
     }
@@ -307,7 +308,7 @@ expression::AbstractExpression* PostgresParser::ColumnRefTransform(
     default: {
       throw NotImplementedException(StringUtil::Format(
           "Type %d of ColumnRef not handled yet...\n",
-          (reinterpret_cast<Node*>(fields->head->data.ptr_value))->type));
+          (reinterpret_cast<Node *>(fields->head->data.ptr_value))->type));
     }
   }
 
@@ -316,36 +317,36 @@ expression::AbstractExpression* PostgresParser::ColumnRefTransform(
 
 // This function takes in a Postgres ParamRef parsenode and transfer into
 // a Peloton tuple value expression.
-expression::AbstractExpression* PostgresParser::ParamRefTransform(
-    ParamRef* root) {
+expression::AbstractExpression *PostgresParser::ParamRefTransform(
+    ParamRef *root) {
   //  LOG_INFO("Parameter number: %d", root->number);
-  expression::AbstractExpression* res =
+  expression::AbstractExpression *res =
       new expression::ParameterValueExpression(root->number - 1);
   return res;
 }
 
 // This function takes in the Case Expression of a Postgres SelectStmt
 // parsenode and transfers it into Peloton AbstractExpression.
-expression::AbstractExpression* PostgresParser::CaseExprTransform(
-    CaseExpr* root) {
+expression::AbstractExpression *PostgresParser::CaseExprTransform(
+    CaseExpr *root) {
   if (root == nullptr) {
     return nullptr;
   }
 
   // Transform the CASE argument
-  auto arg_expr = ExprTransform(reinterpret_cast<Node*>(root->arg));
+  auto arg_expr = ExprTransform(reinterpret_cast<Node *>(root->arg));
 
   // Transform the WHEN conditions
   std::vector<expression::CaseExpression::WhenClause> clauses;
   for (auto cell = root->args->head; cell != nullptr; cell = cell->next) {
-    CaseWhen* w = reinterpret_cast<CaseWhen*>(cell->data.ptr_value);
+    CaseWhen *w = reinterpret_cast<CaseWhen *>(cell->data.ptr_value);
 
     // When condition
-    auto when_expr = ExprTransform(reinterpret_cast<Node*>(w->expr));
+    auto when_expr = ExprTransform(reinterpret_cast<Node *>(w->expr));
     ;
 
     // Result
-    auto result_expr = ExprTransform(reinterpret_cast<Node*>(w->result));
+    auto result_expr = ExprTransform(reinterpret_cast<Node *>(w->result));
 
     // Build When Clause and add it to the list
     clauses.push_back(expression::CaseExpression::WhenClause(
@@ -354,7 +355,8 @@ expression::AbstractExpression* PostgresParser::CaseExprTransform(
   }
 
   // Transform the default result
-  auto defresult_expr = ExprTransform(reinterpret_cast<Node*>(root->defresult));
+  auto defresult_expr =
+      ExprTransform(reinterpret_cast<Node *>(root->defresult));
 
   // Build Case Expression
   return arg_expr != nullptr
@@ -369,15 +371,15 @@ expression::AbstractExpression* PostgresParser::CaseExprTransform(
 
 // This function takes in groupClause and havingClause of a Postgres SelectStmt
 // transfers into a Peloton GroupByDescription object.
-parser::GroupByDescription* PostgresParser::GroupByTransform(List* group,
-                                                             Node* having) {
+parser::GroupByDescription *PostgresParser::GroupByTransform(List *group,
+                                                             Node *having) {
   if (group == nullptr) {
     return nullptr;
   }
 
-  parser::GroupByDescription* result = new parser::GroupByDescription();
+  parser::GroupByDescription *result = new parser::GroupByDescription();
   for (auto cell = group->head; cell != nullptr; cell = cell->next) {
-    Node* temp = reinterpret_cast<Node*>(cell->data.ptr_value);
+    Node *temp = reinterpret_cast<Node *>(cell->data.ptr_value);
     try {
       result->columns.push_back(
           std::unique_ptr<expression::AbstractExpression>(ExprTransform(temp)));
@@ -405,25 +407,25 @@ parser::GroupByDescription* PostgresParser::GroupByTransform(List* group,
 // parsenode and transfers it into a list of Peloton OrderDescription objects
 // std::vector<parser::OrderDescription>* PostgresParser::OrderByTransform(List*
 // order) {
-parser::OrderDescription* PostgresParser::OrderByTransform(List* order) {
+parser::OrderDescription *PostgresParser::OrderByTransform(List *order) {
   if (order == nullptr) {
     return nullptr;
   }
 
-  parser::OrderDescription* result = new OrderDescription();
+  parser::OrderDescription *result = new OrderDescription();
   std::vector<OrderType> types = std::vector<OrderType>();
   std::vector<std::unique_ptr<expression::AbstractExpression>> exprs =
       std::vector<std::unique_ptr<expression::AbstractExpression>>();
 
   for (auto cell = order->head; cell != nullptr; cell = cell->next) {
-    Node* temp = reinterpret_cast<Node*>(cell->data.ptr_value);
+    Node *temp = reinterpret_cast<Node *>(cell->data.ptr_value);
     if (temp->type == T_SortBy) {
-      SortBy* sort = reinterpret_cast<SortBy*>(temp);
-      Node* target = sort->node;
+      SortBy *sort = reinterpret_cast<SortBy *>(temp);
+      Node *target = sort->node;
       if (sort->sortby_dir == SORTBY_ASC || sort->sortby_dir == SORTBY_DEFAULT)
         types.push_back(parser::kOrderAsc);
       if (sort->sortby_dir == SORTBY_DESC) types.push_back(parser::kOrderDesc);
-      expression::AbstractExpression* expr = nullptr;
+      expression::AbstractExpression *expr = nullptr;
       try {
         expr = ExprTransform(target);
       } catch (NotImplementedException e) {
@@ -442,8 +444,8 @@ parser::OrderDescription* PostgresParser::OrderByTransform(List* order) {
 }
 // This function takes in a Posgres value parsenode and transfers it into
 // a Peloton constant value expression.
-expression::AbstractExpression* PostgresParser::ValueTransform(value val) {
-  expression::AbstractExpression* result = nullptr;
+expression::AbstractExpression *PostgresParser::ValueTransform(value val) {
+  expression::AbstractExpression *result = nullptr;
   switch (val.type) {
     case T_Integer:
       result = new expression::ConstantValueExpression(
@@ -471,18 +473,19 @@ expression::AbstractExpression* PostgresParser::ValueTransform(value val) {
 
 // This function takes in a Posgres A_Const parsenode and transfers it into
 // a Peloton constant value expression.
-expression::AbstractExpression* PostgresParser::ConstTransform(A_Const* root) {
+expression::AbstractExpression *PostgresParser::ConstTransform(A_Const *root) {
   return ValueTransform(root->val);
 }
 
-expression::AbstractExpression* PostgresParser::TypeCastTransform(TypeCast* root) {
-  expression::AbstractExpression* result = nullptr;
+expression::AbstractExpression *PostgresParser::TypeCastTransform(
+    TypeCast *root) {
+  expression::AbstractExpression *result = nullptr;
   type::Value source_value;
   switch (root->arg->type) {
     case T_A_Const: {
       std::unique_ptr<expression::ConstantValueExpression> source_expr_ptr(
-        reinterpret_cast<expression::ConstantValueExpression*>(
-          ConstTransform(reinterpret_cast<A_Const*>(root->arg))));
+          reinterpret_cast<expression::ConstantValueExpression *>(
+              ConstTransform(reinterpret_cast<A_Const *>(root->arg))));
       source_value = source_expr_ptr.get()->GetValue();
       break;
     }
@@ -492,33 +495,31 @@ expression::AbstractExpression* PostgresParser::TypeCastTransform(TypeCast* root
           root->arg->type));
   }
 
-  TypeName* type_name = root->typeName;
-  char* name = (reinterpret_cast<value*>(type_name->names->tail->data.ptr_value)
-                    ->val.str);
-  LOG_INFO("name is: %s", name);
+  TypeName *type_name = root->typeName;
+  char *name = (reinterpret_cast<value *>(
+                    type_name->names->tail->data.ptr_value)->val.str);
   type::VarlenType temp(StringToTypeId("INVALID"));
   result = new expression::ConstantValueExpression(
-                temp.CastAs(source_value,
-                            ColumnDefinition::StrToValueType(name)));
+      temp.CastAs(source_value, ColumnDefinition::StrToValueType(name)));
   return result;
 }
 
-expression::AbstractExpression* PostgresParser::FuncCallTransform(
-    FuncCall* root) {
-  expression::AbstractExpression* result = nullptr;
+expression::AbstractExpression *PostgresParser::FuncCallTransform(
+    FuncCall *root) {
+  expression::AbstractExpression *result = nullptr;
   std::string fun_name = StringUtil::Lower(
-      (reinterpret_cast<value*>(root->funcname->head->data.ptr_value))
+      (reinterpret_cast<value *>(root->funcname->head->data.ptr_value))
           ->val.str);
 
   if (!IsAggregateFunction(fun_name)) {
     // Normal functions (i.e. built-in functions or UDFs)
-    fun_name = (reinterpret_cast<value*>(root->funcname->tail->data.ptr_value))
+    fun_name = (reinterpret_cast<value *>(root->funcname->tail->data.ptr_value))
                    ->val.str;
-    std::vector<expression::AbstractExpression*> children;
+    std::vector<expression::AbstractExpression *> children;
     if (root->args != nullptr) {
       for (auto cell = root->args->head; cell != nullptr; cell = cell->next) {
-        auto expr_node = (Node*)cell->data.ptr_value;
-        expression::AbstractExpression* child_expr = nullptr;
+        auto expr_node = (Node *)cell->data.ptr_value;
+        expression::AbstractExpression *child_expr = nullptr;
         try {
           child_expr = ExprTransform(expr_node);
         } catch (NotImplementedException e) {
@@ -533,15 +534,15 @@ expression::AbstractExpression* PostgresParser::FuncCallTransform(
     // Aggregate function
     auto agg_fun_type = StringToExpressionType("AGGREGATE_" + fun_name);
     if (root->agg_star) {
-      expression::AbstractExpression* children =
+      expression::AbstractExpression *children =
           new expression::StarExpression();
       result =
           new expression::AggregateExpression(agg_fun_type, false, children);
     } else {
       if (root->args->length < 2) {
         // auto children_expr_list = TargetTransform(root->args);
-        expression::AbstractExpression* child;
-        auto expr_node = (Node*)root->args->head->data.ptr_value;
+        expression::AbstractExpression *child;
+        auto expr_node = (Node *)root->args->head->data.ptr_value;
         try {
           child = ExprTransform(expr_node);
         } catch (NotImplementedException e) {
@@ -562,8 +563,8 @@ expression::AbstractExpression* PostgresParser::FuncCallTransform(
 // This function takes in the whereClause part of a Postgres SelectStmt
 // parsenode and transfers it into the select_list of a Peloton SelectStatement.
 // It checks the type of each target and call the corresponding helpers.
-std::vector<std::unique_ptr<expression::AbstractExpression>>*
-PostgresParser::TargetTransform(List* root) {
+std::vector<std::unique_ptr<expression::AbstractExpression>> *
+PostgresParser::TargetTransform(List *root) {
   // Statement like 'SELECT;' cannot detect by postgres parser and would lead to
   // null list
   if (root == nullptr) {
@@ -573,8 +574,8 @@ PostgresParser::TargetTransform(List* root) {
   auto result =
       new std::vector<std::unique_ptr<expression::AbstractExpression>>();
   for (auto cell = root->head; cell != nullptr; cell = cell->next) {
-    ResTarget* target = reinterpret_cast<ResTarget*>(cell->data.ptr_value);
-    expression::AbstractExpression* expr = nullptr;
+    ResTarget *target = reinterpret_cast<ResTarget *>(cell->data.ptr_value);
+    expression::AbstractExpression *expr = nullptr;
     try {
       expr = ExprTransform(target->val);
     } catch (NotImplementedException e) {
@@ -589,12 +590,12 @@ PostgresParser::TargetTransform(List* root) {
 
 // This function takes in a Postgres BoolExpr parsenode and transfers into
 // a Peloton conjunction expression.
-expression::AbstractExpression* PostgresParser::BoolExprTransform(
-    BoolExpr* root) {
-  expression::AbstractExpression* result = nullptr;
-  expression::AbstractExpression* next = nullptr;
+expression::AbstractExpression *PostgresParser::BoolExprTransform(
+    BoolExpr *root) {
+  expression::AbstractExpression *result = nullptr;
+  expression::AbstractExpression *next = nullptr;
   for (auto cell = root->args->head; cell != nullptr; cell = cell->next) {
-    Node* node = reinterpret_cast<Node*>(cell->data.ptr_value);
+    Node *node = reinterpret_cast<Node *>(cell->data.ptr_value);
     try {
       next = ExprTransform(node);
     } catch (NotImplementedException e) {
@@ -629,43 +630,43 @@ expression::AbstractExpression* PostgresParser::BoolExprTransform(
   return result;
 }
 
-expression::AbstractExpression* PostgresParser::ExprTransform(Node* node) {
+expression::AbstractExpression *PostgresParser::ExprTransform(Node *node) {
   if (node == nullptr) {
     return nullptr;
   }
 
-  expression::AbstractExpression* expr = nullptr;
+  expression::AbstractExpression *expr = nullptr;
   switch (node->type) {
     case T_ColumnRef: {
-      expr = ColumnRefTransform(reinterpret_cast<ColumnRef*>(node));
+      expr = ColumnRefTransform(reinterpret_cast<ColumnRef *>(node));
       break;
     }
     case T_A_Const: {
-      expr = ConstTransform(reinterpret_cast<A_Const*>(node));
+      expr = ConstTransform(reinterpret_cast<A_Const *>(node));
       break;
     }
     case T_A_Expr: {
-      expr = AExprTransform(reinterpret_cast<A_Expr*>(node));
+      expr = AExprTransform(reinterpret_cast<A_Expr *>(node));
       break;
     }
     case T_ParamRef: {
-      expr = ParamRefTransform(reinterpret_cast<ParamRef*>(node));
+      expr = ParamRefTransform(reinterpret_cast<ParamRef *>(node));
       break;
     }
     case T_FuncCall: {
-      expr = FuncCallTransform(reinterpret_cast<FuncCall*>(node));
+      expr = FuncCallTransform(reinterpret_cast<FuncCall *>(node));
       break;
     }
     case T_BoolExpr: {
-      expr = BoolExprTransform(reinterpret_cast<BoolExpr*>(node));
+      expr = BoolExprTransform(reinterpret_cast<BoolExpr *>(node));
       break;
     }
     case T_CaseExpr: {
-      expr = CaseExprTransform(reinterpret_cast<CaseExpr*>(node));
+      expr = CaseExprTransform(reinterpret_cast<CaseExpr *>(node));
       break;
     }
     case T_NullTest: {
-      expr = NullTestTransform(reinterpret_cast<NullTest*>(node));
+      expr = NullTestTransform(reinterpret_cast<NullTest *>(node));
       break;
     }
     default: {
@@ -680,17 +681,17 @@ expression::AbstractExpression* PostgresParser::ExprTransform(Node* node) {
 // it into Peloton AbstractExpression.
 // TODO: the whole function, needs a function that transforms strings
 // of operators to Peloton expression type (e.g. ">" to COMPARE_GREATERTHAN)
-expression::AbstractExpression* PostgresParser::AExprTransform(A_Expr* root) {
+expression::AbstractExpression *PostgresParser::AExprTransform(A_Expr *root) {
   if (root == nullptr) {
     return nullptr;
   }
 
   LOG_TRACE("A_Expr type: %d\n", root->type);
 
-  UNUSED_ATTRIBUTE expression::AbstractExpression* result = nullptr;
+  UNUSED_ATTRIBUTE expression::AbstractExpression *result = nullptr;
   UNUSED_ATTRIBUTE ExpressionType target_type;
-  const char* name =
-      (reinterpret_cast<value*>(root->name->head->data.ptr_value))->val.str;
+  const char *name =
+      (reinterpret_cast<value *>(root->name->head->data.ptr_value))->val.str;
   if ((root->kind) != AEXPR_DISTINCT) {
     target_type = StringToExpressionType(std::string(name));
   } else {
@@ -701,8 +702,8 @@ expression::AbstractExpression* PostgresParser::AExprTransform(A_Expr* root) {
         StringUtil::Format("COMPARE type %s not supported yet...\n", name));
   }
 
-  expression::AbstractExpression* left_expr = nullptr;
-  expression::AbstractExpression* right_expr = nullptr;
+  expression::AbstractExpression *left_expr = nullptr;
+  expression::AbstractExpression *right_expr = nullptr;
 
   try {
     left_expr = ExprTransform(root->lexpr);
@@ -736,13 +737,13 @@ expression::AbstractExpression* PostgresParser::AExprTransform(A_Expr* root) {
 
 // This function takes in a Postgres NullTest primnode and transfers
 // it into Peloton AbstractExpression.
-expression::AbstractExpression* PostgresParser::NullTestTransform(
-    NullTest* root) {
+expression::AbstractExpression *PostgresParser::NullTestTransform(
+    NullTest *root) {
   if (root == nullptr) {
     return nullptr;
   }
 
-  expression::AbstractExpression* result = nullptr;
+  expression::AbstractExpression *result = nullptr;
   ExpressionType target_type = ExpressionType::OPERATOR_IS_NULL;
   if (root->nulltesttype == IS_NULL) {
     target_type = ExpressionType::OPERATOR_IS_NULL;
@@ -750,22 +751,22 @@ expression::AbstractExpression* PostgresParser::NullTestTransform(
     target_type = ExpressionType::OPERATOR_IS_NOT_NULL;
   }
 
-  expression::AbstractExpression* arg_expr = nullptr;
+  expression::AbstractExpression *arg_expr = nullptr;
   switch (root->arg->type) {
     case T_ColumnRef: {
-      arg_expr = ColumnRefTransform(reinterpret_cast<ColumnRef*>(root->arg));
+      arg_expr = ColumnRefTransform(reinterpret_cast<ColumnRef *>(root->arg));
       break;
     }
     case T_A_Const: {
-      arg_expr = ConstTransform(reinterpret_cast<A_Const*>(root->arg));
+      arg_expr = ConstTransform(reinterpret_cast<A_Const *>(root->arg));
       break;
     }
     case T_A_Expr: {
-      arg_expr = AExprTransform(reinterpret_cast<A_Expr*>(root->arg));
+      arg_expr = AExprTransform(reinterpret_cast<A_Expr *>(root->arg));
       break;
     }
     case T_ParamRef: {
-      arg_expr = ParamRefTransform(reinterpret_cast<ParamRef*>(root->arg));
+      arg_expr = ParamRefTransform(reinterpret_cast<ParamRef *>(root->arg));
       break;
     }
     default: {
@@ -780,11 +781,11 @@ expression::AbstractExpression* PostgresParser::NullTestTransform(
 
 // This function takes in the whereClause part of a Postgres SelectStmt
 // parsenode and transfers it into Peloton AbstractExpression.
-expression::AbstractExpression* PostgresParser::WhereTransform(Node* root) {
+expression::AbstractExpression *PostgresParser::WhereTransform(Node *root) {
   if (root == nullptr) {
     return nullptr;
   }
-  expression::AbstractExpression* result = nullptr;
+  expression::AbstractExpression *result = nullptr;
 
   try {
     result = ExprTransform(root);
@@ -797,18 +798,18 @@ expression::AbstractExpression* PostgresParser::WhereTransform(Node* root) {
 
 // This function takes in the whenClause part of a Postgres CreateTrigStmt
 // parsenode and transfers it into Peloton AbstractExpression.
-expression::AbstractExpression* PostgresParser::WhenTransform(Node* root) {
+expression::AbstractExpression *PostgresParser::WhenTransform(Node *root) {
   if (root == nullptr) {
     return nullptr;
   }
-  expression::AbstractExpression* result = nullptr;
+  expression::AbstractExpression *result = nullptr;
   switch (root->type) {
     case T_A_Expr: {
-      result = AExprTransform(reinterpret_cast<A_Expr*>(root));
+      result = AExprTransform(reinterpret_cast<A_Expr *>(root));
       break;
     }
     case T_BoolExpr: {
-      result = BoolExprTransform(reinterpret_cast<BoolExpr*>(root));
+      result = BoolExprTransform(reinterpret_cast<BoolExpr *>(root));
       break;
     }
     default: { LOG_ERROR("WHEN of type %d not supported yet...", root->type); }
@@ -818,29 +819,29 @@ expression::AbstractExpression* PostgresParser::WhenTransform(Node* root) {
 
 // This helper function takes in a Postgres ColumnDef object and transforms
 // it into a Peloton ColumnDefinition object
-parser::ColumnDefinition* PostgresParser::ColumnDefTransform(ColumnDef* root) {
-  TypeName* type_name = root->typeName;
-  char* name = (reinterpret_cast<value*>(type_name->names->tail->data.ptr_value)
-                    ->val.str);
-  parser::ColumnDefinition* result = nullptr;
+parser::ColumnDefinition *PostgresParser::ColumnDefTransform(ColumnDef *root) {
+  TypeName *type_name = root->typeName;
+  char *name = (reinterpret_cast<value *>(
+                    type_name->names->tail->data.ptr_value)->val.str);
+  parser::ColumnDefinition *result = nullptr;
 
   parser::ColumnDefinition::DataType data_type =
-    parser::ColumnDefinition::StrToDataType(name);
+      parser::ColumnDefinition::StrToDataType(name);
 
   // Transform Varchar len
   result = new ColumnDefinition(root->colname, data_type);
   if (type_name->typmods) {
-    Node* node =
-        reinterpret_cast<Node*>(type_name->typmods->head->data.ptr_value);
+    Node *node =
+        reinterpret_cast<Node *>(type_name->typmods->head->data.ptr_value);
     if (node->type == T_A_Const) {
-      if (reinterpret_cast<A_Const*>(node)->val.type != T_Integer) {
+      if (reinterpret_cast<A_Const *>(node)->val.type != T_Integer) {
         delete result;
         throw NotImplementedException(
             StringUtil::Format("typmods of type %d not supported yet...\n",
-                               reinterpret_cast<A_Const*>(node)->val.type));
+                               reinterpret_cast<A_Const *>(node)->val.type));
       }
       result->varlen =
-          static_cast<size_t>(reinterpret_cast<A_Const*>(node)->val.val.ival);
+          static_cast<size_t>(reinterpret_cast<A_Const *>(node)->val.val.ival);
     } else {
       delete result;
       throw NotImplementedException(StringUtil::Format(
@@ -852,7 +853,7 @@ parser::ColumnDefinition* PostgresParser::ColumnDefTransform(ColumnDef* root) {
   if (root->constraints) {
     for (auto cell = root->constraints->head; cell != nullptr;
          cell = cell->next) {
-      auto constraint = reinterpret_cast<Constraint*>(cell->data.ptr_value);
+      auto constraint = reinterpret_cast<Constraint *>(cell->data.ptr_value);
       if (constraint->contype == CONSTR_PRIMARY)
         result->primary = true;
       else if (constraint->contype == CONSTR_NOTNULL)
@@ -868,8 +869,8 @@ parser::ColumnDefinition* PostgresParser::ColumnDefTransform(ColumnDef* root) {
         if (constraint->pk_attrs != nullptr)
           for (auto attr_cell = constraint->pk_attrs->head;
                attr_cell != nullptr; attr_cell = attr_cell->next) {
-            value* attr_val =
-                reinterpret_cast<value*>(attr_cell->data.ptr_value);
+            value *attr_val =
+                reinterpret_cast<value *>(attr_cell->data.ptr_value);
             result->foreign_key_sink.push_back(std::string(attr_val->val.str));
           }
         // Action type
@@ -907,11 +908,11 @@ parser::ColumnDefinition* PostgresParser::ColumnDefTransform(ColumnDef* root) {
 // and transfers into a Peloton CreateStatement parsenode.
 // Please refer to parser/parsenode.h for the definition of
 // CreateStmt parsenodes.
-parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
-  UNUSED_ATTRIBUTE CreateStmt* temp = root;
-  parser::CreateStatement* result =
+parser::SQLStatement *PostgresParser::CreateTransform(CreateStmt *root) {
+  UNUSED_ATTRIBUTE CreateStmt *temp = root;
+  parser::CreateStatement *result =
       new CreateStatement(CreateStatement::CreateType::kTable);
-  RangeVar* relation = root->relation;
+  RangeVar *relation = root->relation;
   result->table_info_.reset(new parser::TableInfo());
 
   if (relation->relname) {
@@ -923,7 +924,7 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
 
   std::unordered_set<std::string> primary_keys;
   for (auto cell = root->tableElts->head; cell != nullptr; cell = cell->next) {
-    Node* node = reinterpret_cast<Node*>(cell->data.ptr_value);
+    Node *node = reinterpret_cast<Node *>(cell->data.ptr_value);
     if ((node->type) == T_ColumnDef) {
       // Transform Regular Column
       ColumnDefinition* temp = nullptr;
@@ -936,12 +937,12 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
       result->columns.push_back(std::unique_ptr<ColumnDefinition>(temp));
     } else if (node->type == T_Constraint) {
       // Transform Constraints
-      auto constraint = reinterpret_cast<Constraint*>(node);
+      auto constraint = reinterpret_cast<Constraint *>(node);
       if (constraint->contype == CONSTR_PRIMARY) {
         for (auto key_cell = constraint->keys->head; key_cell != nullptr;
              key_cell = key_cell->next) {
           primary_keys.emplace(
-              reinterpret_cast<value*>(key_cell->data.ptr_value)->val.str);
+              reinterpret_cast<value *>(key_cell->data.ptr_value)->val.str);
         }
       } else if (constraint->contype == CONSTR_FOREIGN) {
         auto col = new ColumnDefinition(ColumnDefinition::DataType::FOREIGN);
@@ -949,13 +950,15 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
         // Transform foreign key attributes
         for (auto attr_cell = constraint->fk_attrs->head; attr_cell != nullptr;
              attr_cell = attr_cell->next) {
-          value* attr_val = reinterpret_cast<value*>(attr_cell->data.ptr_value);
+          value *attr_val =
+              reinterpret_cast<value *>(attr_cell->data.ptr_value);
           col->foreign_key_source.push_back(std::string(attr_val->val.str));
         }
         // Transform Primary key attributes
         for (auto attr_cell = constraint->pk_attrs->head; attr_cell != nullptr;
              attr_cell = attr_cell->next) {
-          value* attr_val = reinterpret_cast<value*>(attr_cell->data.ptr_value);
+          value *attr_val =
+              reinterpret_cast<value *>(attr_cell->data.ptr_value);
           col->foreign_key_sink.push_back(std::string(attr_val->val.str));
         }
         // Update Reference Table
@@ -982,7 +985,7 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
   }
 
   // Enforce Primary Keys
-  for (auto& column : result->columns) {
+  for (auto &column : result->columns) {
     // Skip Foreign Key Constraint
     if (column->name.empty()) continue;
     if (primary_keys.find(column->name) != primary_keys.end()) {
@@ -990,20 +993,21 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
     }
   }
 
-  return reinterpret_cast<parser::SQLStatement*>(result);
+  return reinterpret_cast<parser::SQLStatement *>(result);
 }
 
 // This function takes in a Postgres IndexStmt parsenode
 // and transfers into a Peloton CreateStatement parsenode.
 // Please refer to parser/parsenode.h for the definition of
 // IndexStmt parsenodes.
-parser::SQLStatement* PostgresParser::CreateIndexTransform(IndexStmt* root) {
-  parser::CreateStatement* result =
+parser::SQLStatement *PostgresParser::CreateIndexTransform(IndexStmt *root) {
+  parser::CreateStatement *result =
       new parser::CreateStatement(CreateStatement::kIndex);
   result->unique = root->unique;
   for (auto cell = root->indexParams->head; cell != nullptr;
        cell = cell->next) {
-    char* index_attr = reinterpret_cast<IndexElem*>(cell->data.ptr_value)->name;
+    char *index_attr =
+        reinterpret_cast<IndexElem *>(cell->data.ptr_value)->name;
     result->index_attrs.push_back(std::string(index_attr));
   }
   result->index_type = IndexType::BWTREE;
@@ -1017,36 +1021,36 @@ parser::SQLStatement* PostgresParser::CreateIndexTransform(IndexStmt* root) {
 // and transfers into a Peloton CreateStatement parsenode.
 // Please refer to parser/parsenode.h for the definition of
 // CreateTrigStmt parsenodes.
-parser::SQLStatement* PostgresParser::CreateTriggerTransform(
-    CreateTrigStmt* root) {
-  parser::CreateStatement* result =
+parser::SQLStatement *PostgresParser::CreateTriggerTransform(
+    CreateTrigStmt *root) {
+  parser::CreateStatement *result =
       new parser::CreateStatement(CreateStatement::kTrigger);
 
   // funcname
   if (root->funcname) {
     for (auto cell = root->funcname->head; cell != nullptr; cell = cell->next) {
-      char* name = (reinterpret_cast<value*>(cell->data.ptr_value))->val.str;
+      char *name = (reinterpret_cast<value *>(cell->data.ptr_value))->val.str;
       result->trigger_funcname.push_back(std::string(name));
     }
   }
   // args
   if (root->args) {
     for (auto cell = root->args->head; cell != nullptr; cell = cell->next) {
-      char* arg = (reinterpret_cast<value*>(cell->data.ptr_value))->val.str;
+      char *arg = (reinterpret_cast<value *>(cell->data.ptr_value))->val.str;
       result->trigger_args.push_back(std::string(arg));
     }
   }
   // columns
   if (root->columns) {
     for (auto cell = root->columns->head; cell != nullptr; cell = cell->next) {
-      char* column = (reinterpret_cast<value*>(cell->data.ptr_value))->val.str;
+      char *column = (reinterpret_cast<value *>(cell->data.ptr_value))->val.str;
       result->trigger_columns.push_back(std::string(column));
     }
   }
   // when
   result->trigger_when.reset(WhenTransform(root->whenClause));
 
-  int16_t& tgtype = result->trigger_type;
+  int16_t &tgtype = result->trigger_type;
   TRIGGER_CLEAR_TYPE(tgtype);
   if (root->row) TRIGGER_SETT_ROW(tgtype);
   tgtype |= root->timing;
@@ -1064,14 +1068,14 @@ parser::SQLStatement* PostgresParser::CreateTriggerTransform(
 // and transfers into a Peloton CreateStatement parsenode.
 // Please refer to parser/parsenode.h for the definition of
 // CreatedbStmt parsenodes.
-parser::SQLStatement* PostgresParser::CreateDbTransform(CreatedbStmt* root) {
-  parser::CreateStatement* result =
+parser::SQLStatement *PostgresParser::CreateDbTransform(CreatedbStmt *root) {
+  parser::CreateStatement *result =
       new parser::CreateStatement(CreateStatement::kDatabase);
   result->database_name = root->dbname;
   return result;
 }
 
-parser::DropStatement* PostgresParser::DropTransform(DropStmt* root) {
+parser::DropStatement *PostgresParser::DropTransform(DropStmt *root) {
   switch (root->removeType) {
     case ObjectType::OBJECT_TABLE:
       return DropTableTransform(root);
@@ -1084,43 +1088,43 @@ parser::DropStatement* PostgresParser::DropTransform(DropStmt* root) {
   }
 }
 
-parser::DropStatement* PostgresParser::DropTableTransform(DropStmt* root) {
+parser::DropStatement *PostgresParser::DropTableTransform(DropStmt *root) {
   auto res = new DropStatement(DropStatement::EntityType::kTable);
   for (auto cell = root->objects->head; cell != nullptr; cell = cell->next) {
     res->missing = root->missing_ok;
     auto table_info = new TableInfo{};
-    auto table_list = reinterpret_cast<List*>(cell->data.ptr_value);
-    LOG_TRACE("%d", ((Node*)(table_list->head->data.ptr_value))->type);
+    auto table_list = reinterpret_cast<List *>(cell->data.ptr_value);
+    LOG_TRACE("%d", ((Node *)(table_list->head->data.ptr_value))->type);
     table_info->table_name =
-        reinterpret_cast<value*>(table_list->head->data.ptr_value)->val.str;
+        reinterpret_cast<value *>(table_list->head->data.ptr_value)->val.str;
     res->table_info_.reset(table_info);
     break;
   }
   return res;
 }
 
-parser::DropStatement* PostgresParser::DropTriggerTransform(DropStmt* root) {
+parser::DropStatement *PostgresParser::DropTriggerTransform(DropStmt *root) {
   auto res = new DropStatement(DropStatement::EntityType::kTrigger);
   auto cell = root->objects->head;
-  auto list = reinterpret_cast<List*>(cell->data.ptr_value);
+  auto list = reinterpret_cast<List *>(cell->data.ptr_value);
   res->table_name_of_trigger =
-      reinterpret_cast<value*>(list->head->data.ptr_value)->val.str;
+      reinterpret_cast<value *>(list->head->data.ptr_value)->val.str;
   res->trigger_name =
-      reinterpret_cast<value*>(list->head->next->data.ptr_value)->val.str;
+      reinterpret_cast<value *>(list->head->next->data.ptr_value)->val.str;
   return res;
 }
 
-parser::DeleteStatement* PostgresParser::TruncateTransform(TruncateStmt* root) {
+parser::DeleteStatement *PostgresParser::TruncateTransform(TruncateStmt *root) {
   auto result = new DeleteStatement();
   for (auto cell = root->relations->head; cell != nullptr; cell = cell->next) {
     result->table_ref.reset(
-        RangeVarTransform(reinterpret_cast<RangeVar*>(cell->data.ptr_value)));
+        RangeVarTransform(reinterpret_cast<RangeVar *>(cell->data.ptr_value)));
     break;
   }
   return result;
 }
 
-parser::ExecuteStatement* PostgresParser::ExecuteTransform(ExecuteStmt* root) {
+parser::ExecuteStatement *PostgresParser::ExecuteTransform(ExecuteStmt *root) {
   auto result = new ExecuteStatement();
   result->name = root->name;
   if (root->params != nullptr)
@@ -1128,7 +1132,7 @@ parser::ExecuteStatement* PostgresParser::ExecuteTransform(ExecuteStmt* root) {
   return result;
 }
 
-parser::PrepareStatement* PostgresParser::PrepareTransform(PrepareStmt* root) {
+parser::PrepareStatement *PostgresParser::PrepareTransform(PrepareStmt *root) {
   auto res = new PrepareStatement();
   res->name = root->name;
   auto stmt_list = new SQLStatementList();
@@ -1139,14 +1143,14 @@ parser::PrepareStatement* PostgresParser::PrepareTransform(PrepareStmt* root) {
 }
 
 // TODO: Only support COPY TABLE TO FILE and DELIMITER option
-parser::CopyStatement* PostgresParser::CopyTransform(CopyStmt* root) {
+parser::CopyStatement *PostgresParser::CopyTransform(CopyStmt *root) {
   auto res = new CopyStatement(peloton::CopyType::EXPORT_OTHER);
   res->cpy_table.reset(RangeVarTransform(root->relation));
   res->file_path = root->filename;
   for (auto cell = root->options->head; cell != NULL; cell = cell->next) {
-    auto def_elem = reinterpret_cast<DefElem*>(cell->data.ptr_value);
+    auto def_elem = reinterpret_cast<DefElem *>(cell->data.ptr_value);
     if (strcmp(def_elem->defname, "delimiter") == 0) {
-      auto delimiter = reinterpret_cast<value*>(def_elem->arg)->val.str;
+      auto delimiter = reinterpret_cast<value *>(def_elem->arg)->val.str;
       res->delimiter = *delimiter;
       break;
     }
@@ -1155,7 +1159,7 @@ parser::CopyStatement* PostgresParser::CopyTransform(CopyStmt* root) {
 }
 
 // Analyze statment is parsed with vacuum statment.
-parser::AnalyzeStatement* PostgresParser::VacuumTransform(VacuumStmt* root) {
+parser::AnalyzeStatement *PostgresParser::VacuumTransform(VacuumStmt *root) {
   if (root->options != VACOPT_ANALYZE) {
     LOG_TRACE("Vacuum not supported.");
     return nullptr;
@@ -1170,13 +1174,13 @@ parser::AnalyzeStatement* PostgresParser::VacuumTransform(VacuumStmt* root) {
   return res;
 }
 
-std::vector<std::string>* PostgresParser::ColumnNameTransform(List* root) {
+std::vector<std::string> *PostgresParser::ColumnNameTransform(List *root) {
   auto result = new std::vector<std::string>();
 
   if (root == nullptr) return result;
 
   for (auto cell = root->head; cell != NULL; cell = cell->next) {
-    ResTarget* target = (ResTarget*)(cell->data.ptr_value);
+    ResTarget *target = (ResTarget *)(cell->data.ptr_value);
     result->push_back(std::string(target->name));
   }
 
@@ -1187,8 +1191,8 @@ std::vector<std::string>* PostgresParser::ColumnNameTransform(List* root) {
 // parsenode and transfers it into Peloton AbstractExpression.
 // This is a vector pointer of vector pointers because one InsertStmt can insert
 // multiple tuples.
-std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>>*
-PostgresParser::ValueListsTransform(List* root) {
+std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>> *
+PostgresParser::ValueListsTransform(List *root) {
   auto result = new std::vector<
       std::vector<std::unique_ptr<expression::AbstractExpression>>>();
 
@@ -1197,18 +1201,18 @@ PostgresParser::ValueListsTransform(List* root) {
     auto cur_result =
         std::vector<std::unique_ptr<expression::AbstractExpression>>();
 
-    List* target = (List*)(value_list->data.ptr_value);
+    List *target = (List *)(value_list->data.ptr_value);
     for (auto cell = target->head; cell != NULL; cell = cell->next) {
-      auto expr = reinterpret_cast<Expr*>(cell->data.ptr_value);
+      auto expr = reinterpret_cast<Expr *>(cell->data.ptr_value);
       if (expr->type == T_ParamRef)
         cur_result.push_back(std::unique_ptr<expression::AbstractExpression>(
-            ParamRefTransform((ParamRef*)expr)));
+            ParamRefTransform((ParamRef *)expr)));
       else if (expr->type == T_A_Const)
         cur_result.push_back(std::unique_ptr<expression::AbstractExpression>(
-            ConstTransform((A_Const*)expr)));
+            ConstTransform((A_Const *)expr)));
       else if (expr->type == T_TypeCast)
         cur_result.push_back(std::unique_ptr<expression::AbstractExpression>(
-            TypeCastTransform((TypeCast*)expr)));
+            TypeCastTransform((TypeCast *)expr)));
       else if (expr->type == T_SetToDefault) {
         // TODO handle default type
         // add corresponding expression for
@@ -1225,13 +1229,13 @@ PostgresParser::ValueListsTransform(List* root) {
 // This function takes in the paramlist of a Postgres ExecuteStmt
 // parsenode and transfers it into Peloton AbstractExpressio
 std::vector<std::unique_ptr<expression::AbstractExpression>>
-PostgresParser::ParamListTransform(List* root) {
+PostgresParser::ParamListTransform(List *root) {
   std::vector<std::unique_ptr<expression::AbstractExpression>> result =
       std::vector<std::unique_ptr<expression::AbstractExpression>>();
 
   for (auto cell = root->head; cell != NULL; cell = cell->next) {
     result.push_back(std::unique_ptr<expression::AbstractExpression>(
-        ConstTransform((A_Const*)(cell->data.ptr_value))));
+        ConstTransform((A_Const *)(cell->data.ptr_value))));
   }
 
   return result;
@@ -1241,19 +1245,19 @@ PostgresParser::ParamListTransform(List* root) {
 // and transfers into a Peloton InsertStatement.
 // Please refer to parser/parsenode.h for the definition of
 // SelectStmt parsenodes.
-parser::SQLStatement* PostgresParser::InsertTransform(InsertStmt* root) {
+parser::SQLStatement *PostgresParser::InsertTransform(InsertStmt *root) {
   // selectStmt must exist. It would either select from table or directly select
   // some values
   PL_ASSERT(root->selectStmt != NULL);
 
-  auto select_stmt = reinterpret_cast<SelectStmt*>(root->selectStmt);
+  auto select_stmt = reinterpret_cast<SelectStmt *>(root->selectStmt);
 
-  parser::InsertStatement* result = nullptr;
+  parser::InsertStatement *result = nullptr;
   if (select_stmt->fromClause != NULL) {
     // if select from a table to insert
     result = new parser::InsertStatement(InsertType::SELECT);
 
-    result->select.reset(reinterpret_cast<parser::SelectStatement*>(
+    result->select.reset(reinterpret_cast<parser::SelectStatement *>(
         SelectTransform(select_stmt)));
 
   } else {
@@ -1273,15 +1277,15 @@ parser::SQLStatement* PostgresParser::InsertTransform(InsertStmt* root) {
   auto columns = ColumnNameTransform(root->cols);
   result->columns = std::move(*columns);
   delete columns;
-  return (parser::SQLStatement*)result;
+  return (parser::SQLStatement *)result;
 }
 
 // This function takes in a Postgres SelectStmt parsenode
 // and transfers into a Peloton SelectStatement parsenode.
 // Please refer to parser/parsenode.h for the definition of
 // SelectStmt parsenodes.
-parser::SQLStatement* PostgresParser::SelectTransform(SelectStmt* root) {
-  parser::SelectStatement* result;
+parser::SQLStatement *PostgresParser::SelectTransform(SelectStmt *root) {
+  parser::SelectStatement *result;
   switch (root->op) {
     case SETOP_NONE:
       result = new parser::SelectStatement();
@@ -1290,7 +1294,7 @@ parser::SQLStatement* PostgresParser::SelectTransform(SelectStmt* root) {
         result->select_list = std::move(*select_list);
         delete select_list;
         result->from_table.reset(FromTransform(root));
-      } catch (ParserException& e) {
+      } catch (ParserException &e) {
         delete (result);
         throw e;
       }
@@ -1301,17 +1305,17 @@ parser::SQLStatement* PostgresParser::SelectTransform(SelectStmt* root) {
       result->where_clause.reset(WhereTransform(root->whereClause));
       if (root->limitCount != nullptr) {
         int64_t limit =
-            reinterpret_cast<A_Const*>(root->limitCount)->val.val.ival;
+            reinterpret_cast<A_Const *>(root->limitCount)->val.val.ival;
         int64_t offset = 0;
         if (root->limitOffset != nullptr)
-          offset = reinterpret_cast<A_Const*>(root->limitOffset)->val.val.ival;
+          offset = reinterpret_cast<A_Const *>(root->limitOffset)->val.val.ival;
         result->limit.reset(new LimitDescription(limit, offset));
       }
       break;
     case SETOP_UNION:
-      result = reinterpret_cast<parser::SelectStatement*>(
+      result = reinterpret_cast<parser::SelectStatement *>(
           SelectTransform(root->larg));
-      result->union_select.reset(reinterpret_cast<parser::SelectStatement*>(
+      result->union_select.reset(reinterpret_cast<parser::SelectStatement *>(
           SelectTransform(root->rarg)));
       break;
     default:
@@ -1319,23 +1323,23 @@ parser::SQLStatement* PostgresParser::SelectTransform(SelectStmt* root) {
           "Set operation %d not supported yet...\n", root->op));
   }
 
-  return reinterpret_cast<parser::SQLStatement*>(result);
+  return reinterpret_cast<parser::SQLStatement *>(result);
 }
 
 // This function takes in a Postgres DeleteStmt parsenode
 // and transfers into a Peloton DeleteStatement parsenode.
 // Please refer to parser/parsenode.h for the definition of
 // DeleteStmt parsenodes.
-parser::SQLStatement* PostgresParser::DeleteTransform(DeleteStmt* root) {
-  parser::DeleteStatement* result = new parser::DeleteStatement();
+parser::SQLStatement *PostgresParser::DeleteTransform(DeleteStmt *root) {
+  parser::DeleteStatement *result = new parser::DeleteStatement();
   result->table_ref.reset(RangeVarTransform(root->relation));
   result->expr.reset(WhereTransform(root->whereClause));
-  return (parser::SQLStatement*)result;
+  return (parser::SQLStatement *)result;
 }
 
 // Transform Postgres TransacStmt into Peloton TransactionStmt
-parser::TransactionStatement* PostgresParser::TransactionTransform(
-    TransactionStmt* root) {
+parser::TransactionStatement *PostgresParser::TransactionTransform(
+    TransactionStmt *root) {
   if (root->kind == TRANS_STMT_BEGIN) {
     return new parser::TransactionStatement(TransactionStatement::kBegin);
   } else if (root->kind == TRANS_STMT_COMMIT) {
@@ -1352,53 +1356,53 @@ parser::TransactionStatement* PostgresParser::TransactionTransform(
 // a Peloton SQLStatement object. It checks the type of
 // Postgres parsenode of the input and call the corresponding
 // helper function.
-parser::SQLStatement* PostgresParser::NodeTransform(Node* stmt) {
-  parser::SQLStatement* result = nullptr;
+parser::SQLStatement *PostgresParser::NodeTransform(Node *stmt) {
+  parser::SQLStatement *result = nullptr;
   switch (stmt->type) {
     case T_SelectStmt:
-      result = SelectTransform(reinterpret_cast<SelectStmt*>(stmt));
+      result = SelectTransform(reinterpret_cast<SelectStmt *>(stmt));
       break;
     case T_CreateStmt:
-      result = CreateTransform(reinterpret_cast<CreateStmt*>(stmt));
+      result = CreateTransform(reinterpret_cast<CreateStmt *>(stmt));
       break;
     case T_CreatedbStmt:
-      result = CreateDbTransform(reinterpret_cast<CreatedbStmt*>(stmt));
+      result = CreateDbTransform(reinterpret_cast<CreatedbStmt *>(stmt));
       break;
     case T_IndexStmt:
-      result = CreateIndexTransform(reinterpret_cast<IndexStmt*>(stmt));
+      result = CreateIndexTransform(reinterpret_cast<IndexStmt *>(stmt));
       break;
     case T_CreateTrigStmt:
-      result = CreateTriggerTransform(reinterpret_cast<CreateTrigStmt*>(stmt));
+      result = CreateTriggerTransform(reinterpret_cast<CreateTrigStmt *>(stmt));
       break;
     case T_UpdateStmt:
-      result = UpdateTransform((UpdateStmt*)stmt);
+      result = UpdateTransform((UpdateStmt *)stmt);
       break;
     case T_DeleteStmt:
-      result = DeleteTransform((DeleteStmt*)stmt);
+      result = DeleteTransform((DeleteStmt *)stmt);
       break;
     case T_InsertStmt:
-      result = InsertTransform((InsertStmt*)stmt);
+      result = InsertTransform((InsertStmt *)stmt);
       break;
     case T_DropStmt:
-      result = DropTransform((DropStmt*)stmt);
+      result = DropTransform((DropStmt *)stmt);
       break;
     case T_TruncateStmt:
-      result = TruncateTransform((TruncateStmt*)stmt);
+      result = TruncateTransform((TruncateStmt *)stmt);
       break;
     case T_TransactionStmt:
-      result = TransactionTransform((TransactionStmt*)stmt);
+      result = TransactionTransform((TransactionStmt *)stmt);
       break;
     case T_ExecuteStmt:
-      result = ExecuteTransform((ExecuteStmt*)stmt);
+      result = ExecuteTransform((ExecuteStmt *)stmt);
       break;
     case T_PrepareStmt:
-      result = PrepareTransform((PrepareStmt*)stmt);
+      result = PrepareTransform((PrepareStmt *)stmt);
       break;
     case T_CopyStmt:
-      result = CopyTransform((CopyStmt*)stmt);
+      result = CopyTransform((CopyStmt *)stmt);
       break;
     case T_VacuumStmt:
-      result = VacuumTransform((VacuumStmt*)stmt);
+      result = VacuumTransform((VacuumStmt *)stmt);
       break;
     default: {
       throw NotImplementedException(StringUtil::Format(
@@ -1411,7 +1415,7 @@ parser::SQLStatement* PostgresParser::NodeTransform(Node* stmt) {
 // This function transfers a list of Postgres statements into
 // a Peloton SQLStatementList object. It traverses the parse list
 // and call the helper for singles nodes.
-parser::SQLStatementList* PostgresParser::ListTransform(List* root) {
+parser::SQLStatementList *PostgresParser::ListTransform(List *root) {
   auto result = new parser::SQLStatementList();
   if (root == nullptr) {
     return nullptr;
@@ -1419,9 +1423,9 @@ parser::SQLStatementList* PostgresParser::ListTransform(List* root) {
   LOG_TRACE("%d statements in total\n", (root->length));
   try {
     for (auto cell = root->head; cell != nullptr; cell = cell->next) {
-      result->AddStatement(NodeTransform((Node*)cell->data.ptr_value));
+      result->AddStatement(NodeTransform((Node *)cell->data.ptr_value));
     }
-  } catch (ParserException& e) {
+  } catch (ParserException &e) {
     delete result;
     throw e;
   } catch (NotImplementedException e) {
@@ -1432,12 +1436,12 @@ parser::SQLStatementList* PostgresParser::ListTransform(List* root) {
   return result;
 }
 
-std::vector<std::unique_ptr<parser::UpdateClause>>*
-PostgresParser::UpdateTargetTransform(List* root) {
+std::vector<std::unique_ptr<parser::UpdateClause>> *
+PostgresParser::UpdateTargetTransform(List *root) {
   auto result = new std::vector<std::unique_ptr<parser::UpdateClause>>();
   for (auto cell = root->head; cell != NULL; cell = cell->next) {
     auto update_clause = new UpdateClause();
-    ResTarget* target = (ResTarget*)(cell->data.ptr_value);
+    ResTarget *target = (ResTarget *)(cell->data.ptr_value);
     update_clause->column = target->name;
     try {
       update_clause->value.reset(ExprTransform(target->val));
@@ -1452,8 +1456,8 @@ PostgresParser::UpdateTargetTransform(List* root) {
 
 // TODO: Not support with clause, from clause and returning list in update
 // statement in peloton
-parser::UpdateStatement* PostgresParser::UpdateTransform(
-    UpdateStmt* update_stmt) {
+parser::UpdateStatement *PostgresParser::UpdateTransform(
+    UpdateStmt *update_stmt) {
   auto result = new parser::UpdateStatement();
   result->table.reset(RangeVarTransform(update_stmt->relation));
   result->where.reset(WhereTransform(update_stmt->whereClause));
@@ -1464,7 +1468,7 @@ parser::UpdateStatement* PostgresParser::UpdateTransform(
 }
 
 // Call postgres's parser and start transforming it into Peloton's parse tree
-parser::SQLStatementList* PostgresParser::ParseSQLString(const char* text) {
+parser::SQLStatementList *PostgresParser::ParseSQLString(const char *text) {
   auto ctx = pg_query_parse_init();
   auto result = pg_query_parse(text);
   if (result.error) {
@@ -1478,10 +1482,10 @@ parser::SQLStatementList* PostgresParser::ParseSQLString(const char* text) {
 
   // DEBUG only. Comment this out in release mode
   // print_pg_parse_tree(result.tree);
-  parser::SQLStatementList* transform_result;
+  parser::SQLStatementList *transform_result;
   try {
     transform_result = ListTransform(result.tree);
-  } catch (Exception& e) {
+  } catch (Exception &e) {
     pg_query_parse_finish(ctx);
     pg_query_free_parse_result(result);
     throw e;
@@ -1492,18 +1496,18 @@ parser::SQLStatementList* PostgresParser::ParseSQLString(const char* text) {
   return transform_result;
 }
 
-parser::SQLStatementList* PostgresParser::ParseSQLString(
-    const std::string& sql) {
+parser::SQLStatementList *PostgresParser::ParseSQLString(
+    const std::string &sql) {
   return ParseSQLString(sql.c_str());
 }
 
-PostgresParser& PostgresParser::GetInstance() {
+PostgresParser &PostgresParser::GetInstance() {
   static PostgresParser parser;
   return parser;
 }
 
 std::unique_ptr<parser::SQLStatementList> PostgresParser::BuildParseTree(
-    const std::string& query_string) {
+    const std::string &query_string) {
   auto stmt = PostgresParser::ParseSQLString(query_string);
 
   LOG_TRACE("Number of statements: %lu", stmt->GetStatements().size());

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -228,6 +228,8 @@ Value VarlenType::CastAs(const Value &val, const TypeId type_id) const {
       return ValueFactory::CastAsDecimal(val);
     case TypeId::TIMESTAMP:
       return ValueFactory::CastAsTimestamp(val);
+    case TypeId::DATE:
+      return ValueFactory::CastAsDate(val);
     case TypeId::VARCHAR:
     case TypeId::VARBINARY:
       return val.Copy();

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -21,23 +21,21 @@
 namespace peloton {
 namespace type {
 
-#define VARLEN_COMPARE_FUNC(OP) \
-  const char *str1 = left.GetData(); \
-  uint32_t len1 = GetLength(left) - 1; \
-  const char *str2; \
-  uint32_t len2; \
-  if (right.GetTypeId() == TypeId::VARCHAR) { \
-    str2 = right.GetData(); \
-    len2 = GetLength(right) - 1; \
-    return GetCmpBool(TypeUtil::CompareStrings(str1, len1, \
-                                               str2, len2) OP 0); \
-  } else { \
-    auto r_value = right.CastAs(TypeId::VARCHAR); \
-    str2 = r_value.GetData(); \
-    len2 = GetLength(r_value) - 1; \
-    return GetCmpBool(TypeUtil::CompareStrings(str1, len1, \
-                                               str2, len2) OP 0); \
-  } \
+#define VARLEN_COMPARE_FUNC(OP)                                               \
+  const char *str1 = left.GetData();                                          \
+  uint32_t len1 = GetLength(left) - 1;                                        \
+  const char *str2;                                                           \
+  uint32_t len2;                                                              \
+  if (right.GetTypeId() == TypeId::VARCHAR) {                                 \
+    str2 = right.GetData();                                                   \
+    len2 = GetLength(right) - 1;                                              \
+    return GetCmpBool(TypeUtil::CompareStrings(str1, len1, str2, len2) OP 0); \
+  } else {                                                                    \
+    auto r_value = right.CastAs(TypeId::VARCHAR);                             \
+    str2 = r_value.GetData();                                                 \
+    len2 = GetLength(r_value) - 1;                                            \
+    return GetCmpBool(TypeUtil::CompareStrings(str1, len1, str2, len2) OP 0); \
+  }
 
 VarlenType::VarlenType(TypeId type) : Type(type) {}
 
@@ -65,7 +63,7 @@ CmpBool VarlenType::CompareEquals(const Value &left, const Value &right) const {
     return GetCmpBool(GetLength(left) == GetLength(right));
   }
 
-  VARLEN_COMPARE_FUNC(==);
+  VARLEN_COMPARE_FUNC(== );
 }
 
 CmpBool VarlenType::CompareNotEquals(const Value &left,
@@ -77,7 +75,7 @@ CmpBool VarlenType::CompareNotEquals(const Value &left,
     return GetCmpBool(GetLength(left) != GetLength(right));
   }
 
-  VARLEN_COMPARE_FUNC(!=);
+  VARLEN_COMPARE_FUNC(!= );
 }
 
 CmpBool VarlenType::CompareLessThan(const Value &left,
@@ -89,7 +87,7 @@ CmpBool VarlenType::CompareLessThan(const Value &left,
     return GetCmpBool(GetLength(left) < GetLength(right));
   }
 
-  VARLEN_COMPARE_FUNC(<);
+  VARLEN_COMPARE_FUNC(< );
 }
 
 CmpBool VarlenType::CompareLessThanEquals(const Value &left,
@@ -101,7 +99,7 @@ CmpBool VarlenType::CompareLessThanEquals(const Value &left,
     return GetCmpBool(GetLength(left) <= GetLength(right));
   }
 
-  VARLEN_COMPARE_FUNC(<=);
+  VARLEN_COMPARE_FUNC(<= );
 }
 
 CmpBool VarlenType::CompareGreaterThan(const Value &left,
@@ -113,7 +111,7 @@ CmpBool VarlenType::CompareGreaterThan(const Value &left,
     return GetCmpBool(GetLength(left) > GetLength(right));
   }
 
-  VARLEN_COMPARE_FUNC(>);
+  VARLEN_COMPARE_FUNC(> );
 }
 
 CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
@@ -125,17 +123,17 @@ CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
     return GetCmpBool(GetLength(left) >= GetLength(right));
   }
 
-  VARLEN_COMPARE_FUNC(>=);
+  VARLEN_COMPARE_FUNC(>= );
 }
 
-Value VarlenType::Min(const Value& left, const Value& right) const {
+Value VarlenType::Min(const Value &left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
   if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
-Value VarlenType::Max(const Value& left, const Value& right) const {
+Value VarlenType::Max(const Value &left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
   if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -390,5 +390,53 @@ TEST_F(ParserTests, CopyTest) {
     LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());
   }
 }
+
+TEST_F(ParserTests, DateTypeTest) {
+  std::vector<std::string> queries;
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017-01-01'::DATE);");
+  queries.push_back(
+      "CREATE TABLE students (name TEXT, student_number INTEGER, city TEXT, "
+      "graduation DATE)");
+  // Parsing
+  UNUSED_ATTRIBUTE int ii = 0;
+  for (auto query : queries) {
+    std::unique_ptr<parser::SQLStatementList> result(
+        parser::PostgresParser::ParseSQLString(query.c_str()));
+
+    if (result->is_valid == false) {
+      LOG_ERROR("Message: %s, line: %d, col: %d", result->parser_msg,
+                result->error_line, result->error_col);
+    }
+    EXPECT_EQ(result->is_valid, true);
+
+    LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());
+  }
+}
+
+TEST_F(ParserTests, TypeCastTest) {
+  std::vector<std::string> queries;
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::INTEGER);");
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::FLOAT);");
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::DECIMAL);");
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::TEXT);");
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::VARCHAR);");
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::TIMESTAMP);");
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::DATE);");
+  // Parsing
+  UNUSED_ATTRIBUTE int ii = 0;
+  for (auto query : queries) {
+    std::unique_ptr<parser::SQLStatementList> result(
+        parser::PostgresParser::ParseSQLString(query.c_str()));
+
+    if (result->is_valid == false) {
+      LOG_ERROR("Message: %s, line: %d, col: %d", result->parser_msg,
+                result->error_line, result->error_col);
+    }
+    EXPECT_EQ(result->is_valid, true);
+
+    LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());
+  }
+}
+
 }  // namespace test
 }  // namespace peloton

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -165,8 +165,8 @@ TEST_F(ParserTests, SelectParserTest) {
   EXPECT_EQ(list->GetNumStatements(), 1);
   EXPECT_EQ(list->GetStatement(0)->GetType(), StatementType::SELECT);
 
-  parser::SelectStatement* stmt =
-      (parser::SelectStatement*)list->GetStatement(0);
+  parser::SelectStatement *stmt =
+      (parser::SelectStatement *)list->GetStatement(0);
 
   EXPECT_NOTNULL(stmt->from_table);
   EXPECT_NOTNULL(stmt->group_by);
@@ -184,7 +184,7 @@ TEST_F(ParserTests, SelectParserTest) {
             ExpressionType::AGGREGATE_SUM);
 
   // Join Table
-  parser::JoinDefinition* join = stmt->from_table->join.get();
+  parser::JoinDefinition *join = stmt->from_table->join.get();
   EXPECT_EQ(stmt->from_table->type, TableReferenceType::JOIN);
   EXPECT_NOTNULL(join);
   EXPECT_STREQ(join->left->GetTableName().c_str(), "customers");
@@ -224,21 +224,21 @@ TEST_F(ParserTests, TransactionTest) {
 
   std::unique_ptr<parser::SQLStatementList> list(
       parser::PostgresParser::ParseSQLString(valid_queries[0].c_str()));
-  parser::TransactionStatement* stmt =
-      (parser::TransactionStatement*)list->GetStatement(0);
+  parser::TransactionStatement *stmt =
+      (parser::TransactionStatement *)list->GetStatement(0);
   EXPECT_EQ(list->GetStatement(0)->GetType(), StatementType::TRANSACTION);
   EXPECT_EQ(stmt->type, parser::TransactionStatement::kBegin);
 
   list.reset(parser::PostgresParser::ParseSQLString(valid_queries[1].c_str()));
-  stmt = (parser::TransactionStatement*)list->GetStatement(0);
+  stmt = (parser::TransactionStatement *)list->GetStatement(0);
   EXPECT_EQ(stmt->type, parser::TransactionStatement::kBegin);
 
   list.reset(parser::PostgresParser::ParseSQLString(valid_queries[2].c_str()));
-  stmt = (parser::TransactionStatement*)list->GetStatement(0);
+  stmt = (parser::TransactionStatement *)list->GetStatement(0);
   EXPECT_EQ(stmt->type, parser::TransactionStatement::kCommit);
 
   list.reset(parser::PostgresParser::ParseSQLString(valid_queries[3].c_str()));
-  stmt = (parser::TransactionStatement*)list->GetStatement(0);
+  stmt = (parser::TransactionStatement *)list->GetStatement(0);
   EXPECT_EQ(stmt->type, parser::TransactionStatement::kRollback);
 }
 
@@ -381,58 +381,11 @@ TEST_F(ParserTests, CopyTest) {
     }
     EXPECT_TRUE(result->is_valid);
 
-    parser::CopyStatement* copy_stmt =
-        static_cast<parser::CopyStatement*>(result->GetStatement(0));
+    parser::CopyStatement *copy_stmt =
+        static_cast<parser::CopyStatement *>(result->GetStatement(0));
 
     EXPECT_EQ(copy_stmt->delimiter, ',');
     EXPECT_STREQ(copy_stmt->file_path.c_str(), "/home/user/output.csv");
-
-    LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());
-  }
-}
-
-TEST_F(ParserTests, DateTypeTest) {
-  std::vector<std::string> queries;
-  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017-01-01'::DATE);");
-  queries.push_back(
-      "CREATE TABLE students (name TEXT, student_number INTEGER, city TEXT, "
-      "graduation DATE)");
-  // Parsing
-  UNUSED_ATTRIBUTE int ii = 0;
-  for (auto query : queries) {
-    std::unique_ptr<parser::SQLStatementList> result(
-        parser::PostgresParser::ParseSQLString(query.c_str()));
-
-    if (result->is_valid == false) {
-      LOG_ERROR("Message: %s, line: %d, col: %d", result->parser_msg,
-                result->error_line, result->error_col);
-    }
-    EXPECT_EQ(result->is_valid, true);
-
-    LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());
-  }
-}
-
-TEST_F(ParserTests, TypeCastTest) {
-  std::vector<std::string> queries;
-  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::INTEGER);");
-  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::FLOAT);");
-  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::DECIMAL);");
-  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::TEXT);");
-  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::VARCHAR);");
-  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::TIMESTAMP);");
-  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::DATE);");
-  // Parsing
-  UNUSED_ATTRIBUTE int ii = 0;
-  for (auto query : queries) {
-    std::unique_ptr<parser::SQLStatementList> result(
-        parser::PostgresParser::ParseSQLString(query.c_str()));
-
-    if (result->is_valid == false) {
-      LOG_ERROR("Message: %s, line: %d, col: %d", result->parser_msg,
-                result->error_line, result->error_col);
-    }
-    EXPECT_EQ(result->is_valid, true);
 
     LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());
   }

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -234,7 +234,8 @@ TEST_F(PostgresParserTests, JoinTest) {
       "bar.val;");
 
   queries.push_back(
-      "SELECT * FROM foo JOIN bar ON foo.id=bar.id JOIN baz ON foo.id2=baz.id2;");
+      "SELECT * FROM foo JOIN bar ON foo.id=bar.id JOIN baz ON "
+      "foo.id2=baz.id2;");
 
   auto parser = parser::PostgresParser::GetInstance();
   // Parsing
@@ -251,15 +252,16 @@ TEST_F(PostgresParserTests, JoinTest) {
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     // Test for multiple table join
     if (ii == 5) {
-      auto select_stmt =
-          reinterpret_cast<parser::SelectStatement *>(stmt_list->statements[0].get());
+      auto select_stmt = reinterpret_cast<parser::SelectStatement *>(
+          stmt_list->statements[0].get());
       auto join_table = select_stmt->from_table.get();
       EXPECT_TRUE(join_table->type == TableReferenceType::JOIN);
       auto l_join = join_table->join->left.get();
       auto r_table = join_table->join->right.get();
       EXPECT_TRUE(l_join->type == TableReferenceType::JOIN);
       EXPECT_TRUE(r_table->type == TableReferenceType::NAME);
-      LOG_INFO("condition 0 : %s", join_table->join->condition->GetInfo().c_str());
+      LOG_INFO("condition 0 : %s",
+               join_table->join->condition->GetInfo().c_str());
       LOG_INFO("condition 0 : %s", l_join->join->condition->GetInfo().c_str());
     }
   }
@@ -381,7 +383,8 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
       parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
 
-  auto update_stmt = (parser::UpdateStatement *)stmt_list->GetStatements()[0].get();
+  auto update_stmt =
+      (parser::UpdateStatement *)stmt_list->GetStatements()[0].get();
   EXPECT_EQ(update_stmt->table->table_info_->table_name, "stock");
 
   // TODO: Uncomment when the AExpressionTransfrom supports operator expression
@@ -573,10 +576,12 @@ TEST_F(PostgresParserTests, InsertTest) {
     EXPECT_EQ(2, insert_stmt->insert_values.size());
 
     // Test NULL Value parsing
-    EXPECT_TRUE(((expression::ConstantValueExpression *)
-                     insert_stmt->insert_values.at(0).at(0).get())
-                    ->GetValue()
-                    .IsNull());
+    EXPECT_TRUE(
+        ((expression::ConstantValueExpression *)insert_stmt->insert_values.at(0)
+             .at(0)
+             .get())
+            ->GetValue()
+            .IsNull());
     // Test normal value
     type::Value five = type::ValueFactory::GetIntegerValue(5);
     type::CmpBool res = five.CompareEquals(
@@ -718,7 +723,8 @@ TEST_F(PostgresParserTests, CreateDbTest) {
 }
 
 TEST_F(PostgresParserTests, DistinctFromTest) {
-  std::string query = "SELECT id, value FROM foo WHERE id IS DISTINCT FROM value;";
+  std::string query =
+      "SELECT id, value FROM foo WHERE id IS DISTINCT FROM value;";
 
   auto parser = parser::PostgresParser::GetInstance();
   std::unique_ptr<parser::SQLStatementList> stmt_list(
@@ -727,12 +733,14 @@ TEST_F(PostgresParserTests, DistinctFromTest) {
 }
 
 TEST_F(PostgresParserTests, ConstraintTest) {
-  std::string query = "CREATE TABLE table1 ("
+  std::string query =
+      "CREATE TABLE table1 ("
       "a int DEFAULT 1+2,"
       "b int DEFAULT 1 REFERENCES table2 (bb) ON UPDATE CASCADE,"
       "c varchar(32) REFERENCES table3 (cc) MATCH FULL ON DELETE SET NULL,"
       "d int CHECK (d+1 > 0),"
-      "FOREIGN KEY (d) REFERENCES table4 (dd) MATCH SIMPLE ON UPDATE SET DEFAULT"
+      "FOREIGN KEY (d) REFERENCES table4 (dd) MATCH SIMPLE ON UPDATE SET "
+      "DEFAULT"
       ");";
 
   auto parser = parser::PostgresParser::GetInstance();
@@ -751,13 +759,16 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_EQ("a", column->name);
   EXPECT_EQ(parser::ColumnDefinition::DataType::INT, column->type);
   EXPECT_TRUE(column->default_value != nullptr);
-  auto default_expr = (expression::OperatorExpression*) column->default_value.get();
+  auto default_expr =
+      (expression::OperatorExpression *)column->default_value.get();
   EXPECT_TRUE(default_expr != nullptr);
   EXPECT_EQ(ExpressionType::OPERATOR_PLUS, default_expr->GetExpressionType());
   EXPECT_EQ(2, default_expr->GetChildrenSize());
-  auto child1 = (expression::ConstantValueExpression*)default_expr->GetChild(0);
+  auto child1 =
+      (expression::ConstantValueExpression *)default_expr->GetChild(0);
   EXPECT_TRUE(child1 != nullptr);
-  auto child2 = (expression::ConstantValueExpression*)default_expr->GetChild(1);
+  auto child2 =
+      (expression::ConstantValueExpression *)default_expr->GetChild(1);
   EXPECT_TRUE(child2 != nullptr);
   EXPECT_EQ(type::CmpBool::TRUE,
             child1->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
@@ -791,16 +802,20 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_EQ("d", column->name);
   EXPECT_EQ(parser::ColumnDefinition::DataType::INT, column->type);
   EXPECT_TRUE(column->check_expression != nullptr);
-  EXPECT_EQ(ExpressionType::COMPARE_GREATERTHAN, column->check_expression->GetExpressionType());
+  EXPECT_EQ(ExpressionType::COMPARE_GREATERTHAN,
+            column->check_expression->GetExpressionType());
   EXPECT_EQ(2, column->check_expression->GetChildrenSize());
-  auto check_child1 = (expression::OperatorExpression*)column->check_expression->GetChild(0);
+  auto check_child1 =
+      (expression::OperatorExpression *)column->check_expression->GetChild(0);
   EXPECT_TRUE(check_child1 != nullptr);
   EXPECT_EQ(ExpressionType::OPERATOR_PLUS, check_child1->GetExpressionType());
   EXPECT_EQ(2, check_child1->GetChildrenSize());
-  auto plus_child1 = (expression::TupleValueExpression*)check_child1->GetChild(0);
+  auto plus_child1 =
+      (expression::TupleValueExpression *)check_child1->GetChild(0);
   EXPECT_TRUE(plus_child1 != nullptr);
   EXPECT_EQ("d", plus_child1->GetColumnName());
-  auto plus_child2 = (expression::ConstantValueExpression*)check_child1->GetChild(1);
+  auto plus_child2 =
+      (expression::ConstantValueExpression *)check_child1->GetChild(1);
   EXPECT_TRUE(plus_child2 != nullptr);
   EXPECT_EQ(type::CmpBool::TRUE,
             plus_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
@@ -847,7 +862,6 @@ TEST_F(PostgresParserTests, DataTypeTest) {
   EXPECT_EQ(type::TypeId::VARCHAR, column->GetValueType(column->type));
   EXPECT_EQ(peloton::type::PELOTON_TEXT_MAX_LEN, column->varlen);
 
-
   // Check Second column
   column = create_stmt->columns.at(1).get();
   EXPECT_EQ("b", column->name);
@@ -885,7 +899,8 @@ TEST_F(PostgresParserTests, CreateTriggerTest) {
   // are identical to what is specified in the query.
 
   // create type
-  EXPECT_EQ(parser::CreateStatement::CreateType::kTrigger, create_trigger_stmt->type);
+  EXPECT_EQ(parser::CreateStatement::CreateType::kTrigger,
+            create_trigger_stmt->type);
   // trigger name
   EXPECT_EQ("check_update", create_trigger_stmt->trigger_name);
   // table name
@@ -940,8 +955,7 @@ TEST_F(PostgresParserTests, CreateTriggerTest) {
 
 TEST_F(PostgresParserTests, DropTriggerTest) {
   auto parser = parser::PostgresParser::GetInstance();
-  std::string query =
-    "DROP TRIGGER if_dist_exists ON films;";
+  std::string query = "DROP TRIGGER if_dist_exists ON films;";
   std::unique_ptr<parser::SQLStatementList> stmt_list(
       parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
@@ -951,9 +965,10 @@ TEST_F(PostgresParserTests, DropTriggerTest) {
   }
   EXPECT_EQ(StatementType::DROP, stmt_list->GetStatement(0)->GetType());
   auto drop_trigger_stmt =
-    static_cast<parser::DropStatement *>(stmt_list->GetStatement(0));
+      static_cast<parser::DropStatement *>(stmt_list->GetStatement(0));
   // drop type
-  EXPECT_EQ(parser::DropStatement::EntityType::kTrigger, drop_trigger_stmt->type);
+  EXPECT_EQ(parser::DropStatement::EntityType::kTrigger,
+            drop_trigger_stmt->type);
   // trigger name
   EXPECT_EQ("if_dist_exists", drop_trigger_stmt->trigger_name);
   // table name
@@ -969,15 +984,17 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_TRUE(stmt_list->is_valid);
   //  auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
   //  LOG_INFO("%s", stmt_list->GetInfo().c_str());
-  auto select_stmt = (parser::SelectStatement *) stmt_list->GetStatement(0);
+  auto select_stmt = (parser::SelectStatement *)stmt_list->GetStatement(0);
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
 
   // Check ADD(1,a)
-  auto fun_expr = (expression::FunctionExpression*) (select_stmt->select_list.at(0).get());
+  auto fun_expr =
+      (expression::FunctionExpression *)(select_stmt->select_list.at(0).get());
   EXPECT_TRUE(fun_expr != nullptr);
   EXPECT_EQ("add", fun_expr->GetFuncName());
   EXPECT_EQ(2, fun_expr->GetChildrenSize());
-  auto const_expr = (expression::ConstantValueExpression*) fun_expr->GetChild(0);
+  auto const_expr =
+      (expression::ConstantValueExpression *)fun_expr->GetChild(0);
   EXPECT_TRUE(const_expr != nullptr);
   EXPECT_EQ(type::CmpBool::TRUE,
             const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
@@ -986,26 +1003,28 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ("a", tv_expr->GetColumnName());
 
   // Check chr(2)
-  fun_expr = (expression::FunctionExpression*) (select_stmt->select_list.at(1).get());
+  fun_expr =
+      (expression::FunctionExpression *)(select_stmt->select_list.at(1).get());
   EXPECT_TRUE(fun_expr != nullptr);
   EXPECT_EQ("chr", fun_expr->GetFuncName());
   EXPECT_EQ(1, fun_expr->GetChildrenSize());
-  const_expr = (expression::ConstantValueExpression*) fun_expr->GetChild(0);
+  const_expr = (expression::ConstantValueExpression *)fun_expr->GetChild(0);
   EXPECT_TRUE(const_expr != nullptr);
   EXPECT_EQ(type::CmpBool::TRUE,
             const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(99)));
 
   // Check FUN(b) > 2
-  auto op_expr = (expression::OperatorExpression*)select_stmt->where_clause.get();
+  auto op_expr =
+      (expression::OperatorExpression *)select_stmt->where_clause.get();
   EXPECT_TRUE(op_expr != nullptr);
   EXPECT_EQ(ExpressionType::COMPARE_GREATERTHAN, op_expr->GetExpressionType());
-  fun_expr = (expression::FunctionExpression*) op_expr->GetChild(0);
+  fun_expr = (expression::FunctionExpression *)op_expr->GetChild(0);
   EXPECT_EQ("fun", fun_expr->GetFuncName());
   EXPECT_EQ(1, fun_expr->GetChildrenSize());
-  tv_expr = (expression::TupleValueExpression*) fun_expr->GetChild(0);
+  tv_expr = (expression::TupleValueExpression *)fun_expr->GetChild(0);
   EXPECT_TRUE(tv_expr != nullptr);
   EXPECT_EQ("b", tv_expr->GetColumnName());
-  const_expr = (expression::ConstantValueExpression*) op_expr->GetChild(1);
+  const_expr = (expression::ConstantValueExpression *)op_expr->GetChild(1);
   EXPECT_TRUE(const_expr != nullptr);
   EXPECT_EQ(type::CmpBool::TRUE, 
             const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
@@ -1020,6 +1039,66 @@ TEST_F(PostgresParserTests, CaseTest) {
   EXPECT_TRUE(stmt_list->is_valid);
 }
 
+TEST_F(PostgresParserTests, DateTypeTest) {
+  std::vector<std::string> valid_queries;
+  valid_queries.push_back(
+      "INSERT INTO test_table VALUES (1, 2, "
+      "'2017-01-01'::DATE);");
+  valid_queries.push_back("CREATE TABLE students (name TEXT, graduation DATE)");
+  // Parsing
+  UNUSED_ATTRIBUTE int ii = 0;
+  for (auto query : valid_queries) {
+    std::unique_ptr<parser::SQLStatementList> result(
+        parser::PostgresParser::ParseSQLString(query.c_str()));
+
+    if (result->is_valid == false) {
+      LOG_ERROR("Message: %s, line: %d, col: %d", result->parser_msg,
+                result->error_line, result->error_col);
+    }
+    EXPECT_EQ(result->is_valid, true);
+
+    LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());
+  }
+
+  // Check invalid input handling
+  std::vector<std::string> invalid_queries;
+  invalid_queries.push_back(
+      "INSERT INTO test_table VALUES (1, 2, "
+      "'2017-00-01'::DATE);");
+  invalid_queries.push_back(
+      "INSERT INTO test_table VALUES (1, 2, "
+      "'2017-01-011'::DATE);");
+  invalid_queries.push_back(
+      "INSERT INTO test_table VALUES (1, 2, "
+      "'2017-00-'::DATE);");
+  for (auto query : invalid_queries) {
+    EXPECT_THROW(parser::PostgresParser::ParseSQLString(query.c_str()),
+                 peloton::Exception);
+  }
+}
+
+TEST_F(PostgresParserTests, TypeCastTest) {
+  std::vector<std::string> queries;
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::INTEGER);");
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::FLOAT);");
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::DECIMAL);");
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::TEXT);");
+  queries.push_back("INSERT INTO test_table VALUES (1, 2, '2017'::VARCHAR);");
+  // Parsing
+  UNUSED_ATTRIBUTE int ii = 0;
+  for (auto query : queries) {
+    std::unique_ptr<parser::SQLStatementList> result(
+        parser::PostgresParser::ParseSQLString(query.c_str()));
+
+    if (result->is_valid == false) {
+      LOG_ERROR("Message: %s, line: %d, col: %d", result->parser_msg,
+                result->error_line, result->error_col);
+    }
+    EXPECT_EQ(result->is_valid, true);
+
+    LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());
+  }
+}
 
 }  // namespace test
 }  // namespace peloton


### PR DESCRIPTION
This PR adds support for DATE type and transform for TypeCast parsenodes. (Related issues: #909 #852) 
- Added the DATE type to corresponding places.
- Added the transform for TypeCast in Postgres: For type casts, the final cast results will be added to the parse tree (e.g. ' "2017-12-31"::DATE ' will be a single DATE type constant value expression after the transform)
- Added a cast from VARCHAR to DATE type with the default format for date strings: "YYYY-MM-DD".
- Provided an additional fix for handling memory leak in InsertTransform when faced with exceptions.
- Added additional helper functions to transform type names to DataType classes and type::typeId classes.