### PR TITLE
[Cleanup] More 'enum class' fixes

### DIFF
--- a/src/executor/aggregator.cpp
+++ b/src/executor/aggregator.cpp
@@ -283,7 +283,7 @@ bool SortedAggregator::Advance(AbstractTuple *next_tuple) {
       type::Value rval =
           (delegate_tuple_.GetValue(node->GetGroupbyColIds()[grpColOffset]));
 
-      if (lval.CompareNotEquals(rval) == type::CMP_TRUE) {
+      if (lval.CompareNotEquals(rval) == type::CmpBool::TRUE) {
         LOG_TRACE("Group-by columns changed.");
 
         // Call helper to output the current group result

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -677,7 +677,7 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
     }
 
     LOG_TRACE("Difference : %d ", diff);*/
-    if (lhs.CompareEquals(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareEquals(rhs) == type::CmpBool::TRUE) {
       switch (expr_type) {
         case ExpressionType::COMPARE_EQUAL:
         case ExpressionType::COMPARE_LESSTHANOREQUALTO:
@@ -695,7 +695,7 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
                                ExpressionTypeToString(expr_type));
       }
     } else {
-      if (lhs.CompareLessThan(rhs) == type::CMP_TRUE) {
+      if (lhs.CompareLessThan(rhs) == type::CmpBool::TRUE) {
         switch (expr_type) {
           case ExpressionType::COMPARE_NOTEQUAL:
           case ExpressionType::COMPARE_LESSTHAN:
@@ -713,7 +713,7 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
                                  ExpressionTypeToString(expr_type));
         }
       } else {
-        if (lhs.CompareGreaterThan(rhs) == type::CMP_TRUE) {
+        if (lhs.CompareGreaterThan(rhs) == type::CmpBool::TRUE) {
           switch (expr_type) {
             case ExpressionType::COMPARE_NOTEQUAL:
             case ExpressionType::COMPARE_GREATERTHAN:

--- a/src/executor/logical_tile.cpp
+++ b/src/executor/logical_tile.cpp
@@ -555,13 +555,13 @@ void LogicalTile::MaterializeByTiles(
     const peloton::LayoutType peloton_layout_mode) {
   bool row_wise_materialization = true;
 
-  if (peloton_layout_mode == LAYOUT_TYPE_COLUMN)
+  if (peloton_layout_mode == LayoutType::COLUMN)
     row_wise_materialization = false;
 
   // TODO: Make this a parameter
   auto dest_tile_column_count = dest_tile->GetColumnCount();
   oid_t column_count_threshold = 20;
-  if (peloton_layout_mode == LAYOUT_TYPE_HYBRID &&
+  if (peloton_layout_mode == LayoutType::HYBRID &&
       dest_tile_column_count <= column_count_threshold)
     row_wise_materialization = false;
 

--- a/src/executor/materialization_executor.cpp
+++ b/src/executor/materialization_executor.cpp
@@ -99,12 +99,12 @@ void MaterializationExecutor::MaterializeByTiles(
     const peloton::LayoutType peloton_layout_mode) {
   bool row_wise_materialization = true;
 
-  if (peloton_layout_mode == LAYOUT_TYPE_COLUMN) row_wise_materialization = false;
+  if (peloton_layout_mode == LayoutType::COLUMN) row_wise_materialization = false;
 
   // TODO: Make this a parameter
   auto dest_tile_column_count = dest_tile->GetColumnCount();
   oid_t column_count_threshold = 20;
-  if (peloton_layout_mode == LAYOUT_TYPE_HYBRID &&
+  if (peloton_layout_mode == LayoutType::HYBRID &&
       dest_tile_column_count <= column_count_threshold)
     row_wise_materialization = false;
 

--- a/src/executor/merge_join_executor.cpp
+++ b/src/executor/merge_join_executor.cpp
@@ -146,7 +146,7 @@ bool MergeJoinExecutor::DExecute() {
           clause.right_->Evaluate(&left_tuple, &right_tuple, nullptr);
 
       // Left key < Right key, advance left
-      if (left_value.CompareLessThan(right_value) == type::CMP_TRUE) {
+      if (left_value.CompareLessThan(right_value) == type::CmpBool::TRUE) {
         LOG_TRACE("left < right, advance left ");
         left_start_row = left_end_row;
         left_end_row = Advance(left_tile, left_start_row, true);
@@ -154,7 +154,7 @@ bool MergeJoinExecutor::DExecute() {
         break;
       }
       // Left key > Right key, advance right
-      else if (left_value.CompareGreaterThan(right_value) == type::CMP_TRUE) {
+      else if (left_value.CompareGreaterThan(right_value) == type::CmpBool::TRUE) {
         LOG_TRACE("left > right, advance right ");
         right_start_row = right_end_row;
         right_end_row = Advance(right_tile, right_start_row, false);
@@ -260,7 +260,7 @@ size_t MergeJoinExecutor::Advance(LogicalTile *tile, size_t start_row,
       auto next_value =
           expr->Evaluate(&next_tuple, &next_tuple, executor_context_);
 
-      if (!(this_value.CompareEquals(next_value) == type::CMP_TRUE)) {
+      if (!(this_value.CompareEquals(next_value) == type::CmpBool::TRUE)) {
         diff = true;
         break;
       }

--- a/src/executor/order_by_executor.cpp
+++ b/src/executor/order_by_executor.cpp
@@ -201,16 +201,16 @@ bool OrderByExecutor::DoSort() {
         type::Value va = (ta->GetValue(id));
         type::Value vb = (tb->GetValue(id));
         if (!descend_flags[id]) {
-          if (va.CompareLessThan(vb) == type::CMP_TRUE)
+          if (va.CompareLessThan(vb) == type::CmpBool::TRUE)
             return true;
           else {
-            if (va.CompareGreaterThan(vb) == type::CMP_TRUE) return false;
+            if (va.CompareGreaterThan(vb) == type::CmpBool::TRUE) return false;
           }
         } else {
-          if (vb.CompareLessThan(va) == type::CMP_TRUE)
+          if (vb.CompareLessThan(va) == type::CmpBool::TRUE)
             return true;
           else {
-            if (vb.CompareGreaterThan(va) == type::CMP_TRUE) return false;
+            if (vb.CompareGreaterThan(va) == type::CmpBool::TRUE) return false;
           }
         }
       }

--- a/src/include/benchmark/sdbench/sdbench_configuration.h
+++ b/src/include/benchmark/sdbench/sdbench_configuration.h
@@ -52,14 +52,6 @@ enum WriteComplexityType {
   WRITE_COMPLEXITY_TYPE_INSERT = 3
 };
 
-// Copy from types.h for reference
-// typedef enum LayoutType {
-//   LAYOUT_TYPE_INVALID = 0,
-//   LAYOUT_TYPE_ROW = 1,    /* Pure row layout */
-//   LAYOUT_TYPE_COLUMN = 2, /* Pure column layout */
-//   LAYOUT_TYPE_HYBRID = 3  /* Hybrid layout */
-// } LayoutType;
-
 extern int orig_scale_factor;
 
 static const int generator_seed = 50;

--- a/src/include/common/container_tuple.h
+++ b/src/include/common/container_tuple.h
@@ -92,7 +92,7 @@ class ContainerTuple : public AbstractTuple {
       for (size_t idx = 0; idx < column_ids_->size(); idx++) {
         type::Value lhs = (GetValue(column_ids_->at(idx)));
         type::Value rhs = (other.GetValue(other.column_ids_->at(idx)));
-        if (lhs.CompareNotEquals(rhs) == type::CMP_TRUE) {
+        if (lhs.CompareNotEquals(rhs) == type::CmpBool::TRUE) {
           return false;
         }
       }
@@ -101,7 +101,7 @@ class ContainerTuple : public AbstractTuple {
       for (size_t column_itr = 0; column_itr < column_count; column_itr++) {
         type::Value lhs = (GetValue(column_itr));
         type::Value rhs = (other.GetValue(column_itr));
-        if (lhs.CompareNotEquals(rhs) == type::CMP_TRUE) return false;
+        if (lhs.CompareNotEquals(rhs) == type::CmpBool::TRUE) return false;
       }
     }
     return true;
@@ -217,7 +217,7 @@ class ContainerTuple<std::vector<type::Value>> : public AbstractTuple {
     for (size_t column_itr = 0; column_itr < container_->size(); column_itr++) {
       type::Value lhs = GetValue(column_itr);
       type::Value rhs = other.GetValue(column_itr);
-      if (lhs.CompareNotEquals(rhs) == type::CMP_TRUE) return false;
+      if (lhs.CompareNotEquals(rhs) == type::CmpBool::TRUE) return false;
     }
     return true;
   }

--- a/src/include/executor/aggregator.h
+++ b/src/include/executor/aggregator.h
@@ -305,7 +305,7 @@ class HashAggregator : public AbstractAggregator {
     bool operator()(const std::vector<type::Value> &lhs,
                     const std::vector<type::Value> &rhs) const {
       for (size_t i = 0; i < lhs.size() && i < rhs.size(); i++) {
-        if (lhs[i].CompareNotEquals(rhs[i]) == type::CMP_TRUE) return false;
+        if (lhs[i].CompareNotEquals(rhs[i]) == type::CmpBool::TRUE) return false;
       }
       if (lhs.size() == rhs.size()) return true;
       return false;

--- a/src/include/executor/logical_tile.h
+++ b/src/include/executor/logical_tile.h
@@ -318,7 +318,7 @@ class LogicalTile : public Printable {
       const std::unordered_map<storage::Tile *, std::vector<oid_t>>
           &tile_to_cols,
       storage::Tile *dest_tile,
-      const peloton::LayoutType peloton_layout_mode = peloton::LAYOUT_TYPE_ROW);
+      const peloton::LayoutType peloton_layout_mode = peloton::LayoutType::ROW);
 
   /**
    * @brief Generates map from each base tile to columns originally from that

--- a/src/include/executor/materialization_executor.h
+++ b/src/include/executor/materialization_executor.h
@@ -60,7 +60,7 @@ class MaterializationExecutor : public AbstractExecutor {
       const std::unordered_map<storage::Tile *, std::vector<oid_t>> &
           tile_to_cols,
       storage::Tile *dest_tile,
-      const peloton::LayoutType peloton_layout_mode = peloton::LAYOUT_TYPE_ROW);
+      const peloton::LayoutType peloton_layout_mode = peloton::LayoutType::ROW);
 
   LogicalTile *Physify(LogicalTile *source_tile);
   std::unordered_map<oid_t, oid_t> BuildIdentityMapping(

--- a/src/include/expression/constant_value_expression.h
+++ b/src/include/expression/constant_value_expression.h
@@ -48,7 +48,7 @@ class ConstantValueExpression : public AbstractExpression {
     if (exp_type_ != other.GetExpressionType())
       return false;
     auto const_expr = static_cast<const ConstantValueExpression &>(other);
-    return value_.CompareEquals(const_expr.value_);
+    return value_.CompareEquals(const_expr.value_) == type::CmpBool::TRUE;
   }
 
   virtual hash_t HashForExactMatch() const override {

--- a/src/include/index/generic_key.h
+++ b/src/include/index/generic_key.h
@@ -75,9 +75,9 @@ class GenericComparator {
       const type::Value lhs_value = (lhs.ToValue(schema, col_itr));
       const type::Value rhs_value = (rhs.ToValue(schema, col_itr));
 
-      if (lhs_value.CompareLessThan(rhs_value) == type::CMP_TRUE) return true;
+      if (lhs_value.CompareLessThan(rhs_value) == type::CmpBool::TRUE) return true;
 
-      if (lhs_value.CompareGreaterThan(rhs_value) == type::CMP_TRUE)
+      if (lhs_value.CompareGreaterThan(rhs_value) == type::CmpBool::TRUE)
         return false;
     }
 
@@ -108,10 +108,10 @@ class FastGenericComparator {
       bool inlined = schema->IsInlined(col_itr);
 
       if (type::TypeUtil::CompareLessThanRaw(type, lhs_data, rhs_data,
-                                             inlined) == type::CMP_TRUE)
+                                             inlined) == type::CmpBool::TRUE)
         return true;
       else if (type::TypeUtil::CompareGreaterThanRaw(type, lhs_data, rhs_data,
-                                                     inlined) == type::CMP_TRUE)
+                                                     inlined) == type::CmpBool::TRUE)
         return false;
     }
 
@@ -137,10 +137,10 @@ class GenericComparatorRaw {
       const type::Value lhs_value = (lhs.ToValue(schema, column_itr));
       const type::Value rhs_value = (rhs.ToValue(schema, column_itr));
 
-      if (lhs_value.CompareLessThan(rhs_value) == type::CMP_TRUE)
+      if (lhs_value.CompareLessThan(rhs_value) == type::CmpBool::TRUE)
         return VALUE_COMPARE_LESSTHAN;
 
-      if (lhs_value.CompareGreaterThan(rhs_value) == type::CMP_TRUE)
+      if (lhs_value.CompareGreaterThan(rhs_value) == type::CmpBool::TRUE)
         return VALUE_COMPARE_GREATERTHAN;
     }
 

--- a/src/include/index/tuple_key.h
+++ b/src/include/index/tuple_key.h
@@ -178,12 +178,12 @@ class TupleKeyComparator {
         rhTuple.GetValue(rhs.ColumnForIndexColumn(col_itr));
 
       // If there is a field in LHS < RHS then return true;
-      if (lhValue.CompareLessThan(rhValue) == type::CMP_TRUE) {
+      if (lhValue.CompareLessThan(rhValue) == type::CmpBool::TRUE) {
         return true;
       }
       
       // If there is a field in LHS > RHS then return false
-      if (lhValue.CompareGreaterThan(rhValue) == type::CMP_TRUE) {
+      if (lhValue.CompareGreaterThan(rhValue) == type::CmpBool::TRUE) {
         return false;
       }
     }
@@ -235,11 +235,11 @@ class TupleKeyComparatorRaw {
       type::Value rhValue = \
           rhTuple.GetValue(rhs.ColumnForIndexColumn(col_itr));
 
-      if (lhValue.CompareLessThan(rhValue) == type::CMP_TRUE) {
+      if (lhValue.CompareLessThan(rhValue) == type::CmpBool::TRUE) {
         return VALUE_COMPARE_LESSTHAN;
       }
 
-      if (lhValue.CompareGreaterThan(rhValue) == type::CMP_TRUE) {
+      if (lhValue.CompareGreaterThan(rhValue) == type::CmpBool::TRUE) {
         return VALUE_COMPARE_GREATERTHAN;
       }
     }
@@ -293,7 +293,7 @@ class TupleKeyEqualityChecker {
 
       // If any of these two columns differ then just return false
       // because we know they could not be equal 
-      if (lhValue.CompareNotEquals(rhValue) == type::CMP_TRUE) {
+      if (lhValue.CompareNotEquals(rhValue) == type::CmpBool::TRUE) {
         return false;
       }
     }

--- a/src/include/statistics/access_metric.h
+++ b/src/include/statistics/access_metric.h
@@ -131,10 +131,10 @@ class AccessMetric : public AbstractMetric {
 
   // Vector containing all access types
   std::vector<CounterMetric> access_counters_{
-      CounterMetric(COUNTER_METRIC),  // READ_COUNTER
-      CounterMetric(COUNTER_METRIC),  // UPDATE_COUNTER
-      CounterMetric(COUNTER_METRIC),  // INSERT_COUNTER
-      CounterMetric(COUNTER_METRIC)   // DELETE_COUNTER
+      CounterMetric(MetricType::COUNTER),  // READ_COUNTER
+      CounterMetric(MetricType::COUNTER),  // UPDATE_COUNTER
+      CounterMetric(MetricType::COUNTER),  // INSERT_COUNTER
+      CounterMetric(MetricType::COUNTER)   // DELETE_COUNTER
   };
 
   // The different types of accesses. These also

--- a/src/include/statistics/database_metric.h
+++ b/src/include/statistics/database_metric.h
@@ -75,10 +75,10 @@ class DatabaseMetric : public AbstractMetric {
   oid_t database_id_;
 
   // Count of the number of transactions committed
-  CounterMetric txn_committed_{MetricType::COUNTER_METRIC};
+  CounterMetric txn_committed_{MetricType::COUNTER};
 
   // Count of the number of transactions aborted
-  CounterMetric txn_aborted_{MetricType::COUNTER_METRIC};
+  CounterMetric txn_aborted_{MetricType::COUNTER};
 };
 
 }  // namespace stats

--- a/src/include/statistics/index_metric.h
+++ b/src/include/statistics/index_metric.h
@@ -91,7 +91,7 @@ class IndexMetric : public AbstractMetric {
   std::string index_name_;
 
   // Counts the number of index entries accessed
-  AccessMetric index_access_{ACCESS_METRIC};
+  AccessMetric index_access_{MetricType::ACCESS};
 };
 
 }  // namespace stats

--- a/src/include/statistics/query_metric.h
+++ b/src/include/statistics/query_metric.h
@@ -116,13 +116,13 @@ class QueryMetric : public AbstractMetric {
   std::shared_ptr<QueryParams> query_params_;
 
   // The number of tuple accesses
-  AccessMetric query_access_{ACCESS_METRIC};
+  AccessMetric query_access_{MetricType::ACCESS};
 
   // Latency metric
-  LatencyMetric latency_metric_{LATENCY_METRIC, 2};
+  LatencyMetric latency_metric_{MetricType::LATENCY, 2};
 
   // Processor metric
-  ProcessorMetric processor_metric_{PROCESSOR_METRIC};
+  ProcessorMetric processor_metric_{MetricType::PROCESSOR};
 };
 
 }  // namespace stats

--- a/src/include/statistics/table_metric.h
+++ b/src/include/statistics/table_metric.h
@@ -85,7 +85,7 @@ class TableMetric : public AbstractMetric {
   std::string table_name_;
 
   // The number of tuple accesses
-  AccessMetric table_access_{ACCESS_METRIC};
+  AccessMetric table_access_{MetricType::ACCESS};
 };
 
 }  // namespace stats

--- a/src/include/storage/abstract_table.h
+++ b/src/include/storage/abstract_table.h
@@ -55,7 +55,7 @@ class AbstractTable : public Printable {
  protected:
   // Table constructor
   AbstractTable(oid_t table_oid, catalog::Schema *schema, bool own_schema,
-               peloton::LayoutType layout_type = peloton::LAYOUT_TYPE_ROW);
+               peloton::LayoutType layout_type = peloton::LayoutType::ROW);
 
  public:
   //===--------------------------------------------------------------------===//

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -88,7 +88,7 @@ class DataTable : public AbstractTable {
             const oid_t &database_oid, const oid_t &table_oid,
             const size_t &tuples_per_tilegroup, const bool own_schema,
             const bool adapt_table, const bool is_catalog = false,
-            const peloton::LayoutType layout_type = peloton::LAYOUT_TYPE_ROW);
+            const peloton::LayoutType layout_type = peloton::LayoutType::ROW);
 
   ~DataTable();
 

--- a/src/include/storage/table_factory.h
+++ b/src/include/storage/table_factory.h
@@ -34,7 +34,8 @@ class TableFactory {
                                  catalog::Schema *schema,
                                  std::string table_name,
                                  size_t tuples_per_tile_group_count,
-                                 bool own_schema, bool adapt_table, bool is_catalog = false);
+                                 bool own_schema, bool adapt_table,
+                                 bool is_catalog = false);
 
   static TempTable *GetTempTable(catalog::Schema *schema, bool own_schema);
 

--- a/src/include/storage/temp_table.h
+++ b/src/include/storage/temp_table.h
@@ -50,7 +50,7 @@ class TempTable : public AbstractTable {
   // Table constructor
   TempTable(const oid_t &table_oid, catalog::Schema *schema,
             const bool own_schema,
-            const peloton::LayoutType layout_type = peloton::LAYOUT_TYPE_ROW);
+            const peloton::LayoutType layout_type = peloton::LayoutType::ROW);
 
   ~TempTable();
 

--- a/src/include/storage/zone_map_manager.h
+++ b/src/include/storage/zone_map_manager.h
@@ -84,25 +84,25 @@ class ZoneMapManager {
       std::unique_ptr<std::vector<type::Value>> &result_vector);
 
   bool checkEqual(type::Value predicateVal, ColumnStatistics *stats) {
-    return ((stats->min).CompareLessThanEquals(predicateVal)) &&
-           ((stats->max).CompareGreaterThanEquals(predicateVal));
+    return ((stats->min).CompareLessThanEquals(predicateVal)) == type::CmpBool::TRUE &&
+           ((stats->max).CompareGreaterThanEquals(predicateVal) == type::CmpBool::TRUE);
   }
 
   bool checkLessThan(type::Value predicateVal, ColumnStatistics *stats) {
-    return predicateVal.CompareGreaterThan(stats->min);
+    return (predicateVal.CompareGreaterThan(stats->min) == type::CmpBool::TRUE);
   }
 
   bool checkLessThanEquals(type::Value predicateVal, ColumnStatistics *stats) {
-    return predicateVal.CompareGreaterThanEquals(stats->min);
+    return (predicateVal.CompareGreaterThanEquals(stats->min) == type::CmpBool::TRUE);
   }
 
   bool checkGreaterThan(type::Value predicateVal, ColumnStatistics *stats) {
-    return predicateVal.CompareLessThan(stats->max);
+    return (predicateVal.CompareLessThan(stats->max) == type::CmpBool::TRUE);
   }
 
   bool checkGreaterThanEquals(type::Value predicateVal,
                               ColumnStatistics *stats) {
-    return predicateVal.CompareLessThanEquals(stats->max);
+    return (predicateVal.CompareLessThanEquals(stats->max) == type::CmpBool::TRUE);
   }
 
   //===--------------------------------------------------------------------===//

--- a/src/include/type/type.h
+++ b/src/include/type/type.h
@@ -26,7 +26,11 @@ class AbstractPool;
 class Value;
 class ValueFactory;
 
-enum CmpBool { CMP_FALSE = 0, CMP_TRUE = 1, CMP_NULL = 2 };
+enum class CmpBool {
+  FALSE = 0,
+  TRUE = 1,
+  NULL_ = 2
+};
 
 class Type {
  public:

--- a/src/include/type/type_util.h
+++ b/src/include/type/type_util.h
@@ -55,50 +55,50 @@ class TypeUtil {
    */
   static CmpBool CompareEqualsRaw(type::Type type, const char* left,
                                   const char* right, bool inlined) {
-    CmpBool result = CmpBool::CMP_NULL;
+    CmpBool result = CmpBool::NULL_;
     switch (type.GetTypeId()) {
       case TypeId::BOOLEAN:
       case TypeId::TINYINT: {
         result = (*reinterpret_cast<const int8_t*>(left) ==
                           *reinterpret_cast<const int8_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::SMALLINT: {
         result = (*reinterpret_cast<const int16_t*>(left) ==
                           *reinterpret_cast<const int16_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::INTEGER: {
         result = (*reinterpret_cast<const int32_t*>(left) ==
                           *reinterpret_cast<const int32_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::BIGINT: {
         result = (*reinterpret_cast<const int64_t*>(left) ==
                           *reinterpret_cast<const int64_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::DECIMAL: {
         result = (*reinterpret_cast<const double*>(left) ==
                           *reinterpret_cast<const double*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::TIMESTAMP:
       case TypeId::DATE: {
         result = (*reinterpret_cast<const uint64_t*>(left) ==
                           *reinterpret_cast<const uint64_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::VARCHAR:
@@ -110,7 +110,7 @@ class TypeUtil {
           rightPtr = *reinterpret_cast<const char* const*>(right);
         }
         if (leftPtr == nullptr || rightPtr == nullptr) {
-          result = CmpBool::CMP_FALSE;
+          result = CmpBool::FALSE;
           break;
         }
         uint32_t leftLen = *reinterpret_cast<const uint32_t*>(leftPtr);
@@ -134,50 +134,50 @@ class TypeUtil {
    */
   static CmpBool CompareLessThanRaw(const type::Type type, const char* left,
                                     const char* right, bool inlined) {
-    CmpBool result = CmpBool::CMP_NULL;
+    CmpBool result = CmpBool::NULL_;
     switch (type.GetTypeId()) {
       case TypeId::BOOLEAN:
       case TypeId::TINYINT: {
         result = (*reinterpret_cast<const int8_t*>(left) <
                           *reinterpret_cast<const int8_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::SMALLINT: {
         result = (*reinterpret_cast<const int16_t*>(left) <
                           *reinterpret_cast<const int16_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::INTEGER: {
         result = (*reinterpret_cast<const int32_t*>(left) <
                           *reinterpret_cast<const int32_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::BIGINT: {
         result = (*reinterpret_cast<const int64_t*>(left) <
                           *reinterpret_cast<const int64_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::DECIMAL: {
         result = (*reinterpret_cast<const double*>(left) <
                           *reinterpret_cast<const double*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::TIMESTAMP:
       case TypeId::DATE: {
         result = (*reinterpret_cast<const uint64_t*>(left) <
                           *reinterpret_cast<const uint64_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::VARCHAR:
@@ -189,7 +189,7 @@ class TypeUtil {
           rightPtr = *reinterpret_cast<const char* const*>(right);
         }
         if (leftPtr == nullptr || rightPtr == nullptr) {
-          result = CmpBool::CMP_FALSE;
+          result = CmpBool::FALSE;
           break;
         }
         uint32_t leftLen = *reinterpret_cast<const uint32_t*>(leftPtr);
@@ -213,50 +213,50 @@ class TypeUtil {
    */
   static CmpBool CompareGreaterThanRaw(const type::Type type, const char* left,
                                        const char* right, bool inlined) {
-    CmpBool result = CmpBool::CMP_NULL;
+    CmpBool result = CmpBool::NULL_;
     switch (type.GetTypeId()) {
       case TypeId::BOOLEAN:
       case TypeId::TINYINT: {
         result = (*reinterpret_cast<const int8_t*>(left) >
                           *reinterpret_cast<const int8_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::SMALLINT: {
         result = (*reinterpret_cast<const int16_t*>(left) >
                           *reinterpret_cast<const int16_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::INTEGER: {
         result = (*reinterpret_cast<const int32_t*>(left) >
                           *reinterpret_cast<const int32_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::BIGINT: {
         result = (*reinterpret_cast<const int64_t*>(left) >
                           *reinterpret_cast<const int64_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::DECIMAL: {
         result = (*reinterpret_cast<const double*>(left) >
                           *reinterpret_cast<const double*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::TIMESTAMP:
       case TypeId::DATE: {
         result = (*reinterpret_cast<const uint64_t*>(left) >
                           *reinterpret_cast<const uint64_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::VARCHAR:
@@ -268,7 +268,7 @@ class TypeUtil {
           rightPtr = *reinterpret_cast<const char* const*>(right);
         }
         if (leftPtr == nullptr || rightPtr == nullptr) {
-          result = CmpBool::CMP_FALSE;
+          result = CmpBool::FALSE;
           break;
         }
         uint32_t leftLen = *reinterpret_cast<const uint32_t*>(leftPtr);

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -923,12 +923,14 @@ CheckpointingType StringToCheckpointingType(const std::string &str);
 std::ostream &operator<<(std::ostream &os, const CheckpointingType &type);
 
 /* Possible values for peloton_tilegroup_layout GUC */
-typedef enum LayoutType {
-  LAYOUT_TYPE_INVALID = INVALID_TYPE_ID,
-  LAYOUT_TYPE_ROW = 1,    /* Pure row layout */
-  LAYOUT_TYPE_COLUMN = 2, /* Pure column layout */
-  LAYOUT_TYPE_HYBRID = 3  /* Hybrid layout */
-} LayoutType;
+enum class LayoutType {
+  INVALID = INVALID_TYPE_ID,
+  ROW = 1,    /* Pure row layout */
+  COLUMN = 2, /* Pure column layout */
+  HYBRID = 3  /* Hybrid layout */
+};
+std::string LayoutTypeToString(LayoutType type);
+std::ostream &operator<<(std::ostream &os, const LayoutType &type);
 
 //===--------------------------------------------------------------------===//
 // Trigger Types
@@ -1063,7 +1065,10 @@ static const int INVALID_FILE_DESCRIPTOR = -1;
 // Tuple serialization formats
 // ------------------------------------------------------------------
 
-enum class TupleSerializationFormat { NATIVE = 0, DR = 1 };
+enum class TupleSerializationFormat {
+  NATIVE = 0,
+  DR = 1
+};
 
 // ------------------------------------------------------------------
 // Entity types

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -354,7 +354,7 @@ enum class NetworkTransactionStateType : unsigned char {
   FAIL = 'E',
 };
 
-enum SqlStateErrorCode {
+enum class SqlStateErrorCode {
   SERIALIZATION_ERROR = '1',
 };
 
@@ -992,29 +992,29 @@ enum class StatsType {
   ENABLE = 1,
 };
 
-enum MetricType {
+enum class MetricType {
   // Metric type is invalid
-  INVALID_METRIC = INVALID_TYPE_ID,
+  INVALID = INVALID_TYPE_ID,
   // Metric to count a number
-  COUNTER_METRIC = 1,
+  COUNTER = 1,
   // Access information, e.g., # tuples read, inserted, updated, deleted
-  ACCESS_METRIC = 2,
+  ACCESS = 2,
   // Life time of a object
-  LIFETIME_METRIC = 3,
+  LIFETIME = 3,
   // Statistics for a specific database
-  DATABASE_METRIC = 4,
+  DATABASE = 4,
   // Statistics for a specific table
-  TABLE_METRIC = 5,
+  TABLE = 5,
   // Statistics for a specific index
-  INDEX_METRIC = 6,
+  INDEX = 6,
   // Latency of transactions
-  LATENCY_METRIC = 7,
+  LATENCY = 7,
   // Timestamp, e.g., creation time of a table/index
-  TEMPORAL_METRIC = 8,
+  TEMPORAL = 8,
   // Statistics for a specific table
-  QUERY_METRIC = 9,
+  QUERY = 9,
   // Statistics for CPU
-  PROCESSOR_METRIC = 10,
+  PROCESSOR = 10,
 };
 
 // All builtin operators we currently support
@@ -1080,12 +1080,6 @@ enum class EntityType {
 std::string EntityTypeToString(EntityType type);
 EntityType StringToEntityType(const std::string &str);
 std::ostream &operator<<(std::ostream &os, const EntityType &type);
-
-// ------------------------------------------------------------------
-// Endianess
-// ------------------------------------------------------------------
-
-enum Endianess { BYTE_ORDER_BIG_ENDIAN = 0, BYTE_ORDER_LITTLE_ENDIAN = 1 };
 
 //===--------------------------------------------------------------------===//
 // Type definitions.

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -31,7 +31,7 @@ namespace type {
 class Type;
 
 inline CmpBool GetCmpBool(bool boolean) {
-  return boolean ? CMP_TRUE : CMP_FALSE;
+  return boolean ? CmpBool::TRUE : CmpBool::FALSE;
 }
 
 // A value is an abstract class that represents a view over SQL data stored in
@@ -278,7 +278,7 @@ class Value : public Printable {
   // For unordered_map
   struct equal_to {
     inline bool operator()(const Value &x, const Value &y) const {
-      return Type::GetInstance(x.type_id_)->CompareEquals(x, y) == CMP_TRUE;
+      return Type::GetInstance(x.type_id_)->CompareEquals(x, y) == CmpBool::TRUE;
     }
   };
 

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -60,7 +60,7 @@ class ValueFactory {
 
   static inline Value GetBooleanValue(CmpBool value) {
     return Value(TypeId::BOOLEAN,
-                 value == CMP_NULL ? PELOTON_BOOLEAN_NULL : (int8_t)value);
+                 value == CmpBool::NULL_ ? PELOTON_BOOLEAN_NULL : (int8_t)value);
   }
 
   static inline Value GetBooleanValue(bool value) {

--- a/src/index/index.cpp
+++ b/src/index/index.cpp
@@ -271,7 +271,7 @@ bool Index::Compare(const AbstractTuple &index_key,
     }
 
     LOG_TRACE("Difference : %d ", diff);*/
-    if (lhs.CompareEquals(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareEquals(rhs) == type::CmpBool::TRUE) {
       switch (expr_type) {
         case ExpressionType::COMPARE_EQUAL:
         case ExpressionType::COMPARE_LESSTHANOREQUALTO:
@@ -289,7 +289,7 @@ bool Index::Compare(const AbstractTuple &index_key,
                                ExpressionTypeToString(expr_type));
       }
     } else {
-      if (lhs.CompareLessThan(rhs) == type::CMP_TRUE) {
+      if (lhs.CompareLessThan(rhs) == type::CmpBool::TRUE) {
         switch (expr_type) {
           case ExpressionType::COMPARE_NOTEQUAL:
           case ExpressionType::COMPARE_LESSTHAN:
@@ -307,7 +307,7 @@ bool Index::Compare(const AbstractTuple &index_key,
                                  ExpressionTypeToString(expr_type));
         }
       } else {
-        if (lhs.CompareGreaterThan(rhs) == type::CMP_TRUE) {
+        if (lhs.CompareGreaterThan(rhs) == type::CmpBool::TRUE) {
           switch (expr_type) {
             case ExpressionType::COMPARE_NOTEQUAL:
             case ExpressionType::COMPARE_GREATERTHAN:

--- a/src/index/index_util.cpp
+++ b/src/index/index_util.cpp
@@ -191,12 +191,12 @@ bool IndexUtil::ValuePairComparator(const std::pair<type::Value, int> &i,
                                     const std::pair<type::Value, int> &j) {
 
   // If first elements are equal then compare the second element
-  if (i.first.CompareEquals(j.first) == type::CMP_TRUE) {
+  if (i.first.CompareEquals(j.first) == type::CmpBool::TRUE) {
     return i.second < j.second;
   }
   
   // Otherwise compare the first element for "<" or ">"
-  return i.first.CompareLessThan(j.first) == type::CMP_TRUE;
+  return i.first.CompareLessThan(j.first) == type::CmpBool::TRUE;
 }
 
 void IndexUtil::ConstructIntervals(oid_t leading_column_id,
@@ -312,7 +312,7 @@ void IndexUtil::FindMaxMinInColumns(oid_t leading_column_id,
                 values[i].GetInfo().c_str());
       if (non_leading_columns[column_id].first.IsNull() ||
           non_leading_columns[column_id].first
-            .CompareGreaterThan(values[i]) == type::CMP_TRUE) {
+            .CompareGreaterThan(values[i]) == type::CmpBool::TRUE) {
         LOG_TRACE("Update min\n");
         non_leading_columns[column_id].first = values[i].Copy();
       }
@@ -325,7 +325,7 @@ void IndexUtil::FindMaxMinInColumns(oid_t leading_column_id,
                 values[i].GetInfo().c_str());
       if (non_leading_columns[column_id].first.IsNull() ||
           non_leading_columns[column_id].second.
-            CompareLessThan(values[i]) == type::CMP_TRUE) {
+            CompareLessThan(values[i]) == type::CmpBool::TRUE) {
         LOG_TRACE("Update max\n");
         non_leading_columns[column_id].second = values[i].Copy();
       }

--- a/src/main/sdbench/sdbench_configuration.cpp
+++ b/src/main/sdbench/sdbench_configuration.cpp
@@ -173,18 +173,19 @@ static void ValidateScaleFactor(const configuration &state) {
 }
 
 static void ValidateLayout(const configuration &state) {
-  if (state.layout_mode < 1 || state.layout_mode > 3) {
-    LOG_ERROR("Invalid layout :: %d", state.layout_mode);
+  if (state.layout_mode == LayoutType::INVALID) {
+    LOG_ERROR("Invalid layout :: %s",
+              LayoutTypeToString(state.layout_mode).c_str());
     exit(EXIT_FAILURE);
   } else {
     switch (state.layout_mode) {
-      case LAYOUT_TYPE_ROW:
+      case LayoutType::ROW:
         LOG_INFO("%s : ROW", "layout ");
         break;
-      case LAYOUT_TYPE_COLUMN:
+      case LayoutType::COLUMN:
         LOG_INFO("%s : COLUMN", "layout ");
         break;
-      case LAYOUT_TYPE_HYBRID:
+      case LayoutType::HYBRID:
         LOG_INFO("%s : HYBRID", "layout ");
         break;
       default:
@@ -397,7 +398,7 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   state.projectivity = 0.01;
 
   // Layout parameter
-  state.layout_mode = LAYOUT_TYPE_ROW;
+  state.layout_mode = LayoutType::ROW;
 
   // Learning rate
   state.analyze_sample_count_threshold = 100;

--- a/src/main/sdbench/sdbench_loader.cpp
+++ b/src/main/sdbench/sdbench_loader.cpp
@@ -47,7 +47,7 @@ namespace sdbench {
 
 std::unique_ptr<storage::DataTable> sdbench_table;
 
-void CreateTable(peloton::LayoutType layout_type) {
+void CreateTable(UNUSED_ATTRIBUTE peloton::LayoutType layout_type) {
   const oid_t col_count = state.attribute_count + 1;
   const bool is_inlined = true;
 
@@ -73,7 +73,7 @@ void CreateTable(peloton::LayoutType layout_type) {
   bool adapt_table = true;
   sdbench_table.reset(storage::TableFactory::GetDataTable(
       INVALID_OID, INVALID_OID, table_schema, table_name,
-      state.tuples_per_tilegroup, own_schema, adapt_table, layout_type));
+      state.tuples_per_tilegroup, own_schema, adapt_table));
 }
 
 void LoadTable() {

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -1389,7 +1389,7 @@ void BenchmarkPrepare() {
   }
 
   // Start layout tuner
-  if (state.layout_mode == LAYOUT_TYPE_HYBRID) {
+  if (state.layout_mode == LayoutType::HYBRID) {
     layout_tuner.AddTable(sdbench_table.get());
 
     // Start layout tuner
@@ -1407,7 +1407,7 @@ void BenchmarkCleanUp() {
     index_tuner.ClearTables();
   }
 
-  if (state.layout_mode == LAYOUT_TYPE_HYBRID) {
+  if (state.layout_mode == LayoutType::HYBRID) {
     layout_tuner.Stop();
     layout_tuner.ClearTables();
   }

--- a/src/statistics/access_metric.cpp
+++ b/src/statistics/access_metric.cpp
@@ -17,7 +17,7 @@ namespace peloton {
 namespace stats {
 
 void AccessMetric::Aggregate(AbstractMetric &source) {
-  PL_ASSERT(source.GetType() == ACCESS_METRIC);
+  PL_ASSERT(source.GetType() == MetricType::ACCESS);
 
   auto access_metric = static_cast<AccessMetric &>(source);
   for (size_t i = 0; i < NUM_COUNTERS; ++i) {

--- a/src/statistics/backend_stats_context.cpp
+++ b/src/statistics/backend_stats_context.cpp
@@ -47,7 +47,7 @@ BackendStatsContext* BackendStatsContext::GetInstance() {
 
 BackendStatsContext::BackendStatsContext(size_t max_latency_history,
                                          bool regiser_to_aggregator)
-    : txn_latencies_(LATENCY_METRIC, max_latency_history) {
+    : txn_latencies_(MetricType::LATENCY, max_latency_history) {
   std::thread::id this_id = std::this_thread::get_id();
   thread_id_ = this_id;
 
@@ -69,7 +69,7 @@ TableMetric* BackendStatsContext::GetTableMetric(oid_t database_id,
                                                  oid_t table_id) {
   if (table_metrics_.find(table_id) == table_metrics_.end()) {
     table_metrics_[table_id] = std::unique_ptr<TableMetric>(
-        new TableMetric{TABLE_METRIC, database_id, table_id});
+        new TableMetric{MetricType::TABLE, database_id, table_id});
   }
   return table_metrics_[table_id].get();
 }
@@ -78,7 +78,7 @@ TableMetric* BackendStatsContext::GetTableMetric(oid_t database_id,
 DatabaseMetric* BackendStatsContext::GetDatabaseMetric(oid_t database_id) {
   if (database_metrics_.find(database_id) == database_metrics_.end()) {
     database_metrics_[database_id] = std::unique_ptr<DatabaseMetric>(
-        new DatabaseMetric{DATABASE_METRIC, database_id});
+        new DatabaseMetric{MetricType::DATABASE, database_id});
   }
   return database_metrics_[database_id].get();
 }
@@ -92,7 +92,7 @@ IndexMetric* BackendStatsContext::GetIndexMetric(oid_t database_id,
   // Index metric doesn't exist yet
   if (index_metrics_.Contains(index_id) == false) {
     index_metric.reset(
-        new IndexMetric{INDEX_METRIC, database_id, table_id, index_id});
+        new IndexMetric{MetricType::INDEX, database_id, table_id, index_id});
     index_metrics_.Insert(index_id, index_metric);
     index_id_lock.Lock();
     index_ids_.insert(index_id);
@@ -222,7 +222,7 @@ void BackendStatsContext::InitQueryMetric(
     const std::shared_ptr<QueryMetric::QueryParams> params) {
   // TODO currently all queries belong to DEFAULT_DB
   ongoing_query_metric_.reset(new QueryMetric(
-      QUERY_METRIC, statement->GetQueryString(), params, DEFAULT_DB_ID));
+      MetricType::QUERY, statement->GetQueryString(), params, DEFAULT_DB_ID));
 }
 
 //===--------------------------------------------------------------------===//
@@ -290,7 +290,7 @@ void BackendStatsContext::Reset() {
     // Reset database metrics
     if (database_metrics_.find(database_id) == database_metrics_.end()) {
       database_metrics_[database_id] = std::unique_ptr<DatabaseMetric>(
-          new DatabaseMetric{DATABASE_METRIC, database_id});
+          new DatabaseMetric{MetricType::DATABASE, database_id});
     }
 
     // Reset table metrics
@@ -301,7 +301,7 @@ void BackendStatsContext::Reset() {
 
       if (table_metrics_.find(table_id) == table_metrics_.end()) {
         table_metrics_[table_id] = std::unique_ptr<TableMetric>(
-            new TableMetric{TABLE_METRIC, database_id, table_id});
+            new TableMetric{MetricType::TABLE, database_id, table_id});
       }
 
       // Reset indexes metrics
@@ -312,7 +312,7 @@ void BackendStatsContext::Reset() {
         oid_t index_id = index->GetOid();
         if (index_metrics_.Contains(index_id) == false) {
           std::shared_ptr<IndexMetric> index_metric(
-              new IndexMetric{INDEX_METRIC, database_id, table_id, index_id});
+              new IndexMetric{MetricType::INDEX, database_id, table_id, index_id});
           index_metrics_.Insert(index_id, index_metric);
           index_ids_.insert(index_id);
         }

--- a/src/statistics/counter_metric.cpp
+++ b/src/statistics/counter_metric.cpp
@@ -21,7 +21,7 @@ CounterMetric::CounterMetric(MetricType type) : AbstractMetric(type) {
 }
 
 void CounterMetric::Aggregate(AbstractMetric &source) {
-  PL_ASSERT(source.GetType() == COUNTER_METRIC);
+  PL_ASSERT(source.GetType() == MetricType::COUNTER);
   count_ += static_cast<CounterMetric &>(source).GetCounter();
 }
 

--- a/src/statistics/database_metric.cpp
+++ b/src/statistics/database_metric.cpp
@@ -20,7 +20,7 @@ DatabaseMetric::DatabaseMetric(MetricType type, oid_t database_id)
     : AbstractMetric(type), database_id_(database_id) {}
 
 void DatabaseMetric::Aggregate(AbstractMetric& source) {
-  PL_ASSERT(source.GetType() == DATABASE_METRIC);
+  PL_ASSERT(source.GetType() == MetricType::DATABASE);
 
   DatabaseMetric& db_metric = static_cast<DatabaseMetric&>(source);
   txn_committed_.Aggregate(db_metric.GetTxnCommitted());

--- a/src/statistics/index_metric.cpp
+++ b/src/statistics/index_metric.cpp
@@ -36,7 +36,7 @@ IndexMetric::IndexMetric(MetricType type, oid_t database_id, oid_t table_id,
 }
 
 void IndexMetric::Aggregate(AbstractMetric& source) {
-  assert(source.GetType() == INDEX_METRIC);
+  assert(source.GetType() == MetricType::INDEX);
 
   IndexMetric& index_metric = static_cast<IndexMetric&>(source);
   index_access_.Aggregate(index_metric.GetIndexAccess());

--- a/src/statistics/latency_metric.cpp
+++ b/src/statistics/latency_metric.cpp
@@ -25,7 +25,7 @@ LatencyMetric::LatencyMetric(MetricType type, size_t max_history)
 }
 
 void LatencyMetric::Aggregate(AbstractMetric& source) {
-  PL_ASSERT(source.GetType() == LATENCY_METRIC);
+  PL_ASSERT(source.GetType() == MetricType::LATENCY);
 
   LatencyMetric& latency_metric = static_cast<LatencyMetric&>(source);
   CircularBuffer<double> source_latencies = latency_metric.Copy();

--- a/src/statistics/stats_aggregator.cpp
+++ b/src/statistics/stats_aggregator.cpp
@@ -133,7 +133,7 @@ void StatsAggregator::UpdateQueryMetrics(int64_t time_stamp,
                                          concurrency::TransactionContext *txn) {
   // Get the target query metrics table
   LOG_TRACE("Inserting Query Metric Tuples");
-  // auto query_metrics_table = GetMetricTable(QUERY_METRIC_NAME);
+  // auto query_metrics_table = GetMetricTable(MetricType::QUERY_NAME);
 
   std::shared_ptr<QueryMetric> query_metric;
   auto &completed_query_metrics = aggregated_stats_.GetCompletedQueryMetrics();

--- a/src/statistics/table_metric.cpp
+++ b/src/statistics/table_metric.cpp
@@ -30,7 +30,7 @@ TableMetric::TableMetric(MetricType type, oid_t database_id, oid_t table_id)
 }
 
 void TableMetric::Aggregate(AbstractMetric& source) {
-  assert(source.GetType() == TABLE_METRIC);
+  assert(source.GetType() == MetricType::TABLE);
 
   TableMetric& table_metric = static_cast<TableMetric&>(source);
   table_access_.Aggregate(table_metric.GetTableAccess());

--- a/src/storage/abstract_table.cpp
+++ b/src/storage/abstract_table.cpp
@@ -39,25 +39,25 @@ column_map_type AbstractTable::GetTileGroupLayout() const {
   auto col_count = schema->GetColumnCount();
 
   // pure row layout map
-  if (layout_type == LAYOUT_TYPE_ROW) {
+  if (layout_type == LayoutType::ROW) {
     for (oid_t col_itr = 0; col_itr < col_count; col_itr++) {
       column_map[col_itr] = std::make_pair(0, col_itr);
     }
   }
   // pure column layout map
-  else if (layout_type == LAYOUT_TYPE_COLUMN) {
+  else if (layout_type == LayoutType::COLUMN) {
     for (oid_t col_itr = 0; col_itr < col_count; col_itr++) {
       column_map[col_itr] = std::make_pair(col_itr, 0);
     }
   }
   // hybrid layout map
-  else if (layout_type == LAYOUT_TYPE_HYBRID) {
+  else if (layout_type == LayoutType::HYBRID) {
     for (oid_t col_itr = 0; col_itr < col_count; col_itr++) {
       column_map[col_itr] = std::make_pair(0, col_itr);
     }
   } else {
     throw Exception("Unknown tilegroup layout option : " +
-                    std::to_string(layout_type));
+                    LayoutTypeToString(layout_type));
   }
 
   return column_map;

--- a/src/storage/tuple.cpp
+++ b/src/storage/tuple.cpp
@@ -312,7 +312,7 @@ bool Tuple::EqualsNoSchemaCheck(const AbstractTuple &other) const {
   for (int column_itr = 0; column_itr < column_count; column_itr++) {
     type::Value lhs = (GetValue(column_itr));
     type::Value rhs = (other.GetValue(column_itr));
-    if (lhs.CompareNotEquals(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareNotEquals(rhs) == type::CmpBool::TRUE) {
       return false;
     }
   }
@@ -325,7 +325,7 @@ bool Tuple::EqualsNoSchemaCheck(const AbstractTuple &other,
   for (auto column_itr : columns) {
     type::Value lhs = (GetValue(column_itr));
     type::Value rhs = (other.GetValue(column_itr));
-    if (lhs.CompareNotEquals(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareNotEquals(rhs) == type::CmpBool::TRUE) {
       return false;
     }
   }
@@ -363,10 +363,10 @@ int Tuple::Compare(const Tuple &other) const {
   for (int column_itr = 0; column_itr < column_count; column_itr++) {
     type::Value lhs = (GetValue(column_itr));
     type::Value rhs = (other.GetValue(column_itr));
-    if (lhs.CompareGreaterThan(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareGreaterThan(rhs) == type::CmpBool::TRUE) {
       return 1;
     }
-    if (lhs.CompareLessThan(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareLessThan(rhs) == type::CmpBool::TRUE) {
       return -1;
     }
   }
@@ -379,10 +379,10 @@ int Tuple::Compare(const Tuple &other,
   for (auto column_itr : columns) {
     type::Value lhs = (GetValue(column_itr));
     type::Value rhs = (other.GetValue(column_itr));
-    if (lhs.CompareGreaterThan(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareGreaterThan(rhs) == type::CmpBool::TRUE) {
       return 1;
     }
-    if (lhs.CompareLessThan(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareLessThan(rhs) == type::CmpBool::TRUE) {
       return -1;
     }
   }

--- a/src/storage/zone_map_manager.cpp
+++ b/src/storage/zone_map_manager.cpp
@@ -96,10 +96,10 @@ void ZoneMapManager::CreateOrUpdateZoneMapForTileGroup(
     oid_t num_tuple_slots = tile_group->GetAllocatedTupleCount();
     for (oid_t tuple_itr = 0; tuple_itr < num_tuple_slots; tuple_itr++) {
       type::Value current_val = tile_group->GetValue(tuple_itr, col_itr);
-      if (current_val.CompareGreaterThan(max)) {
+      if (current_val.CompareGreaterThan(max) == type::CmpBool::TRUE) {
         max = current_val;
       }
-      if (current_val.CompareLessThan(min)) {
+      if (current_val.CompareLessThan(min) == type::CmpBool::TRUE) {
         min = current_val;
       }
     }

--- a/src/type/array_type.cpp
+++ b/src/type/array_type.cpp
@@ -80,7 +80,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
       std::vector<bool>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetBooleanValue(ValueFactory::GetBooleanValue(*it).CompareEquals(object));
-        if (ValueFactory::GetBooleanValue(*it).CompareEquals(object) == CMP_TRUE) return res;
+        if (ValueFactory::GetBooleanValue(*it).CompareEquals(object) == CmpBool::TRUE) return res;
       }
       return ValueFactory::GetBooleanValue(false);
     }

--- a/src/type/bigint_type.cpp
+++ b/src/type/bigint_type.cpp
@@ -187,7 +187,7 @@ CmpBool BigintType::CompareEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   BIGINT_COMPARE_FUNC(==);
 
@@ -199,7 +199,7 @@ CmpBool BigintType::CompareNotEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   BIGINT_COMPARE_FUNC(!=);
 
@@ -211,7 +211,7 @@ CmpBool BigintType::CompareLessThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   BIGINT_COMPARE_FUNC(<);
 
@@ -223,7 +223,7 @@ CmpBool BigintType::CompareLessThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   BIGINT_COMPARE_FUNC(<=);
 
@@ -235,7 +235,7 @@ CmpBool BigintType::CompareGreaterThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   BIGINT_COMPARE_FUNC(>);
 
@@ -247,7 +247,7 @@ CmpBool BigintType::CompareGreaterThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   BIGINT_COMPARE_FUNC(>=);
 

--- a/src/type/boolean_type.cpp
+++ b/src/type/boolean_type.cpp
@@ -29,7 +29,7 @@ CmpBool BooleanType::CompareEquals(const Value& left,
                                    const Value& right) const {
   PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(==);
 }
 
@@ -37,7 +37,7 @@ CmpBool BooleanType::CompareNotEquals(const Value& left,
                                       const Value& right) const {
   PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(!=);
 }
 
@@ -45,7 +45,7 @@ CmpBool BooleanType::CompareLessThan(const Value& left,
                                      const Value& right) const {
   PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(<);
 }
 
@@ -53,7 +53,7 @@ CmpBool BooleanType::CompareLessThanEquals(const Value& left,
                                            const Value& right) const {
   PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(<=);
 }
 
@@ -61,7 +61,7 @@ CmpBool BooleanType::CompareGreaterThan(const Value& left,
                                         const Value& right) const {
   PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(>);
 }
 
@@ -69,21 +69,21 @@ CmpBool BooleanType::CompareGreaterThanEquals(const Value& left,
                                               const Value& right) const {
   PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(>=);
 }
 
 Value BooleanType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value BooleanType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareGreaterThanEquals(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 

--- a/src/type/date_type.cpp
+++ b/src/type/date_type.cpp
@@ -21,55 +21,55 @@ DateType::DateType() : Type(TypeId::DATE) {}
 
 CmpBool DateType::CompareEquals(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() == right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareNotEquals(const Value& left,
                                    const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (right.IsNull()) return CMP_NULL;
+  if (right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() != right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareLessThan(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() < right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareLessThanEquals(const Value& left,
                                         const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() <= right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareGreaterThan(const Value& left,
                                      const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() > right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareGreaterThanEquals(const Value& left,
                                            const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() >= right.GetAs<int32_t>());
 }
 
 Value DateType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value DateType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareGreaterThan(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareGreaterThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 

--- a/src/type/decimal_type.cpp
+++ b/src/type/decimal_type.cpp
@@ -163,7 +163,7 @@ Value DecimalType::Min(const Value& left, const Value &right) const {
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
-  if (left.CompareLessThanEquals(right) == CMP_TRUE)
+  if (left.CompareLessThanEquals(right) == CmpBool::TRUE)
     return left.Copy();
   return right.Copy();
 }
@@ -174,7 +174,7 @@ Value DecimalType::Max(const Value& left, const Value &right) const {
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
-  if (left.CompareGreaterThanEquals(right) == CMP_TRUE)
+  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE)
     return left.Copy();
   return right.Copy();
 }
@@ -198,7 +198,7 @@ CmpBool DecimalType::CompareEquals(const Value& left, const Value &right) const 
   PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
     
   DECIMAL_COMPARE_FUNC(==);
 
@@ -209,7 +209,7 @@ CmpBool DecimalType::CompareNotEquals(const Value& left, const Value &right) con
   PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   DECIMAL_COMPARE_FUNC(!=);
 
@@ -220,7 +220,7 @@ CmpBool DecimalType::CompareLessThan(const Value& left, const Value &right) cons
   PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   DECIMAL_COMPARE_FUNC(<);
 
@@ -231,7 +231,7 @@ CmpBool DecimalType::CompareLessThanEquals(const Value& left, const Value &right
   PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   DECIMAL_COMPARE_FUNC(<=);
 
@@ -242,7 +242,7 @@ CmpBool DecimalType::CompareGreaterThan(const Value& left, const Value &right) c
   PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   DECIMAL_COMPARE_FUNC(>);
 
@@ -253,7 +253,7 @@ CmpBool DecimalType::CompareGreaterThanEquals(const Value& left, const Value &ri
   PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   DECIMAL_COMPARE_FUNC(>=);
 

--- a/src/type/integer_parent_type.cpp
+++ b/src/type/integer_parent_type.cpp
@@ -28,7 +28,7 @@ Value IntegerParentType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
 
-  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
@@ -37,7 +37,7 @@ Value IntegerParentType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
 
-  if (left.CompareGreaterThanEquals(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 

--- a/src/type/integer_type.cpp
+++ b/src/type/integer_type.cpp
@@ -191,7 +191,7 @@ CmpBool IntegerType::CompareEquals(const Value& left, const Value &right) const 
   PL_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   INT_COMPARE_FUNC(==);
 
@@ -203,7 +203,7 @@ CmpBool IntegerType::CompareNotEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   INT_COMPARE_FUNC(!=);
 
@@ -215,7 +215,7 @@ CmpBool IntegerType::CompareLessThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   INT_COMPARE_FUNC(<);
 
@@ -227,7 +227,7 @@ CmpBool IntegerType::CompareLessThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   INT_COMPARE_FUNC(<=);
 
@@ -239,7 +239,7 @@ CmpBool IntegerType::CompareGreaterThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   INT_COMPARE_FUNC(>);
 
@@ -251,7 +251,7 @@ CmpBool IntegerType::CompareGreaterThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   INT_COMPARE_FUNC(>=);
 

--- a/src/type/smallint_type.cpp
+++ b/src/type/smallint_type.cpp
@@ -198,7 +198,7 @@ CmpBool SmallintType::CompareEquals(const Value& left,
   PL_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   SMALLINT_COMPARE_FUNC(==);
 
@@ -210,7 +210,7 @@ CmpBool SmallintType::CompareNotEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   SMALLINT_COMPARE_FUNC(!=);
 
@@ -222,7 +222,7 @@ CmpBool SmallintType::CompareLessThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   SMALLINT_COMPARE_FUNC(<);
 
@@ -234,7 +234,7 @@ CmpBool SmallintType::CompareLessThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   SMALLINT_COMPARE_FUNC(<=);
 
@@ -246,7 +246,7 @@ CmpBool SmallintType::CompareGreaterThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   SMALLINT_COMPARE_FUNC(>);
 
@@ -258,7 +258,7 @@ CmpBool SmallintType::CompareGreaterThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   SMALLINT_COMPARE_FUNC(>=);
 

--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -26,56 +26,56 @@ TimestampType::TimestampType()
 CmpBool TimestampType::CompareEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() == right.GetAs<uint64_t>());
 }
 
 CmpBool TimestampType::CompareNotEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() != right.GetAs<uint64_t>());
 }
 
 CmpBool TimestampType::CompareLessThan(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() < right.GetAs<uint64_t>());
 }
 
 CmpBool TimestampType::CompareLessThanEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() <= right.GetAs<uint64_t>());
 }
 
 CmpBool TimestampType::CompareGreaterThan(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int64_t>() > right.GetAs<int64_t>());
 }
 
 CmpBool TimestampType::CompareGreaterThanEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() >= right.GetAs<uint64_t>());
 }
 
 Value TimestampType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value TimestampType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareGreaterThanEquals(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 

--- a/src/type/tinyint_type.cpp
+++ b/src/type/tinyint_type.cpp
@@ -191,7 +191,7 @@ CmpBool TinyintType::CompareEquals(const Value& left, const Value &right) const 
   PL_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   TINYINT_COMPARE_FUNC(==);
 
@@ -203,7 +203,7 @@ CmpBool TinyintType::CompareNotEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   TINYINT_COMPARE_FUNC(!=);
 
@@ -215,7 +215,7 @@ CmpBool TinyintType::CompareLessThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   TINYINT_COMPARE_FUNC(<);
 
@@ -227,7 +227,7 @@ CmpBool TinyintType::CompareLessThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   TINYINT_COMPARE_FUNC(<=);
 
@@ -239,7 +239,7 @@ CmpBool TinyintType::CompareGreaterThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   TINYINT_COMPARE_FUNC(>);
 
@@ -251,7 +251,7 @@ CmpBool TinyintType::CompareGreaterThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   TINYINT_COMPARE_FUNC(>=);
 

--- a/src/type/types.cpp
+++ b/src/type/types.cpp
@@ -2692,7 +2692,7 @@ std::ostream &operator<<(std::ostream &os, const PropertyType &type) {
 //===--------------------------------------------------------------------===//
 std::string SqlStateErrorCodeToString(SqlStateErrorCode code) {
   switch (code) {
-    case SERIALIZATION_ERROR:
+    case SqlStateErrorCode::SERIALIZATION_ERROR:
       return "40001";
     default:
       return "INVALID";

--- a/src/type/types.cpp
+++ b/src/type/types.cpp
@@ -2352,6 +2352,37 @@ std::ostream &operator<<(std::ostream &os, const CheckpointingType &type) {
   return os;
 }
 
+std::string LayoutTypeToString(LayoutType type) {
+  switch (type) {
+    case LayoutType::INVALID: {
+      return "INVALID";
+    }
+    case LayoutType::ROW: {
+      return "ROW";
+    }
+    case LayoutType::COLUMN: {
+      return "COLUMN";
+    }
+    case LayoutType::HYBRID: {
+      return "HYBRID";
+    }
+    default: {
+      throw ConversionException(StringUtil::Format(
+          "No string conversion for LayoutType value '%d'",
+          static_cast<int>(type)));
+    }
+  }
+  return "INVALID";
+}
+
+std::ostream &operator<<(std::ostream &os, const LayoutType &type) {
+  os << LayoutTypeToString(type);
+  return os;
+}
+
+
+
+
 type::TypeId PostgresValueTypeToPelotonValueType(PostgresValueType type) {
   switch (type) {
     case PostgresValueType::BOOLEAN:

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -59,7 +59,7 @@ char *VarlenType::GetData(char *storage) {
 
 CmpBool VarlenType::CompareEquals(const Value &left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) == GetLength(right));
@@ -71,7 +71,7 @@ CmpBool VarlenType::CompareEquals(const Value &left, const Value &right) const {
 CmpBool VarlenType::CompareNotEquals(const Value &left,
                                      const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) != GetLength(right));
@@ -83,7 +83,7 @@ CmpBool VarlenType::CompareNotEquals(const Value &left,
 CmpBool VarlenType::CompareLessThan(const Value &left,
                                     const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) < GetLength(right));
@@ -95,7 +95,7 @@ CmpBool VarlenType::CompareLessThan(const Value &left,
 CmpBool VarlenType::CompareLessThanEquals(const Value &left,
                                           const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) <= GetLength(right));
@@ -107,7 +107,7 @@ CmpBool VarlenType::CompareLessThanEquals(const Value &left,
 CmpBool VarlenType::CompareGreaterThan(const Value &left,
                                        const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) > GetLength(right));
@@ -119,7 +119,7 @@ CmpBool VarlenType::CompareGreaterThan(const Value &left,
 CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
                                              const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) >= GetLength(right));
@@ -131,14 +131,14 @@ CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
 Value VarlenType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value VarlenType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareGreaterThanEquals(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -299,7 +299,7 @@ TEST_F(BinderCorrectnessTest, FunctionExpressionTest) {
       dynamic_cast<parser::SelectStatement*>(stmt)->select_list[0].get());
   EXPECT_TRUE(funct_expr->Evaluate(nullptr, nullptr, nullptr)
                   .CompareEquals(type::ValueFactory::GetVarcharValue("est")) ==
-              type::CMP_TRUE);
+              type::CmpBool::TRUE);
 
   txn_manager.CommitTransaction(txn);
 }

--- a/test/codegen/case_translator_test.cpp
+++ b/test/codegen/case_translator_test.cpp
@@ -90,17 +90,17 @@ TEST_F(CaseTranslatorTest, SimpleCase) {
   const auto &results = buffer.GetOutputTuples();
   EXPECT_EQ(NumRowsInTestTable(), results.size());
   EXPECT_TRUE(results[0].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(0)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(0)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[0].GetValue(1).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(0)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(0)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[1].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(10)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(10)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[1].GetValue(1).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(1)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(1)) == type::CmpBool::TRUE);
 
   for (uint32_t i = 2; i < NumRowsInTestTable(); i++) {
     EXPECT_TRUE(results[i].GetValue(1).CompareEquals(
-                    type::ValueFactory::GetBigIntValue(0)) == type::CMP_TRUE);
+                    type::ValueFactory::GetBigIntValue(0)) == type::CmpBool::TRUE);
   }
 }
 
@@ -156,17 +156,17 @@ TEST_F(CaseTranslatorTest, SimpleCaseMoreWhen) {
   const auto &results = buffer.GetOutputTuples();
   EXPECT_EQ(NumRowsInTestTable(), results.size());
   EXPECT_TRUE(results[0].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(0)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(0)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[0].GetValue(1).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(0)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(0)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[1].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(10)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(10)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[1].GetValue(1).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(1)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(1)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[2].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(20)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(20)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[2].GetValue(1).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(2)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(2)) == type::CmpBool::TRUE);
 }
 
 }  // namespace test

--- a/test/codegen/group_by_translator_test.cpp
+++ b/test/codegen/group_by_translator_test.cpp
@@ -91,7 +91,7 @@ TEST_F(GroupByTranslatorTest, SingleColumnGrouping) {
   // Each group should have a count of one (since the grouping column is unique)
   type::Value const_one = type::ValueFactory::GetIntegerValue(1);
   for (const auto &tuple : results) {
-    EXPECT_TRUE(tuple.GetValue(1).CompareEquals(const_one) == type::CMP_TRUE);
+    EXPECT_TRUE(tuple.GetValue(1).CompareEquals(const_one) == type::CmpBool::TRUE);
   }
 }
 
@@ -153,7 +153,7 @@ TEST_F(GroupByTranslatorTest, MultiColumnGrouping) {
   type::Value const_one = type::ValueFactory::GetIntegerValue(1);
   for (const auto &tuple : results) {
     type::Value group_count = tuple.GetValue(2);
-    EXPECT_TRUE(group_count.CompareEquals(const_one) == type::CMP_TRUE);
+    EXPECT_TRUE(group_count.CompareEquals(const_one) == type::CmpBool::TRUE);
   }
 }
 
@@ -385,7 +385,7 @@ TEST_F(GroupByTranslatorTest, SingleCountStar) {
   const auto &results = buffer.GetOutputTuples();
   EXPECT_EQ(1, results.size());
   EXPECT_TRUE(results[0].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(10)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(10)) == type::CmpBool::TRUE);
 }
 
 TEST_F(GroupByTranslatorTest, MinAndMax) {
@@ -451,12 +451,12 @@ TEST_F(GroupByTranslatorTest, MinAndMax) {
   // maximum row ID is equal to # inserted - 1. Therefore:
   // MAX(a) = (# inserted - 1) * 10 = (10 - 1) * 10 = 9 * 10 = 90
   EXPECT_TRUE(results[0].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(90)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(90)) == type::CmpBool::TRUE);
 
   // The values of 'b' are equal to the (zero-indexed) row ID * 10 + 1. The
   // minimum row ID is 0. Therefore: MIN(b) = 0 * 10 + 1 = 1
   EXPECT_TRUE(results[0].GetValue(1).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(1)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(1)) == type::CmpBool::TRUE);
 }
 
 }  // namespace test

--- a/test/codegen/hash_join_translator_test.cpp
+++ b/test/codegen/hash_join_translator_test.cpp
@@ -124,7 +124,7 @@ TEST_F(HashJoinTranslatorTest, SingleHashJoinColumnTest) {
     LOG_DEBUG("=====> Output: %s", tuple.GetInfo().c_str());
 
     // Check that the joins keys are actually equal
-    EXPECT_EQ(type::CMP_TRUE,
+    EXPECT_EQ(type::CmpBool::TRUE,
               tuple.GetValue(0).CompareEquals(tuple.GetValue(1)));
   }
 }

--- a/test/codegen/insert_translator_test.cpp
+++ b/test/codegen/insert_translator_test.cpp
@@ -97,13 +97,13 @@ TEST_F(InsertTranslatorTest, InsertOneTuple) {
   // Check that we got all the results
   auto &results_table1 = buffer_table1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetDecimalValue(2)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("Tuple1")));
 
 }
@@ -158,21 +158,21 @@ TEST_F(InsertTranslatorTest, InsertScanTranslator) {
   // Check that we got all the results
   auto &results_table1 = buffer_table1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("3")));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(90)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(91)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(92)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("93")));
 }
 
@@ -227,19 +227,19 @@ TEST_F(InsertTranslatorTest, InsertScanTranslatorWithNull) {
   // Check that we got all the results
   auto &results_table1 = buffer_table1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(1).IsNull());
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(2).CompareEquals(
+  EXPECT_TRUE(results_table1[0].GetValue(1).IsNull());
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("3")));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(90)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(1).IsNull());
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(2).CompareEquals(
+  EXPECT_TRUE(results_table1[9].GetValue(1).IsNull());
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(92)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("93")));
 }
 
@@ -293,21 +293,21 @@ TEST_F(InsertTranslatorTest, InsertScanColumnTranslator) {
   // Check that we got all the results
   auto &results_table1 = buffer_table1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("3")));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(91)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(90)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(92)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("93")));
 }
 

--- a/test/codegen/order_by_translator_test.cpp
+++ b/test/codegen/order_by_translator_test.cpp
@@ -61,7 +61,7 @@ TEST_F(OrderByTranslatorTest, SingleIntColAscTest) {
       results.begin(), results.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
         auto is_lte = t1.GetValue(0).CompareLessThanEquals(t2.GetValue(0));
-        return is_lte == type::CMP_TRUE;
+        return is_lte == type::CmpBool::TRUE;
       }));
 }
 
@@ -99,7 +99,7 @@ TEST_F(OrderByTranslatorTest, SingleIntColDescTest) {
       results.begin(), results.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
         auto is_gte = t1.GetValue(0).CompareGreaterThanEquals(t2.GetValue(0));
-        return is_gte == type::CMP_TRUE;
+        return is_gte == type::CmpBool::TRUE;
       }));
 }
 
@@ -137,14 +137,14 @@ TEST_F(OrderByTranslatorTest, MultiIntColAscTest) {
   EXPECT_TRUE(std::is_sorted(
       results.begin(), results.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
-        if (t1.GetValue(1).CompareEquals(t2.GetValue(0)) == type::CMP_TRUE) {
+        if (t1.GetValue(1).CompareEquals(t2.GetValue(0)) == type::CmpBool::TRUE) {
           // t1.b == t2.b => t1.a <= t2.a
           return t1.GetValue(0).CompareLessThanEquals(t2.GetValue(0)) ==
-                 type::CMP_TRUE;
+                 type::CmpBool::TRUE;
         } else {
           // t1.b != t2.b => t1.b < t2.b
           return t1.GetValue(1).CompareLessThan(t2.GetValue(1)) ==
-                 type::CMP_TRUE;
+                 type::CmpBool::TRUE;
         }
       }));
 }
@@ -183,14 +183,14 @@ TEST_F(OrderByTranslatorTest, MultiIntColMixedTest) {
   EXPECT_TRUE(std::is_sorted(
       results.begin(), results.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
-        if (t1.GetValue(1).CompareEquals(t2.GetValue(1)) == type::CMP_TRUE) {
+        if (t1.GetValue(1).CompareEquals(t2.GetValue(1)) == type::CmpBool::TRUE) {
           // t1.b == t2.b => t1.a <= t2.a
           return t1.GetValue(0).CompareLessThanEquals(t2.GetValue(0)) ==
-                 type::CMP_TRUE;
+                 type::CmpBool::TRUE;
         } else {
           // t1.b != t2.b => t1.b > t2.b
           return t1.GetValue(1).CompareGreaterThan(t2.GetValue(1)) ==
-                 type::CMP_TRUE;
+                 type::CmpBool::TRUE;
         }
       }));
 }

--- a/test/codegen/parameterization_test.cpp
+++ b/test/codegen/parameterization_test.cpp
@@ -210,11 +210,11 @@ TEST_F(ParameterizationTest, ConstParameterWithConjunction) {
 
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(1, results.size());
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(21)));
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetDecimalValue(22)));
 
   // SELECT a, b, c FROM table where a >= 30 and b = 31;
@@ -247,11 +247,11 @@ TEST_F(ParameterizationTest, ConstParameterWithConjunction) {
 
   const auto &results_2 = buffer_2.GetOutputTuples();
   ASSERT_EQ(1, results_2.size());
-  EXPECT_EQ(type::CMP_TRUE, results_2[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_2[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(30)));
-  EXPECT_EQ(type::CMP_TRUE, results_2[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_2[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(31)));
-  EXPECT_EQ(type::CMP_TRUE, results_2[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_2[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetDecimalValue(32)));
   EXPECT_TRUE(cached);
 
@@ -328,9 +328,9 @@ TEST_F(ParameterizationTest, ParamParameterWithConjunction) {
 
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(NumRowsInTestTable() - 2, results.size());
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(type::CMP_FALSE, results[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::FALSE, results[0].GetValue(3).CompareEquals(
                                  type::ValueFactory::GetVarcharValue("")));
   EXPECT_FALSE(cached);
 
@@ -368,9 +368,9 @@ TEST_F(ParameterizationTest, ParamParameterWithConjunction) {
 
   const auto &results_2 = buffer_2.GetOutputTuples();
   ASSERT_EQ(NumRowsInTestTable() - 3, results_2.size());
-  EXPECT_EQ(type::CMP_TRUE, results_2[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_2[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(30)));
-  EXPECT_EQ(type::CMP_FALSE, results_2[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::FALSE, results_2[0].GetValue(3).CompareEquals(
                                  type::ValueFactory::GetVarcharValue("empty")));
   EXPECT_TRUE(cached);
 
@@ -408,9 +408,9 @@ TEST_F(ParameterizationTest, ParamParameterWithConjunction) {
 
   const auto &results_3 = buffer_3.GetOutputTuples();
   ASSERT_EQ(NumRowsInTestTable() - 3, results_3.size());
-  EXPECT_EQ(type::CMP_TRUE, results_3[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_3[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(30)));
-  EXPECT_EQ(type::CMP_FALSE, results_3[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::FALSE, results_3[0].GetValue(3).CompareEquals(
                                  type::ValueFactory::GetVarcharValue("empty")));
   EXPECT_TRUE(cached);
 
@@ -448,9 +448,9 @@ TEST_F(ParameterizationTest, ParamParameterWithConjunction) {
 
   const auto &results_4 = buffer_4.GetOutputTuples();
   ASSERT_EQ(NumRowsInTestTable() - 3, results_3.size());
-  EXPECT_EQ(type::CMP_TRUE, results_4[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_4[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(30)));
-  EXPECT_EQ(type::CMP_FALSE, results_4[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::FALSE, results_4[0].GetValue(3).CompareEquals(
                                  type::ValueFactory::GetVarcharValue("empty")));
   EXPECT_TRUE(cached);
 }

--- a/test/codegen/query_cache_test.cpp
+++ b/test/codegen/query_cache_test.cpp
@@ -246,9 +246,9 @@ TEST_F(QueryCacheTest, CacheSeqScanPlan) {
   // Check that we got all the results
   const auto& results_1 = buffer_1.GetOutputTuples();
   EXPECT_EQ(1, results_1.size());
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(21)));
   EXPECT_FALSE(cached);
 
@@ -258,9 +258,9 @@ TEST_F(QueryCacheTest, CacheSeqScanPlan) {
 
   const auto& results_2 = buffer_2.GetOutputTuples();
   EXPECT_EQ(1, results_2.size());
-  EXPECT_EQ(type::CMP_TRUE, results_2[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_2[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(type::CMP_TRUE, results_2[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_2[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(21)));
   EXPECT_TRUE(cached);
   EXPECT_EQ(1, codegen::QueryCache::Instance().GetCount());
@@ -304,7 +304,7 @@ TEST_F(QueryCacheTest, CacheHashJoinPlan) {
 
     // Check that the joins keys are actually equal
     EXPECT_EQ(tuple.GetValue(0).CompareEquals(tuple.GetValue(1)),
-              type::CMP_TRUE);
+              type::CmpBool::TRUE);
   }
 
   // We collect the results of the query into an in-memory buffer
@@ -322,7 +322,7 @@ TEST_F(QueryCacheTest, CacheHashJoinPlan) {
 
     // Check that the joins keys are actually equal
     EXPECT_EQ(tuple.GetValue(0).CompareEquals(tuple.GetValue(1)),
-              type::CMP_TRUE);
+              type::CmpBool::TRUE);
   }
   EXPECT_EQ(1, codegen::QueryCache::Instance().GetCount());
 
@@ -385,7 +385,7 @@ TEST_F(QueryCacheTest, CacheOrderByPlan) {
       results_1.begin(), results_1.end(),
       [](const codegen::WrappedTuple& t1, const codegen::WrappedTuple& t2) {
         auto is_gte = t1.GetValue(0).CompareGreaterThanEquals(t2.GetValue(0));
-        return is_gte == type::CMP_TRUE;
+        return is_gte == type::CmpBool::TRUE;
       }));
 
   CompileAndExecuteCache(order_by_plan_2, buffer_2,
@@ -397,7 +397,7 @@ TEST_F(QueryCacheTest, CacheOrderByPlan) {
       results_2.begin(), results_2.end(),
       [](const codegen::WrappedTuple& t1, const codegen::WrappedTuple& t2) {
         auto is_gte = t1.GetValue(0).CompareGreaterThanEquals(t2.GetValue(0));
-        return is_gte == type::CMP_TRUE;
+        return is_gte == type::CmpBool::TRUE;
       }));
 
   auto found =

--- a/test/codegen/table_scan_translator_test.cpp
+++ b/test/codegen/table_scan_translator_test.cpp
@@ -216,18 +216,18 @@ TEST_F(TableScanTranslatorTest, SimplePredicateWithNull) {
   EXPECT_EQ(2, results.size());
 
   // First tuple should be (0, 1)
-  EXPECT_EQ(type::CmpBool::CMP_TRUE,
+  EXPECT_EQ(type::CmpBool::TRUE,
             results[0].GetValue(0).CompareEquals(
                 type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(type::CmpBool::CMP_TRUE,
+  EXPECT_EQ(type::CmpBool::TRUE,
             results[0].GetValue(1).CompareEquals(
                 type::ValueFactory::GetIntegerValue(1)));
 
   // Second tuple should be (10, 11)
-  EXPECT_EQ(type::CmpBool::CMP_TRUE,
+  EXPECT_EQ(type::CmpBool::TRUE,
             results[1].GetValue(0).CompareEquals(
                 type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_EQ(type::CmpBool::CMP_TRUE,
+  EXPECT_EQ(type::CmpBool::TRUE,
             results[1].GetValue(1).CompareEquals(
                 type::ValueFactory::GetIntegerValue(11)));
 }
@@ -295,9 +295,9 @@ TEST_F(TableScanTranslatorTest, ScanWithConjunctionPredicate) {
   // Check output results
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(1, results.size());
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(21)));
 }
 
@@ -583,9 +583,9 @@ TEST_F(TableScanTranslatorTest, ScanWithModuloPredicate) {
   // Check output results
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(1, results.size());
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
 }
 

--- a/test/codegen/update_translator_test.cpp
+++ b/test/codegen/update_translator_test.cpp
@@ -115,21 +115,21 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstant) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("3")));
-  EXPECT_EQ(type::CMP_TRUE, results_1[9].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[9].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[9].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[9].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(91)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[9].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[9].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(92)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[9].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[9].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("93")));
 }
 
@@ -209,13 +209,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantAndPredicate) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(40)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(49)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(42)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("43")));
 
 }
@@ -304,13 +304,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAnOperatorExpression) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(40)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(49)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(42)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("43")));
 
 }
@@ -410,13 +410,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAnOperatorExpressionComplex) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(41)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(81)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(42)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("43")));
 
 }
@@ -498,13 +498,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantPrimary) {
   // Check that we got all the results
   auto &results_5 = buffer_5.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_5[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_5[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_5[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_5[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(11)));
-  EXPECT_EQ(type::CMP_TRUE, results_5[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_5[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(12)));
-  EXPECT_EQ(type::CMP_TRUE, results_5[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_5[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("13")));
 }
 
@@ -583,13 +583,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithCast) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(11)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("13")));
 
   // Get the scan plan without a predicate with four columns
@@ -655,13 +655,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithCast) {
   // Check that we got all the results
   auto &results_3 = buffer_3.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_3[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_3[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_EQ(type::CMP_TRUE, results_3[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_3[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(11)));
-  EXPECT_EQ(type::CMP_TRUE, results_3[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_3[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(3)));
-  EXPECT_EQ(type::CMP_TRUE, results_3[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_3[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("13")));
 }
 

--- a/test/codegen/zone_map_scan_test.cpp
+++ b/test/codegen/zone_map_scan_test.cpp
@@ -146,9 +146,9 @@ TEST_F(ZoneMapScanTest, ScanwithConjunctionPredicate) {
   // Check output results
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(1, results.size());
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(21)));
 }
 }

--- a/test/common/container_tuple_test.cpp
+++ b/test/common/container_tuple_test.cpp
@@ -37,7 +37,7 @@ TEST_F(ContainerTupleTests, VectorValue) {
 
   for (size_t i = 0; i < values.size(); i++) {
     LOG_INFO("%s", ctuple.GetValue(i).GetInfo().c_str());
-    EXPECT_TRUE(values[i].CompareEquals(ctuple.GetValue(i)) == type::CMP_TRUE);
+    EXPECT_TRUE(values[i].CompareEquals(ctuple.GetValue(i)) == type::CmpBool::TRUE);
   }
 }
 

--- a/test/executor/aggregate_test.cpp
+++ b/test/executor/aggregate_test.cpp
@@ -126,16 +126,16 @@ TEST_F(AggregateTests, SortedDistinctTest) {
   type::Value val = (result_tile->GetValue(0, 2));
   type::CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 3));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(2)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(5, 2));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(51)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(5, 3));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(52)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 }
 
 TEST_F(AggregateTests, SortedSumGroupByTest) {
@@ -227,16 +227,16 @@ TEST_F(AggregateTests, SortedSumGroupByTest) {
   type::Value val = (result_tile->GetValue(0, 0));
   type::CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(105)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(1, 0));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(1, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(355)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 }
 
 TEST_F(AggregateTests, SortedSumMaxGroupByTest) {
@@ -333,16 +333,16 @@ TEST_F(AggregateTests, SortedSumMaxGroupByTest) {
   type::Value val = (result_tile->GetValue(0, 0));
   type::CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(105)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 2));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(42)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(1, 0));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 }
 
 TEST_F(AggregateTests, MinMaxTest) {
@@ -454,16 +454,16 @@ TEST_F(AggregateTests, MinMaxTest) {
   type::Value val = (result_tile->GetValue(0, 0));
   type::CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(91)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 2));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(2)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 3));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(92)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 }
 
 TEST_F(AggregateTests, HashDistinctTest) {
@@ -741,15 +741,15 @@ TEST_F(AggregateTests, HashCountDistinctGroupByTest) {
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(0)));
   type::CmpBool cmp1 =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE || cmp1 == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE || cmp1 == type::CmpBool::TRUE);
 
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(5)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 
   val = (result_tile->GetValue(0, 2));
   cmp = (val.CompareLessThanEquals(type::ValueFactory::GetIntegerValue(3)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 }
 
 TEST_F(AggregateTests, PlainSumCountDistinctTest) {
@@ -854,13 +854,13 @@ TEST_F(AggregateTests, PlainSumCountDistinctTest) {
   type::Value val = (result_tile->GetValue(0, 0));
   type::CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(50)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 2));
   cmp = (val.CompareLessThanEquals(type::ValueFactory::GetIntegerValue(3)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 }
 
 }  // namespace test

--- a/test/executor/materialization_test.cpp
+++ b/test/executor/materialization_test.cpp
@@ -81,18 +81,18 @@ TEST_F(MaterializationTests, SingleBaseTileTest) {
     type::Value val1 = (result_base_tile->GetValue(i, 1));
     type::CmpBool cmp = (val0.CompareEquals(
       type::ValueFactory::GetIntegerValue(TestingExecutorUtil::PopulatedValue(i, 0))));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
     cmp = val1.CompareEquals(type::ValueFactory::GetIntegerValue(
         TestingExecutorUtil::PopulatedValue(i, 1)));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 
     // Double check that logical tile is functioning.
     type::Value logic_val0 = (result_logical_tile->GetValue(i, 0));
     type::Value logic_val1 = (result_logical_tile->GetValue(i, 1));
     cmp = (logic_val0.CompareEquals(val0));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
     cmp = (logic_val1.CompareEquals(val1));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   }
 }
 
@@ -154,28 +154,28 @@ TEST_F(MaterializationTests, TwoBaseTilesWithReorderTest) {
     // Output column 2.
     type::CmpBool cmp(val2.CompareEquals(
       type::ValueFactory::GetIntegerValue(TestingExecutorUtil::PopulatedValue(i, 0))));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 
     // Output column 1.
     cmp = (val1.CompareEquals(type::ValueFactory::GetIntegerValue(
         TestingExecutorUtil::PopulatedValue(i, 1))));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 
     // Output column 0.
     cmp = (val0.CompareEquals(type::ValueFactory::GetVarcharValue(
         std::to_string(TestingExecutorUtil::PopulatedValue(i, 3)))));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 
     // Double check that logical tile is functioning.
     type::Value logic_val0 = (result_logical_tile->GetValue(i, 0));
     type::Value logic_val1 = (result_logical_tile->GetValue(i, 1));
     type::Value logic_val2 = (result_logical_tile->GetValue(i, 2));
     cmp = (logic_val0.CompareEquals(val0));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
     cmp = (logic_val1.CompareEquals(val1));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
     cmp = (logic_val2.CompareEquals(val2));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   }
 }
 

--- a/test/executor/seq_scan_test.cpp
+++ b/test/executor/seq_scan_test.cpp
@@ -238,7 +238,7 @@ void RunTest(executor::SeqScanExecutor &executor, int expected_num_tiles,
           (type::ValueFactory::GetVarcharValue(std::to_string(val2)));
       type::Value val =
           (result_tiles[i]->GetValue(new_tuple_id, expected_num_cols - 1));
-      EXPECT_TRUE(val.CompareEquals(string_value) == type::CMP_TRUE);
+      EXPECT_TRUE(val.CompareEquals(string_value) == type::CmpBool::TRUE);
     }
     EXPECT_EQ(0, expected_tuples_left.size());
   }

--- a/test/executor/tile_group_layout_test.cpp
+++ b/test/executor/tile_group_layout_test.cpp
@@ -60,7 +60,16 @@ namespace test {
 
 class TileGroupLayoutTests : public PelotonTest {};
 
-void ExecuteTileGroupTest(peloton::LayoutType layout_type) {
+// FIXME: PAVLO: 2017-12-21
+// I was going to through and changing LayoutType to be 
+// an 'enum class' instead of just an 'enum'. When I did that,
+// the invocation to TableFactory::GetDataTable() broke because
+// now it didn't like the LayoutType parameter. I looked into it
+// and found that the TableFactory doesn't even take in a LayoutType
+// parameter at all. It was only working because the LayoutType
+// was getting cast to a bool. So as it stands now, this test case
+// does *not* check whether we can have different layouts in a TileGroup. 
+void ExecuteTileGroupTest(UNUSED_ATTRIBUTE peloton::LayoutType layout_type) {
   const int tuples_per_tilegroup_count = 10;
   const int tile_group_count = 5;
   const int tuple_count = tuples_per_tilegroup_count * tile_group_count;
@@ -89,7 +98,7 @@ void ExecuteTileGroupTest(peloton::LayoutType layout_type) {
   bool adapt_table = true;
   std::unique_ptr<storage::DataTable> table(storage::TableFactory::GetDataTable(
       INVALID_OID, INVALID_OID, table_schema, table_name,
-      tuples_per_tilegroup_count, own_schema, adapt_table, layout_type));
+      tuples_per_tilegroup_count, own_schema, adapt_table));
 
   // PRIMARY INDEX
   if (indexes == true) {
@@ -209,11 +218,11 @@ void ExecuteTileGroupTest(peloton::LayoutType layout_type) {
 }
 
 TEST_F(TileGroupLayoutTests, RowLayout) {
-  ExecuteTileGroupTest(LAYOUT_TYPE_ROW);
+  ExecuteTileGroupTest(LayoutType::ROW);
 }
 
 TEST_F(TileGroupLayoutTests, ColumnLayout) {
-  ExecuteTileGroupTest(LAYOUT_TYPE_COLUMN);
+  ExecuteTileGroupTest(LayoutType::COLUMN);
 }
 
 }  // namespace test

--- a/test/expression/expression_test.cpp
+++ b/test/expression/expression_test.cpp
@@ -213,7 +213,7 @@ TEST_F(ExpressionTests, ExtractDateTests) {
   //    type::Value expected = type::ValueFactory::GetDecimalValue(x.second);
   //    type::Value result = extract_expr->Evaluate(nullptr, nullptr, nullptr);
   //    EXPECT_FALSE(result.IsNull());
-  //    EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  //    EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
   //  }
 }
 
@@ -264,14 +264,14 @@ TEST_F(ExpressionTests, SimpleCase) {
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   type::Value result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   type::Value expected = type::ValueFactory::GetIntegerValue(2);
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 
   // Test with A = 2, should get 3
   tuple->SetValue(0, type::ValueFactory::GetIntegerValue(2), nullptr);
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   expected = type::ValueFactory::GetIntegerValue(3);
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 }
 
 TEST_F(ExpressionTests, SimpleCaseCopyTest) {
@@ -323,14 +323,14 @@ TEST_F(ExpressionTests, SimpleCaseCopyTest) {
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   type::Value result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   type::Value expected = type::ValueFactory::GetIntegerValue(2);
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 
   // Test with A = 2, should get 3
   tuple->SetValue(0, type::ValueFactory::GetIntegerValue(2), nullptr);
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   expected = type::ValueFactory::GetIntegerValue(3);
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 }
 
 TEST_F(ExpressionTests, SimpleCaseWithDefault) {
@@ -377,14 +377,14 @@ TEST_F(ExpressionTests, SimpleCaseWithDefault) {
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   type::Value result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   type::Value expected = type::ValueFactory::GetIntegerValue(2);
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 
   // Test with A = 2, should get 3
   tuple->SetValue(0, type::ValueFactory::GetIntegerValue(2), nullptr);
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   expected = type::ValueFactory::GetIntegerValue(3);
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 }
 
 }  // namespace test

--- a/test/function/date_functions_test.cpp
+++ b/test/function/date_functions_test.cpp
@@ -55,7 +55,7 @@ void ExtractTestHelper(DatePartType part, std::string &date,
   // Then check that it equals our expected value
   LOG_TRACE("COMPARE: %s = %s\n", expected.ToString().c_str(),
             result.ToString().c_str());
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 }
 
 // Invoke DateFunctions::Extract(NULL)

--- a/test/logging/recovery_test.cpp
+++ b/test/logging/recovery_test.cpp
@@ -311,16 +311,16 @@
 
 //   type::Value rval0 = (recovery_table->GetTileGroupById(100)->GetValue(5, 0));
 //   type::CmpBool cmp0 = (val0.CompareEquals(rval0));
-//   EXPECT_TRUE(cmp0 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp0 == type::CmpBool::TRUE);
 //   type::Value rval1 = (recovery_table->GetTileGroupById(100)->GetValue(5, 1));
 //   type::CmpBool cmp1 = (val1.CompareEquals(rval1));
-//   EXPECT_TRUE(cmp1 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp1 == type::CmpBool::TRUE);
 //   type::Value rval2 = (recovery_table->GetTileGroupById(100)->GetValue(5, 2));
 //   type::CmpBool cmp2 = (val2.CompareEquals(rval2));
-//   EXPECT_TRUE(cmp2 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp2 == type::CmpBool::TRUE);
 //   type::Value rval3 = (recovery_table->GetTileGroupById(100)->GetValue(5, 3));
 //   type::CmpBool cmp3 = (val3.CompareEquals(rval3));
-//   EXPECT_TRUE(cmp3 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp3 == type::CmpBool::TRUE);
 
 //   EXPECT_EQ(recovery_table->GetTupleCount(), 1);
 //   EXPECT_EQ(recovery_table->GetTileGroupCount(), 2);
@@ -365,16 +365,16 @@
 
 //   type::Value rval0 = (recovery_table->GetTileGroupById(100)->GetValue(5, 0));
 //   type::CmpBool cmp0 = (val0.CompareEquals(rval0));
-//   EXPECT_TRUE(cmp0 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp0 == type::CmpBool::TRUE);
 //   type::Value rval1 = (recovery_table->GetTileGroupById(100)->GetValue(5, 1));
 //   type::CmpBool cmp1 = (val1.CompareEquals(rval1));
-//   EXPECT_TRUE(cmp1 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp1 == type::CmpBool::TRUE);
 //   type::Value rval2 = (recovery_table->GetTileGroupById(100)->GetValue(5, 2));
 //   type::CmpBool cmp2 = (val2.CompareEquals(rval2));
-//   EXPECT_TRUE(cmp2 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp2 == type::CmpBool::TRUE);
 //   type::Value rval3 = (recovery_table->GetTileGroupById(100)->GetValue(5, 3));
 //   type::CmpBool cmp3 = (val3.CompareEquals(rval3));
-//   EXPECT_TRUE(cmp3 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp3 == type::CmpBool::TRUE);
 
 //   EXPECT_EQ(recovery_table->GetTupleCount(), 0);
 //   EXPECT_EQ(recovery_table->GetTileGroupCount(), 2);

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -389,7 +389,7 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   EXPECT_EQ(update_stmt->updates.at(0)->column, "s_quantity");
   auto constant =
       (expression::ConstantValueExpression *)update_stmt->updates.at(0)->value.get();
-  EXPECT_TRUE(constant->GetValue().CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, constant->GetValue().CompareEquals(
       type::ValueFactory::GetDecimalValue(48)));
 
   // Test Second Set Condition
@@ -399,7 +399,7 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   auto child1 = (expression::TupleValueExpression *)op_expr->GetChild(0);
   EXPECT_EQ(child1->GetColumnName(), "s_ytd");
   auto child2 = (expression::ConstantValueExpression *)op_expr->GetChild(1);
-  EXPECT_TRUE(
+  EXPECT_EQ(type::CmpBool::TRUE, 
       child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
 
   // Test Where clause
@@ -410,14 +410,14 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   auto column = (expression::TupleValueExpression *)cond1->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_i_id");
   constant = (expression::ConstantValueExpression *)cond1->GetChild(1);
-  EXPECT_TRUE(constant->GetValue().CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, constant->GetValue().CompareEquals(
       type::ValueFactory::GetIntegerValue(68999)));
   auto cond2 = (expression::OperatorExpression *)where->GetChild(1);
   EXPECT_EQ(cond2->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
   column = (expression::TupleValueExpression *)cond2->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_w_id");
   constant = (expression::ConstantValueExpression *)cond2->GetChild(1);
-  EXPECT_TRUE(constant->GetValue().CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, constant->GetValue().CompareEquals(
       type::ValueFactory::GetIntegerValue(4)));
 }
 
@@ -582,7 +582,7 @@ TEST_F(PostgresParserTests, InsertTest) {
     type::CmpBool res = five.CompareEquals(
         ((expression::ConstantValueExpression *)
              insert_stmt->insert_values.at(1).at(1).get())->GetValue());
-    EXPECT_EQ(1, res);
+    EXPECT_EQ(type::CmpBool::TRUE, res);
 
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
@@ -759,8 +759,10 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_TRUE(child1 != nullptr);
   auto child2 = (expression::ConstantValueExpression*)default_expr->GetChild(1);
   EXPECT_TRUE(child2 != nullptr);
-  EXPECT_TRUE(child1->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_TRUE(child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            child1->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
 
   // Check Second column
   column = create_stmt->columns.at(1).get();
@@ -800,10 +802,12 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_EQ("d", plus_child1->GetColumnName());
   auto plus_child2 = (expression::ConstantValueExpression*)check_child1->GetChild(1);
   EXPECT_TRUE(plus_child2 != nullptr);
-  EXPECT_TRUE(plus_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            plus_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
   auto check_child2 = (expression::ConstantValueExpression*)column->check_expression->GetChild(1);
   EXPECT_TRUE(check_child2 != nullptr);
-  EXPECT_TRUE(check_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(0)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            check_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(0)));
 
   // Check Fifth column
   column = create_stmt->columns.at(4).get();
@@ -975,7 +979,8 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ(2, fun_expr->GetChildrenSize());
   auto const_expr = (expression::ConstantValueExpression*) fun_expr->GetChild(0);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_TRUE(const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
   auto tv_expr = (expression::TupleValueExpression*) fun_expr->GetChild(1);
   EXPECT_TRUE(tv_expr != nullptr);
   EXPECT_EQ("a", tv_expr->GetColumnName());
@@ -987,7 +992,8 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ(1, fun_expr->GetChildrenSize());
   const_expr = (expression::ConstantValueExpression*) fun_expr->GetChild(0);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_TRUE(const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(99)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(99)));
 
   // Check FUN(b) > 2
   auto op_expr = (expression::OperatorExpression*)select_stmt->where_clause.get();
@@ -1001,7 +1007,8 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ("b", tv_expr->GetColumnName());
   const_expr = (expression::ConstantValueExpression*) op_expr->GetChild(1);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_TRUE(const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
+  EXPECT_EQ(type::CmpBool::TRUE, 
+            const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
 }
 
 TEST_F(PostgresParserTests, CaseTest) {

--- a/test/storage/masked_tuple_test.cpp
+++ b/test/storage/masked_tuple_test.cpp
@@ -41,7 +41,7 @@ void MaskedTupleTestHelper(storage::MaskedTuple *masked_tuple,
         v.CompareEquals(type::ValueFactory::GetIntegerValue(expected));
     LOG_TRACE("mask[%d]->%d ==> (Expected=%d / Result=%s)", i, mask[i],
               expected, v.GetInfo().c_str());
-    EXPECT_EQ(type::CmpBool::CMP_TRUE, result);
+    EXPECT_EQ(type::CmpBool::TRUE, result);
   }
 }
 
@@ -80,7 +80,7 @@ TEST_F(MaskedTupleTests, BasicTest) {
     int expected = values[i];
     auto result =
         v.CompareEquals(type::ValueFactory::GetIntegerValue(expected));
-    EXPECT_EQ(type::CmpBool::CMP_TRUE, result);
+    EXPECT_EQ(type::CmpBool::TRUE, result);
   }
 
   // CREATE MASKED TUPLE

--- a/test/storage/temp_table_test.cpp
+++ b/test/storage/temp_table_test.cpp
@@ -90,7 +90,7 @@ TEST_F(TempTableTests, InsertTest) {
         // I have to do this because we can't put type::Value into a std::set
         bool found = false;
         for (auto val : values) {
-          found = val.CompareEquals(tupleVal) == type::CMP_TRUE;
+          found = val.CompareEquals(tupleVal) == type::CmpBool::TRUE;
           if (found) break;
         }  // FOR
         EXPECT_TRUE(found);

--- a/test/type/array_value_test.cpp
+++ b/test/type/array_value_test.cpp
@@ -274,49 +274,49 @@ TEST_F(ArrayValueTests, InListTest) {
 void CheckEqual(type::Value v1, type::Value v2) {
   type::CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE(result[0] == type::CMP_TRUE);
+  EXPECT_TRUE(result[0] == type::CmpBool::TRUE);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE(result[1] == type::CMP_FALSE);
+  EXPECT_TRUE(result[1] == type::CmpBool::FALSE);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE(result[2] == type::CMP_FALSE);
+  EXPECT_TRUE(result[2] == type::CmpBool::FALSE);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE(result[3] == type::CMP_TRUE);
+  EXPECT_TRUE(result[3] == type::CmpBool::TRUE);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE(result[4] == type::CMP_FALSE);
+  EXPECT_TRUE(result[4] == type::CmpBool::FALSE);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE(result[5] == type::CMP_TRUE);
+  EXPECT_TRUE(result[5] == type::CmpBool::TRUE);
 }
 
 void CheckLessThan(type::Value v1, type::Value v2) {
   type::CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE(result[0] == type::CMP_FALSE);
+  EXPECT_TRUE(result[0] == type::CmpBool::FALSE);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE(result[1] == type::CMP_TRUE);
+  EXPECT_TRUE(result[1] == type::CmpBool::TRUE);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE(result[2] == type::CMP_TRUE);
+  EXPECT_TRUE(result[2] == type::CmpBool::TRUE);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE(result[3] == type::CMP_TRUE);
+  EXPECT_TRUE(result[3] == type::CmpBool::TRUE);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE(result[4] == type::CMP_FALSE);
+  EXPECT_TRUE(result[4] == type::CmpBool::FALSE);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE(result[5] == type::CMP_FALSE);
+  EXPECT_TRUE(result[5] == type::CmpBool::FALSE);
 }
 
 void CheckGreaterThan(type::Value v1, type::Value v2) {
   type::CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE(result[0] == type::CMP_FALSE);
+  EXPECT_TRUE(result[0] == type::CmpBool::FALSE);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE(result[1] == type::CMP_TRUE);
+  EXPECT_TRUE(result[1] == type::CmpBool::TRUE);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE(result[2] == type::CMP_FALSE);
+  EXPECT_TRUE(result[2] == type::CmpBool::FALSE);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE(result[3] == type::CMP_FALSE);
+  EXPECT_TRUE(result[3] == type::CmpBool::FALSE);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE(result[4] == type::CMP_TRUE);
+  EXPECT_TRUE(result[4] == type::CmpBool::TRUE);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE(result[5] == type::CMP_TRUE);
+  EXPECT_TRUE(result[5] == type::CmpBool::TRUE);
 }
 
 TEST_F(ArrayValueTests, CompareTest) {
@@ -340,7 +340,7 @@ TEST_F(ArrayValueTests, CompareTest) {
   type::Value v = type::ValueFactory::GetVarcharValue("");
 
   // Test null varchar
-  EXPECT_TRUE(v.CompareEquals(type::ValueFactory::GetVarcharValue(nullptr, 0)) == type::CMP_NULL);
+  EXPECT_TRUE(v.CompareEquals(type::ValueFactory::GetVarcharValue(nullptr, 0)) == type::CmpBool::NULL_);
 }
 }
 }

--- a/test/type/boolean_value_test.cpp
+++ b/test/type/boolean_value_test.cpp
@@ -115,9 +115,9 @@ TEST_F(BooleanValueTests, ComparisonTest) {
 
         if (expected_null) expected = false;
 
-        EXPECT_EQ(expected, result == type::CMP_TRUE);
-        EXPECT_EQ(!expected, result == type::CMP_FALSE);
-        EXPECT_EQ(expected_null, result == type::CMP_NULL);
+        EXPECT_EQ(expected, result == type::CmpBool::TRUE);
+        EXPECT_EQ(!expected, result == type::CmpBool::FALSE);
+        EXPECT_EQ(expected_null, result == type::CmpBool::NULL_);
       }
     }
   }
@@ -167,7 +167,7 @@ TEST_F(BooleanValueTests, HashTest) {
       auto hash0 = val0.Hash();
       auto hash1 = val1.Hash();
 
-      if (result == type::CMP_TRUE) {
+      if (result == type::CmpBool::TRUE) {
         EXPECT_EQ(hash0, hash1);
       } else {
         EXPECT_NE(hash0, hash1);

--- a/test/type/date_value_test.cpp
+++ b/test/type/date_value_test.cpp
@@ -100,10 +100,10 @@ TEST_F(DateValueTests, ComparisonTest) {
                   val1.ToString().c_str(), expected, result);
 
         if (expected_null) {
-          EXPECT_EQ(expected_null, result == type::CMP_NULL);
+          EXPECT_EQ(expected_null, result == type::CmpBool::NULL_);
         } else {
-          EXPECT_EQ(expected, result == type::CMP_TRUE);
-          EXPECT_EQ(!expected, result == type::CMP_FALSE);
+          EXPECT_EQ(expected, result == type::CmpBool::TRUE);
+          EXPECT_EQ(!expected, result == type::CmpBool::FALSE);
         }
       }
     }
@@ -155,7 +155,7 @@ TEST_F(DateValueTests, CopyTest) {
   type::Value val0 =
       type::ValueFactory::GetDateValue(static_cast<int32_t>(1000000));
   type::Value val1 = val0.Copy();
-  EXPECT_TRUE(val0.CompareEquals(val1) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, val0.CompareEquals(val1));
 }
 
 TEST_F(DateValueTests, CastTest) {
@@ -166,12 +166,12 @@ TEST_F(DateValueTests, CastTest) {
 
   result = val_null.CastAs(type::TypeId::DATE);
   EXPECT_TRUE(result.IsNull());
-  EXPECT_TRUE(result.CompareEquals(val_null) == type::CMP_NULL);
+  EXPECT_EQ(type::CmpBool::NULL_, result.CompareEquals(val_null));
   EXPECT_EQ(result.GetTypeId(), val_null.GetTypeId());
 
   result = val_null.CastAs(type::TypeId::VARCHAR);
   EXPECT_TRUE(result.IsNull());
-  EXPECT_TRUE(result.CompareEquals(str_null) == type::CMP_NULL);
+  EXPECT_EQ(type::CmpBool::NULL_, result.CompareEquals(str_null));
   EXPECT_EQ(result.GetTypeId(), str_null.GetTypeId());
 
   EXPECT_THROW(val_null.CastAs(type::TypeId::BOOLEAN), peloton::Exception);

--- a/test/type/numeric_value_test.cpp
+++ b/test/type/numeric_value_test.cpp
@@ -56,49 +56,49 @@ int64_t RANDOM64() {
 void CheckEqual(type::Value &v1, type::Value &v2) {
   type::CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE((result[0]) );
+  EXPECT_EQ(type::CmpBool::TRUE, result[0]);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE((result[1]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[1]);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE((result[2]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[2]);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE((result[3]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[3]);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE((result[4]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[4]);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE((result[5]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[5]);
 }
 
 void CheckLessThan(type::Value &v1, type::Value &v2) {
   type::CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE((result[0]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[0]);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE((result[1]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[1]);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE((result[2]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[2]);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE((result[3]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[3]);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE((result[4]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[4]);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE((result[5]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[5]);
 }
 
 void CheckGreaterThan(type::Value &v1, type::Value &v2) {
   type::CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE((result[0]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[0]);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE((result[1]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[1]);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE((result[2]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[2]);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE((result[3]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[3]);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE((result[4]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[4]);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE((result[5]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[5]);
 }
 
 // Compare two integers
@@ -664,7 +664,7 @@ TEST_F(NumericValueTests, NullValueTest) {
   bool_result[4] = type::ValueFactory::GetIntegerValue(rand()).CompareEquals(
     type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL));
   for (int i = 0; i < 5; i++) {
-    EXPECT_TRUE(bool_result[i] == type::CMP_NULL);
+    EXPECT_TRUE(bool_result[i] == type::CmpBool::NULL_);
   }
 
   bool_result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL).CompareEquals(
@@ -678,7 +678,7 @@ TEST_F(NumericValueTests, NullValueTest) {
   bool_result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL).CompareEquals(
     type::ValueFactory::GetIntegerValue(rand()));
   for (int i = 0; i < 5; i++) {
-    EXPECT_TRUE(bool_result[i] == type::CMP_NULL);
+    EXPECT_TRUE(bool_result[i] == type::CmpBool::NULL_);
   }
 
   type::Value result[5];

--- a/test/type/timestamp_value_test.cpp
+++ b/test/type/timestamp_value_test.cpp
@@ -100,10 +100,10 @@ TEST_F(TimestampValueTests, ComparisonTest) {
                   val1.ToString().c_str(), expected, result);
 
         if (expected_null) {
-          EXPECT_EQ(expected_null, result == type::CMP_NULL);
+          EXPECT_EQ(expected_null, result == type::CmpBool::NULL_);
         } else {
-          EXPECT_EQ(expected, result == type::CMP_TRUE);
-          EXPECT_EQ(!expected, result == type::CMP_FALSE);
+          EXPECT_EQ(expected, result == type::CmpBool::TRUE);
+          EXPECT_EQ(!expected, result == type::CmpBool::FALSE);
         }
       }
     }
@@ -155,7 +155,7 @@ TEST_F(TimestampValueTests, CopyTest) {
   type::Value val0 =
       type::ValueFactory::GetTimestampValue(static_cast<uint64_t>(1000000));
   type::Value val1 = val0.Copy();
-  EXPECT_TRUE(val0.CompareEquals(val1) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, val0.CompareEquals(val1));
 }
 
 TEST_F(TimestampValueTests, CastTest) {
@@ -166,12 +166,12 @@ TEST_F(TimestampValueTests, CastTest) {
 
   result = valNull.CastAs(type::TypeId::TIMESTAMP);
   EXPECT_TRUE(result.IsNull());
-  EXPECT_TRUE(result.CompareEquals(valNull) == type::CMP_NULL);
+  EXPECT_EQ(type::CmpBool::NULL_, result.CompareEquals(valNull));
   EXPECT_EQ(result.GetTypeId(), valNull.GetTypeId());
 
   result = valNull.CastAs(type::TypeId::VARCHAR);
   EXPECT_TRUE(result.IsNull());
-  EXPECT_TRUE(result.CompareEquals(strNull) == type::CMP_NULL);
+  EXPECT_EQ(type::CmpBool::NULL_, result.CompareEquals(strNull));
   EXPECT_EQ(result.GetTypeId(), strNull.GetTypeId());
 
   EXPECT_THROW(valNull.CastAs(type::TypeId::BOOLEAN), peloton::Exception);

--- a/test/type/type_util_test.cpp
+++ b/test/type/type_util_test.cpp
@@ -128,14 +128,16 @@ TEST_F(TypeUtilTests, CompareEqualsRawTest) {
 
   const int num_cols = (int)schema->GetColumnCount();
   for (int tuple_idx = 1; tuple_idx < 3; tuple_idx++) {
-    bool expected = (tuple_idx == 2);
+    type::CmpBool expected = (tuple_idx == 2 ?
+                                type::CmpBool::TRUE :
+                                type::CmpBool::FALSE);
 
     for (int i = 0; i < num_cols; i++) {
       const char* val0 = tuples[0]->GetDataPtr(i);
       const char* val1 = tuples[tuple_idx]->GetDataPtr(i);
       auto type = schema->GetColumn(i).GetType();
       bool inlined = schema->IsInlined(i);
-      bool result = type::TypeUtil::CompareEqualsRaw(type, val0, val1, inlined);
+      type::CmpBool result = type::TypeUtil::CompareEqualsRaw(type, val0, val1, inlined);
 
       LOG_TRACE(
           "'%s'=='%s' => Expected:%s / Result:%s",
@@ -164,13 +166,12 @@ TEST_F(TypeUtilTests, CompareLessThanRawTest) {
       const char* val1 = tuples[tuple_idx]->GetDataPtr(i);
       auto type = schema->GetColumn(i).GetType();
       bool inlined = schema->IsInlined(i);
-      bool result =
+      type::CmpBool result =
           type::TypeUtil::CompareLessThanRaw(type, val0, val1, inlined);
 
       auto fullVal0 = tuples[0]->GetValue(i);
       auto fullVal1 = tuples[tuple_idx]->GetValue(i);
-      bool expected =
-          (fullVal0.CompareLessThan(fullVal1) == type::CmpBool::CMP_TRUE);
+      type::CmpBool expected = fullVal0.CompareLessThan(fullVal1);
 
       EXPECT_EQ(expected, result);
     }  // FOR (columns)
@@ -192,13 +193,12 @@ TEST_F(TypeUtilTests, CompareGreaterThanRawTest) {
       const char* val1 = tuples[tuple_idx]->GetDataPtr(i);
       auto type = schema->GetColumn(i).GetType();
       bool inlined = schema->IsInlined(i);
-      bool result =
+      type::CmpBool result =
           type::TypeUtil::CompareGreaterThanRaw(type, val0, val1, inlined);
 
       auto fullVal0 = tuples[0]->GetValue(i);
       auto fullVal1 = tuples[tuple_idx]->GetValue(i);
-      bool expected =
-          (fullVal0.CompareGreaterThan(fullVal1) == type::CmpBool::CMP_TRUE);
+      type::CmpBool expected = fullVal0.CompareGreaterThan(fullVal1);
 
       EXPECT_EQ(expected, result);
     }  // FOR (columns)
@@ -229,10 +229,10 @@ TEST_F(TypeUtilTests, CompareStringsTest) {
           type::CmpBool result = type::GetCmpBool(
               type::TypeUtil::CompareStrings(str1.c_str(), i,
                                              str2.c_str(), j) < 0);
-          if (result != type::CmpBool::CMP_TRUE) {
+          if (result != type::CmpBool::TRUE) {
             LOG_ERROR("INVALID '%s' < '%s'", str1.c_str(), str2.c_str());
           }
-          EXPECT_EQ(type::CmpBool::CMP_TRUE, result);
+          EXPECT_EQ(type::CmpBool::TRUE, result);
         } // FOR (upper2)
       } // FOR (str2)
     } // FOR (upper1)

--- a/test/type/value_factory_test.cpp
+++ b/test/type/value_factory_test.cpp
@@ -109,7 +109,7 @@ TEST_F(ValueFactoryTests, CastTest) {
   EXPECT_EQ(v3.GetTypeId(), type::TypeId::VARCHAR);
 
   type::Value v4(type::ValueFactory::Clone(v3));
-  EXPECT_TRUE(v3.CompareEquals(v4) == type::CMP_TRUE);
+  EXPECT_TRUE(v3.CompareEquals(v4) == type::CmpBool::TRUE);
 
   type::Value v5(type::ValueFactory::CastAsVarchar(type::Value(type::TypeId::TINYINT, (int8_t)type::PELOTON_INT8_MAX)));
   EXPECT_EQ(v5.ToString(), "127");
@@ -161,7 +161,7 @@ TEST_F(ValueFactoryTests, SerializationTest) {
       type::Value expected = (expect_min ?
                                 type::Type::GetMinValue(col_type) :
                                 type::Type::GetMaxValue(col_type));
-      EXPECT_EQ(type::CMP_TRUE, v.CompareEquals(expected));
+      EXPECT_EQ(type::CmpBool::TRUE, v.CompareEquals(expected));
     }
   }
 }

--- a/test/type/value_test.cpp
+++ b/test/type/value_test.cpp
@@ -45,7 +45,7 @@ TEST_F(ValueTests, HashTest) {
               max_val.ToString().c_str(), min_val.ToString().c_str());
 
     // They should not be equal
-    EXPECT_EQ(type::CmpBool::CMP_FALSE, max_val.CompareEquals(min_val));
+    EXPECT_EQ(type::CmpBool::FALSE, max_val.CompareEquals(min_val));
 
     // Nor should their hash values be equal
     auto max_hash = max_val.Hash();
@@ -55,7 +55,7 @@ TEST_F(ValueTests, HashTest) {
     // But if I copy the first value then the hashes should be the same
     auto copyVal = max_val.Copy();
     auto copyHash = copyVal.Hash();
-    EXPECT_EQ(type::CmpBool::CMP_TRUE, max_val.CompareEquals(copyVal));
+    EXPECT_EQ(type::CmpBool::TRUE, max_val.CompareEquals(copyVal));
     EXPECT_EQ(max_hash, copyHash);
   }  // FOR
 }
@@ -69,8 +69,8 @@ TEST_F(ValueTests, MinMaxTest) {
     if (col_type == type::TypeId::VARCHAR) {
       max_val = type::ValueFactory::GetVarcharValue(std::string("AAA"), nullptr);
       min_val = type::ValueFactory::GetVarcharValue(std::string("ZZZ"), nullptr);
-      EXPECT_EQ(type::CMP_FALSE, min_val.CompareLessThan(max_val));
-      EXPECT_EQ(type::CMP_FALSE, max_val.CompareGreaterThan(min_val));
+      EXPECT_EQ(type::CmpBool::FALSE, min_val.CompareLessThan(max_val));
+      EXPECT_EQ(type::CmpBool::FALSE, max_val.CompareGreaterThan(min_val));
     }
 
     // FIXME: Broken types!!!
@@ -78,14 +78,14 @@ TEST_F(ValueTests, MinMaxTest) {
     LOG_DEBUG("MinMax: %s", TypeIdToString(col_type).c_str());
 
     // Check that we always get the correct MIN value
-    EXPECT_EQ(type::CMP_TRUE, min_val.Min(min_val).CompareEquals(min_val));
-    EXPECT_EQ(type::CMP_TRUE, min_val.Min(max_val).CompareEquals(min_val));
-    EXPECT_EQ(type::CMP_TRUE, min_val.Min(min_val).CompareEquals(min_val));
+    EXPECT_EQ(type::CmpBool::TRUE, min_val.Min(min_val).CompareEquals(min_val));
+    EXPECT_EQ(type::CmpBool::TRUE, min_val.Min(max_val).CompareEquals(min_val));
+    EXPECT_EQ(type::CmpBool::TRUE, min_val.Min(min_val).CompareEquals(min_val));
 
     // Check that we always get the correct MAX value
-    EXPECT_EQ(type::CMP_TRUE, max_val.Max(min_val).CompareEquals(max_val));
-    EXPECT_EQ(type::CMP_TRUE, min_val.Max(max_val).CompareEquals(max_val));
-    EXPECT_EQ(type::CMP_TRUE, max_val.Max(min_val).CompareEquals(max_val));
+    EXPECT_EQ(type::CmpBool::TRUE, max_val.Max(min_val).CompareEquals(max_val));
+    EXPECT_EQ(type::CmpBool::TRUE, min_val.Max(max_val).CompareEquals(max_val));
+    EXPECT_EQ(type::CmpBool::TRUE, max_val.Max(min_val).CompareEquals(max_val));
   } // FOR
 }
 
@@ -106,7 +106,7 @@ TEST_F(ValueTests, VarcharCopyTest) {
 
     // But their underlying data should be equal
     auto result = val1.CompareEquals(val2);
-    EXPECT_EQ(type::CmpBool::CMP_TRUE, result);
+    EXPECT_EQ(type::CmpBool::TRUE, result);
   }  // FOR
 }
 }


### PR DESCRIPTION
I switched following types to `enum class`.
* `LayoutType`
* `CmpBool` (should probably move that into `peloton` namespace instead of `peloton::type`
* `MetricType`
* `SqlStateErrorCode`

I also removed `Endianess` because that wasn't being used anywhere.