### PR TITLE
[Clean-Up] Add the ClearGarbage back to StopGC.

### DIFF
--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -278,6 +278,15 @@ void TransactionLevelGCManager::ClearGarbage(int thread_id) {
   return;
 }
 
+void TransactionLevelGCManager::StopGC() {
+  LOG_TRACE("Stopping GC");
+  this->is_running_ = false;
+  // clear the garbage in each GC thread
+  for (int thread_id = 0; thread_id < gc_thread_count_; ++thread_id) {
+    ClearGarbage(thread_id);
+  }
+}
+
 void TransactionLevelGCManager::UnlinkVersions(
     const std::shared_ptr<GarbageContext> &garbage_ctx) {
   for (auto entry : *(garbage_ctx->gc_set_.get())) {

--- a/src/include/gc/transaction_level_gc_manager.h
+++ b/src/include/gc/transaction_level_gc_manager.h
@@ -106,10 +106,12 @@ class TransactionLevelGCManager : public GCManager {
     }
   };
 
-  virtual void StopGC() override {
-    LOG_TRACE("Stopping GC");
-    this->is_running_ = false;
-  }
+  /**
+   * @brief This stops the Garbage Collector when Peloton shuts down
+   *
+   * @return No return value.
+   */
+  virtual void StopGC() override;
 
   virtual void RecycleTransaction(std::shared_ptr<GCSet> gc_set,
                                   std::shared_ptr<GCObjectSet> gc_object_set,
@@ -145,6 +147,12 @@ class TransactionLevelGCManager : public GCManager {
     return (unsigned int)thread_id % gc_thread_count_;
   }
 
+  /**
+   * @brief Unlink and reclaim the tuples remained in a garbage collection
+   * thread when the Garbage Collector stops.
+   *
+   * @return No return value.
+   */
   void ClearGarbage(int thread_id);
 
   void Running(const int &thread_id);
@@ -170,9 +178,8 @@ class TransactionLevelGCManager : public GCManager {
 
   // queues for to-be-unlinked tuples.
   // # unlink_queues == # gc_threads
-  std::vector<
-      std::shared_ptr<peloton::LockFreeQueue<std::shared_ptr<GarbageContext>>>>
-      unlink_queues_;
+  std::vector<std::shared_ptr<
+      peloton::LockFreeQueue<std::shared_ptr<GarbageContext>>>> unlink_queues_;
 
   // local queues for to-be-unlinked tuples.
   // # local_unlink_queues == # gc_threads


### PR DESCRIPTION
This adds the call to ClearGarbage function back to the Garbage Collector. It turns out that the Garbage Collector already has a StopGC function that will be called when Peloton shuts down. So I just added the call there.