### PR TITLE
[Cleanup] Fix issue #983

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if(UNIX OR APPLE)
 endif()
 
 # ---[ Warnings
-peloton_warnings_disable(CMAKE_CXX_FLAGS -Wno-strict-aliasing)
+peloton_warnings_disable(CMAKE_CXX_FLAGS -Wno-strict-aliasing -Wno-implicit-fallthrough)
 
 # Turn on sanitizers if necessary.
 if(USE_SANITIZER)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,6 +1,12 @@
 # This list is required for static linking and exported to PelotonConfig.cmake
 set(Peloton_LINKER_LIBS "")
 
+# GCC 7 requires libatomic for cmpxchg16b instructions (used by libpg_query)
+if(CMAKE_COMPILER_IS_GNUCXX AND
+    (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 7.0 OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0))
+      list(APPEND Peloton_LINKER_LIBS "-latomic")
+endif()
+
 # ---[ Boost
 find_package(Boost 1.46 REQUIRED COMPONENTS system filesystem thread)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -78,7 +78,8 @@ elif [[ "$DISTRO" == *"FEDORA"* ]]; then
         llvm-devel \
         llvm-static \
         libedit-devel \
-        postgresql
+        postgresql \
+        libatomic
 
 ## ------------------------------------------------
 ## REDHAT

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ peloton_protobuf_generate_cpp_py(${proto_gen_folder} proto_srcs proto_hdrs proto
 
 # include python files either to force generation
 add_library(peloton-proto STATIC ${proto_hdrs} ${proto_srcs} ${proto_python})
+target_compile_options(peloton-proto PRIVATE "-Wno-unused-parameter")
 set(Peloton_LINKER_LIBS peloton-proto ${Peloton_LINKER_LIBS}) # note, crucial to prepend!
 peloton_default_properties(peloton-proto)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ add_custom_target(libpg_query ALL
 peloton_pickup_peloton_sources(${PROJECT_SOURCE_DIR})
 
 add_library(peloton SHARED ${srcs})
-
+add_dependencies(peloton libpg_query)
 target_link_libraries(peloton ${Peloton_LINKER_LIBS} peloton-proto ${PROJECT_SOURCE_DIR}/third_party/libpg_query/libpg_query.a)
 
 peloton_default_properties(peloton)

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -24,7 +24,7 @@
 namespace peloton {
 namespace binder {
 
-BindNodeVisitor::BindNodeVisitor(concurrency::Transaction *txn,
+BindNodeVisitor::BindNodeVisitor(concurrency::TransactionContext *txn,
                                  std::string default_database_name)
     : txn_(txn), default_database_name_(default_database_name) {
   context_ = nullptr;

--- a/src/binder/binder_context.cpp
+++ b/src/binder/binder_context.cpp
@@ -22,7 +22,7 @@ namespace binder {
 
 void BinderContext::AddTable(parser::TableRef* table_ref,
                              const std::string default_database_name,
-                             concurrency::Transaction* txn) {
+                             concurrency::TransactionContext* txn) {
   // using catalog object to retrieve meta-data
   table_ref->TryBindDatabaseName(default_database_name);
   auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
@@ -41,7 +41,7 @@ void BinderContext::AddTable(parser::TableRef* table_ref,
 
 void BinderContext::AddTable(const std::string db_name,
                              const std::string table_name,
-                             concurrency::Transaction* txn) {
+                             concurrency::TransactionContext* txn) {
   // using catalog object to retrieve meta-data
   auto table_object =
       catalog::Catalog::GetInstance()->GetTableObject(db_name, table_name, txn);
@@ -58,7 +58,7 @@ void BinderContext::AddTable(const std::string db_name,
 bool BinderContext::GetColumnPosTuple(
     std::string& col_name, std::tuple<oid_t, oid_t>& table_id_tuple,
     std::tuple<oid_t, oid_t, oid_t>& col_pos_tuple, type::TypeId& value_type,
-    concurrency::Transaction* txn) {
+    concurrency::TransactionContext* txn) {
   try {
     auto db_oid = std::get<0>(table_id_tuple);
     auto table_oid = std::get<1>(table_id_tuple);
@@ -82,7 +82,7 @@ bool BinderContext::GetColumnPosTuple(
 bool BinderContext::GetColumnPosTuple(
     std::shared_ptr<BinderContext> current_context, std::string& col_name,
     std::tuple<oid_t, oid_t, oid_t>& col_pos_tuple, std::string& table_alias,
-    type::TypeId& value_type, concurrency::Transaction* txn) {
+    type::TypeId& value_type, concurrency::TransactionContext* txn) {
   bool find_matched = false;
   while (current_context != nullptr && !find_matched) {
     for (auto entry : current_context->table_alias_map) {

--- a/src/catalog/abstract_catalog.cpp
+++ b/src/catalog/abstract_catalog.cpp
@@ -54,7 +54,7 @@ AbstractCatalog::AbstractCatalog(oid_t catalog_table_oid,
 }
 
 AbstractCatalog::AbstractCatalog(const std::string &catalog_table_ddl,
-                                 concurrency::Transaction *txn) {
+                                 concurrency::TransactionContext *txn) {
   // get catalog table schema
   auto &peloton_parser = parser::PostgresParser::GetInstance();
   auto create_plan = std::dynamic_pointer_cast<planner::CreatePlan>(
@@ -85,11 +85,11 @@ AbstractCatalog::AbstractCatalog(const std::string &catalog_table_ddl,
 
 /*@brief   insert tuple(reord) helper function
 * @param   tuple     tuple to be inserted
-* @param   txn       Transaction
+* @param   txn       TransactionContext
 * @return  Whether insertion is Successful
 */
 bool AbstractCatalog::InsertTuple(std::unique_ptr<storage::Tuple> tuple,
-                                  concurrency::Transaction *txn) {
+                                  concurrency::TransactionContext *txn) {
   if (txn == nullptr)
     throw CatalogException("Insert tuple requires transaction");
 
@@ -106,12 +106,12 @@ bool AbstractCatalog::InsertTuple(std::unique_ptr<storage::Tuple> tuple,
 /*@brief   Delete a tuple using index scan
 * @param   index_offset  Offset of index for scan
 * @param   values        Values for search
-* @param   txn           Transaction
+* @param   txn           TransactionContext
 * @return  Whether deletion is Successful
 */
 bool AbstractCatalog::DeleteWithIndexScan(oid_t index_offset,
                                           std::vector<type::Value> values,
-                                          concurrency::Transaction *txn) {
+                                          concurrency::TransactionContext *txn) {
   if (txn == nullptr)
     throw CatalogException("Delete tuple requires transaction");
 
@@ -156,14 +156,14 @@ bool AbstractCatalog::DeleteWithIndexScan(oid_t index_offset,
 * @param   column_offsets    Column ids for search (projection)
 * @param   index_offset      Offset of index for scan
 * @param   values            Values for search
-* @param   txn               Transaction
+* @param   txn               TransactionContext
 * @return  Unique pointer of vector of logical tiles
 */
 std::unique_ptr<std::vector<std::unique_ptr<executor::LogicalTile>>>
 AbstractCatalog::GetResultWithIndexScan(std::vector<oid_t> column_offsets,
                                         oid_t index_offset,
                                         std::vector<type::Value> values,
-                                        concurrency::Transaction *txn) const {
+                                        concurrency::TransactionContext *txn) const {
   if (txn == nullptr) throw CatalogException("Scan table requires transaction");
 
   // Index scan
@@ -205,14 +205,14 @@ AbstractCatalog::GetResultWithIndexScan(std::vector<oid_t> column_offsets,
 * shouldn't build too many indexes on one catalog table
 * @param   column_offsets    Column ids for search (projection)
 * @param   predicate         predicate for this sequential scan query
-* @param   txn               Transaction
+* @param   txn               TransactionContext
 *
 * @return  Unique pointer of vector of logical tiles
 */
 std::unique_ptr<std::vector<std::unique_ptr<executor::LogicalTile>>>
 AbstractCatalog::GetResultWithSeqScan(std::vector<oid_t> column_offsets,
                                       expression::AbstractExpression *predicate,
-                                      concurrency::Transaction *txn) {
+                                      concurrency::TransactionContext *txn) {
   if (txn == nullptr) throw CatalogException("Scan table requires transaction");
 
   // Sequential scan

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -163,7 +163,7 @@ void Catalog::Bootstrap() {
 //===----------------------------------------------------------------------===//
 
 ResultType Catalog::CreateDatabase(const std::string &database_name,
-                                   concurrency::Transaction *txn) {
+                                   concurrency::TransactionContext *txn) {
   if (txn == nullptr)
     throw CatalogException("Do not have transaction to create database " +
                            database_name);
@@ -202,13 +202,13 @@ ResultType Catalog::CreateDatabase(const std::string &database_name,
  * @param   database_name    the database which the table belongs to
  * @param   table_name       name of the table to add index on
  * @param   schema           schema, a.k.a metadata of the table
- * @param   txn              Transaction
- * @return  Transaction ResultType(SUCCESS or FAILURE)
+ * @param   txn              TransactionContext
+ * @return  TransactionContext ResultType(SUCCESS or FAILURE)
  */
 ResultType Catalog::CreateTable(const std::string &database_name,
                                 const std::string &table_name,
                                 std::unique_ptr<catalog::Schema> schema,
-                                concurrency::Transaction *txn, bool is_catalog,
+                                concurrency::TransactionContext *txn, bool is_catalog,
                                 oid_t tuples_per_tilegroup) {
   if (txn == nullptr)
     throw CatalogException("Do not have transaction to create table " +
@@ -286,11 +286,11 @@ ResultType Catalog::CreateTable(const std::string &database_name,
  * If you want to create index on table outside, call CreateIndex() instead
  * @param   database_oid     the database which the indexed table belongs to
  * @param   table_oid        oid of the table to add index on
- * @param   txn              Transaction
- * @return  Transaction ResultType(SUCCESS or FAILURE)
+ * @param   txn              TransactionContext
+ * @return  TransactionContext ResultType(SUCCESS or FAILURE)
  */
 ResultType Catalog::CreatePrimaryIndex(oid_t database_oid, oid_t table_oid,
-                                       concurrency::Transaction *txn) {
+                                       concurrency::TransactionContext *txn) {
   LOG_TRACE("Trying to create primary index for table %d", table_oid);
 
   auto storage_manager = storage::StorageManager::GetInstance();
@@ -354,17 +354,17 @@ ResultType Catalog::CreatePrimaryIndex(oid_t database_oid, oid_t table_oid,
  * @param   index_name       name of the table to add index on
  * @param   unique_keys      index supports duplicate key or not
  * @param   index_type       the type of index(default value is BWTREE)
- * @param   txn              Transaction
+ * @param   txn              TransactionContext
  * @param   is_catalog       index is built on catalog table or not(useful in
  * catalog table Initialization)
- * @return  Transaction ResultType(SUCCESS or FAILURE)
+ * @return  TransactionContext ResultType(SUCCESS or FAILURE)
  */
 ResultType Catalog::CreateIndex(const std::string &database_name,
                                 const std::string &table_name,
                                 const std::vector<oid_t> &key_attrs,
                                 const std::string &index_name, bool unique_keys,
                                 IndexType index_type,
-                                concurrency::Transaction *txn) {
+                                concurrency::TransactionContext *txn) {
   if (txn == nullptr)
     throw CatalogException("Do not have transaction to create database " +
                            index_name);
@@ -400,7 +400,7 @@ ResultType Catalog::CreateIndex(oid_t database_oid, oid_t table_oid,
                                 const std::string &index_name,
                                 IndexType index_type,
                                 IndexConstraintType index_constraint,
-                                bool unique_keys, concurrency::Transaction *txn,
+                                bool unique_keys, concurrency::TransactionContext *txn,
                                 bool is_catalog) {
   if (txn == nullptr)
     throw CatalogException("Do not have transaction to create index " +
@@ -462,7 +462,7 @@ ResultType Catalog::CreateIndex(oid_t database_oid, oid_t table_oid,
  * only for test purposes
  */
 ResultType Catalog::DropDatabaseWithName(const std::string &database_name,
-                                         concurrency::Transaction *txn) {
+                                         concurrency::TransactionContext *txn) {
   if (txn == nullptr)
     throw CatalogException("Do not have transaction to drop database " +
                            database_name);
@@ -477,7 +477,7 @@ ResultType Catalog::DropDatabaseWithName(const std::string &database_name,
 }
 
 ResultType Catalog::DropDatabaseWithOid(oid_t database_oid,
-                                        concurrency::Transaction *txn) {
+                                        concurrency::TransactionContext *txn) {
   if (txn == nullptr)
     throw CatalogException("Do not have transaction to drop database " +
                            std::to_string(database_oid));
@@ -510,12 +510,12 @@ ResultType Catalog::DropDatabaseWithOid(oid_t database_oid,
  * tile_groups
  * @param   database_name    the database which the dropped table belongs to
  * @param   table_name       the dropped table name
- * @param   txn              Transaction
- * @return  Transaction ResultType(SUCCESS or FAILURE)
+ * @param   txn              TransactionContext
+ * @return  TransactionContext ResultType(SUCCESS or FAILURE)
  */
 ResultType Catalog::DropTable(const std::string &database_name,
                               const std::string &table_name,
-                              concurrency::Transaction *txn) {
+                              concurrency::TransactionContext *txn) {
   if (txn == nullptr)
     throw CatalogException("Do not have transaction to drop table " +
                            table_name);
@@ -546,11 +546,11 @@ ResultType Catalog::DropTable(const std::string &database_name,
  * tile_groups
  * @param   database_oid    the database which the dropped table belongs to
  * @param   table_oid       the dropped table name
- * @param   txn             Transaction
- * @return  Transaction ResultType(SUCCESS or FAILURE)
+ * @param   txn             TransactionContext
+ * @return  TransactionContext ResultType(SUCCESS or FAILURE)
  */
 ResultType Catalog::DropTable(oid_t database_oid, oid_t table_oid,
-                              concurrency::Transaction *txn) {
+                              concurrency::TransactionContext *txn) {
   LOG_TRACE("Dropping table %d from database %d", database_oid, table_oid);
   auto storage_manager = storage::StorageManager::GetInstance();
   auto database = storage_manager->GetDatabaseWithOid(database_oid);
@@ -572,10 +572,10 @@ ResultType Catalog::DropTable(oid_t database_oid, oid_t table_oid,
 
 /*@brief   Drop Index on table
  * @param   index_oid      the oid of the index to be dropped
- * @param   txn            Transaction
- * @return  Transaction ResultType(SUCCESS or FAILURE)
+ * @param   txn            TransactionContext
+ * @return  TransactionContext ResultType(SUCCESS or FAILURE)
  */
-ResultType Catalog::DropIndex(oid_t index_oid, concurrency::Transaction *txn) {
+ResultType Catalog::DropIndex(oid_t index_oid, concurrency::TransactionContext *txn) {
   if (txn == nullptr)
     throw CatalogException("Do not have transaction to drop index " +
                            std::to_string(index_oid));
@@ -619,7 +619,7 @@ ResultType Catalog::DropIndex(oid_t index_oid, concurrency::Transaction *txn) {
  * throw exception and abort txn if not exists/invisible
  * */
 storage::Database *Catalog::GetDatabaseWithName(
-    const std::string &database_name, concurrency::Transaction *txn) const {
+    const std::string &database_name, concurrency::TransactionContext *txn) const {
   PL_ASSERT(txn != nullptr);
 
   // Check in pg_database using txn
@@ -640,7 +640,7 @@ storage::Database *Catalog::GetDatabaseWithName(
  * */
 storage::DataTable *Catalog::GetTableWithName(const std::string &database_name,
                                               const std::string &table_name,
-                                              concurrency::Transaction *txn) {
+                                              concurrency::TransactionContext *txn) {
   PL_ASSERT(txn != nullptr);
 
   LOG_TRACE("Looking for table %s in database %s", table_name.c_str(),
@@ -660,7 +660,7 @@ storage::DataTable *Catalog::GetTableWithName(const std::string &database_name,
  * throw exception and abort txn if not exists/invisible
  * */
 std::shared_ptr<DatabaseCatalogObject> Catalog::GetDatabaseObject(
-    const std::string &database_name, concurrency::Transaction *txn) {
+    const std::string &database_name, concurrency::TransactionContext *txn) {
   if (txn == nullptr) {
     throw CatalogException("Do not have transaction to get table object " +
                            database_name);
@@ -680,7 +680,7 @@ std::shared_ptr<DatabaseCatalogObject> Catalog::GetDatabaseObject(
 }
 
 std::shared_ptr<DatabaseCatalogObject> Catalog::GetDatabaseObject(
-    oid_t database_oid, concurrency::Transaction *txn) {
+    oid_t database_oid, concurrency::TransactionContext *txn) {
   if (txn == nullptr) {
     throw CatalogException("Do not have transaction to get database object " +
                            std::to_string(database_oid));
@@ -706,7 +706,7 @@ std::shared_ptr<DatabaseCatalogObject> Catalog::GetDatabaseObject(
  * */
 std::shared_ptr<TableCatalogObject> Catalog::GetTableObject(
     const std::string &database_name, const std::string &table_name,
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   if (txn == nullptr) {
     throw CatalogException("Do not have transaction to get table object " +
                            database_name + "." + table_name);
@@ -738,7 +738,7 @@ std::shared_ptr<TableCatalogObject> Catalog::GetTableObject(
 }
 
 std::shared_ptr<TableCatalogObject> Catalog::GetTableObject(
-    oid_t database_oid, oid_t table_oid, concurrency::Transaction *txn) {
+    oid_t database_oid, oid_t table_oid, concurrency::TransactionContext *txn) {
   if (txn == nullptr) {
     throw CatalogException("Do not have transaction to get table object " +
                            std::to_string(database_oid) + "." +
@@ -810,7 +810,7 @@ Catalog::~Catalog() {
 void Catalog::AddBuiltinFunction(
     const std::string &name, const std::vector<type::TypeId> &argument_types,
     const type::TypeId return_type, oid_t prolang, const std::string &func_name,
-    function::BuiltInFuncType func, concurrency::Transaction *txn) {
+    function::BuiltInFuncType func, concurrency::TransactionContext *txn) {
   if (!ProcCatalog::GetInstance().InsertProc(name, return_type, argument_types,
                                              prolang, func_name, pool_.get(),
                                              txn)) {

--- a/src/catalog/column_stats_catalog.cpp
+++ b/src/catalog/column_stats_catalog.cpp
@@ -22,12 +22,12 @@ namespace peloton {
 namespace catalog {
 
 ColumnStatsCatalog *ColumnStatsCatalog::GetInstance(
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   static ColumnStatsCatalog column_stats_catalog{txn};
   return &column_stats_catalog;
 }
 
-ColumnStatsCatalog::ColumnStatsCatalog(concurrency::Transaction *txn)
+ColumnStatsCatalog::ColumnStatsCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
                       "." COLUMN_STATS_CATALOG_NAME
                       " ("
@@ -60,7 +60,7 @@ bool ColumnStatsCatalog::InsertColumnStats(
     double cardinality, double frac_null, std::string most_common_vals,
     std::string most_common_freqs, std::string histogram_bounds,
     std::string column_name, bool has_index, type::AbstractPool *pool,
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
 
@@ -112,7 +112,7 @@ bool ColumnStatsCatalog::InsertColumnStats(
 
 bool ColumnStatsCatalog::DeleteColumnStats(oid_t database_id, oid_t table_id,
                                            oid_t column_id,
-                                           concurrency::Transaction *txn) {
+                                           concurrency::TransactionContext *txn) {
   oid_t index_offset = IndexId::SECONDARY_KEY_0;  // Secondary key index
 
   std::vector<type::Value> values;
@@ -125,7 +125,7 @@ bool ColumnStatsCatalog::DeleteColumnStats(oid_t database_id, oid_t table_id,
 
 std::unique_ptr<std::vector<type::Value>> ColumnStatsCatalog::GetColumnStats(
     oid_t database_id, oid_t table_id, oid_t column_id,
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   std::vector<oid_t> column_ids(
       {ColumnId::NUM_ROWS, ColumnId::CARDINALITY, ColumnId::FRAC_NULL,
        ColumnId::MOST_COMMON_VALS, ColumnId::MOST_COMMON_FREQS,
@@ -173,7 +173,7 @@ std::unique_ptr<std::vector<type::Value>> ColumnStatsCatalog::GetColumnStats(
 
 // Return value: number of column stats
 size_t ColumnStatsCatalog::GetTableStats(
-    oid_t database_id, oid_t table_id, concurrency::Transaction *txn,
+    oid_t database_id, oid_t table_id, concurrency::TransactionContext *txn,
     std::map<oid_t, std::unique_ptr<std::vector<type::Value>>>
         &column_stats_map) {
   std::vector<oid_t> column_ids(

--- a/src/catalog/database_metrics_catalog.cpp
+++ b/src/catalog/database_metrics_catalog.cpp
@@ -20,12 +20,12 @@ namespace peloton {
 namespace catalog {
 
 DatabaseMetricsCatalog *DatabaseMetricsCatalog::GetInstance(
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   static DatabaseMetricsCatalog database_metrics_catalog{txn};
   return &database_metrics_catalog;
 }
 
-DatabaseMetricsCatalog::DatabaseMetricsCatalog(concurrency::Transaction *txn)
+DatabaseMetricsCatalog::DatabaseMetricsCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
                       "." DATABASE_METRICS_CATALOG_NAME
                       " ("
@@ -41,7 +41,7 @@ DatabaseMetricsCatalog::~DatabaseMetricsCatalog() {}
 
 bool DatabaseMetricsCatalog::InsertDatabaseMetrics(
     oid_t database_oid, oid_t txn_committed, oid_t txn_aborted,
-    oid_t time_stamp, type::AbstractPool *pool, concurrency::Transaction *txn) {
+    oid_t time_stamp, type::AbstractPool *pool, concurrency::TransactionContext *txn) {
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
 
@@ -60,7 +60,7 @@ bool DatabaseMetricsCatalog::InsertDatabaseMetrics(
 }
 
 bool DatabaseMetricsCatalog::DeleteDatabaseMetrics(
-    oid_t database_oid, concurrency::Transaction *txn) {
+    oid_t database_oid, concurrency::TransactionContext *txn) {
   oid_t index_offset = IndexId::PRIMARY_KEY;  // Primary key index
 
   std::vector<type::Value> values;

--- a/src/catalog/index_metrics_catalog.cpp
+++ b/src/catalog/index_metrics_catalog.cpp
@@ -20,12 +20,12 @@ namespace peloton {
 namespace catalog {
 
 IndexMetricsCatalog *IndexMetricsCatalog::GetInstance(
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   static IndexMetricsCatalog index_metrics_catalog{txn};
   return &index_metrics_catalog;
 }
 
-IndexMetricsCatalog::IndexMetricsCatalog(concurrency::Transaction *txn)
+IndexMetricsCatalog::IndexMetricsCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
                       "." INDEX_METRICS_CATALOG_NAME
                       " ("
@@ -45,7 +45,7 @@ IndexMetricsCatalog::~IndexMetricsCatalog() {}
 bool IndexMetricsCatalog::InsertIndexMetrics(
     oid_t database_oid, oid_t table_oid, oid_t index_oid, int64_t reads,
     int64_t deletes, int64_t inserts, int64_t time_stamp,
-    type::AbstractPool *pool, concurrency::Transaction *txn) {
+    type::AbstractPool *pool, concurrency::TransactionContext *txn) {
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
 
@@ -70,7 +70,7 @@ bool IndexMetricsCatalog::InsertIndexMetrics(
 }
 
 bool IndexMetricsCatalog::DeleteIndexMetrics(oid_t index_oid,
-                                             concurrency::Transaction *txn) {
+                                             concurrency::TransactionContext *txn) {
   oid_t index_offset = IndexId::PRIMARY_KEY;  // Primary key index
 
   std::vector<type::Value> values;

--- a/src/catalog/language_catalog.cpp
+++ b/src/catalog/language_catalog.cpp
@@ -24,14 +24,14 @@ LanguageCatalogObject::LanguageCatalogObject(executor::LogicalTile *tuple)
     : lang_oid_(tuple->GetValue(0, 0).GetAs<oid_t>()),
       lang_name_(tuple->GetValue(0, 1).GetAs<const char *>()) {}
 
-LanguageCatalog &LanguageCatalog::GetInstance(concurrency::Transaction *txn) {
+LanguageCatalog &LanguageCatalog::GetInstance(concurrency::TransactionContext *txn) {
   static LanguageCatalog language_catalog{txn};
   return language_catalog;
 }
 
 LanguageCatalog::~LanguageCatalog(){};
 
-LanguageCatalog::LanguageCatalog(concurrency::Transaction *txn)
+LanguageCatalog::LanguageCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
                       "." LANGUAGE_CATALOG_NAME
                       " ("
@@ -46,7 +46,7 @@ LanguageCatalog::LanguageCatalog(concurrency::Transaction *txn)
 // insert a new language by name
 bool LanguageCatalog::InsertLanguage(const std::string &lanname,
                                      type::AbstractPool *pool,
-                                     concurrency::Transaction *txn) {
+                                     concurrency::TransactionContext *txn) {
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
 
@@ -63,7 +63,7 @@ bool LanguageCatalog::InsertLanguage(const std::string &lanname,
 
 // delete a language by name
 bool LanguageCatalog::DeleteLanguage(const std::string &lanname,
-                                     concurrency::Transaction *txn) {
+                                     concurrency::TransactionContext *txn) {
   oid_t index_offset = IndexId::SECONDARY_KEY_0;
 
   std::vector<type::Value> values;
@@ -74,7 +74,7 @@ bool LanguageCatalog::DeleteLanguage(const std::string &lanname,
 }
 
 std::unique_ptr<LanguageCatalogObject> LanguageCatalog::GetLanguageByOid(
-    oid_t lang_oid, concurrency::Transaction *txn) const {
+    oid_t lang_oid, concurrency::TransactionContext *txn) const {
   std::vector<oid_t> column_ids(all_column_ids);
   oid_t index_offset = IndexId::PRIMARY_KEY;
   std::vector<type::Value> values;
@@ -94,7 +94,7 @@ std::unique_ptr<LanguageCatalogObject> LanguageCatalog::GetLanguageByOid(
 }
 
 std::unique_ptr<LanguageCatalogObject> LanguageCatalog::GetLanguageByName(
-    const std::string &lang_name, concurrency::Transaction *txn) const {
+    const std::string &lang_name, concurrency::TransactionContext *txn) const {
   std::vector<oid_t> column_ids(all_column_ids);
   oid_t index_offset = IndexId::SECONDARY_KEY_0;
   std::vector<type::Value> values;

--- a/src/catalog/proc_catalog.cpp
+++ b/src/catalog/proc_catalog.cpp
@@ -24,7 +24,7 @@ namespace catalog {
 #define PROC_CATALOG_NAME "pg_proc"
 
 ProcCatalogObject::ProcCatalogObject(executor::LogicalTile *tile,
-                                     concurrency::Transaction *txn)
+                                     concurrency::TransactionContext *txn)
     : oid_(tile->GetValue(0, 0).GetAs<oid_t>()),
       name_(tile->GetValue(0, 1).GetAs<const char *>()),
       ret_type_(tile->GetValue(0, 2).GetAs<type::TypeId>()),
@@ -37,14 +37,14 @@ std::unique_ptr<LanguageCatalogObject> ProcCatalogObject::GetLanguage() const {
   return LanguageCatalog::GetInstance().GetLanguageByOid(GetLangOid(), txn_);
 }
 
-ProcCatalog &ProcCatalog::GetInstance(concurrency::Transaction *txn) {
+ProcCatalog &ProcCatalog::GetInstance(concurrency::TransactionContext *txn) {
   static ProcCatalog proc_catalog{txn};
   return proc_catalog;
 }
 
 ProcCatalog::~ProcCatalog(){};
 
-ProcCatalog::ProcCatalog(concurrency::Transaction *txn)
+ProcCatalog::ProcCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
                       "." PROC_CATALOG_NAME
                       " ("
@@ -65,7 +65,7 @@ bool ProcCatalog::InsertProc(const std::string &proname,
                              const std::vector<type::TypeId> &proargtypes,
                              oid_t prolang, const std::string &prosrc,
                              type::AbstractPool *pool,
-                             concurrency::Transaction *txn) {
+                             concurrency::TransactionContext *txn) {
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
 
@@ -90,7 +90,7 @@ bool ProcCatalog::InsertProc(const std::string &proname,
 }
 
 std::unique_ptr<ProcCatalogObject> ProcCatalog::GetProcByOid(
-    oid_t proc_oid, concurrency::Transaction *txn) const {
+    oid_t proc_oid, concurrency::TransactionContext *txn) const {
   std::vector<oid_t> column_ids(all_column_ids);
   oid_t index_offset = IndexId::PRIMARY_KEY;
   std::vector<type::Value> values;
@@ -112,7 +112,7 @@ std::unique_ptr<ProcCatalogObject> ProcCatalog::GetProcByOid(
 std::unique_ptr<ProcCatalogObject> ProcCatalog::GetProcByName(
     const std::string &proc_name,
     const std::vector<type::TypeId> &proc_arg_types,
-    concurrency::Transaction *txn) const {
+    concurrency::TransactionContext *txn) const {
   std::vector<oid_t> column_ids(all_column_ids);
   oid_t index_offset = IndexId::SECONDARY_KEY_0;
   std::vector<type::Value> values;

--- a/src/catalog/query_metrics_catalog.cpp
+++ b/src/catalog/query_metrics_catalog.cpp
@@ -21,12 +21,12 @@ namespace peloton {
 namespace catalog {
 
 QueryMetricsCatalog *QueryMetricsCatalog::GetInstance(
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   static QueryMetricsCatalog query_metrics_catalog{txn};
   return &query_metrics_catalog;
 }
 
-QueryMetricsCatalog::QueryMetricsCatalog(concurrency::Transaction *txn)
+QueryMetricsCatalog::QueryMetricsCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
                       "." QUERY_METRICS_CATALOG_NAME
                       " ("
@@ -59,7 +59,7 @@ bool QueryMetricsCatalog::InsertQueryMetrics(
     const stats::QueryMetric::QueryParamBuf &value_buf, int64_t reads,
     int64_t updates, int64_t deletes, int64_t inserts, int64_t latency,
     int64_t cpu_time, int64_t time_stamp, type::AbstractPool *pool,
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
 
@@ -108,7 +108,7 @@ bool QueryMetricsCatalog::InsertQueryMetrics(
 
 bool QueryMetricsCatalog::DeleteQueryMetrics(const std::string &name,
                                              oid_t database_oid,
-                                             concurrency::Transaction *txn) {
+                                             concurrency::TransactionContext *txn) {
   oid_t index_offset = IndexId::SECONDARY_KEY_0;  // Secondary key index
 
   std::vector<type::Value> values;
@@ -120,7 +120,7 @@ bool QueryMetricsCatalog::DeleteQueryMetrics(const std::string &name,
 
 stats::QueryMetric::QueryParamBuf QueryMetricsCatalog::GetParamTypes(
     const std::string &name, oid_t database_oid,
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   std::vector<oid_t> column_ids({ColumnId::PARAM_TYPES});  // param_types
   oid_t index_offset = IndexId::SECONDARY_KEY_0;  // Secondary key index
   std::vector<type::Value> values;
@@ -147,7 +147,7 @@ stats::QueryMetric::QueryParamBuf QueryMetricsCatalog::GetParamTypes(
 
 int64_t QueryMetricsCatalog::GetNumParams(const std::string &name,
                                           oid_t database_oid,
-                                          concurrency::Transaction *txn) {
+                                          concurrency::TransactionContext *txn) {
   std::vector<oid_t> column_ids({ColumnId::NUM_PARAMS});  // num_params
   oid_t index_offset = IndexId::SECONDARY_KEY_0;          // Secondary key index
   std::vector<type::Value> values;

--- a/src/catalog/settings_catalog.cpp
+++ b/src/catalog/settings_catalog.cpp
@@ -21,12 +21,12 @@
 namespace peloton {
 namespace catalog {
 
-SettingsCatalog &SettingsCatalog::GetInstance(concurrency::Transaction *txn) {
+SettingsCatalog &SettingsCatalog::GetInstance(concurrency::TransactionContext *txn) {
   static SettingsCatalog settings_catalog{txn};
   return settings_catalog;
 }
 
-SettingsCatalog::SettingsCatalog(concurrency::Transaction *txn)
+SettingsCatalog::SettingsCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
                       "." SETTINGS_CATALOG_NAME
                       " ("
@@ -53,7 +53,7 @@ bool SettingsCatalog::InsertSetting(
     const std::string &description, const std::string &min_value,
     const std::string &max_value, const std::string &default_value,
     bool is_mutable, bool is_persistent, type::AbstractPool *pool,
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   // Create the tuple first
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
@@ -84,7 +84,7 @@ bool SettingsCatalog::InsertSetting(
 }
 
 bool SettingsCatalog::DeleteSetting(const std::string &name,
-                                    concurrency::Transaction *txn) {
+                                    concurrency::TransactionContext *txn) {
   oid_t index_offset = 0;
   std::vector<type::Value> values;
   values.push_back(type::ValueFactory::GetVarcharValue(name, nullptr).Copy());
@@ -93,7 +93,7 @@ bool SettingsCatalog::DeleteSetting(const std::string &name,
 }
 
 std::string SettingsCatalog::GetSettingValue(const std::string &name,
-                                             concurrency::Transaction *txn) {
+                                             concurrency::TransactionContext *txn) {
   std::vector<oid_t> column_ids({static_cast<int>(ColumnId::VALUE)});
   oid_t index_offset = static_cast<int>(IndexId::SECONDARY_KEY_0);
   std::vector<type::Value> values;
@@ -114,7 +114,7 @@ std::string SettingsCatalog::GetSettingValue(const std::string &name,
 }
 
 std::string SettingsCatalog::GetDefaultValue(const std::string &name,
-                                             concurrency::Transaction *txn) {
+                                             concurrency::TransactionContext *txn) {
   std::vector<oid_t> column_ids({static_cast<int>(ColumnId::VALUE)});
   oid_t index_offset = static_cast<int>(IndexId::SECONDARY_KEY_0);
   std::vector<type::Value> values;

--- a/src/catalog/table_metrics_catalog.cpp
+++ b/src/catalog/table_metrics_catalog.cpp
@@ -20,12 +20,12 @@ namespace peloton {
 namespace catalog {
 
 TableMetricsCatalog *TableMetricsCatalog::GetInstance(
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   static TableMetricsCatalog table_metrics_catalog{txn};
   return &table_metrics_catalog;
 }
 
-TableMetricsCatalog::TableMetricsCatalog(concurrency::Transaction *txn)
+TableMetricsCatalog::TableMetricsCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
                       "." TABLE_METRICS_CATALOG_NAME
                       " ("
@@ -45,7 +45,7 @@ TableMetricsCatalog::~TableMetricsCatalog() {}
 bool TableMetricsCatalog::InsertTableMetrics(
     oid_t database_oid, oid_t table_oid, int64_t reads, int64_t updates,
     int64_t deletes, int64_t inserts, int64_t time_stamp,
-    type::AbstractPool *pool, concurrency::Transaction *txn) {
+    type::AbstractPool *pool, concurrency::TransactionContext *txn) {
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
 
@@ -70,7 +70,7 @@ bool TableMetricsCatalog::InsertTableMetrics(
 }
 
 bool TableMetricsCatalog::DeleteTableMetrics(oid_t table_oid,
-                                             concurrency::Transaction *txn) {
+                                             concurrency::TransactionContext *txn) {
   oid_t index_offset = IndexId::PRIMARY_KEY;  // Primary key index
 
   std::vector<type::Value> values;

--- a/src/catalog/trigger_catalog.cpp
+++ b/src/catalog/trigger_catalog.cpp
@@ -21,12 +21,12 @@
 namespace peloton {
 namespace catalog {
 
-TriggerCatalog &TriggerCatalog::GetInstance(concurrency::Transaction *txn) {
+TriggerCatalog &TriggerCatalog::GetInstance(concurrency::TransactionContext *txn) {
   static TriggerCatalog trigger_catalog{txn};
   return trigger_catalog;
 }
 
-TriggerCatalog::TriggerCatalog(concurrency::Transaction *txn)
+TriggerCatalog::TriggerCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
                       "." TRIGGER_CATALOG_NAME
                       " ("
@@ -63,7 +63,7 @@ bool TriggerCatalog::InsertTrigger(oid_t table_oid, std::string trigger_name,
                                    type::Value fire_condition,
                                    type::Value timestamp,
                                    type::AbstractPool *pool,
-                                   concurrency::Transaction *txn) {
+                                   concurrency::TransactionContext *txn) {
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
 
@@ -94,7 +94,7 @@ bool TriggerCatalog::InsertTrigger(oid_t table_oid, std::string trigger_name,
 ResultType TriggerCatalog::DropTrigger(const std::string &database_name,
                                        const std::string &table_name,
                                        const std::string &trigger_name,
-                                       concurrency::Transaction *txn) {
+                                       concurrency::TransactionContext *txn) {
   if (txn == nullptr) {
     LOG_TRACE("Do not have transaction to drop trigger: %s",
               table_name.c_str());
@@ -130,7 +130,7 @@ ResultType TriggerCatalog::DropTrigger(const std::string &database_name,
 }
 
 oid_t TriggerCatalog::GetTriggerOid(std::string trigger_name, oid_t table_oid,
-                                    concurrency::Transaction *txn) {
+                                    concurrency::TransactionContext *txn) {
   std::vector<oid_t> column_ids({ColumnId::TRIGGER_OID});
   oid_t index_offset = IndexId::NAME_TABLE_KEY_2;
   std::vector<type::Value> values;
@@ -155,7 +155,7 @@ oid_t TriggerCatalog::GetTriggerOid(std::string trigger_name, oid_t table_oid,
 
 bool TriggerCatalog::DeleteTriggerByName(const std::string &trigger_name,
                                          oid_t table_oid,
-                                         concurrency::Transaction *txn) {
+                                         concurrency::TransactionContext *txn) {
   oid_t index_offset = IndexId::NAME_TABLE_KEY_2;
   std::vector<type::Value> values;
   values.push_back(type::ValueFactory::GetVarcharValue(trigger_name).Copy());
@@ -165,7 +165,7 @@ bool TriggerCatalog::DeleteTriggerByName(const std::string &trigger_name,
 }
 
 std::unique_ptr<trigger::TriggerList> TriggerCatalog::GetTriggersByType(
-    oid_t table_oid, int16_t trigger_type, concurrency::Transaction *txn) {
+    oid_t table_oid, int16_t trigger_type, concurrency::TransactionContext *txn) {
   LOG_INFO("Get triggers for table %d", table_oid);
   // select trigger_name, fire condition, function_name, function_args
   std::vector<oid_t> column_ids(
@@ -207,7 +207,7 @@ std::unique_ptr<trigger::TriggerList> TriggerCatalog::GetTriggersByType(
 }
 
 std::unique_ptr<trigger::TriggerList> TriggerCatalog::GetTriggers(
-    oid_t table_oid, concurrency::Transaction *txn) {
+    oid_t table_oid, concurrency::TransactionContext *txn) {
   LOG_DEBUG("Get triggers for table %d", table_oid);
   // select trigger_name, fire condition, function_name, function_args
   std::vector<oid_t> column_ids(

--- a/src/catalog/zone_map_catalog.cpp
+++ b/src/catalog/zone_map_catalog.cpp
@@ -27,12 +27,12 @@ namespace catalog {
 // but #796 is still not merged when I am writing this code and I really
 // am sorry to do this. When PelotonMain() becomes a reality, I will
 // fix this for sure.
-ZoneMapCatalog *ZoneMapCatalog::GetInstance(concurrency::Transaction *txn) {
+ZoneMapCatalog *ZoneMapCatalog::GetInstance(concurrency::TransactionContext *txn) {
   static ZoneMapCatalog zone_map_catalog{txn};
   return &zone_map_catalog;
 }
 
-ZoneMapCatalog::ZoneMapCatalog(concurrency::Transaction *txn)
+ZoneMapCatalog::ZoneMapCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
                       "." ZONE_MAP_CATALOG_NAME
                       " ("
@@ -54,7 +54,7 @@ ZoneMapCatalog::~ZoneMapCatalog() {}
 bool ZoneMapCatalog::InsertColumnStatistics(
     oid_t database_id, oid_t table_id, oid_t tile_group_id, oid_t column_id,
     std::string minimum, std::string maximum, std::string type,
-    type::AbstractPool *pool, concurrency::Transaction *txn) {
+    type::AbstractPool *pool, concurrency::TransactionContext *txn) {
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
 
@@ -81,7 +81,7 @@ bool ZoneMapCatalog::InsertColumnStatistics(
 bool ZoneMapCatalog::DeleteColumnStatistics(oid_t database_id, oid_t table_id,
                                             oid_t tile_group_id,
                                             oid_t column_id,
-                                            concurrency::Transaction *txn) {
+                                            concurrency::TransactionContext *txn) {
   oid_t index_offset = static_cast<int>(IndexId::SECONDARY_KEY_0);
   std::vector<type::Value> values({
     type::ValueFactory::GetIntegerValue(database_id),
@@ -94,7 +94,7 @@ bool ZoneMapCatalog::DeleteColumnStatistics(oid_t database_id, oid_t table_id,
 
 std::unique_ptr<std::vector<type::Value>> ZoneMapCatalog::GetColumnStatistics(
     oid_t database_id, oid_t table_id, oid_t tile_group_id, oid_t column_id,
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   std::vector<oid_t> column_ids(
       {static_cast<int>(ColumnId::MINIMUM), 
        static_cast<int>(ColumnId::MAXIMUM), 

--- a/src/codegen/compilation_context.cpp
+++ b/src/codegen/compilation_context.cpp
@@ -13,6 +13,7 @@
 #include "codegen/compilation_context.h"
 
 #include "codegen/function_builder.h"
+#include "codegen/proxy/storage_manager_proxy.h"
 #include "codegen/proxy/executor_context_proxy.h"
 #include "codegen/proxy/query_parameters_proxy.h"
 #include "codegen/proxy/storage_manager_proxy.h"

--- a/src/codegen/compilation_context.cpp
+++ b/src/codegen/compilation_context.cpp
@@ -13,10 +13,9 @@
 #include "codegen/compilation_context.h"
 
 #include "codegen/function_builder.h"
-#include "codegen/proxy/storage_manager_proxy.h"
-#include "codegen/proxy/transaction_proxy.h"
 #include "codegen/proxy/executor_context_proxy.h"
 #include "codegen/proxy/query_parameters_proxy.h"
+#include "codegen/proxy/storage_manager_proxy.h"
 #include "common/logger.h"
 #include "common/timer.h"
 
@@ -31,11 +30,8 @@ CompilationContext::CompilationContext(Query &query,
       parameter_cache_(parameters_map_),
       result_consumer_(result_consumer),
       codegen_(query_.GetCodeContext()) {
-  // Allocate a storage manager and transaction instance in the runtime state
+  // Allocate a storage manager instance in the runtime state
   auto &runtime_state = GetRuntimeState();
-
-  auto *txn_type = TransactionProxy::GetType(codegen_)->getPointerTo();
-  txn_state_id_ = runtime_state.RegisterState("transaction", txn_type);
 
   auto *storage_manager_ptr_type =
       StorageManagerProxy::GetType(codegen_)->getPointerTo();
@@ -139,11 +135,6 @@ void CompilationContext::GenerateHelperFunctions() {
 // Get the storage manager pointer from the runtime state
 llvm::Value *CompilationContext::GetStorageManagerPtr() {
   return GetRuntimeState().LoadStateValue(codegen_, storage_manager_state_id_);
-}
-
-// Get the transaction pointer from the runtime state
-llvm::Value *CompilationContext::GetTransactionPtr() {
-  return GetRuntimeState().LoadStateValue(codegen_, txn_state_id_);
 }
 
 llvm::Value *CompilationContext::GetExecutorContextPtr() {

--- a/src/codegen/operator/table_scan_translator.cpp
+++ b/src/codegen/operator/table_scan_translator.cpp
@@ -13,6 +13,7 @@
 #include "codegen/operator/table_scan_translator.h"
 
 #include "codegen/lang/if.h"
+#include "codegen/proxy/executor_context_proxy.h"
 #include "codegen/proxy/storage_manager_proxy.h"
 #include "codegen/proxy/transaction_runtime_proxy.h"
 #include "codegen/proxy/runtime_functions_proxy.h"
@@ -75,8 +76,9 @@ void TableScanTranslator::Produce() const {
   llvm::Value *storage_manager_ptr = GetStorageManagerPtr();
   llvm::Value *db_oid = codegen.Const32(table.GetDatabaseOid());
   llvm::Value *table_oid = codegen.Const32(table.GetOid());
-  llvm::Value *table_ptr = codegen.Call(StorageManagerProxy::GetTableWithOid,
-                                        {storage_manager_ptr, db_oid, table_oid});
+  llvm::Value *table_ptr =
+      codegen.Call(StorageManagerProxy::GetTableWithOid,
+                   {storage_manager_ptr, db_oid, table_oid});
 
   // The selection vector for the scan
   Vector sel_vec{LoadStateValue(selection_vector_id_),
@@ -192,7 +194,10 @@ void TableScanTranslator::ScanConsumer::SetupRowBatch(
 void TableScanTranslator::ScanConsumer::FilterRowsByVisibility(
     CodeGen &codegen, llvm::Value *tid_start, llvm::Value *tid_end,
     Vector &selection_vector) const {
-  llvm::Value *txn = translator_.GetCompilationContext().GetTransactionPtr();
+  llvm::Value *executor_context_ptr =
+      translator_.GetCompilationContext().GetExecutorContextPtr();
+  llvm::Value *txn = codegen.Call(ExecutorContextProxy::GetTransaction,
+                                  {executor_context_ptr});
   llvm::Value *raw_sel_vec = selection_vector.GetVectorPtr();
 
   // Invoke TransactionRuntime::PerformRead(...)

--- a/src/codegen/proxy/deleter_proxy.cpp
+++ b/src/codegen/proxy/deleter_proxy.cpp
@@ -14,7 +14,7 @@
 
 #include "codegen/proxy/data_table_proxy.h"
 #include "codegen/proxy/executor_context_proxy.h"
-#include "codegen/proxy/transaction_proxy.h"
+#include "codegen/proxy/transaction_context_proxy.h"
 #include "codegen/proxy/executor_context_proxy.h"
 
 namespace peloton {

--- a/src/codegen/proxy/executor_context_proxy.cpp
+++ b/src/codegen/proxy/executor_context_proxy.cpp
@@ -12,10 +12,15 @@
 
 #include "codegen/proxy/executor_context_proxy.h"
 
+#include "codegen/proxy/transaction_proxy.h"
+
 namespace peloton {
 namespace codegen {
 
 DEFINE_TYPE(ExecutorContext, "executor::ExecutorContext", MEMBER(opaque));
+
+// Define a method that proxies executor::ExecutorContext::GetTransaction()
+DEFINE_METHOD(peloton::executor, ExecutorContext, GetTransaction);
 
 }  // namespace codegen
 }  // namespace peloton

--- a/src/codegen/proxy/executor_context_proxy.cpp
+++ b/src/codegen/proxy/executor_context_proxy.cpp
@@ -11,8 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "codegen/proxy/executor_context_proxy.h"
-
-#include "codegen/proxy/transaction_proxy.h"
+#include "codegen/proxy/transaction_context_proxy.h"
 
 namespace peloton {
 namespace codegen {

--- a/src/codegen/proxy/inserter_proxy.cpp
+++ b/src/codegen/proxy/inserter_proxy.cpp
@@ -13,7 +13,7 @@
 #include "codegen/proxy/inserter_proxy.h"
 
 #include "codegen/proxy/data_table_proxy.h"
-#include "codegen/proxy/transaction_proxy.h"
+#include "codegen/proxy/transaction_context_proxy.h"
 #include "codegen/proxy/executor_context_proxy.h"
 #include "codegen/proxy/tuple_proxy.h"
 #include "codegen/proxy/pool_proxy.h"

--- a/src/codegen/proxy/query_parameters_proxy.cpp
+++ b/src/codegen/proxy/query_parameters_proxy.cpp
@@ -13,7 +13,7 @@
 #include "codegen/proxy/query_parameters_proxy.h"
 
 #include "codegen/proxy/data_table_proxy.h"
-#include "codegen/proxy/transaction_proxy.h"
+#include "codegen/proxy/transaction_context_proxy.h"
 
 namespace peloton {
 namespace codegen {

--- a/src/codegen/proxy/transaction_context_proxy.cpp
+++ b/src/codegen/proxy/transaction_context_proxy.cpp
@@ -2,20 +2,20 @@
 //
 //                         Peloton
 //
-// transaction_proxy.cpp
+// transaction_context_proxy.cpp
 //
-// Identification: src/codegen/proxy/transaction_proxy.cpp
+// Identification: src/codegen/proxy/transaction_context_proxy.cpp
 //
 // Copyright (c) 2015-2017, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
-#include "codegen/proxy/transaction_proxy.h"
+#include "codegen/proxy/transaction_context_proxy.h"
 
 namespace peloton {
 namespace codegen {
 
-DEFINE_TYPE(Transaction, "peloton::concurrency::Transaction", MEMBER(opaque));
+DEFINE_TYPE(TransactionContext, "peloton::concurrency::TransactionContext", MEMBER(opaque));
 
 }  // namespace codegen
 }  // namespace peloton

--- a/src/codegen/proxy/transaction_runtime_proxy.cpp
+++ b/src/codegen/proxy/transaction_runtime_proxy.cpp
@@ -14,7 +14,7 @@
 
 #include "codegen/transaction_runtime.h"
 #include "codegen/proxy/data_table_proxy.h"
-#include "codegen/proxy/transaction_proxy.h"
+#include "codegen/proxy/transaction_context_proxy.h"
 #include "codegen/proxy/tile_group_proxy.h"
 #include "codegen/proxy/value_proxy.h"
 

--- a/src/codegen/proxy/updater_proxy.cpp
+++ b/src/codegen/proxy/updater_proxy.cpp
@@ -16,7 +16,7 @@
 #include "codegen/proxy/executor_context_proxy.h"
 #include "codegen/proxy/target_proxy.h"
 #include "codegen/proxy/tile_group_proxy.h"
-#include "codegen/proxy/transaction_proxy.h"
+#include "codegen/proxy/transaction_context_proxy.h"
 #include "codegen/proxy/value_proxy.h"
 #include "codegen/proxy/pool_proxy.h"
 

--- a/src/codegen/query.cpp
+++ b/src/codegen/query.cpp
@@ -30,8 +30,8 @@ Query::Query(const planner::AbstractPlan &query_plan)
 // that order. We also need to correctly handle cases where _any_ of those
 // functions throw exceptions.
 void Query::Execute(executor::ExecutorContext &executor_context,
-                    QueryParameters &query_parameters,
-                    char *consumer_arg, RuntimeStats *stats) {
+                    QueryParameters &query_parameters, char *consumer_arg,
+                    RuntimeStats *stats) {
   CodeGen codegen{GetCodeContext()};
 
   llvm::Type *runtime_state_type = runtime_state_.FinalizeType(codegen);
@@ -49,7 +49,6 @@ void Query::Execute(executor::ExecutorContext &executor_context,
 
   // We use this handy class to avoid complex casting and pointer manipulation
   struct FunctionArguments {
-    concurrency::Transaction *txn;
     storage::StorageManager *storage_manager;
     executor::ExecutorContext *executor_context;
     QueryParameters *query_parameters;
@@ -59,7 +58,6 @@ void Query::Execute(executor::ExecutorContext &executor_context,
 
   // Set up the function arguments
   auto *func_args = reinterpret_cast<FunctionArguments *>(param_data.get());
-  func_args->txn = executor_context.GetTransaction();
   func_args->storage_manager = storage::StorageManager::GetInstance();
   func_args->executor_context = &executor_context;
   func_args->query_parameters = &query_parameters;

--- a/src/codegen/transaction_runtime.cpp
+++ b/src/codegen/transaction_runtime.cpp
@@ -14,7 +14,7 @@
 
 #include "catalog/manager.h"
 #include "common/container_tuple.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/executor_context.h"
 #include "storage/tile_group.h"
@@ -26,7 +26,7 @@ namespace codegen {
 // TODO: Right now, we split this check into two loops: a visibility check and
 //       the actual reading. Can this be merged?
 uint32_t TransactionRuntime::PerformVectorizedRead(
-    concurrency::Transaction &txn, storage::TileGroup &tile_group,
+    concurrency::TransactionContext &txn, storage::TileGroup &tile_group,
     uint32_t tid_start, uint32_t tid_end, uint32_t *selection_vector) {
   // Get the transaction manager
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
@@ -66,7 +66,7 @@ uint32_t TransactionRuntime::PerformVectorizedRead(
   return out_idx;
 }
 
-bool TransactionRuntime::IsOwner(concurrency::Transaction &txn,
+bool TransactionRuntime::IsOwner(concurrency::TransactionContext &txn,
                                  storage::TileGroupHeader *tile_group_header,
                                  uint32_t tuple_offset) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
@@ -79,7 +79,7 @@ bool TransactionRuntime::IsOwner(concurrency::Transaction &txn,
   return false;
 }
 
-bool TransactionRuntime::AcquireOwnership(concurrency::Transaction &txn,
+bool TransactionRuntime::AcquireOwnership(concurrency::TransactionContext &txn,
     storage::TileGroupHeader *tile_group_header, uint32_t tuple_offset) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   bool is_owner = txn_manager.IsOwner(&txn, tile_group_header, tuple_offset);
@@ -105,7 +105,7 @@ bool TransactionRuntime::AcquireOwnership(concurrency::Transaction &txn,
   return true;
 }
 
-void TransactionRuntime::YieldOwnership(concurrency::Transaction &txn,
+void TransactionRuntime::YieldOwnership(concurrency::TransactionContext &txn,
     storage::TileGroupHeader *tile_group_header, uint32_t tuple_offset) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   bool is_owner = txn_manager.IsOwner(&txn, tile_group_header, tuple_offset);

--- a/src/common/allocator.cpp
+++ b/src/common/allocator.cpp
@@ -38,42 +38,42 @@ void do_deletion(void *location) { free(location); }
 
 }  // namespace peloton
 
-void *operator new(size_t size) throw(std::bad_alloc) {
+void *operator new(size_t size) {
   return peloton::do_allocation(size, true);
 }
 
-void *operator new(size_t size, const std::nothrow_t &) throw() {
+void *operator new(size_t size, const std::nothrow_t &) noexcept {
   return peloton::do_allocation(size, false);
 }
 
-void *operator new[](size_t size) throw(std::bad_alloc) {
+void *operator new[](size_t size) {
   return peloton::do_allocation(size, true);
 }
 
-void *operator new[](size_t size, std::nothrow_t &) throw() {
+void *operator new[](size_t size, std::nothrow_t &) noexcept {
   return peloton::do_allocation(size, false);
 }
 
-void operator delete(void *location) throw() {
+void operator delete(void *location) noexcept {
   return peloton::do_deletion(location);
 }
 
-void operator delete(void *location, __attribute__ ((unused)) size_t size) throw() {
+void operator delete(void *location, __attribute__ ((unused)) size_t size) noexcept {
   return peloton::do_deletion(location);
 }
 
-void operator delete(void *location, const std::nothrow_t &) throw() {
+void operator delete(void *location, const std::nothrow_t &) noexcept {
   return peloton::do_deletion(location);
 }
 
-void operator delete[](void *location) throw() {
+void operator delete[](void *location) noexcept {
   return peloton::do_deletion(location);
 }
 
-void operator delete[](void *location, __attribute__ ((unused)) size_t size) throw() {
+void operator delete[](void *location, __attribute__ ((unused)) size_t size) noexcept {
   return peloton::do_deletion(location);
 }
 
-void operator delete[](void *location, const std::nothrow_t &) throw() {
+void operator delete[](void *location, const std::nothrow_t &) noexcept {
   return peloton::do_deletion(location);
 }

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -17,7 +17,7 @@
 #include "common/exception.h"
 #include "common/logger.h"
 #include "common/platform.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "gc/gc_manager_factory.h"
 #include "logging/log_manager_factory.h"
 #include "settings/settings_manager.h"
@@ -96,7 +96,7 @@ TimestampOrderingTransactionManager::GetInstance(
 
 // check whether the current transaction owns the tuple version.
 bool TimestampOrderingTransactionManager::IsOwner(
-    Transaction *const current_txn,
+    TransactionContext *const current_txn,
     const storage::TileGroupHeader *const tile_group_header,
     const oid_t &tuple_id) {
   auto tuple_txn_id = tile_group_header->GetTransactionId(tuple_id);
@@ -106,7 +106,7 @@ bool TimestampOrderingTransactionManager::IsOwner(
 
 // check whether any other transaction owns the tuple version.
 bool TimestampOrderingTransactionManager::IsOwned(
-    Transaction *const current_txn,
+    TransactionContext *const current_txn,
     const storage::TileGroupHeader *const tile_group_header,
     const oid_t &tuple_id) {
   auto tuple_txn_id = tile_group_header->GetTransactionId(tuple_id);
@@ -129,7 +129,7 @@ bool TimestampOrderingTransactionManager::IsOwned(
 //     without creating a new version.
 // IsWritten() method is designed for distinguishing these two cases.
 bool TimestampOrderingTransactionManager::IsWritten(
-    UNUSED_ATTRIBUTE Transaction *const current_txn,
+    UNUSED_ATTRIBUTE TransactionContext *const current_txn,
     const storage::TileGroupHeader *const tile_group_header,
     const oid_t &tuple_id) {
   auto tuple_begin_cid = tile_group_header->GetBeginCommitId(tuple_id);
@@ -141,7 +141,7 @@ bool TimestampOrderingTransactionManager::IsWritten(
 // transaction.
 // the version must be the latest version in the version chain.
 bool TimestampOrderingTransactionManager::IsOwnable(
-    UNUSED_ATTRIBUTE Transaction *const current_txn,
+    UNUSED_ATTRIBUTE TransactionContext *const current_txn,
     const storage::TileGroupHeader *const tile_group_header,
     const oid_t &tuple_id) {
   auto tuple_txn_id = tile_group_header->GetTransactionId(tuple_id);
@@ -150,7 +150,7 @@ bool TimestampOrderingTransactionManager::IsOwnable(
 }
 
 bool TimestampOrderingTransactionManager::AcquireOwnership(
-    Transaction *const current_txn,
+    TransactionContext *const current_txn,
     const storage::TileGroupHeader *const tile_group_header,
     const oid_t &tuple_id) {
   auto txn_id = current_txn->GetTransactionId();
@@ -190,7 +190,7 @@ bool TimestampOrderingTransactionManager::AcquireOwnership(
 // It should not be called if the tuple is in the write set as commit and abort
 // will release the write lock anyway.
 void TimestampOrderingTransactionManager::YieldOwnership(
-    UNUSED_ATTRIBUTE Transaction *const current_txn,
+    UNUSED_ATTRIBUTE TransactionContext *const current_txn,
     const storage::TileGroupHeader *const tile_group_header,
     const oid_t &tuple_id) {
   PL_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id));
@@ -198,7 +198,7 @@ void TimestampOrderingTransactionManager::YieldOwnership(
 }
 
 bool TimestampOrderingTransactionManager::PerformRead(
-    Transaction *const current_txn, const ItemPointer &read_location,
+    TransactionContext *const current_txn, const ItemPointer &read_location,
     bool acquire_ownership) {
   ItemPointer location = read_location;
 
@@ -462,7 +462,7 @@ bool TimestampOrderingTransactionManager::PerformRead(
 }
 
 void TimestampOrderingTransactionManager::PerformInsert(
-    Transaction *const current_txn, const ItemPointer &location,
+    TransactionContext *const current_txn, const ItemPointer &location,
     ItemPointer *index_entry_ptr) {
   PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 
@@ -500,7 +500,7 @@ void TimestampOrderingTransactionManager::PerformInsert(
 }
 
 void TimestampOrderingTransactionManager::PerformUpdate(
-    Transaction *const current_txn, const ItemPointer &location,
+    TransactionContext *const current_txn, const ItemPointer &location,
     const ItemPointer &new_location) {
   PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 
@@ -584,7 +584,7 @@ void TimestampOrderingTransactionManager::PerformUpdate(
 
 // NOTE: this function is deprecated.
 void TimestampOrderingTransactionManager::PerformUpdate(
-    Transaction *const current_txn UNUSED_ATTRIBUTE,
+    TransactionContext *const current_txn UNUSED_ATTRIBUTE,
     const ItemPointer &location) {
   PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 
@@ -617,7 +617,7 @@ void TimestampOrderingTransactionManager::PerformUpdate(
 }
 
 void TimestampOrderingTransactionManager::PerformDelete(
-    Transaction *const current_txn, const ItemPointer &location,
+    TransactionContext *const current_txn, const ItemPointer &location,
     const ItemPointer &new_location) {
   PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 
@@ -703,7 +703,7 @@ void TimestampOrderingTransactionManager::PerformDelete(
 }
 
 void TimestampOrderingTransactionManager::PerformDelete(
-    Transaction *const current_txn, const ItemPointer &location) {
+    TransactionContext *const current_txn, const ItemPointer &location) {
   PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 
   oid_t tile_group_id = location.block;
@@ -737,7 +737,7 @@ void TimestampOrderingTransactionManager::PerformDelete(
 }
 
 ResultType TimestampOrderingTransactionManager::CommitTransaction(
-    Transaction *const current_txn) {
+    TransactionContext *const current_txn) {
   LOG_TRACE("Committing peloton txn : %" PRId64, current_txn->GetTransactionId());
 
   //////////////////////////////////////////////////////////
@@ -922,7 +922,7 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
 }
 
 ResultType TimestampOrderingTransactionManager::AbortTransaction(
-    Transaction *const current_txn) {
+    TransactionContext *const current_txn) {
   // a pre-declared read-only transaction will never abort.
   PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -2,15 +2,15 @@
 //
 //                         Peloton
 //
-// transaction.cpp
+// transaction_context.cpp
 //
-// Identification: src/concurrency/transaction.cpp
+// Identification: src/concurrency/transaction_context.cpp
 //
 // Copyright (c) 2015-16, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 
 #include <sstream>
 
@@ -27,7 +27,7 @@ namespace peloton {
 namespace concurrency {
 
 /*
- * Transaction state transition:
+ * TransactionContext state transition:
  *                r           r/ro            u/r/ro
  *              +--<--+     +---<--+        +---<--+
  *           r  |     |     |      |        |      |     d
@@ -48,21 +48,21 @@ namespace concurrency {
  *    i : insert
  */
 
-Transaction::Transaction(const size_t thread_id,
+TransactionContext::TransactionContext(const size_t thread_id,
                          const IsolationLevelType isolation,
                          const cid_t &read_id) {
   Init(thread_id, isolation, read_id);
 }
 
-Transaction::Transaction(const size_t thread_id,
+TransactionContext::TransactionContext(const size_t thread_id,
                          const IsolationLevelType isolation,
                          const cid_t &read_id, const cid_t &commit_id) {
   Init(thread_id, isolation, read_id, commit_id);
 }
 
-Transaction::~Transaction() {}
+TransactionContext::~TransactionContext() {}
 
-void Transaction::Init(const size_t thread_id,
+void TransactionContext::Init(const size_t thread_id,
                        const IsolationLevelType isolation, const cid_t &read_id,
                        const cid_t &commit_id) {
   read_id_ = read_id;
@@ -89,7 +89,7 @@ void Transaction::Init(const size_t thread_id,
   on_commit_triggers_.reset();
 }
 
-RWType Transaction::GetRWType(const ItemPointer &location) {
+RWType TransactionContext::GetRWType(const ItemPointer &location) {
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
   auto itr = rw_set_.find(tile_group_id);
@@ -105,7 +105,7 @@ RWType Transaction::GetRWType(const ItemPointer &location) {
   return inner_itr->second;
 }
 
-void Transaction::RecordRead(const ItemPointer &location) {
+void TransactionContext::RecordRead(const ItemPointer &location) {
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
 
@@ -118,7 +118,7 @@ void Transaction::RecordRead(const ItemPointer &location) {
   }
 }
 
-void Transaction::RecordReadOwn(const ItemPointer &location) {
+void TransactionContext::RecordReadOwn(const ItemPointer &location) {
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
 
@@ -135,7 +135,7 @@ void Transaction::RecordReadOwn(const ItemPointer &location) {
   }
 }
 
-void Transaction::RecordUpdate(const ItemPointer &location) {
+void TransactionContext::RecordUpdate(const ItemPointer &location) {
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
 
@@ -165,7 +165,7 @@ void Transaction::RecordUpdate(const ItemPointer &location) {
   }
 }
 
-void Transaction::RecordInsert(const ItemPointer &location) {
+void TransactionContext::RecordInsert(const ItemPointer &location) {
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
 
@@ -177,7 +177,7 @@ void Transaction::RecordInsert(const ItemPointer &location) {
   }
 }
 
-bool Transaction::RecordDelete(const ItemPointer &location) {
+bool TransactionContext::RecordDelete(const ItemPointer &location) {
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
 
@@ -212,7 +212,7 @@ bool Transaction::RecordDelete(const ItemPointer &location) {
   return false;
 }
 
-const std::string Transaction::GetInfo() const {
+const std::string TransactionContext::GetInfo() const {
   std::ostringstream os;
 
   os << "\tTxn :: @" << this << " ID : " << std::setw(4) << txn_id_
@@ -223,14 +223,14 @@ const std::string Transaction::GetInfo() const {
   return os.str();
 }
 
-void Transaction::AddOnCommitTrigger(trigger::TriggerData &trigger_data) {
+void TransactionContext::AddOnCommitTrigger(trigger::TriggerData &trigger_data) {
   if (on_commit_triggers_ == nullptr) {
     on_commit_triggers_.reset(new trigger::TriggerSet());
   }
   on_commit_triggers_->push_back(trigger_data);
 }
 
-void Transaction::ExecOnCommitTriggers() {
+void TransactionContext::ExecOnCommitTriggers() {
   if (on_commit_triggers_ != nullptr) {
     on_commit_triggers_->ExecTriggers();
   }

--- a/src/executor/aggregator.cpp
+++ b/src/executor/aggregator.cpp
@@ -283,7 +283,7 @@ bool SortedAggregator::Advance(AbstractTuple *next_tuple) {
       type::Value rval =
           (delegate_tuple_.GetValue(node->GetGroupbyColIds()[grpColOffset]));
 
-      if (lval.CompareNotEquals(rval) == type::CMP_TRUE) {
+      if (lval.CompareNotEquals(rval) == type::CmpBool::TRUE) {
         LOG_TRACE("Group-by columns changed.");
 
         // Call helper to output the current group result

--- a/src/executor/create_executor.cpp
+++ b/src/executor/create_executor.cpp
@@ -17,7 +17,7 @@
 #include "catalog/trigger_catalog.h"
 #include "catalog/database_catalog.h"
 #include "catalog/table_catalog.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "executor/executor_context.h"
 #include "planner/create_plan.h"
 #include "storage/database.h"

--- a/src/executor/drop_executor.cpp
+++ b/src/executor/drop_executor.cpp
@@ -15,7 +15,7 @@
 #include "catalog/catalog.h"
 #include "catalog/trigger_catalog.h"
 #include "common/logger.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "executor/executor_context.h"
 #include "planner/drop_plan.h"
 

--- a/src/executor/executor_context.cpp
+++ b/src/executor/executor_context.cpp
@@ -12,15 +12,15 @@
 
 #include "type/value.h"
 #include "executor/executor_context.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 
 namespace peloton {
 namespace executor {
 
-ExecutorContext::ExecutorContext(concurrency::Transaction *transaction)
+ExecutorContext::ExecutorContext(concurrency::TransactionContext *transaction)
     : transaction_(transaction) {}
 
-ExecutorContext::ExecutorContext(concurrency::Transaction *transaction,
+ExecutorContext::ExecutorContext(concurrency::TransactionContext *transaction,
                                  const std::vector<type::Value> &params)
     : transaction_(transaction),
       params_(params) {}
@@ -29,7 +29,7 @@ ExecutorContext::~ExecutorContext() {
   // params will be freed automatically
 }
 
-concurrency::Transaction *ExecutorContext::GetTransaction() const {
+concurrency::TransactionContext *ExecutorContext::GetTransaction() const {
   return transaction_;
 }
 

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -677,7 +677,7 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
     }
 
     LOG_TRACE("Difference : %d ", diff);*/
-    if (lhs.CompareEquals(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareEquals(rhs) == type::CmpBool::TRUE) {
       switch (expr_type) {
         case ExpressionType::COMPARE_EQUAL:
         case ExpressionType::COMPARE_LESSTHANOREQUALTO:
@@ -695,7 +695,7 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
                                ExpressionTypeToString(expr_type));
       }
     } else {
-      if (lhs.CompareLessThan(rhs) == type::CMP_TRUE) {
+      if (lhs.CompareLessThan(rhs) == type::CmpBool::TRUE) {
         switch (expr_type) {
           case ExpressionType::COMPARE_NOTEQUAL:
           case ExpressionType::COMPARE_LESSTHAN:
@@ -713,7 +713,7 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
                                  ExpressionTypeToString(expr_type));
         }
       } else {
-        if (lhs.CompareGreaterThan(rhs) == type::CMP_TRUE) {
+        if (lhs.CompareGreaterThan(rhs) == type::CmpBool::TRUE) {
           switch (expr_type) {
             case ExpressionType::COMPARE_NOTEQUAL:
             case ExpressionType::COMPARE_GREATERTHAN:

--- a/src/executor/logical_tile.cpp
+++ b/src/executor/logical_tile.cpp
@@ -555,13 +555,13 @@ void LogicalTile::MaterializeByTiles(
     const peloton::LayoutType peloton_layout_mode) {
   bool row_wise_materialization = true;
 
-  if (peloton_layout_mode == LAYOUT_TYPE_COLUMN)
+  if (peloton_layout_mode == LayoutType::COLUMN)
     row_wise_materialization = false;
 
   // TODO: Make this a parameter
   auto dest_tile_column_count = dest_tile->GetColumnCount();
   oid_t column_count_threshold = 20;
-  if (peloton_layout_mode == LAYOUT_TYPE_HYBRID &&
+  if (peloton_layout_mode == LayoutType::HYBRID &&
       dest_tile_column_count <= column_count_threshold)
     row_wise_materialization = false;
 

--- a/src/executor/materialization_executor.cpp
+++ b/src/executor/materialization_executor.cpp
@@ -99,12 +99,12 @@ void MaterializationExecutor::MaterializeByTiles(
     const peloton::LayoutType peloton_layout_mode) {
   bool row_wise_materialization = true;
 
-  if (peloton_layout_mode == LAYOUT_TYPE_COLUMN) row_wise_materialization = false;
+  if (peloton_layout_mode == LayoutType::COLUMN) row_wise_materialization = false;
 
   // TODO: Make this a parameter
   auto dest_tile_column_count = dest_tile->GetColumnCount();
   oid_t column_count_threshold = 20;
-  if (peloton_layout_mode == LAYOUT_TYPE_HYBRID &&
+  if (peloton_layout_mode == LayoutType::HYBRID &&
       dest_tile_column_count <= column_count_threshold)
     row_wise_materialization = false;
 

--- a/src/executor/merge_join_executor.cpp
+++ b/src/executor/merge_join_executor.cpp
@@ -146,7 +146,7 @@ bool MergeJoinExecutor::DExecute() {
           clause.right_->Evaluate(&left_tuple, &right_tuple, nullptr);
 
       // Left key < Right key, advance left
-      if (left_value.CompareLessThan(right_value) == type::CMP_TRUE) {
+      if (left_value.CompareLessThan(right_value) == type::CmpBool::TRUE) {
         LOG_TRACE("left < right, advance left ");
         left_start_row = left_end_row;
         left_end_row = Advance(left_tile, left_start_row, true);
@@ -154,7 +154,7 @@ bool MergeJoinExecutor::DExecute() {
         break;
       }
       // Left key > Right key, advance right
-      else if (left_value.CompareGreaterThan(right_value) == type::CMP_TRUE) {
+      else if (left_value.CompareGreaterThan(right_value) == type::CmpBool::TRUE) {
         LOG_TRACE("left > right, advance right ");
         right_start_row = right_end_row;
         right_end_row = Advance(right_tile, right_start_row, false);
@@ -260,7 +260,7 @@ size_t MergeJoinExecutor::Advance(LogicalTile *tile, size_t start_row,
       auto next_value =
           expr->Evaluate(&next_tuple, &next_tuple, executor_context_);
 
-      if (!(this_value.CompareEquals(next_value) == type::CMP_TRUE)) {
+      if (!(this_value.CompareEquals(next_value) == type::CmpBool::TRUE)) {
         diff = true;
         break;
       }

--- a/src/executor/order_by_executor.cpp
+++ b/src/executor/order_by_executor.cpp
@@ -201,16 +201,16 @@ bool OrderByExecutor::DoSort() {
         type::Value va = (ta->GetValue(id));
         type::Value vb = (tb->GetValue(id));
         if (!descend_flags[id]) {
-          if (va.CompareLessThan(vb) == type::CMP_TRUE)
+          if (va.CompareLessThan(vb) == type::CmpBool::TRUE)
             return true;
           else {
-            if (va.CompareGreaterThan(vb) == type::CMP_TRUE) return false;
+            if (va.CompareGreaterThan(vb) == type::CmpBool::TRUE) return false;
           }
         } else {
-          if (vb.CompareLessThan(va) == type::CMP_TRUE)
+          if (vb.CompareLessThan(va) == type::CmpBool::TRUE)
             return true;
           else {
-            if (vb.CompareGreaterThan(va) == type::CMP_TRUE) return false;
+            if (vb.CompareGreaterThan(va) == type::CmpBool::TRUE) return false;
           }
         }
       }

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -81,9 +81,7 @@ void PlanExecutor::ExecutePlan(
         // Construct the returned results
         for (auto &tuple : tuples) {
           for (unsigned int i = 0; i < tile->GetColumnCount(); i++) {
-            auto res = ResultValue();
-            PlanExecutor::copyFromTo(tuple[i], res);
-            result.push_back(std::move(res));
+            result.push_back(std::move(tuple[i]));
             LOG_TRACE("column content: %s",
                       tuple[i].c_str() != nullptr ?  tuple[i].c_str() : "-emptry-");
           }
@@ -129,12 +127,10 @@ void PlanExecutor::ExecutePlan(
   const auto &results = consumer.GetOutputTuples();
   for (const auto &tuple : results) {
     for (uint32_t i = 0; i < tuple.tuple_.size(); i++) {
-      auto res = ResultValue();
       auto column_val = tuple.GetValue(i);
       auto str = column_val.IsNull() ? "" : column_val.ToString();
-      PlanExecutor::copyFromTo(str, res);
       LOG_TRACE("column content: [%s]", str.c_str());
-      result.push_back(std::move(res));
+      result.push_back(std::move(str));
     }
   }
   p_status.m_processed = executor_context->num_processed;

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -43,7 +43,7 @@ void CleanExecutorTree(executor::AbstractExecutor *root);
  */
 void PlanExecutor::ExecutePlan(
     std::shared_ptr<planner::AbstractPlan> plan,
-    concurrency::Transaction *txn, const std::vector<type::Value> &params,
+    concurrency::TransactionContext *txn, const std::vector<type::Value> &params,
     std::vector<ResultValue> &result,
     const std::vector<int> &result_format, executor::ExecuteResult &p_status) {
   PL_ASSERT(plan != nullptr && txn != nullptr);

--- a/src/executor/update_executor.cpp
+++ b/src/executor/update_executor.cpp
@@ -17,7 +17,7 @@
 #include "executor/logical_tile.h"
 #include "executor/executor_context.h"
 #include "common/container_tuple.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "storage/data_table.h"
 #include "storage/tile_group_header.h"

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -278,6 +278,15 @@ void TransactionLevelGCManager::ClearGarbage(int thread_id) {
   return;
 }
 
+void TransactionLevelGCManager::StopGC() {
+  LOG_TRACE("Stopping GC");
+  this->is_running_ = false;
+  // clear the garbage in each GC thread
+  for (int thread_id = 0; thread_id < gc_thread_count_; ++thread_id) {
+    ClearGarbage(thread_id);
+  }
+}
+
 void TransactionLevelGCManager::UnlinkVersions(
     const std::shared_ptr<GarbageContext> &garbage_ctx) {
   for (auto entry : *(garbage_ctx->gc_set_.get())) {

--- a/src/include/benchmark/sdbench/sdbench_configuration.h
+++ b/src/include/benchmark/sdbench/sdbench_configuration.h
@@ -52,14 +52,6 @@ enum WriteComplexityType {
   WRITE_COMPLEXITY_TYPE_INSERT = 3
 };
 
-// Copy from types.h for reference
-// typedef enum LayoutType {
-//   LAYOUT_TYPE_INVALID = 0,
-//   LAYOUT_TYPE_ROW = 1,    /* Pure row layout */
-//   LAYOUT_TYPE_COLUMN = 2, /* Pure column layout */
-//   LAYOUT_TYPE_HYBRID = 3  /* Hybrid layout */
-// } LayoutType;
-
 extern int orig_scale_factor;
 
 static const int generator_seed = 50;

--- a/src/include/binder/bind_node_visitor.h
+++ b/src/include/binder/bind_node_visitor.h
@@ -36,7 +36,7 @@ namespace binder {
 
 class BindNodeVisitor : public SqlNodeVisitor {
  public:
-  BindNodeVisitor(concurrency::Transaction *txn,
+  BindNodeVisitor(concurrency::TransactionContext *txn,
                   std::string default_database_name);
 
   void BindNameToNode(parser::SQLStatement *tree);
@@ -69,11 +69,11 @@ class BindNodeVisitor : public SqlNodeVisitor {
   void Visit(expression::OperatorExpression *expr) override;
   void Visit(expression::AggregateExpression *expr) override;
 
-  void SetTxn(concurrency::Transaction *txn) { this->txn_ = txn; }
+  void SetTxn(concurrency::TransactionContext *txn) { this->txn_ = txn; }
 
  private:
   std::shared_ptr<BinderContext> context_;
-  concurrency::Transaction *txn_;
+  concurrency::TransactionContext *txn_;
   std::string default_database_name_;
 };
 

--- a/src/include/binder/binder_context.h
+++ b/src/include/binder/binder_context.h
@@ -22,7 +22,7 @@ struct TableRef;
 }
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }
 
 namespace binder {
@@ -43,11 +43,11 @@ class BinderContext {
   // Update the table alias map given a table reference (in the from clause)
   void AddTable(parser::TableRef* table_ref,
                 const std::string default_database_name,
-                concurrency::Transaction* txn);
+                concurrency::TransactionContext* txn);
 
   // Update the table alias map given a table reference (in the from clause)
   void AddTable(const std::string db_name, const std::string table_name,
-                concurrency::Transaction* txn);
+                concurrency::TransactionContext* txn);
 
   static bool HasTables(std::shared_ptr<BinderContext> current_context) {
     if (current_context == nullptr) return false;
@@ -63,7 +63,7 @@ class BinderContext {
                                 std::tuple<oid_t, oid_t>& table_id_tuple,
                                 std::tuple<oid_t, oid_t, oid_t>& col_pos_tuple,
                                 type::TypeId& value_type,
-                                concurrency::Transaction* txn);
+                                concurrency::TransactionContext* txn);
 
   // Construct the column position tuple given only the column name and the
   // context. Also set the value type based on column type
@@ -74,7 +74,7 @@ class BinderContext {
                                 std::tuple<oid_t, oid_t, oid_t>& col_pos_tuple,
                                 std::string& table_alias,
                                 type::TypeId& value_type,
-                                concurrency::Transaction* txn);
+                                concurrency::TransactionContext* txn);
 
   // Construct the table id tuple given the table alias
   static bool GetTableIdTuple(std::shared_ptr<BinderContext> current_context,

--- a/src/include/catalog/abstract_catalog.h
+++ b/src/include/catalog/abstract_catalog.h
@@ -20,7 +20,7 @@
 namespace peloton {
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }
 
 namespace executor {
@@ -51,26 +51,26 @@ class AbstractCatalog {
 
   /* For other catalogs */
   AbstractCatalog(const std::string &catalog_table_ddl,
-                  concurrency::Transaction *txn);
+                  concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Helper Functions
   //===--------------------------------------------------------------------===//
   bool InsertTuple(std::unique_ptr<storage::Tuple> tuple,
-                   concurrency::Transaction *txn);
+                   concurrency::TransactionContext *txn);
 
   bool DeleteWithIndexScan(oid_t index_offset, std::vector<type::Value> values,
-                           concurrency::Transaction *txn);
+                           concurrency::TransactionContext *txn);
 
   std::unique_ptr<std::vector<std::unique_ptr<executor::LogicalTile>>>
   GetResultWithIndexScan(std::vector<oid_t> column_offsets, oid_t index_offset,
                          std::vector<type::Value> values,
-                         concurrency::Transaction *txn) const;
+                         concurrency::TransactionContext *txn) const;
 
   std::unique_ptr<std::vector<std::unique_ptr<executor::LogicalTile>>>
   GetResultWithSeqScan(std::vector<oid_t> column_offsets,
                        expression::AbstractExpression *predicate,
-                       concurrency::Transaction *txn);
+                       concurrency::TransactionContext *txn);
 
   void AddIndex(const std::vector<oid_t> &key_attrs, oid_t index_oid,
                 const std::string &index_name,

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -26,7 +26,7 @@ class TableCatalogObject;
 }  // namespace catalog
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }  // namespace concurrency
 
 namespace index {
@@ -81,31 +81,31 @@ class Catalog {
   //===--------------------------------------------------------------------===//
   // Create a database
   ResultType CreateDatabase(const std::string &database_name,
-                            concurrency::Transaction *txn);
+                            concurrency::TransactionContext *txn);
 
   // Create a table in a database
   ResultType CreateTable(
       const std::string &database_name, const std::string &table_name,
-      std::unique_ptr<catalog::Schema>, concurrency::Transaction *txn,
+      std::unique_ptr<catalog::Schema>, concurrency::TransactionContext *txn,
       bool is_catalog = false,
       oid_t tuples_per_tilegroup = DEFAULT_TUPLES_PER_TILEGROUP);
 
   // Create the primary key index for a table, don't call this function outside
   // catalog.cpp
   ResultType CreatePrimaryIndex(oid_t database_oid, oid_t table_oid,
-                                concurrency::Transaction *txn);
+                                concurrency::TransactionContext *txn);
   // Create index for a table
   ResultType CreateIndex(const std::string &database_name,
                          const std::string &table_name,
                          const std::vector<oid_t> &key_attrs,
                          const std::string &index_name, bool unique_keys,
-                         IndexType index_type, concurrency::Transaction *txn);
+                         IndexType index_type, concurrency::TransactionContext *txn);
 
   ResultType CreateIndex(oid_t database_oid, oid_t table_oid,
                          const std::vector<oid_t> &key_attrs,
                          const std::string &index_name, IndexType index_type,
                          IndexConstraintType index_constraint, bool unique_keys,
-                         concurrency::Transaction *txn,
+                         concurrency::TransactionContext *txn,
                          bool is_catalog = false);
 
   //===--------------------------------------------------------------------===//
@@ -113,21 +113,21 @@ class Catalog {
   //===--------------------------------------------------------------------===//
   // Drop a database with its name
   ResultType DropDatabaseWithName(const std::string &database_name,
-                                  concurrency::Transaction *txn);
+                                  concurrency::TransactionContext *txn);
 
   // Drop a database with its oid
   ResultType DropDatabaseWithOid(oid_t database_oid,
-                                 concurrency::Transaction *txn);
+                                 concurrency::TransactionContext *txn);
 
   // Drop a table using table name
   ResultType DropTable(const std::string &database_name,
                        const std::string &table_name,
-                       concurrency::Transaction *txn);
+                       concurrency::TransactionContext *txn);
   // Drop a table, use this one in the future
   ResultType DropTable(oid_t database_oid, oid_t table_oid,
-                       concurrency::Transaction *txn);
+                       concurrency::TransactionContext *txn);
   // Drop an index, using its index_oid
-  ResultType DropIndex(oid_t index_oid, concurrency::Transaction *txn);
+  ResultType DropIndex(oid_t index_oid, concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // GET WITH NAME - CHECK FROM CATALOG TABLES, USING TRANSACTION
@@ -138,7 +138,7 @@ class Catalog {
    * throw exception and abort txn if not exists/invisible
    * */
   storage::Database *GetDatabaseWithName(const std::string &db_name,
-                                         concurrency::Transaction *txn) const;
+                                         concurrency::TransactionContext *txn) const;
 
   /* Check table from pg_table with table_name using txn,
    * get it from storage layer using table_oid,
@@ -146,16 +146,16 @@ class Catalog {
    * */
   storage::DataTable *GetTableWithName(const std::string &database_name,
                                        const std::string &table_name,
-                                       concurrency::Transaction *txn);
+                                       concurrency::TransactionContext *txn);
 
   /* Check table from pg_database with database_name using txn,
    * get it from storage layer using table_oid,
    * throw exception and abort txn if not exists/invisible
    * */
   std::shared_ptr<DatabaseCatalogObject> GetDatabaseObject(
-      const std::string &database_name, concurrency::Transaction *txn);
+      const std::string &database_name, concurrency::TransactionContext *txn);
   std::shared_ptr<DatabaseCatalogObject> GetDatabaseObject(
-      oid_t database_oid, concurrency::Transaction *txn);
+      oid_t database_oid, concurrency::TransactionContext *txn);
 
   /* Check table from pg_table with table_name using txn,
    * get it from storage layer using table_oid,
@@ -163,9 +163,9 @@ class Catalog {
    * */
   std::shared_ptr<TableCatalogObject> GetTableObject(
       const std::string &database_name, const std::string &table_name,
-      concurrency::Transaction *txn);
+      concurrency::TransactionContext *txn);
   std::shared_ptr<TableCatalogObject> GetTableObject(
-      oid_t database_oid, oid_t table_oid, concurrency::Transaction *txn);
+      oid_t database_oid, oid_t table_oid, concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // DEPRECATED FUNCTIONS
@@ -191,7 +191,7 @@ class Catalog {
                           const type::TypeId return_type, oid_t prolang,
                           const std::string &func_name,
                           function::BuiltInFuncType func,
-                          concurrency::Transaction *txn);
+                          concurrency::TransactionContext *txn);
 
   const FunctionData GetFunction(
       const std::string &name, const std::vector<type::TypeId> &argument_types);

--- a/src/include/catalog/column_catalog.h
+++ b/src/include/catalog/column_catalog.h
@@ -72,7 +72,7 @@ class ColumnCatalog : public AbstractCatalog {
   // Global Singleton, only the first call requires passing parameters.
   static ColumnCatalog *GetInstance(storage::Database *pg_catalog = nullptr,
                                     type::AbstractPool *pool = nullptr,
-                                    concurrency::Transaction *txn = nullptr);
+                                    concurrency::TransactionContext *txn = nullptr);
 
   ~ColumnCatalog();
 
@@ -86,20 +86,20 @@ class ColumnCatalog : public AbstractCatalog {
                     oid_t column_id, oid_t column_offset,
                     type::TypeId column_type, bool is_inlined,
                     const std::vector<Constraint> &constraints,
-                    type::AbstractPool *pool, concurrency::Transaction *txn);
+                    type::AbstractPool *pool, concurrency::TransactionContext *txn);
   bool DeleteColumn(oid_t table_oid, const std::string &column_name,
-                    concurrency::Transaction *txn);
-  bool DeleteColumns(oid_t table_oid, concurrency::Transaction *txn);
+                    concurrency::TransactionContext *txn);
+  bool DeleteColumns(oid_t table_oid, concurrency::TransactionContext *txn);
 
  private:
   //===--------------------------------------------------------------------===//
   // Read Related API(only called within table catalog object)
   //===--------------------------------------------------------------------===//
   const std::unordered_map<oid_t, std::shared_ptr<ColumnCatalogObject>>
-  GetColumnObjects(oid_t table_oid, concurrency::Transaction *txn);
+  GetColumnObjects(oid_t table_oid, concurrency::TransactionContext *txn);
 
   ColumnCatalog(storage::Database *pg_catalog, type::AbstractPool *pool,
-                concurrency::Transaction *txn);
+                concurrency::TransactionContext *txn);
 
   std::unique_ptr<catalog::Schema> InitializeSchema();
 

--- a/src/include/catalog/column_stats_catalog.h
+++ b/src/include/catalog/column_stats_catalog.h
@@ -51,7 +51,7 @@ class ColumnStatsCatalog : public AbstractCatalog {
 
   // Global Singleton
   static ColumnStatsCatalog *GetInstance(
-      concurrency::Transaction *txn = nullptr);
+      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -62,19 +62,19 @@ class ColumnStatsCatalog : public AbstractCatalog {
                          std::string most_common_freqs,
                          std::string histogram_bounds, std::string column_name,
                          bool has_index, type::AbstractPool *pool,
-                         concurrency::Transaction *txn);
+                         concurrency::TransactionContext *txn);
   bool DeleteColumnStats(oid_t database_id, oid_t table_id, oid_t column_id,
-                         concurrency::Transaction *txn);
+                         concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
   //===--------------------------------------------------------------------===//
   std::unique_ptr<std::vector<type::Value>> GetColumnStats(
       oid_t database_id, oid_t table_id, oid_t column_id,
-      concurrency::Transaction *txn);
+      concurrency::TransactionContext *txn);
 
   size_t GetTableStats(
-      oid_t database_id, oid_t table_id, concurrency::Transaction *txn,
+      oid_t database_id, oid_t table_id, concurrency::TransactionContext *txn,
       std::map<oid_t, std::unique_ptr<std::vector<type::Value>>> &
           column_stats_map);
   // TODO: add more if needed
@@ -106,7 +106,7 @@ class ColumnStatsCatalog : public AbstractCatalog {
   };
 
  private:
-  ColumnStatsCatalog(concurrency::Transaction *txn);
+  ColumnStatsCatalog(concurrency::TransactionContext *txn);
 
   enum IndexId {
     SECONDARY_KEY_0 = 0,

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -43,7 +43,7 @@ class DatabaseCatalogObject {
 
  public:
   DatabaseCatalogObject(executor::LogicalTile *tile,
-                        concurrency::Transaction *txn);
+                        concurrency::TransactionContext *txn);
 
   void EvictAllTableObjects();
   std::shared_ptr<TableCatalogObject> GetTableObject(oid_t table_oid,
@@ -85,7 +85,7 @@ class DatabaseCatalogObject {
 
   // Pointer to its corresponding transaction
   // This object is only visible during this transaction
-  concurrency::Transaction *txn;
+  concurrency::TransactionContext *txn;
 };
 
 class DatabaseCatalog : public AbstractCatalog {
@@ -100,7 +100,7 @@ class DatabaseCatalog : public AbstractCatalog {
   // Global Singleton, only the first call requires passing parameters.
   static DatabaseCatalog *GetInstance(storage::Database *pg_catalog = nullptr,
                                       type::AbstractPool *pool = nullptr,
-                                      concurrency::Transaction *txn = nullptr);
+                                      concurrency::TransactionContext *txn = nullptr);
 
   inline oid_t GetNextOid() { return oid_++ | DATABASE_OID_MASK; }
 
@@ -108,21 +108,21 @@ class DatabaseCatalog : public AbstractCatalog {
   // write Related API
   //===--------------------------------------------------------------------===//
   bool InsertDatabase(oid_t database_oid, const std::string &database_name,
-                      type::AbstractPool *pool, concurrency::Transaction *txn);
-  bool DeleteDatabase(oid_t database_oid, concurrency::Transaction *txn);
+                      type::AbstractPool *pool, concurrency::TransactionContext *txn);
+  bool DeleteDatabase(oid_t database_oid, concurrency::TransactionContext *txn);
 
  private:
   //===--------------------------------------------------------------------===//
   // Read Related API
   //===--------------------------------------------------------------------===//
   std::shared_ptr<DatabaseCatalogObject> GetDatabaseObject(
-      oid_t database_oid, concurrency::Transaction *txn);
+      oid_t database_oid, concurrency::TransactionContext *txn);
   std::shared_ptr<DatabaseCatalogObject> GetDatabaseObject(
-      const std::string &database_name, concurrency::Transaction *txn);
+      const std::string &database_name, concurrency::TransactionContext *txn);
 
  private:
   DatabaseCatalog(storage::Database *pg_catalog, type::AbstractPool *pool,
-                  concurrency::Transaction *txn);
+                  concurrency::TransactionContext *txn);
 
   std::unique_ptr<catalog::Schema> InitializeSchema();
 

--- a/src/include/catalog/database_metrics_catalog.h
+++ b/src/include/catalog/database_metrics_catalog.h
@@ -40,7 +40,7 @@ class DatabaseMetricsCatalog : public AbstractCatalog {
 
   // Global Singleton
   static DatabaseMetricsCatalog *GetInstance(
-      concurrency::Transaction *txn = nullptr);
+      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -48,13 +48,13 @@ class DatabaseMetricsCatalog : public AbstractCatalog {
   bool InsertDatabaseMetrics(oid_t database_oid, oid_t txn_committed,
                              oid_t txn_aborted, oid_t time_stamp,
                              type::AbstractPool *pool,
-                             concurrency::Transaction *txn);
-  bool DeleteDatabaseMetrics(oid_t database_oid, concurrency::Transaction *txn);
+                             concurrency::TransactionContext *txn);
+  bool DeleteDatabaseMetrics(oid_t database_oid, concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
   //===--------------------------------------------------------------------===//
-  oid_t GetTimeStamp(oid_t database_oid, concurrency::Transaction *txn);
+  oid_t GetTimeStamp(oid_t database_oid, concurrency::TransactionContext *txn);
   // TODO: add more if needed
 
   enum ColumnId {
@@ -66,7 +66,7 @@ class DatabaseMetricsCatalog : public AbstractCatalog {
   };
 
  private:
-  DatabaseMetricsCatalog(concurrency::Transaction *txn);
+  DatabaseMetricsCatalog(concurrency::TransactionContext *txn);
 
   enum IndexId {
     PRIMARY_KEY = 0,

--- a/src/include/catalog/index_catalog.h
+++ b/src/include/catalog/index_catalog.h
@@ -75,7 +75,7 @@ class IndexCatalog : public AbstractCatalog {
   // Global Singleton, only the first call requires passing parameters.
   static IndexCatalog *GetInstance(storage::Database *pg_catalog = nullptr,
                                    type::AbstractPool *pool = nullptr,
-                                   concurrency::Transaction *txn = nullptr);
+                                   concurrency::TransactionContext *txn = nullptr);
 
   inline oid_t GetNextOid() { return oid_++ | INDEX_OID_MASK; }
 
@@ -86,23 +86,23 @@ class IndexCatalog : public AbstractCatalog {
                    oid_t table_oid, IndexType index_type,
                    IndexConstraintType index_constraint, bool unique_keys,
                    std::vector<oid_t> indekeys, type::AbstractPool *pool,
-                   concurrency::Transaction *txn);
-  bool DeleteIndex(oid_t index_oid, concurrency::Transaction *txn);
+                   concurrency::TransactionContext *txn);
+  bool DeleteIndex(oid_t index_oid, concurrency::TransactionContext *txn);
 
  private:
   //===--------------------------------------------------------------------===//
   // Read Related API
   //===--------------------------------------------------------------------===//
   std::shared_ptr<IndexCatalogObject> GetIndexObject(
-      oid_t index_oid, concurrency::Transaction *txn);
+      oid_t index_oid, concurrency::TransactionContext *txn);
   std::shared_ptr<IndexCatalogObject> GetIndexObject(
-      const std::string &index_name, concurrency::Transaction *txn);
+      const std::string &index_name, concurrency::TransactionContext *txn);
   const std::unordered_map<oid_t, std::shared_ptr<IndexCatalogObject>>
-  GetIndexObjects(oid_t table_oid, concurrency::Transaction *txn);
+  GetIndexObjects(oid_t table_oid, concurrency::TransactionContext *txn);
 
  private:
   IndexCatalog(storage::Database *pg_catalog, type::AbstractPool *pool,
-               concurrency::Transaction *txn);
+               concurrency::TransactionContext *txn);
 
   std::unique_ptr<catalog::Schema> InitializeSchema();
 

--- a/src/include/catalog/index_metrics_catalog.h
+++ b/src/include/catalog/index_metrics_catalog.h
@@ -43,7 +43,7 @@ class IndexMetricsCatalog : public AbstractCatalog {
 
   // Global Singleton
   static IndexMetricsCatalog *GetInstance(
-      concurrency::Transaction *txn = nullptr);
+      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // Write Related API
@@ -51,8 +51,8 @@ class IndexMetricsCatalog : public AbstractCatalog {
   bool InsertIndexMetrics(oid_t database_oid, oid_t table_oid, oid_t index_oid,
                           int64_t reads, int64_t deletes, int64_t inserts,
                           int64_t time_stamp, type::AbstractPool *pool,
-                          concurrency::Transaction *txn);
-  bool DeleteIndexMetrics(oid_t index_oid, concurrency::Transaction *txn);
+                          concurrency::TransactionContext *txn);
+  bool DeleteIndexMetrics(oid_t index_oid, concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
@@ -60,7 +60,7 @@ class IndexMetricsCatalog : public AbstractCatalog {
   // TODO: add if needed
 
  private:
-  IndexMetricsCatalog(concurrency::Transaction *txn);
+  IndexMetricsCatalog(concurrency::TransactionContext *txn);
 
   enum ColumnId {
     DATABASE_OID = 0,

--- a/src/include/catalog/language_catalog.h
+++ b/src/include/catalog/language_catalog.h
@@ -54,26 +54,26 @@ class LanguageCatalog : public AbstractCatalog {
   ~LanguageCatalog();
 
   // Global Singleton
-  static LanguageCatalog &GetInstance(concurrency::Transaction *txn = nullptr);
+  static LanguageCatalog &GetInstance(concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
   //===--------------------------------------------------------------------===//
   bool InsertLanguage(const std::string &lanname, type::AbstractPool *pool,
-                      concurrency::Transaction *txn);
+                      concurrency::TransactionContext *txn);
 
   bool DeleteLanguage(const std::string &lanname,
-                      concurrency::Transaction *txn);
+                      concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
   //===--------------------------------------------------------------------===//
 
   std::unique_ptr<LanguageCatalogObject> GetLanguageByOid(
-      oid_t lang_oid, concurrency::Transaction *txn) const;
+      oid_t lang_oid, concurrency::TransactionContext *txn) const;
 
   std::unique_ptr<LanguageCatalogObject> GetLanguageByName(
-      const std::string &lang_name, concurrency::Transaction *txn) const;
+      const std::string &lang_name, concurrency::TransactionContext *txn) const;
 
   enum ColumnId {
     OID = 0,
@@ -83,7 +83,7 @@ class LanguageCatalog : public AbstractCatalog {
   std::vector<oid_t> all_column_ids = {0, 1};
 
  private:
-  LanguageCatalog(concurrency::Transaction *txn);
+  LanguageCatalog(concurrency::TransactionContext *txn);
 
   oid_t GetNextOid() { return oid_++ | LANGUAGE_OID_MASK; }
 

--- a/src/include/catalog/proc_catalog.h
+++ b/src/include/catalog/proc_catalog.h
@@ -41,7 +41,7 @@ class LanguageCatalogObject;
 //===----------------------------------------------------------------------===//
 class ProcCatalogObject {
  public:
-  ProcCatalogObject(executor::LogicalTile *tile, concurrency::Transaction *txn);
+  ProcCatalogObject(executor::LogicalTile *tile, concurrency::TransactionContext *txn);
 
   // Accessors
 
@@ -69,7 +69,7 @@ class ProcCatalogObject {
   std::string src_;
 
   // Only valid in this transaction
-  concurrency::Transaction *txn_;
+  concurrency::TransactionContext *txn_;
 };
 
 //===----------------------------------------------------------------------===//
@@ -80,7 +80,7 @@ class ProcCatalog : public AbstractCatalog {
   ~ProcCatalog();
 
   // Global Singleton
-  static ProcCatalog &GetInstance(concurrency::Transaction *txn = nullptr);
+  static ProcCatalog &GetInstance(concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -88,19 +88,19 @@ class ProcCatalog : public AbstractCatalog {
   bool InsertProc(const std::string &proname, type::TypeId prorettype,
                   const std::vector<type::TypeId> &proargtypes, oid_t prolang,
                   const std::string &prosrc, type::AbstractPool *pool,
-                  concurrency::Transaction *txn);
+                  concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
   //===--------------------------------------------------------------------===//
 
   std::unique_ptr<ProcCatalogObject> GetProcByOid(
-      oid_t proc_oid, concurrency::Transaction *txn) const;
+      oid_t proc_oid, concurrency::TransactionContext *txn) const;
 
   std::unique_ptr<ProcCatalogObject> GetProcByName(
       const std::string &proc_name,
       const std::vector<type::TypeId> &proc_arg_types,
-      concurrency::Transaction *txn) const;
+      concurrency::TransactionContext *txn) const;
 
   enum ColumnId {
     OID = 0,
@@ -114,7 +114,7 @@ class ProcCatalog : public AbstractCatalog {
   std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5};
 
  private:
-  ProcCatalog(concurrency::Transaction *txn);
+  ProcCatalog(concurrency::TransactionContext *txn);
 
   oid_t GetNextOid() { return oid_++ | PROC_OID_MASK; }
 

--- a/src/include/catalog/query_metrics_catalog.h
+++ b/src/include/catalog/query_metrics_catalog.h
@@ -49,7 +49,7 @@ class QueryMetricsCatalog : public AbstractCatalog {
 
   // Global Singleton
   static QueryMetricsCatalog *GetInstance(
-      concurrency::Transaction *txn = nullptr);
+      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -62,18 +62,18 @@ class QueryMetricsCatalog : public AbstractCatalog {
                           int64_t reads, int64_t updates, int64_t deletes,
                           int64_t inserts, int64_t latency, int64_t cpu_time,
                           int64_t time_stamp, type::AbstractPool *pool,
-                          concurrency::Transaction *txn);
+                          concurrency::TransactionContext *txn);
   bool DeleteQueryMetrics(const std::string &name, oid_t database_oid,
-                          concurrency::Transaction *txn);
+                          concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
   //===--------------------------------------------------------------------===//
   stats::QueryMetric::QueryParamBuf GetParamTypes(
       const std::string &name, oid_t database_oid,
-      concurrency::Transaction *txn);
+      concurrency::TransactionContext *txn);
   int64_t GetNumParams(const std::string &name, oid_t database_oid,
-                       concurrency::Transaction *txn);
+                       concurrency::TransactionContext *txn);
   // TODO: add more if needed
 
   enum ColumnId {
@@ -94,7 +94,7 @@ class QueryMetricsCatalog : public AbstractCatalog {
   };
 
  private:
-  QueryMetricsCatalog(concurrency::Transaction *txn);
+  QueryMetricsCatalog(concurrency::TransactionContext *txn);
 
   enum IndexId {
     SECONDARY_KEY_0 = 0,

--- a/src/include/catalog/settings_catalog.h
+++ b/src/include/catalog/settings_catalog.h
@@ -22,7 +22,7 @@ class SettingsCatalog : public AbstractCatalog {
   ~SettingsCatalog();
 
   // Global Singleton
-  static SettingsCatalog &GetInstance(concurrency::Transaction *txn = nullptr);
+  static SettingsCatalog &GetInstance(concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -32,18 +32,18 @@ class SettingsCatalog : public AbstractCatalog {
                      const std::string &min_value, const std::string &max_value,
                      const std::string &default_value, bool is_mutable,
                      bool is_persistent, type::AbstractPool *pool,
-                     concurrency::Transaction *txn);
+                     concurrency::TransactionContext *txn);
 
-  bool DeleteSetting(const std::string &name, concurrency::Transaction *txn);
+  bool DeleteSetting(const std::string &name, concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
   //===--------------------------------------------------------------------===//
   std::string GetSettingValue(const std::string &name,
-                              concurrency::Transaction *txn);
+                              concurrency::TransactionContext *txn);
 
   std::string GetDefaultValue(const std::string &name,
-                              concurrency::Transaction *txn);
+                              concurrency::TransactionContext *txn);
 
   enum class ColumnId {
     NAME = 0,
@@ -59,7 +59,7 @@ class SettingsCatalog : public AbstractCatalog {
   };
 
  private:
-  SettingsCatalog(concurrency::Transaction *txn);
+  SettingsCatalog(concurrency::TransactionContext *txn);
 
   enum class IndexId {
     SECONDARY_KEY_0 = 0,

--- a/src/include/catalog/table_catalog.h
+++ b/src/include/catalog/table_catalog.h
@@ -45,7 +45,7 @@ class TableCatalogObject {
   friend class ColumnCatalog;
 
  public:
-  TableCatalogObject(executor::LogicalTile *tile, concurrency::Transaction *txn,
+  TableCatalogObject(executor::LogicalTile *tile, concurrency::TransactionContext *txn,
                      int tupleId = 0);
 
  public:
@@ -105,7 +105,7 @@ class TableCatalogObject {
   bool valid_column_objects;
 
   // Pointer to its corresponding transaction
-  concurrency::Transaction *txn;
+  concurrency::TransactionContext *txn;
 };
 
 class TableCatalog : public AbstractCatalog {
@@ -121,7 +121,7 @@ class TableCatalog : public AbstractCatalog {
   // Global Singleton, only the first call requires passing parameters.
   static TableCatalog *GetInstance(storage::Database *pg_catalog = nullptr,
                                    type::AbstractPool *pool = nullptr,
-                                   concurrency::Transaction *txn = nullptr);
+                                   concurrency::TransactionContext *txn = nullptr);
 
   inline oid_t GetNextOid() { return oid_++ | TABLE_OID_MASK; }
 
@@ -130,24 +130,24 @@ class TableCatalog : public AbstractCatalog {
   //===--------------------------------------------------------------------===//
   bool InsertTable(oid_t table_oid, const std::string &table_name,
                    oid_t database_oid, type::AbstractPool *pool,
-                   concurrency::Transaction *txn);
-  bool DeleteTable(oid_t table_oid, concurrency::Transaction *txn);
+                   concurrency::TransactionContext *txn);
+  bool DeleteTable(oid_t table_oid, concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read Related API
   //===--------------------------------------------------------------------===//
  private:
   std::shared_ptr<TableCatalogObject> GetTableObject(
-      oid_t table_oid, concurrency::Transaction *txn);
+      oid_t table_oid, concurrency::TransactionContext *txn);
   std::shared_ptr<TableCatalogObject> GetTableObject(
       const std::string &table_name, oid_t database_oid,
-      concurrency::Transaction *txn);
+      concurrency::TransactionContext *txn);
   std::unordered_map<oid_t, std::shared_ptr<TableCatalogObject>>
-  GetTableObjects(oid_t database_oid, concurrency::Transaction *txn);
+  GetTableObjects(oid_t database_oid, concurrency::TransactionContext *txn);
 
  private:
   TableCatalog(storage::Database *pg_catalog, type::AbstractPool *pool,
-               concurrency::Transaction *txn);
+               concurrency::TransactionContext *txn);
 
   std::unique_ptr<catalog::Schema> InitializeSchema();
 

--- a/src/include/catalog/table_metrics_catalog.h
+++ b/src/include/catalog/table_metrics_catalog.h
@@ -43,7 +43,7 @@ class TableMetricsCatalog : public AbstractCatalog {
 
   // Global Singleton
   static TableMetricsCatalog *GetInstance(
-      concurrency::Transaction *txn = nullptr);
+      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // Write Related API
@@ -51,8 +51,8 @@ class TableMetricsCatalog : public AbstractCatalog {
   bool InsertTableMetrics(oid_t database_oid, oid_t table_oid, int64_t reads,
                           int64_t updates, int64_t deletes, int64_t inserts,
                           int64_t time_stamp, type::AbstractPool *pool,
-                          concurrency::Transaction *txn);
-  bool DeleteTableMetrics(oid_t table_oid, concurrency::Transaction *txn);
+                          concurrency::TransactionContext *txn);
+  bool DeleteTableMetrics(oid_t table_oid, concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
@@ -60,7 +60,7 @@ class TableMetricsCatalog : public AbstractCatalog {
   // TODO: add if needed
 
  private:
-  TableMetricsCatalog(concurrency::Transaction *txn);
+  TableMetricsCatalog(concurrency::TransactionContext *txn);
 
   enum ColumnId {
     DATABASE_OID = 0,

--- a/src/include/catalog/trigger_catalog.h
+++ b/src/include/catalog/trigger_catalog.h
@@ -50,7 +50,7 @@ class TriggerCatalog : public AbstractCatalog {
   ~TriggerCatalog();
 
   // Global Singleton
-  static TriggerCatalog &GetInstance(concurrency::Transaction *txn = nullptr);
+  static TriggerCatalog &GetInstance(concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -59,31 +59,31 @@ class TriggerCatalog : public AbstractCatalog {
                      int16_t trigger_type, std::string proc_oid,
                      std::string function_arguments, type::Value fire_condition,
                      type::Value timestamp, type::AbstractPool *pool,
-                     concurrency::Transaction *txn);
+                     concurrency::TransactionContext *txn);
 
   ResultType DropTrigger(const std::string &database_name,
                          const std::string &table_name,
                          const std::string &trigger_name,
-                         concurrency::Transaction *txn);
+                         concurrency::TransactionContext *txn);
 
   bool DeleteTriggerByName(const std::string &trigger_name, oid_t table_oid,
-                           concurrency::Transaction *txn);
+                           concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // get triggers for a specific table; one table may have multiple triggers
   // of the same type
   //===--------------------------------------------------------------------===//
   std::unique_ptr<trigger::TriggerList> GetTriggersByType(
-      oid_t table_oid, int16_t trigger_type, concurrency::Transaction *txn);
+      oid_t table_oid, int16_t trigger_type, concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // get all types of triggers for a specific table
   //===--------------------------------------------------------------------===//
   std::unique_ptr<trigger::TriggerList> GetTriggers(
-      oid_t table_oid, concurrency::Transaction *txn);
+      oid_t table_oid, concurrency::TransactionContext *txn);
 
   oid_t GetTriggerOid(std::string trigger_name, oid_t table_oid,
-                      concurrency::Transaction *txn);
+                      concurrency::TransactionContext *txn);
 
   enum ColumnId {
     TRIGGER_OID = 0,
@@ -97,7 +97,7 @@ class TriggerCatalog : public AbstractCatalog {
   };
 
  private:
-  TriggerCatalog(concurrency::Transaction *txn);
+  TriggerCatalog(concurrency::TransactionContext *txn);
 
   oid_t GetNextOid() { return oid_++ | TRIGGER_OID_MASK; }
 

--- a/src/include/catalog/zone_map_catalog.h
+++ b/src/include/catalog/zone_map_catalog.h
@@ -31,7 +31,7 @@ class ZoneMapCatalog : public AbstractCatalog {
   // am sorry to do this. When PelotonMain() becomes a reality, I will
   // fix this for sure.
 
-  static ZoneMapCatalog *GetInstance(concurrency::Transaction *txn = nullptr);
+  static ZoneMapCatalog *GetInstance(concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -40,11 +40,11 @@ class ZoneMapCatalog : public AbstractCatalog {
                               oid_t tile_group_id, oid_t column_id,
                               std::string minimum, std::string maximum,
                               std::string type, type::AbstractPool *pool,
-                              concurrency::Transaction *txn);
+                              concurrency::TransactionContext *txn);
 
   bool DeleteColumnStatistics(oid_t database_id, oid_t table_id,
                               oid_t tile_group_id, oid_t column_id,
-                              concurrency::Transaction *txn);
+                              concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
@@ -52,7 +52,7 @@ class ZoneMapCatalog : public AbstractCatalog {
 
   std::unique_ptr<std::vector<type::Value>> GetColumnStatistics(
       oid_t database_id, oid_t table_id, oid_t tile_group_id, oid_t column_id,
-      concurrency::Transaction *txn);
+      concurrency::TransactionContext *txn);
 
   enum class ColumnId {
     DATABASE_ID = 0,
@@ -71,7 +71,7 @@ class ZoneMapCatalog : public AbstractCatalog {
   };
 
  private:
-  ZoneMapCatalog(concurrency::Transaction *txn);
+  ZoneMapCatalog(concurrency::TransactionContext *txn);
 
   enum class IndexId {
     SECONDARY_KEY_0 = 0,

--- a/src/include/codegen/compilation_context.h
+++ b/src/include/codegen/compilation_context.h
@@ -17,11 +17,11 @@
 
 #include "codegen/code_context.h"
 #include "codegen/codegen.h"
-#include "codegen/runtime_state.h"
 #include "codegen/expression/expression_translator.h"
 #include "codegen/operator/operator_translator.h"
-#include "codegen/query_compiler.h"
 #include "codegen/query.h"
+#include "codegen/query_compiler.h"
+#include "codegen/runtime_state.h"
 #include "codegen/translator_factory.h"
 
 namespace peloton {
@@ -72,21 +72,14 @@ class CompilationContext {
 
   RuntimeState &GetRuntimeState() const { return query_.GetRuntimeState(); }
 
-//  const QueryParameters &GetQueryParameters() const {
-//    return parameters_;
-//  }
+  const ParameterCache &GetParameterCache() const { return parameter_cache_; }
 
-  const ParameterCache &GetParameterCache() const {
-    return parameter_cache_;
+  QueryResultConsumer &GetQueryResultConsumer() const {
+    return result_consumer_;
   }
-
-  QueryResultConsumer &GetQueryResultConsumer() const { return result_consumer_; }
 
   // Get a pointer to the storage manager object from the runtime state
   llvm::Value *GetStorageManagerPtr();
-
-  // Get a pointer to the transaction object from runtime state
-  llvm::Value *GetTransactionPtr();
 
   // Get a pointer to the executor context instance
   llvm::Value *GetExecutorContextPtr();
@@ -95,8 +88,8 @@ class CompilationContext {
   llvm::Value *GetQueryParametersPtr();
 
   // Get the parameter index to be used to get value for the given expression
-  size_t GetParameterIdx(const expression::AbstractExpression *expression)
-      const {
+  size_t GetParameterIdx(
+      const expression::AbstractExpression *expression) const {
     return parameters_map_.GetIndex(expression);
   }
 
@@ -141,7 +134,6 @@ class CompilationContext {
   TranslatorFactory translator_factory_;
 
   // The runtime state IDs
-  RuntimeState::StateID txn_state_id_;
   RuntimeState::StateID storage_manager_state_id_;
   RuntimeState::StateID executor_context_state_id_;
   RuntimeState::StateID query_parameters_state_id_;

--- a/src/include/codegen/deleter.h
+++ b/src/include/codegen/deleter.h
@@ -20,7 +20,7 @@
 namespace peloton {
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }  // namespace concurrency
 
 namespace executor {

--- a/src/include/codegen/inserter.h
+++ b/src/include/codegen/inserter.h
@@ -19,7 +19,7 @@
 namespace peloton {
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }  // namespace concurrency
 
 namespace executor {

--- a/src/include/codegen/proxy/executor_context_proxy.h
+++ b/src/include/codegen/proxy/executor_context_proxy.h
@@ -23,6 +23,9 @@ PROXY(ExecutorContext) {
   /// We don't need access to internal fields, so use an opaque byte array
   DECLARE_MEMBER(0, char[sizeof(executor::ExecutorContext)], opaque);
   DECLARE_TYPE;
+
+  /// Proxy peloton::executor::ExecutorContext::GetTransaction()
+  DECLARE_METHOD(GetTransaction);
 };
 
 TYPE_BUILDER(ExecutorContext, executor::ExecutorContext);

--- a/src/include/codegen/proxy/transaction_context_proxy.h
+++ b/src/include/codegen/proxy/transaction_context_proxy.h
@@ -2,9 +2,9 @@
 //
 //                         Peloton
 //
-// transaction_proxy.h
+// transaction_context_proxy.h
 //
-// Identification: src/include/codegen/proxy/transaction_proxy.h
+// Identification: src/include/codegen/proxy/transaction_context_proxy.h
 //
 // Copyright (c) 2015-2017, Carnegie Mellon University Database Group
 //
@@ -14,17 +14,17 @@
 
 #include "codegen/proxy/proxy.h"
 #include "codegen/proxy/type_builder.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 
 namespace peloton {
 namespace codegen {
 
-PROXY(Transaction) {
-  DECLARE_MEMBER(0, char[sizeof(concurrency::Transaction)], opaque);
+PROXY(TransactionContext) {
+  DECLARE_MEMBER(0, char[sizeof(concurrency::TransactionContext)], opaque);
   DECLARE_TYPE;
 };
 
-TYPE_BUILDER(Transaction, concurrency::Transaction);
+TYPE_BUILDER(TransactionContext, concurrency::TransactionContext);
 
 }  // namespace codegen
 }  // namespace peloton

--- a/src/include/codegen/proxy/zone_map_proxy.h
+++ b/src/include/codegen/proxy/zone_map_proxy.h
@@ -16,9 +16,9 @@
 #include "codegen/proxy/proxy.h"
 #include "codegen/proxy/type_builder.h"
 #include "storage/zone_map_manager.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "codegen/proxy/value_proxy.h"
-#include "codegen/proxy/transaction_proxy.h"
+#include "codegen/proxy/transaction_context_proxy.h"
 #include "codegen/proxy/data_table_proxy.h"
 #include "type/value.h"
 

--- a/src/include/codegen/query.h
+++ b/src/include/codegen/query.h
@@ -20,7 +20,7 @@
 namespace peloton {
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }  // namespace concurrency
 
 namespace executor {

--- a/src/include/codegen/transaction_runtime.h
+++ b/src/include/codegen/transaction_runtime.h
@@ -17,7 +17,7 @@
 namespace peloton {
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }  // namespace concurrency
 
 namespace executor {
@@ -44,22 +44,22 @@ class TransactionRuntime {
  public:
   // Perform a read operation for all tuples in the given tile group with IDs
   // in the range [tid_start, tid_end) in the context of the given transaction
-  static uint32_t PerformVectorizedRead(concurrency::Transaction &txn,
+  static uint32_t PerformVectorizedRead(concurrency::TransactionContext &txn,
                                         storage::TileGroup &tile_group,
                                         uint32_t tid_start, uint32_t tid_end,
                                         uint32_t *selection_vector);
   // Check Ownership
-  static bool IsOwner(concurrency::Transaction &txn,
+  static bool IsOwner(concurrency::TransactionContext &txn,
                       storage::TileGroupHeader *tile_group_header,
                       uint32_t tuple_offset);
   // Acquire Ownership
-  static bool AcquireOwnership(concurrency::Transaction &txn,
+  static bool AcquireOwnership(concurrency::TransactionContext &txn,
                                storage::TileGroupHeader *tile_group_header,
                                uint32_t tuple_offset);
   // Yield Ownership
   // Note: this should be called when failed after acquired ownership
   //       otherwise, ownership is yielded inside transaction functions
-  static void YieldOwnership(concurrency::Transaction &txn,
+  static void YieldOwnership(concurrency::TransactionContext &txn,
                              storage::TileGroupHeader *tile_group_header,
                              uint32_t tuple_offset);
 };

--- a/src/include/codegen/updater.h
+++ b/src/include/codegen/updater.h
@@ -19,7 +19,7 @@
 namespace peloton {
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }  // namespace concurrency
 
 namespace storage {

--- a/src/include/common/container_tuple.h
+++ b/src/include/common/container_tuple.h
@@ -92,7 +92,7 @@ class ContainerTuple : public AbstractTuple {
       for (size_t idx = 0; idx < column_ids_->size(); idx++) {
         type::Value lhs = (GetValue(column_ids_->at(idx)));
         type::Value rhs = (other.GetValue(other.column_ids_->at(idx)));
-        if (lhs.CompareNotEquals(rhs) == type::CMP_TRUE) {
+        if (lhs.CompareNotEquals(rhs) == type::CmpBool::TRUE) {
           return false;
         }
       }
@@ -101,7 +101,7 @@ class ContainerTuple : public AbstractTuple {
       for (size_t column_itr = 0; column_itr < column_count; column_itr++) {
         type::Value lhs = (GetValue(column_itr));
         type::Value rhs = (other.GetValue(column_itr));
-        if (lhs.CompareNotEquals(rhs) == type::CMP_TRUE) return false;
+        if (lhs.CompareNotEquals(rhs) == type::CmpBool::TRUE) return false;
       }
     }
     return true;
@@ -217,7 +217,7 @@ class ContainerTuple<std::vector<type::Value>> : public AbstractTuple {
     for (size_t column_itr = 0; column_itr < container_->size(); column_itr++) {
       type::Value lhs = GetValue(column_itr);
       type::Value rhs = other.GetValue(column_itr);
-      if (lhs.CompareNotEquals(rhs) == type::CMP_TRUE) return false;
+      if (lhs.CompareNotEquals(rhs) == type::CmpBool::TRUE) return false;
     }
     return true;
   }

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -98,7 +98,7 @@ class Exception : public std::runtime_error {
       case ExceptionType::SERIALIZATION:
         return "Serialization";
       case ExceptionType::TRANSACTION:
-        return "Transaction";
+        return "TransactionContext";
       case ExceptionType::NOT_IMPLEMENTED:
         return "Not implemented";
       case ExceptionType::EXPRESSION:

--- a/src/include/common/statement.h
+++ b/src/include/common/statement.h
@@ -29,7 +29,7 @@ class AbstractPlan;
 // std::string since the result is sent to the client over the network.
 // Previously it used to be StatementResult of type
 // std::pair<std::vector<unsigned char>, std::vector<unsigned char>>.
-typedef std::vector<unsigned char> ResultValue;
+using ResultValue = std::string;
 
 // FIELD INFO TYPE : field name, oid (data type), size
 typedef std::tuple<std::string, oid_t, size_t> FieldInfo;

--- a/src/include/concurrency/timestamp_ordering_transaction_manager.h
+++ b/src/include/concurrency/timestamp_ordering_transaction_manager.h
@@ -37,68 +37,68 @@ class TimestampOrderingTransactionManager : public TransactionManager {
 
   // This method tests whether the current transaction is the owner of this version.
   virtual bool IsOwner(
-      Transaction *const current_txn,
+      TransactionContext *const current_txn,
       const storage::TileGroupHeader *const tile_group_header,
       const oid_t &tuple_id);
 
   // This method tests whether any other transaction has owned this version.
   virtual bool IsOwned(
-      Transaction *const current_txn,
+      TransactionContext *const current_txn,
       const storage::TileGroupHeader *const tile_group_header,
       const oid_t &tuple_id);
 
   // This method tests whether the current transaction has created this version of the tuple
   virtual bool IsWritten(
-      Transaction *const current_txn,
+      TransactionContext *const current_txn,
       const storage::TileGroupHeader *const tile_group_header,
       const oid_t &tuple_id);
 
   // This method tests whether it is possible to obtain the ownership.
   virtual bool IsOwnable(
-      Transaction *const current_txn,
+      TransactionContext *const current_txn,
       const storage::TileGroupHeader *const tile_group_header,
       const oid_t &tuple_id);
 
   // This method is used to acquire the ownership of a tuple for a transaction.
   virtual bool AcquireOwnership(
-      Transaction *const current_txn,
+      TransactionContext *const current_txn,
       const storage::TileGroupHeader *const tile_group_header,
       const oid_t &tuple_id);
 
   // This method is used by executor to yield ownership after the acquired
   // ownership.
   virtual void YieldOwnership(
-      Transaction *const current_txn,
+      TransactionContext *const current_txn,
       const storage::TileGroupHeader *const tile_group_header,
       const oid_t &tuple_id);
 
   // The index_entry_ptr is the address of the head node of the version chain,
   // which is directly pointed by the primary index.
-  virtual void PerformInsert(Transaction *const current_txn,
+  virtual void PerformInsert(TransactionContext *const current_txn,
                              const ItemPointer &location,
                              ItemPointer *index_entry_ptr = nullptr);
 
-  virtual bool PerformRead(Transaction *const current_txn,
+  virtual bool PerformRead(TransactionContext *const current_txn,
                            const ItemPointer &location,
                            bool acquire_ownership = false);
 
-  virtual void PerformUpdate(Transaction *const current_txn,
+  virtual void PerformUpdate(TransactionContext *const current_txn,
                              const ItemPointer &old_location,
                              const ItemPointer &new_location);
 
-  virtual void PerformDelete(Transaction *const current_txn,
+  virtual void PerformDelete(TransactionContext *const current_txn,
                              const ItemPointer &old_location,
                              const ItemPointer &new_location);
 
-  virtual void PerformUpdate(Transaction *const current_txn,
+  virtual void PerformUpdate(TransactionContext *const current_txn,
                              const ItemPointer &location);
 
-  virtual void PerformDelete(Transaction *const current_txn,
+  virtual void PerformDelete(TransactionContext *const current_txn,
                              const ItemPointer &location);
 
-  virtual ResultType CommitTransaction(Transaction *const current_txn);
+  virtual ResultType CommitTransaction(TransactionContext *const current_txn);
 
-  virtual ResultType AbortTransaction(Transaction *const current_txn);
+  virtual ResultType AbortTransaction(TransactionContext *const current_txn);
 
 
 private:

--- a/src/include/concurrency/transaction_context.h
+++ b/src/include/concurrency/transaction_context.h
@@ -2,9 +2,9 @@
 //
 //                         Peloton
 //
-// transaction.h
+// transaction_context.h
 //
-// Identification: src/include/concurrency/transaction.h
+// Identification: src/include/concurrency/transaction_context.h
 //
 // Copyright (c) 2015-16, Carnegie Mellon University Database Group
 //
@@ -34,20 +34,20 @@ class TriggerData;
 namespace concurrency {
 
 //===--------------------------------------------------------------------===//
-// Transaction
+// TransactionContext
 //===--------------------------------------------------------------------===//
 
-class Transaction : public Printable {
-  Transaction(Transaction const &) = delete;
+class TransactionContext : public Printable {
+  TransactionContext(TransactionContext const &) = delete;
 
  public:
-  Transaction(const size_t thread_id, const IsolationLevelType isolation,
+  TransactionContext(const size_t thread_id, const IsolationLevelType isolation,
               const cid_t &read_id);
 
-  Transaction(const size_t thread_id, const IsolationLevelType isolation,
+  TransactionContext(const size_t thread_id, const IsolationLevelType isolation,
               const cid_t &read_id, const cid_t &commit_id);
 
-  ~Transaction();
+  ~TransactionContext();
 
  private:
   void Init(const size_t thread_id, const IsolationLevelType isolation,

--- a/src/include/concurrency/transaction_manager.h
+++ b/src/include/concurrency/transaction_manager.h
@@ -19,7 +19,7 @@
 #include <utility>
 
 #include "storage/tile_group_header.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/epoch_manager_factory.h"
 #include "common/logger.h"
 
@@ -38,7 +38,7 @@ class Manager;
 
 namespace concurrency {
 
-class Transaction;
+class TransactionContext;
 
 class TransactionManager {
  public:
@@ -56,92 +56,92 @@ class TransactionManager {
 
   // This method is used for avoiding concurrent inserts.
   bool IsOccupied(
-      Transaction *const current_txn, 
+      TransactionContext *const current_txn,
       const void *position_ptr);
 
   VisibilityType IsVisible(
-      Transaction *const current_txn, 
+      TransactionContext *const current_txn,
       const storage::TileGroupHeader *const tile_group_header,
       const oid_t &tuple_id,
       const VisibilityIdType type = VisibilityIdType::READ_ID);
 
   // This method test whether the current transaction is the owner of this version.
   virtual bool IsOwner(
-      Transaction *const current_txn, 
+      TransactionContext *const current_txn,
       const storage::TileGroupHeader *const tile_group_header,
       const oid_t &tuple_id) = 0;
 
   // This method tests whether any other transaction has owned this version.
   virtual bool IsOwned(
-      Transaction *const current_txn,
+      TransactionContext *const current_txn,
       const storage::TileGroupHeader *const tile_group_header,
       const oid_t &tuple_id) = 0;
 
   // This method tests whether the current transaction has created this version of the tuple
   virtual bool IsWritten(
-    Transaction *const current_txn,
+    TransactionContext *const current_txn,
     const storage::TileGroupHeader *const tile_group_header,
     const oid_t &tuple_id) = 0;
 
   // This method tests whether it is possible to obtain the ownership.
   virtual bool IsOwnable(
-      Transaction *const current_txn, 
+      TransactionContext *const current_txn,
       const storage::TileGroupHeader *const tile_group_header,
       const oid_t &tuple_id) = 0;
 
   // This method is used to acquire the ownership of a tuple for a transaction.
   virtual bool AcquireOwnership(
-      Transaction *const current_txn, 
+      TransactionContext *const current_txn,
       const storage::TileGroupHeader *const tile_group_header, 
       const oid_t &tuple_id) = 0;
 
   // This method is used by executor to yield ownership after the acquired ownership.
   virtual void YieldOwnership(
-      Transaction *const current_txn, 
+      TransactionContext *const current_txn,
       // const oid_t &tile_group_id, 
       const storage::TileGroupHeader *const tile_group_header, 
       const oid_t &tuple_id) = 0;
 
   // The index_entry_ptr is the address of the head node of the version chain, 
   // which is directly pointed by the primary index.
-  virtual void PerformInsert(Transaction *const current_txn, 
+  virtual void PerformInsert(TransactionContext *const current_txn,
                              const ItemPointer &location, 
                              ItemPointer *index_entry_ptr = nullptr) = 0;
 
-  virtual bool PerformRead(Transaction *const current_txn, 
+  virtual bool PerformRead(TransactionContext *const current_txn,
                            const ItemPointer &location,
                            bool acquire_ownership = false) = 0;
 
-  virtual void PerformUpdate(Transaction *const current_txn, 
+  virtual void PerformUpdate(TransactionContext *const current_txn,
                              const ItemPointer &old_location,
                              const ItemPointer &new_location) = 0;
 
-  virtual void PerformDelete(Transaction *const current_txn, 
+  virtual void PerformDelete(TransactionContext *const current_txn,
                              const ItemPointer &old_location,
                              const ItemPointer &new_location) = 0;
 
-  virtual void PerformUpdate(Transaction *const current_txn, 
+  virtual void PerformUpdate(TransactionContext *const current_txn,
                              const ItemPointer &location) = 0;
 
-  virtual void PerformDelete(Transaction *const current_txn, 
+  virtual void PerformDelete(TransactionContext *const current_txn,
                              const ItemPointer &location) = 0;
 
-  void SetTransactionResult(Transaction *const current_txn, const ResultType result) {
+  void SetTransactionResult(TransactionContext *const current_txn, const ResultType result) {
     current_txn->SetResult(result);
   }
 
-  Transaction *BeginTransaction(const IsolationLevelType type) {
+  TransactionContext *BeginTransaction(const IsolationLevelType type) {
     return BeginTransaction(0, type);
   }
 
-  Transaction *BeginTransaction(const size_t thread_id = 0, 
+  TransactionContext *BeginTransaction(const size_t thread_id = 0,
                                 const IsolationLevelType type = isolation_level_);
 
-  void EndTransaction(Transaction *current_txn);
+  void EndTransaction(TransactionContext *current_txn);
 
-  virtual ResultType CommitTransaction(Transaction *const current_txn) = 0;
+  virtual ResultType CommitTransaction(TransactionContext *const current_txn) = 0;
 
-  virtual ResultType AbortTransaction(Transaction *const current_txn) = 0;
+  virtual ResultType AbortTransaction(TransactionContext *const current_txn) = 0;
 
   // this function generates the maximum commit id of committed transactions.
   // please note that this function only returns a "safe" value instead of a

--- a/src/include/executor/aggregator.h
+++ b/src/include/executor/aggregator.h
@@ -305,7 +305,7 @@ class HashAggregator : public AbstractAggregator {
     bool operator()(const std::vector<type::Value> &lhs,
                     const std::vector<type::Value> &rhs) const {
       for (size_t i = 0; i < lhs.size() && i < rhs.size(); i++) {
-        if (lhs[i].CompareNotEquals(rhs[i]) == type::CMP_TRUE) return false;
+        if (lhs[i].CompareNotEquals(rhs[i]) == type::CmpBool::TRUE) return false;
       }
       if (lhs.size() == rhs.size()) return true;
       return false;

--- a/src/include/executor/executor_context.h
+++ b/src/include/executor/executor_context.h
@@ -20,7 +20,7 @@ namespace peloton {
 //class Value;
 
 namespace concurrency{
-class Transaction;
+class TransactionContext;
 }
 
 namespace executor {
@@ -36,14 +36,14 @@ class ExecutorContext {
   ExecutorContext(ExecutorContext &&) = delete;
   ExecutorContext &operator=(ExecutorContext &&) = delete;
 
-  ExecutorContext(concurrency::Transaction *transaction);
+  ExecutorContext(concurrency::TransactionContext *transaction);
 
-  ExecutorContext(concurrency::Transaction *transaction,
+  ExecutorContext(concurrency::TransactionContext *transaction,
                   const std::vector<type::Value> &params);
 
   ~ExecutorContext();
 
-  concurrency::Transaction *GetTransaction() const;
+  concurrency::TransactionContext *GetTransaction() const;
 
   const std::vector<type::Value> &GetParams() const;
 
@@ -63,7 +63,7 @@ class ExecutorContext {
   //===--------------------------------------------------------------------===//
 
   // transaction
-  concurrency::Transaction *transaction_;
+  concurrency::TransactionContext *transaction_;
 
   // params
   std::vector<type::Value> params_;

--- a/src/include/executor/logical_tile.h
+++ b/src/include/executor/logical_tile.h
@@ -318,7 +318,7 @@ class LogicalTile : public Printable {
       const std::unordered_map<storage::Tile *, std::vector<oid_t>>
           &tile_to_cols,
       storage::Tile *dest_tile,
-      const peloton::LayoutType peloton_layout_mode = peloton::LAYOUT_TYPE_ROW);
+      const peloton::LayoutType peloton_layout_mode = peloton::LayoutType::ROW);
 
   /**
    * @brief Generates map from each base tile to columns originally from that

--- a/src/include/executor/materialization_executor.h
+++ b/src/include/executor/materialization_executor.h
@@ -60,7 +60,7 @@ class MaterializationExecutor : public AbstractExecutor {
       const std::unordered_map<storage::Tile *, std::vector<oid_t>> &
           tile_to_cols,
       storage::Tile *dest_tile,
-      const peloton::LayoutType peloton_layout_mode = peloton::LAYOUT_TYPE_ROW);
+      const peloton::LayoutType peloton_layout_mode = peloton::LayoutType::ROW);
 
   LogicalTile *Physify(LogicalTile *source_tile);
   std::unordered_map<oid_t, oid_t> BuildIdentityMapping(

--- a/src/include/executor/plan_executor.h
+++ b/src/include/executor/plan_executor.h
@@ -53,18 +53,6 @@ class PlanExecutor {
  public:
   PlanExecutor(){};
 
-  // Copy From
-  static inline void copyFromTo(const std::string &src,
-                                std::vector<unsigned char> &dst) {
-    if (src.c_str() == nullptr) {
-      return;
-    }
-    size_t len = src.size();
-    for (unsigned int i = 0; i < len; i++) {
-      dst.push_back((unsigned char)src[i]);
-    }
-  }
-
   /*
    * @brief Use std::vector<type::Value> as params to make it more elegant
    * for network

--- a/src/include/executor/plan_executor.h
+++ b/src/include/executor/plan_executor.h
@@ -19,7 +19,7 @@
 namespace peloton {
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }
 
 namespace executor {
@@ -72,7 +72,7 @@ class PlanExecutor {
    * pass value list directly rather than passing Postgres's ParamListInfo
    */
   static void ExecutePlan(std::shared_ptr<planner::AbstractPlan> plan,
-                                   concurrency::Transaction* txn,
+                                   concurrency::TransactionContext* txn,
                                    const std::vector<type::Value> &params,
                                    std::vector<ResultValue> &result,
                                    const std::vector<int> &result_format,

--- a/src/include/expression/constant_value_expression.h
+++ b/src/include/expression/constant_value_expression.h
@@ -48,7 +48,7 @@ class ConstantValueExpression : public AbstractExpression {
     if (exp_type_ != other.GetExpressionType())
       return false;
     auto const_expr = static_cast<const ConstantValueExpression &>(other);
-    return value_.CompareEquals(const_expr.value_);
+    return value_.CompareEquals(const_expr.value_) == type::CmpBool::TRUE;
   }
 
   virtual hash_t HashForExactMatch() const override {

--- a/src/include/gc/transaction_level_gc_manager.h
+++ b/src/include/gc/transaction_level_gc_manager.h
@@ -106,10 +106,12 @@ class TransactionLevelGCManager : public GCManager {
     }
   };
 
-  virtual void StopGC() override {
-    LOG_TRACE("Stopping GC");
-    this->is_running_ = false;
-  }
+  /**
+   * @brief This stops the Garbage Collector when Peloton shuts down
+   *
+   * @return No return value.
+   */
+  virtual void StopGC() override;
 
   virtual void RecycleTransaction(std::shared_ptr<GCSet> gc_set,
                                   std::shared_ptr<GCObjectSet> gc_object_set,
@@ -145,6 +147,12 @@ class TransactionLevelGCManager : public GCManager {
     return (unsigned int)thread_id % gc_thread_count_;
   }
 
+  /**
+   * @brief Unlink and reclaim the tuples remained in a garbage collection
+   * thread when the Garbage Collector stops.
+   *
+   * @return No return value.
+   */
   void ClearGarbage(int thread_id);
 
   void Running(const int &thread_id);
@@ -170,9 +178,8 @@ class TransactionLevelGCManager : public GCManager {
 
   // queues for to-be-unlinked tuples.
   // # unlink_queues == # gc_threads
-  std::vector<
-      std::shared_ptr<peloton::LockFreeQueue<std::shared_ptr<GarbageContext>>>>
-      unlink_queues_;
+  std::vector<std::shared_ptr<
+      peloton::LockFreeQueue<std::shared_ptr<GarbageContext>>>> unlink_queues_;
 
   // local queues for to-be-unlinked tuples.
   // # local_unlink_queues == # gc_threads

--- a/src/include/index/bwtree.h
+++ b/src/include/index/bwtree.h
@@ -53,6 +53,7 @@
 #ifdef BWTREE_PELOTON
 
 #include "index/index.h"
+#include "util/global.h"
 
 #endif
 
@@ -4358,6 +4359,7 @@ abort_traverse:
           bwt_printf("ERROR: Observed LeafRemoveNode in delta chain\n");
 
           assert(false);
+          PELOTON_FALLTHROUGH;
         } // case LeafRemoveType
         case NodeType::LeafMergeType: {
           bwt_printf("Observed a merge node on leaf delta chain\n");
@@ -4543,6 +4545,7 @@ abort_traverse:
           bwt_printf("ERROR: Observed LeafRemoveNode in delta chain\n");
 
           assert(false);
+          PELOTON_FALLTHROUGH;
         } // case LeafRemoveType
         case NodeType::LeafMergeType: {
           bwt_printf("Observed a merge node on leaf delta chain\n");
@@ -4743,6 +4746,7 @@ abort_traverse:
           bwt_printf("ERROR: Observed LeafRemoveNode in delta chain\n");
 
           assert(false);
+          PELOTON_FALLTHROUGH;
         } // case LeafRemoveType
         case NodeType::LeafMergeType: {
           bwt_printf("Observed a merge node on leaf delta chain\n");
@@ -5074,6 +5078,7 @@ abort_traverse:
           bwt_printf("ERROR: LeafRemoveNode not allowed\n");
 
           assert(false);
+          PELOTON_FALLTHROUGH;
         } // case LeafRemoveType
         case NodeType::LeafSplitType: {
           const LeafSplitNode *split_node_p = \
@@ -5960,11 +5965,10 @@ before_switch:
 
           return;
         } // if ret == true
-
         //
         // FALL THROUGH IF POSTING MERGE DELTA SUCCEEDS
         //
-
+        PELOTON_FALLTHROUGH;
       } // case Inner/LeafRemoveType
       case NodeType::InnerMergeType:
       case NodeType::LeafMergeType: {

--- a/src/include/index/generic_key.h
+++ b/src/include/index/generic_key.h
@@ -75,9 +75,9 @@ class GenericComparator {
       const type::Value lhs_value = (lhs.ToValue(schema, col_itr));
       const type::Value rhs_value = (rhs.ToValue(schema, col_itr));
 
-      if (lhs_value.CompareLessThan(rhs_value) == type::CMP_TRUE) return true;
+      if (lhs_value.CompareLessThan(rhs_value) == type::CmpBool::TRUE) return true;
 
-      if (lhs_value.CompareGreaterThan(rhs_value) == type::CMP_TRUE)
+      if (lhs_value.CompareGreaterThan(rhs_value) == type::CmpBool::TRUE)
         return false;
     }
 
@@ -108,10 +108,10 @@ class FastGenericComparator {
       bool inlined = schema->IsInlined(col_itr);
 
       if (type::TypeUtil::CompareLessThanRaw(type, lhs_data, rhs_data,
-                                             inlined) == type::CMP_TRUE)
+                                             inlined) == type::CmpBool::TRUE)
         return true;
       else if (type::TypeUtil::CompareGreaterThanRaw(type, lhs_data, rhs_data,
-                                                     inlined) == type::CMP_TRUE)
+                                                     inlined) == type::CmpBool::TRUE)
         return false;
     }
 
@@ -137,10 +137,10 @@ class GenericComparatorRaw {
       const type::Value lhs_value = (lhs.ToValue(schema, column_itr));
       const type::Value rhs_value = (rhs.ToValue(schema, column_itr));
 
-      if (lhs_value.CompareLessThan(rhs_value) == type::CMP_TRUE)
+      if (lhs_value.CompareLessThan(rhs_value) == type::CmpBool::TRUE)
         return VALUE_COMPARE_LESSTHAN;
 
-      if (lhs_value.CompareGreaterThan(rhs_value) == type::CMP_TRUE)
+      if (lhs_value.CompareGreaterThan(rhs_value) == type::CmpBool::TRUE)
         return VALUE_COMPARE_GREATERTHAN;
     }
 

--- a/src/include/index/tuple_key.h
+++ b/src/include/index/tuple_key.h
@@ -178,12 +178,12 @@ class TupleKeyComparator {
         rhTuple.GetValue(rhs.ColumnForIndexColumn(col_itr));
 
       // If there is a field in LHS < RHS then return true;
-      if (lhValue.CompareLessThan(rhValue) == type::CMP_TRUE) {
+      if (lhValue.CompareLessThan(rhValue) == type::CmpBool::TRUE) {
         return true;
       }
       
       // If there is a field in LHS > RHS then return false
-      if (lhValue.CompareGreaterThan(rhValue) == type::CMP_TRUE) {
+      if (lhValue.CompareGreaterThan(rhValue) == type::CmpBool::TRUE) {
         return false;
       }
     }
@@ -235,11 +235,11 @@ class TupleKeyComparatorRaw {
       type::Value rhValue = \
           rhTuple.GetValue(rhs.ColumnForIndexColumn(col_itr));
 
-      if (lhValue.CompareLessThan(rhValue) == type::CMP_TRUE) {
+      if (lhValue.CompareLessThan(rhValue) == type::CmpBool::TRUE) {
         return VALUE_COMPARE_LESSTHAN;
       }
 
-      if (lhValue.CompareGreaterThan(rhValue) == type::CMP_TRUE) {
+      if (lhValue.CompareGreaterThan(rhValue) == type::CmpBool::TRUE) {
         return VALUE_COMPARE_GREATERTHAN;
       }
     }
@@ -293,7 +293,7 @@ class TupleKeyEqualityChecker {
 
       // If any of these two columns differ then just return false
       // because we know they could not be equal 
-      if (lhValue.CompareNotEquals(rhValue) == type::CMP_TRUE) {
+      if (lhValue.CompareNotEquals(rhValue) == type::CmpBool::TRUE) {
         return false;
       }
     }

--- a/src/include/logging/logical_logger.h
+++ b/src/include/logging/logical_logger.h
@@ -18,7 +18,7 @@
 #include <stack>
 #include <unordered_map>
 
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/epoch_manager.h"
 #include "logging/log_buffer.h"
 #include "logging/log_record.h"

--- a/src/include/network/marshal.h
+++ b/src/include/network/marshal.h
@@ -173,7 +173,8 @@ struct Client {
 extern void PacketPutByte(OutputPacket *pkt, const uchar c);
 
 /* packet_put_string - used to write a string into a packet */
-extern void PacketPutString(OutputPacket *pkt, const std::string &str);
+extern void PacketPutStringWithTerminator(OutputPacket *pkt,
+                                          const std::string &str);
 
 /* packet_put_int - used to write a single int into a packet */
 extern void PacketPutInt(OutputPacket *pkt, int n, int base);
@@ -182,7 +183,7 @@ extern void PacketPutInt(OutputPacket *pkt, int n, int base);
 extern void PacketPutCbytes(OutputPacket *pkt, const uchar *b, int len);
 
 /* packet_put_bytes - used to write a uchar vector into a packet */
-extern void PacketPutBytes(OutputPacket *pkt, const std::string &data);
+extern void PacketPutString(OutputPacket *pkt, const std::string &data);
 
 /*
 * Unmarshallers

--- a/src/include/network/marshal.h
+++ b/src/include/network/marshal.h
@@ -182,7 +182,7 @@ extern void PacketPutInt(OutputPacket *pkt, int n, int base);
 extern void PacketPutCbytes(OutputPacket *pkt, const uchar *b, int len);
 
 /* packet_put_bytes - used to write a uchar vector into a packet */
-extern void PacketPutBytes(OutputPacket *pkt, const std::vector<uchar> &data);
+extern void PacketPutBytes(OutputPacket *pkt, const std::string &data);
 
 /*
 * Unmarshallers

--- a/src/include/optimizer/abstract_optimizer.h
+++ b/src/include/optimizer/abstract_optimizer.h
@@ -27,7 +27,7 @@ class SQLStatementList;
 }
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }
 
 namespace optimizer {
@@ -48,7 +48,7 @@ class AbstractOptimizer {
   virtual std::shared_ptr<planner::AbstractPlan> BuildPelotonPlanTree(
       const std::unique_ptr<parser::SQLStatementList> &parse_tree, 
       const std::string default_database_name,
-      concurrency::Transaction *txn) = 0;
+      concurrency::TransactionContext *txn) = 0;
 
   virtual void Reset(){};
 };

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -36,7 +36,7 @@ class OperatorExpression;
 }
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }
 
 namespace optimizer {
@@ -59,7 +59,7 @@ class Optimizer : public AbstractOptimizer {
   std::shared_ptr<planner::AbstractPlan> BuildPelotonPlanTree(
       const std::unique_ptr<parser::SQLStatementList> &parse_tree,
       const std::string default_database_name,
-      concurrency::Transaction *txn) override;
+      concurrency::TransactionContext *txn) override;
 
   void Reset() override;
 
@@ -72,7 +72,7 @@ class Optimizer : public AbstractOptimizer {
    * return: the DDL plan if it is a DDL statement
    */
   std::unique_ptr<planner::AbstractPlan> HandleDDLStatement(
-      parser::SQLStatement *tree, bool &is_ddl_stmt, concurrency::Transaction *txn);
+      parser::SQLStatement *tree, bool &is_ddl_stmt, concurrency::TransactionContext *txn);
 
   /* TransformQueryTree - create an initial operator tree for the given query
    * to be used in performing optimization.
@@ -81,7 +81,7 @@ class Optimizer : public AbstractOptimizer {
    * return: the root group expression for the inserted query
    */
   std::shared_ptr<GroupExpression> InsertQueryTree(parser::SQLStatement *tree,
-                                                   concurrency::Transaction *txn);
+                                                   concurrency::TransactionContext *txn);
 
   /* GetQueryTreeRequiredProperties - get the required physical properties for
    * a peloton query tree.

--- a/src/include/optimizer/property.h
+++ b/src/include/optimizer/property.h
@@ -48,7 +48,7 @@ class Property {
 
   template <typename T>
   const T *As() const {
-    if (this != nullptr && typeid(*this) == typeid(T)) {
+    if (typeid(*this) == typeid(T)) {
       return reinterpret_cast<const T *>(this);
     }
     return nullptr;

--- a/src/include/optimizer/property_set.h
+++ b/src/include/optimizer/property_set.h
@@ -35,6 +35,13 @@ class PropertySet {
 
   const std::shared_ptr<Property> GetPropertyOfType(PropertyType type) const;
 
+  template <typename T>
+  const T *GetPropertyOfTypeAs(PropertyType type) const {
+    auto property = GetPropertyOfType(type);
+    if (property) return property->As<T>();
+    return nullptr;
+  }
+
   hash_t Hash() const;
 
   // whether this property set contains a specific property

--- a/src/include/optimizer/query_to_operator_transformer.h
+++ b/src/include/optimizer/query_to_operator_transformer.h
@@ -22,7 +22,7 @@ class SQLStatement;
 }  // namespace parser
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }
 
 namespace optimizer {
@@ -33,7 +33,7 @@ class ColumnManager;
 // Transform a query from parsed statement to operator expressions.
 class QueryToOperatorTransformer : public SqlNodeVisitor {
  public:
-  QueryToOperatorTransformer(concurrency::Transaction *txn);
+  QueryToOperatorTransformer(concurrency::TransactionContext *txn);
 
   std::shared_ptr<OperatorExpression> ConvertToOpExpression(
       parser::SQLStatement *op);
@@ -66,7 +66,7 @@ class QueryToOperatorTransformer : public SqlNodeVisitor {
   type::TypeId output_type;
   int output_size;
   bool output_inlined;
-  concurrency::Transaction *txn_;
+  concurrency::TransactionContext *txn_;
 
 };
 

--- a/src/include/optimizer/stats/stats_storage.h
+++ b/src/include/optimizer/stats/stats_storage.h
@@ -49,14 +49,14 @@ class StatsStorage {
 
   void InsertOrUpdateTableStats(storage::DataTable *table,
                                 TableStatsCollector *table_stats_collector,
-                                concurrency::Transaction *txn = nullptr);
+                                concurrency::TransactionContext *txn = nullptr);
 
   void InsertOrUpdateColumnStats(
       oid_t database_id, oid_t table_id, oid_t column_id, int num_rows,
       double cardinality, double frac_null, std::string most_common_vals,
       std::string most_common_freqs, std::string histogram_bounds,
       std::string column_name, bool has_index = false,
-      concurrency::Transaction *txn = nullptr);
+      concurrency::TransactionContext *txn = nullptr);
 
   std::shared_ptr<ColumnStats> GetColumnStatsByID(oid_t database_id,
                                                   oid_t table_id,
@@ -69,10 +69,10 @@ class StatsStorage {
 
   /* Functions for triggerring stats collection */
 
-  ResultType AnalyzeStatsForAllTables(concurrency::Transaction *txn = nullptr);
+  ResultType AnalyzeStatsForAllTables(concurrency::TransactionContext *txn = nullptr);
 
   ResultType AnalyzeStatsForTable(storage::DataTable *table,
-                                  concurrency::Transaction *txn = nullptr);
+                                  concurrency::TransactionContext *txn = nullptr);
 
   ResultType AnalayzeStatsForColumns(storage::DataTable *table,
                                      std::vector<std::string> column_names);

--- a/src/include/optimizer/stats/tuple_samples_storage.h
+++ b/src/include/optimizer/stats/tuple_samples_storage.h
@@ -28,7 +28,7 @@ class Tuple;
 }
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }
 
 namespace executor {
@@ -55,19 +55,19 @@ class TupleSamplesStorage {
       std::vector<std::unique_ptr<storage::Tuple>> &sampled_tuples);
 
   ResultType DeleteSamplesTable(oid_t database_id, oid_t table_id,
-                                concurrency::Transaction *txn = nullptr);
+                                concurrency::TransactionContext *txn = nullptr);
 
   bool InsertSampleTuple(storage::DataTable *samples_table,
                          std::unique_ptr<storage::Tuple> tuple,
-                         concurrency::Transaction *txn);
+                         concurrency::TransactionContext *txn);
 
   ResultType CollectSamplesForTable(storage::DataTable *data_table,
-                                    concurrency::Transaction *txn = nullptr);
+                                    concurrency::TransactionContext *txn = nullptr);
 
   std::unique_ptr<std::vector<std::unique_ptr<executor::LogicalTile>>>
   GetTuplesWithSeqScan(storage::DataTable *data_table,
                        std::vector<oid_t> column_offsets,
-                       concurrency::Transaction *txn);
+                       concurrency::TransactionContext *txn);
 
   std::unique_ptr<std::vector<std::unique_ptr<executor::LogicalTile>>>
   GetTupleSamples(oid_t database_id, oid_t table_id);

--- a/src/include/planner/analyze_plan.h
+++ b/src/include/planner/analyze_plan.h
@@ -27,7 +27,7 @@ namespace catalog {
 class Schema;
 }
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }
 
 namespace planner {
@@ -42,15 +42,15 @@ class AnalyzePlan : public AbstractPlan {
 
   explicit AnalyzePlan(std::string table_name,
                        std::string database_name,
-                       concurrency::Transaction *txn);
+                       concurrency::TransactionContext *txn);
 
   explicit AnalyzePlan(std::string table_name, 
                        std::string database_name, 
                        std::vector<char *> column_names,
-                       concurrency::Transaction *txn);
+                       concurrency::TransactionContext *txn);
 
   explicit AnalyzePlan(parser::AnalyzeStatement *parse_tree,
-                       concurrency::Transaction *txn);
+                       concurrency::TransactionContext *txn);
 
   inline PlanNodeType GetPlanNodeType() const { return PlanNodeType::ANALYZE; }
 

--- a/src/include/planner/drop_plan.h
+++ b/src/include/planner/drop_plan.h
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "planner/abstract_plan.h"
 
 namespace peloton {

--- a/src/include/statistics/access_metric.h
+++ b/src/include/statistics/access_metric.h
@@ -131,10 +131,10 @@ class AccessMetric : public AbstractMetric {
 
   // Vector containing all access types
   std::vector<CounterMetric> access_counters_{
-      CounterMetric(COUNTER_METRIC),  // READ_COUNTER
-      CounterMetric(COUNTER_METRIC),  // UPDATE_COUNTER
-      CounterMetric(COUNTER_METRIC),  // INSERT_COUNTER
-      CounterMetric(COUNTER_METRIC)   // DELETE_COUNTER
+      CounterMetric(MetricType::COUNTER),  // READ_COUNTER
+      CounterMetric(MetricType::COUNTER),  // UPDATE_COUNTER
+      CounterMetric(MetricType::COUNTER),  // INSERT_COUNTER
+      CounterMetric(MetricType::COUNTER)   // DELETE_COUNTER
   };
 
   // The different types of accesses. These also

--- a/src/include/statistics/database_metric.h
+++ b/src/include/statistics/database_metric.h
@@ -75,10 +75,10 @@ class DatabaseMetric : public AbstractMetric {
   oid_t database_id_;
 
   // Count of the number of transactions committed
-  CounterMetric txn_committed_{MetricType::COUNTER_METRIC};
+  CounterMetric txn_committed_{MetricType::COUNTER};
 
   // Count of the number of transactions aborted
-  CounterMetric txn_aborted_{MetricType::COUNTER_METRIC};
+  CounterMetric txn_aborted_{MetricType::COUNTER};
 };
 
 }  // namespace stats

--- a/src/include/statistics/index_metric.h
+++ b/src/include/statistics/index_metric.h
@@ -91,7 +91,7 @@ class IndexMetric : public AbstractMetric {
   std::string index_name_;
 
   // Counts the number of index entries accessed
-  AccessMetric index_access_{ACCESS_METRIC};
+  AccessMetric index_access_{MetricType::ACCESS};
 };
 
 }  // namespace stats

--- a/src/include/statistics/query_metric.h
+++ b/src/include/statistics/query_metric.h
@@ -116,13 +116,13 @@ class QueryMetric : public AbstractMetric {
   std::shared_ptr<QueryParams> query_params_;
 
   // The number of tuple accesses
-  AccessMetric query_access_{ACCESS_METRIC};
+  AccessMetric query_access_{MetricType::ACCESS};
 
   // Latency metric
-  LatencyMetric latency_metric_{LATENCY_METRIC, 2};
+  LatencyMetric latency_metric_{MetricType::LATENCY, 2};
 
   // Processor metric
-  ProcessorMetric processor_metric_{PROCESSOR_METRIC};
+  ProcessorMetric processor_metric_{MetricType::PROCESSOR};
 };
 
 }  // namespace stats

--- a/src/include/statistics/stats_aggregator.h
+++ b/src/include/statistics/stats_aggregator.h
@@ -25,7 +25,7 @@
 #include "statistics/backend_stats_context.h"
 #include "storage/database.h"
 #include "storage/data_table.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 
 //===--------------------------------------------------------------------===//
 // GUC Variables
@@ -154,15 +154,15 @@ class StatsAggregator {
 
   // Update the table metrics with a given database
   void UpdateTableMetrics(storage::Database *database, int64_t time_stamp,
-                          concurrency::Transaction *txn);
+                          concurrency::TransactionContext *txn);
 
   // Update the index metrics with a given table
   void UpdateIndexMetrics(storage::Database *database,
                           storage::DataTable *table, int64_t time_stamp,
-                          concurrency::Transaction *txn);
+                          concurrency::TransactionContext *txn);
 
   // Write all query metrics to a metric table
-  void UpdateQueryMetrics(int64_t time_stamp, concurrency::Transaction *txn);
+  void UpdateQueryMetrics(int64_t time_stamp, concurrency::TransactionContext *txn);
 
   // Aggregate stats periodically
   void RunAggregator();

--- a/src/include/statistics/table_metric.h
+++ b/src/include/statistics/table_metric.h
@@ -85,7 +85,7 @@ class TableMetric : public AbstractMetric {
   std::string table_name_;
 
   // The number of tuple accesses
-  AccessMetric table_access_{ACCESS_METRIC};
+  AccessMetric table_access_{MetricType::ACCESS};
 };
 
 }  // namespace stats

--- a/src/include/storage/abstract_table.h
+++ b/src/include/storage/abstract_table.h
@@ -32,7 +32,7 @@ namespace peloton {
 typedef std::map<oid_t, std::pair<oid_t, oid_t>> column_map_type;
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }
 
 namespace catalog {
@@ -65,7 +65,7 @@ class AbstractTable : public Printable {
   // insert tuple in table. the pointer to the index entry is returned as
   // index_entry_ptr.
   virtual ItemPointer InsertTuple(const Tuple *tuple,
-                                  concurrency::Transaction *transaction,
+                                  concurrency::TransactionContext *transaction,
                                   ItemPointer **index_entry_ptr = nullptr) = 0;
 
   // designed for tables without primary key. e.g., output table used by

--- a/src/include/storage/abstract_table.h
+++ b/src/include/storage/abstract_table.h
@@ -55,7 +55,7 @@ class AbstractTable : public Printable {
  protected:
   // Table constructor
   AbstractTable(oid_t table_oid, catalog::Schema *schema, bool own_schema,
-               peloton::LayoutType layout_type = peloton::LAYOUT_TYPE_ROW);
+               peloton::LayoutType layout_type = peloton::LayoutType::ROW);
 
  public:
   //===--------------------------------------------------------------------===//

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -51,7 +51,7 @@ class LogManager;
 }
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }
 
 namespace storage {
@@ -111,13 +111,13 @@ class DataTable : public AbstractTable {
   // as we implement logical-pointer indexing mechanism, targets_ptr is
   // required.
   bool InstallVersion(const AbstractTuple *tuple, const TargetList *targets_ptr,
-                      concurrency::Transaction *transaction,
+                      concurrency::TransactionContext *transaction,
                       ItemPointer *index_entry_ptr);
 
   // insert tuple in table. the pointer to the index entry is returned as
   // index_entry_ptr.
   ItemPointer InsertTuple(const Tuple *tuple,
-                          concurrency::Transaction *transaction,
+                          concurrency::TransactionContext *transaction,
                           ItemPointer **index_entry_ptr = nullptr);
   // designed for tables without primary key. e.g., output table used by
   // aggregate_executor.
@@ -125,7 +125,7 @@ class DataTable : public AbstractTable {
 
   // Insert tuple with ItemPointer provided explicitly
   bool InsertTuple(const AbstractTuple *tuple, ItemPointer location,
-      concurrency::Transaction *transaction, ItemPointer **index_entry_ptr);
+      concurrency::TransactionContext *transaction, ItemPointer **index_entry_ptr);
 
   //===--------------------------------------------------------------------===//
   // TILE GROUP
@@ -161,7 +161,7 @@ class DataTable : public AbstractTable {
 
   trigger::TriggerList* GetTriggerList();
 
-  void UpdateTriggerListFromCatalog(concurrency::Transaction *txn);
+  void UpdateTriggerListFromCatalog(concurrency::TransactionContext *txn);
 
 
   //===--------------------------------------------------------------------===//
@@ -274,7 +274,7 @@ class DataTable : public AbstractTable {
   // the last argument is the index entry in primary index holding the new
   // tuple.
   bool InsertInIndexes(const AbstractTuple *tuple, ItemPointer location,
-                       concurrency::Transaction *transaction,
+                       concurrency::TransactionContext *transaction,
                        ItemPointer **index_entry_ptr);
 
   static void SetActiveTileGroupCount(const size_t active_tile_group_count) {
@@ -329,7 +329,7 @@ class DataTable : public AbstractTable {
 
   bool InsertInSecondaryIndexes(const AbstractTuple *tuple,
                                 const TargetList *targets_ptr,
-                                concurrency::Transaction *transaction,
+                                concurrency::TransactionContext *transaction,
                                 ItemPointer *index_entry_ptr);
 
   // check the foreign key constraints

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -88,7 +88,7 @@ class DataTable : public AbstractTable {
             const oid_t &database_oid, const oid_t &table_oid,
             const size_t &tuples_per_tilegroup, const bool own_schema,
             const bool adapt_table, const bool is_catalog = false,
-            const peloton::LayoutType layout_type = peloton::LAYOUT_TYPE_ROW);
+            const peloton::LayoutType layout_type = peloton::LayoutType::ROW);
 
   ~DataTable();
 

--- a/src/include/storage/table_factory.h
+++ b/src/include/storage/table_factory.h
@@ -34,7 +34,8 @@ class TableFactory {
                                  catalog::Schema *schema,
                                  std::string table_name,
                                  size_t tuples_per_tile_group_count,
-                                 bool own_schema, bool adapt_table, bool is_catalog = false);
+                                 bool own_schema, bool adapt_table,
+                                 bool is_catalog = false);
 
   static TempTable *GetTempTable(catalog::Schema *schema, bool own_schema);
 

--- a/src/include/storage/table_factory.h
+++ b/src/include/storage/table_factory.h
@@ -34,8 +34,8 @@ class TableFactory {
                                  catalog::Schema *schema,
                                  std::string table_name,
                                  size_t tuples_per_tile_group_count,
-                                 bool own_schema, bool adapt_table,
-                                 bool is_catalog = false);
+                                 bool own_schema, bool adapt_table, bool is_catalog = false,
+                                 peloton::LayoutType layout_type = peloton::LayoutType::ROW);
 
   static TempTable *GetTempTable(catalog::Schema *schema, bool own_schema);
 

--- a/src/include/storage/temp_table.h
+++ b/src/include/storage/temp_table.h
@@ -61,7 +61,7 @@ class TempTable : public AbstractTable {
   // insert tuple in table. the pointer to the index entry is returned as
   // index_entry_ptr.
   ItemPointer InsertTuple(const Tuple *tuple,
-                          concurrency::Transaction *transaction,
+                          concurrency::TransactionContext *transaction,
                           ItemPointer **index_entry_ptr = nullptr) override;
 
   // designed for tables without primary key. e.g., output table used by

--- a/src/include/storage/temp_table.h
+++ b/src/include/storage/temp_table.h
@@ -50,7 +50,7 @@ class TempTable : public AbstractTable {
   // Table constructor
   TempTable(const oid_t &table_oid, catalog::Schema *schema,
             const bool own_schema,
-            const peloton::LayoutType layout_type = peloton::LAYOUT_TYPE_ROW);
+            const peloton::LayoutType layout_type = peloton::LayoutType::ROW);
 
   ~TempTable();
 

--- a/src/include/storage/zone_map_manager.h
+++ b/src/include/storage/zone_map_manager.h
@@ -18,7 +18,7 @@
 #include "common/macros.h"
 #include "type/types.h"
 #include "type/value_factory.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 namespace peloton {
 namespace storage {
 
@@ -47,17 +47,17 @@ class ZoneMapManager {
   void CreateZoneMapTableInCatalog();
 
   void CreateZoneMapsForTable(storage::DataTable *table,
-                              concurrency::Transaction *txn);
+                              concurrency::TransactionContext *txn);
 
   void CreateOrUpdateZoneMapForTileGroup(storage::DataTable *table, 
                                          oid_t tile_group_idx,
-                                        concurrency::Transaction *txn);
+                                        concurrency::TransactionContext *txn);
 
   void CreateOrUpdateZoneMapInCatalog(oid_t database_id, oid_t table_id,
                                       oid_t tile_group_id, oid_t col_itr,
                                       std::string min, std::string max,
                                       std::string type,
-                                      concurrency::Transaction *txn);
+                                      concurrency::TransactionContext *txn);
 
   std::unique_ptr<ZoneMapManager::ColumnStatistics> GetZoneMapFromCatalog(
       oid_t database_id, oid_t table_id, oid_t tile_group_id, oid_t col_itr);

--- a/src/include/storage/zone_map_manager.h
+++ b/src/include/storage/zone_map_manager.h
@@ -84,25 +84,25 @@ class ZoneMapManager {
       std::unique_ptr<std::vector<type::Value>> &result_vector);
 
   bool checkEqual(type::Value predicateVal, ColumnStatistics *stats) {
-    return ((stats->min).CompareLessThanEquals(predicateVal)) &&
-           ((stats->max).CompareGreaterThanEquals(predicateVal));
+    return ((stats->min).CompareLessThanEquals(predicateVal)) == type::CmpBool::TRUE &&
+           ((stats->max).CompareGreaterThanEquals(predicateVal) == type::CmpBool::TRUE);
   }
 
   bool checkLessThan(type::Value predicateVal, ColumnStatistics *stats) {
-    return predicateVal.CompareGreaterThan(stats->min);
+    return (predicateVal.CompareGreaterThan(stats->min) == type::CmpBool::TRUE);
   }
 
   bool checkLessThanEquals(type::Value predicateVal, ColumnStatistics *stats) {
-    return predicateVal.CompareGreaterThanEquals(stats->min);
+    return (predicateVal.CompareGreaterThanEquals(stats->min) == type::CmpBool::TRUE);
   }
 
   bool checkGreaterThan(type::Value predicateVal, ColumnStatistics *stats) {
-    return predicateVal.CompareLessThan(stats->max);
+    return (predicateVal.CompareLessThan(stats->max) == type::CmpBool::TRUE);
   }
 
   bool checkGreaterThanEquals(type::Value predicateVal,
                               ColumnStatistics *stats) {
-    return predicateVal.CompareLessThanEquals(stats->max);
+    return (predicateVal.CompareLessThanEquals(stats->max) == type::CmpBool::TRUE);
   }
 
   //===--------------------------------------------------------------------===//

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -18,7 +18,7 @@
 
 #include "common/portal.h"
 #include "common/statement.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "executor/plan_executor.h"
 #include "optimizer/abstract_optimizer.h"
 #include "parser/sql_statement.h"
@@ -84,7 +84,7 @@ class TrafficCop {
   FieldInfo GetColumnFieldForValueType(std::string column_name,
                                        type::TypeId column_type);
 
-  void SetTcopTxnState(concurrency::Transaction *txn) {
+  void SetTcopTxnState(concurrency::TransactionContext * txn) {
     tcop_txn_state_.emplace(txn, ResultType::SUCCESS);
   }
 
@@ -172,7 +172,7 @@ class TrafficCop {
 
   // pair of txn ptr and the result so-far for that txn
   // use a stack to support nested-txns
-  using TcopTxnState = std::pair<concurrency::Transaction *, ResultType>;
+  using TcopTxnState = std::pair<concurrency::TransactionContext *, ResultType>;
   std::stack<TcopTxnState> tcop_txn_state_;
 
   static TcopTxnState &GetDefaultTxnState();

--- a/src/include/trigger/trigger.h
+++ b/src/include/trigger/trigger.h
@@ -26,7 +26,7 @@
 namespace peloton {
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }
 
 namespace trigger {
@@ -95,7 +95,7 @@ class Trigger {
 
   // only apply to the simple case: old.balance != new.balance
   void SerializeWhen(SerializeOutput &output, oid_t database_oid,
-                     oid_t table_oid, concurrency::Transaction *txn);
+                     oid_t table_oid, concurrency::TransactionContext *txn);
   expression::AbstractExpression *DeserializeWhen(SerializeInput &input);
 
  private:
@@ -145,7 +145,7 @@ class TriggerList {
   // Insert/Update/Delete are events that invoke triggers
 
   bool ExecTriggers(TriggerType exec_type,
-                    concurrency::Transaction *txn = nullptr,
+                    concurrency::TransactionContext *txn = nullptr,
                     storage::Tuple *new_tuple = nullptr,
                     executor::ExecutorContext *executor_context_ = nullptr,
                     storage::Tuple *old_tuple = nullptr,

--- a/src/include/type/type.h
+++ b/src/include/type/type.h
@@ -26,7 +26,11 @@ class AbstractPool;
 class Value;
 class ValueFactory;
 
-enum CmpBool { CMP_FALSE = 0, CMP_TRUE = 1, CMP_NULL = 2 };
+enum class CmpBool {
+  FALSE = 0,
+  TRUE = 1,
+  NULL_ = 2
+};
 
 class Type {
  public:

--- a/src/include/type/type_util.h
+++ b/src/include/type/type_util.h
@@ -55,50 +55,50 @@ class TypeUtil {
    */
   static CmpBool CompareEqualsRaw(type::Type type, const char* left,
                                   const char* right, bool inlined) {
-    CmpBool result = CmpBool::CMP_NULL;
+    CmpBool result = CmpBool::NULL_;
     switch (type.GetTypeId()) {
       case TypeId::BOOLEAN:
       case TypeId::TINYINT: {
         result = (*reinterpret_cast<const int8_t*>(left) ==
                           *reinterpret_cast<const int8_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::SMALLINT: {
         result = (*reinterpret_cast<const int16_t*>(left) ==
                           *reinterpret_cast<const int16_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::INTEGER: {
         result = (*reinterpret_cast<const int32_t*>(left) ==
                           *reinterpret_cast<const int32_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::BIGINT: {
         result = (*reinterpret_cast<const int64_t*>(left) ==
                           *reinterpret_cast<const int64_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::DECIMAL: {
         result = (*reinterpret_cast<const double*>(left) ==
                           *reinterpret_cast<const double*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::TIMESTAMP:
       case TypeId::DATE: {
         result = (*reinterpret_cast<const uint64_t*>(left) ==
                           *reinterpret_cast<const uint64_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::VARCHAR:
@@ -110,7 +110,7 @@ class TypeUtil {
           rightPtr = *reinterpret_cast<const char* const*>(right);
         }
         if (leftPtr == nullptr || rightPtr == nullptr) {
-          result = CmpBool::CMP_FALSE;
+          result = CmpBool::FALSE;
           break;
         }
         uint32_t leftLen = *reinterpret_cast<const uint32_t*>(leftPtr);
@@ -134,50 +134,50 @@ class TypeUtil {
    */
   static CmpBool CompareLessThanRaw(const type::Type type, const char* left,
                                     const char* right, bool inlined) {
-    CmpBool result = CmpBool::CMP_NULL;
+    CmpBool result = CmpBool::NULL_;
     switch (type.GetTypeId()) {
       case TypeId::BOOLEAN:
       case TypeId::TINYINT: {
         result = (*reinterpret_cast<const int8_t*>(left) <
                           *reinterpret_cast<const int8_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::SMALLINT: {
         result = (*reinterpret_cast<const int16_t*>(left) <
                           *reinterpret_cast<const int16_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::INTEGER: {
         result = (*reinterpret_cast<const int32_t*>(left) <
                           *reinterpret_cast<const int32_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::BIGINT: {
         result = (*reinterpret_cast<const int64_t*>(left) <
                           *reinterpret_cast<const int64_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::DECIMAL: {
         result = (*reinterpret_cast<const double*>(left) <
                           *reinterpret_cast<const double*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::TIMESTAMP:
       case TypeId::DATE: {
         result = (*reinterpret_cast<const uint64_t*>(left) <
                           *reinterpret_cast<const uint64_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::VARCHAR:
@@ -189,7 +189,7 @@ class TypeUtil {
           rightPtr = *reinterpret_cast<const char* const*>(right);
         }
         if (leftPtr == nullptr || rightPtr == nullptr) {
-          result = CmpBool::CMP_FALSE;
+          result = CmpBool::FALSE;
           break;
         }
         uint32_t leftLen = *reinterpret_cast<const uint32_t*>(leftPtr);
@@ -213,50 +213,50 @@ class TypeUtil {
    */
   static CmpBool CompareGreaterThanRaw(const type::Type type, const char* left,
                                        const char* right, bool inlined) {
-    CmpBool result = CmpBool::CMP_NULL;
+    CmpBool result = CmpBool::NULL_;
     switch (type.GetTypeId()) {
       case TypeId::BOOLEAN:
       case TypeId::TINYINT: {
         result = (*reinterpret_cast<const int8_t*>(left) >
                           *reinterpret_cast<const int8_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::SMALLINT: {
         result = (*reinterpret_cast<const int16_t*>(left) >
                           *reinterpret_cast<const int16_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::INTEGER: {
         result = (*reinterpret_cast<const int32_t*>(left) >
                           *reinterpret_cast<const int32_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::BIGINT: {
         result = (*reinterpret_cast<const int64_t*>(left) >
                           *reinterpret_cast<const int64_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::DECIMAL: {
         result = (*reinterpret_cast<const double*>(left) >
                           *reinterpret_cast<const double*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::TIMESTAMP:
       case TypeId::DATE: {
         result = (*reinterpret_cast<const uint64_t*>(left) >
                           *reinterpret_cast<const uint64_t*>(right)
-                      ? CmpBool::CMP_TRUE
-                      : CmpBool::CMP_FALSE);
+                      ? CmpBool::TRUE
+                      : CmpBool::FALSE);
         break;
       }
       case TypeId::VARCHAR:
@@ -268,7 +268,7 @@ class TypeUtil {
           rightPtr = *reinterpret_cast<const char* const*>(right);
         }
         if (leftPtr == nullptr || rightPtr == nullptr) {
-          result = CmpBool::CMP_FALSE;
+          result = CmpBool::FALSE;
           break;
         }
         uint32_t leftLen = *reinterpret_cast<const uint32_t*>(leftPtr);

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -923,12 +923,14 @@ CheckpointingType StringToCheckpointingType(const std::string &str);
 std::ostream &operator<<(std::ostream &os, const CheckpointingType &type);
 
 /* Possible values for peloton_tilegroup_layout GUC */
-typedef enum LayoutType {
-  LAYOUT_TYPE_INVALID = INVALID_TYPE_ID,
-  LAYOUT_TYPE_ROW = 1,    /* Pure row layout */
-  LAYOUT_TYPE_COLUMN = 2, /* Pure column layout */
-  LAYOUT_TYPE_HYBRID = 3  /* Hybrid layout */
-} LayoutType;
+enum class LayoutType {
+  INVALID = INVALID_TYPE_ID,
+  ROW = 1,    /* Pure row layout */
+  COLUMN = 2, /* Pure column layout */
+  HYBRID = 3  /* Hybrid layout */
+};
+std::string LayoutTypeToString(LayoutType type);
+std::ostream &operator<<(std::ostream &os, const LayoutType &type);
 
 //===--------------------------------------------------------------------===//
 // Trigger Types
@@ -1063,7 +1065,10 @@ static const int INVALID_FILE_DESCRIPTOR = -1;
 // Tuple serialization formats
 // ------------------------------------------------------------------
 
-enum class TupleSerializationFormat { NATIVE = 0, DR = 1 };
+enum class TupleSerializationFormat {
+  NATIVE = 0,
+  DR = 1
+};
 
 // ------------------------------------------------------------------
 // Entity types

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -354,7 +354,7 @@ enum class NetworkTransactionStateType : unsigned char {
   FAIL = 'E',
 };
 
-enum SqlStateErrorCode {
+enum class SqlStateErrorCode {
   SERIALIZATION_ERROR = '1',
 };
 
@@ -992,29 +992,29 @@ enum class StatsType {
   ENABLE = 1,
 };
 
-enum MetricType {
+enum class MetricType {
   // Metric type is invalid
-  INVALID_METRIC = INVALID_TYPE_ID,
+  INVALID = INVALID_TYPE_ID,
   // Metric to count a number
-  COUNTER_METRIC = 1,
+  COUNTER = 1,
   // Access information, e.g., # tuples read, inserted, updated, deleted
-  ACCESS_METRIC = 2,
+  ACCESS = 2,
   // Life time of a object
-  LIFETIME_METRIC = 3,
+  LIFETIME = 3,
   // Statistics for a specific database
-  DATABASE_METRIC = 4,
+  DATABASE = 4,
   // Statistics for a specific table
-  TABLE_METRIC = 5,
+  TABLE = 5,
   // Statistics for a specific index
-  INDEX_METRIC = 6,
+  INDEX = 6,
   // Latency of transactions
-  LATENCY_METRIC = 7,
+  LATENCY = 7,
   // Timestamp, e.g., creation time of a table/index
-  TEMPORAL_METRIC = 8,
+  TEMPORAL = 8,
   // Statistics for a specific table
-  QUERY_METRIC = 9,
+  QUERY = 9,
   // Statistics for CPU
-  PROCESSOR_METRIC = 10,
+  PROCESSOR = 10,
 };
 
 // All builtin operators we currently support
@@ -1080,12 +1080,6 @@ enum class EntityType {
 std::string EntityTypeToString(EntityType type);
 EntityType StringToEntityType(const std::string &str);
 std::ostream &operator<<(std::ostream &os, const EntityType &type);
-
-// ------------------------------------------------------------------
-// Endianess
-// ------------------------------------------------------------------
-
-enum Endianess { BYTE_ORDER_BIG_ENDIAN = 0, BYTE_ORDER_LITTLE_ENDIAN = 1 };
 
 //===--------------------------------------------------------------------===//
 // Type definitions.

--- a/src/include/type/types.h
+++ b/src/include/type/types.h
@@ -896,7 +896,7 @@ std::ostream &operator<<(std::ostream &os, const LoggingType &type);
 enum class LogRecordType {
   INVALID = INVALID_TYPE_ID,
 
-  // Transaction-related records
+  // TransactionContext-related records
   TRANSACTION_BEGIN = 1,
   TRANSACTION_COMMIT = 2,
 

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -31,7 +31,7 @@ namespace type {
 class Type;
 
 inline CmpBool GetCmpBool(bool boolean) {
-  return boolean ? CMP_TRUE : CMP_FALSE;
+  return boolean ? CmpBool::TRUE : CmpBool::FALSE;
 }
 
 // A value is an abstract class that represents a view over SQL data stored in
@@ -278,7 +278,7 @@ class Value : public Printable {
   // For unordered_map
   struct equal_to {
     inline bool operator()(const Value &x, const Value &y) const {
-      return Type::GetInstance(x.type_id_)->CompareEquals(x, y) == CMP_TRUE;
+      return Type::GetInstance(x.type_id_)->CompareEquals(x, y) == CmpBool::TRUE;
     }
   };
 

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -60,7 +60,7 @@ class ValueFactory {
 
   static inline Value GetBooleanValue(CmpBool value) {
     return Value(TypeId::BOOLEAN,
-                 value == CMP_NULL ? PELOTON_BOOLEAN_NULL : (int8_t)value);
+                 value == CmpBool::NULL_ ? PELOTON_BOOLEAN_NULL : (int8_t)value);
   }
 
   static inline Value GetBooleanValue(bool value) {

--- a/src/include/util/global.h
+++ b/src/include/util/global.h
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// global.h
+//
+// Identification: /src/include/util/global.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#if defined __clang__
+#define PELOTON_FALLTHROUGH [[clang::fallthrough]]
+#elif defined __GNUC__ && __GNUC__ >= 7
+#define PELOTON_FALLTHROUGH [[fallthrough]]
+#else
+#define PELOTON_FALLTHROUGH
+#endif

--- a/src/index/index.cpp
+++ b/src/index/index.cpp
@@ -271,7 +271,7 @@ bool Index::Compare(const AbstractTuple &index_key,
     }
 
     LOG_TRACE("Difference : %d ", diff);*/
-    if (lhs.CompareEquals(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareEquals(rhs) == type::CmpBool::TRUE) {
       switch (expr_type) {
         case ExpressionType::COMPARE_EQUAL:
         case ExpressionType::COMPARE_LESSTHANOREQUALTO:
@@ -289,7 +289,7 @@ bool Index::Compare(const AbstractTuple &index_key,
                                ExpressionTypeToString(expr_type));
       }
     } else {
-      if (lhs.CompareLessThan(rhs) == type::CMP_TRUE) {
+      if (lhs.CompareLessThan(rhs) == type::CmpBool::TRUE) {
         switch (expr_type) {
           case ExpressionType::COMPARE_NOTEQUAL:
           case ExpressionType::COMPARE_LESSTHAN:
@@ -307,7 +307,7 @@ bool Index::Compare(const AbstractTuple &index_key,
                                  ExpressionTypeToString(expr_type));
         }
       } else {
-        if (lhs.CompareGreaterThan(rhs) == type::CMP_TRUE) {
+        if (lhs.CompareGreaterThan(rhs) == type::CmpBool::TRUE) {
           switch (expr_type) {
             case ExpressionType::COMPARE_NOTEQUAL:
             case ExpressionType::COMPARE_GREATERTHAN:

--- a/src/index/index_util.cpp
+++ b/src/index/index_util.cpp
@@ -191,12 +191,12 @@ bool IndexUtil::ValuePairComparator(const std::pair<type::Value, int> &i,
                                     const std::pair<type::Value, int> &j) {
 
   // If first elements are equal then compare the second element
-  if (i.first.CompareEquals(j.first) == type::CMP_TRUE) {
+  if (i.first.CompareEquals(j.first) == type::CmpBool::TRUE) {
     return i.second < j.second;
   }
   
   // Otherwise compare the first element for "<" or ">"
-  return i.first.CompareLessThan(j.first) == type::CMP_TRUE;
+  return i.first.CompareLessThan(j.first) == type::CmpBool::TRUE;
 }
 
 void IndexUtil::ConstructIntervals(oid_t leading_column_id,
@@ -312,7 +312,7 @@ void IndexUtil::FindMaxMinInColumns(oid_t leading_column_id,
                 values[i].GetInfo().c_str());
       if (non_leading_columns[column_id].first.IsNull() ||
           non_leading_columns[column_id].first
-            .CompareGreaterThan(values[i]) == type::CMP_TRUE) {
+            .CompareGreaterThan(values[i]) == type::CmpBool::TRUE) {
         LOG_TRACE("Update min\n");
         non_leading_columns[column_id].first = values[i].Copy();
       }
@@ -325,7 +325,7 @@ void IndexUtil::FindMaxMinInColumns(oid_t leading_column_id,
                 values[i].GetInfo().c_str());
       if (non_leading_columns[column_id].first.IsNull() ||
           non_leading_columns[column_id].second.
-            CompareLessThan(values[i]) == type::CMP_TRUE) {
+            CompareLessThan(values[i]) == type::CmpBool::TRUE) {
         LOG_TRACE("Update max\n");
         non_leading_columns[column_id].second = values[i].Copy();
       }

--- a/src/main/sdbench/sdbench_configuration.cpp
+++ b/src/main/sdbench/sdbench_configuration.cpp
@@ -173,18 +173,19 @@ static void ValidateScaleFactor(const configuration &state) {
 }
 
 static void ValidateLayout(const configuration &state) {
-  if (state.layout_mode < 1 || state.layout_mode > 3) {
-    LOG_ERROR("Invalid layout :: %d", state.layout_mode);
+  if (state.layout_mode == LayoutType::INVALID) {
+    LOG_ERROR("Invalid layout :: %s",
+              LayoutTypeToString(state.layout_mode).c_str());
     exit(EXIT_FAILURE);
   } else {
     switch (state.layout_mode) {
-      case LAYOUT_TYPE_ROW:
+      case LayoutType::ROW:
         LOG_INFO("%s : ROW", "layout ");
         break;
-      case LAYOUT_TYPE_COLUMN:
+      case LayoutType::COLUMN:
         LOG_INFO("%s : COLUMN", "layout ");
         break;
-      case LAYOUT_TYPE_HYBRID:
+      case LayoutType::HYBRID:
         LOG_INFO("%s : HYBRID", "layout ");
         break;
       default:
@@ -397,7 +398,7 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   state.projectivity = 0.01;
 
   // Layout parameter
-  state.layout_mode = LAYOUT_TYPE_ROW;
+  state.layout_mode = LayoutType::ROW;
 
   // Learning rate
   state.analyze_sample_count_threshold = 100;

--- a/src/main/sdbench/sdbench_loader.cpp
+++ b/src/main/sdbench/sdbench_loader.cpp
@@ -26,7 +26,7 @@
 #include "common/item_pointer.h"
 #include "common/logger.h"
 #include "common/macros.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/abstract_executor.h"
 #include "executor/insert_executor.h"

--- a/src/main/sdbench/sdbench_loader.cpp
+++ b/src/main/sdbench/sdbench_loader.cpp
@@ -47,7 +47,7 @@ namespace sdbench {
 
 std::unique_ptr<storage::DataTable> sdbench_table;
 
-void CreateTable(peloton::LayoutType layout_type) {
+void CreateTable(UNUSED_ATTRIBUTE peloton::LayoutType layout_type) {
   const oid_t col_count = state.attribute_count + 1;
   const bool is_inlined = true;
 
@@ -73,7 +73,7 @@ void CreateTable(peloton::LayoutType layout_type) {
   bool adapt_table = true;
   sdbench_table.reset(storage::TableFactory::GetDataTable(
       INVALID_OID, INVALID_OID, table_schema, table_name,
-      state.tuples_per_tilegroup, own_schema, adapt_table, layout_type));
+      state.tuples_per_tilegroup, own_schema, adapt_table));
 }
 
 void LoadTable() {

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -1389,7 +1389,7 @@ void BenchmarkPrepare() {
   }
 
   // Start layout tuner
-  if (state.layout_mode == LAYOUT_TYPE_HYBRID) {
+  if (state.layout_mode == LayoutType::HYBRID) {
     layout_tuner.AddTable(sdbench_table.get());
 
     // Start layout tuner
@@ -1407,7 +1407,7 @@ void BenchmarkCleanUp() {
     index_tuner.ClearTables();
   }
 
-  if (state.layout_mode == LAYOUT_TYPE_HYBRID) {
+  if (state.layout_mode == LayoutType::HYBRID) {
     layout_tuner.Stop();
     layout_tuner.ClearTables();
   }

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -32,7 +32,7 @@
 #include "common/logger.h"
 #include "common/macros.h"
 #include "common/timer.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "type/types.h"
 #include "type/value.h"

--- a/src/main/tpcc/tpcc_delivery.cpp
+++ b/src/main/tpcc/tpcc_delivery.cpp
@@ -43,7 +43,7 @@
 #include "common/timer.h"
 #include "common/generator.h"
 
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 
 #include "executor/executor_context.h"

--- a/src/main/tpcc/tpcc_loader.cpp
+++ b/src/main/tpcc/tpcc_loader.cpp
@@ -24,7 +24,7 @@
 #include "benchmark/tpcc/tpcc_configuration.h"
 #include "catalog/catalog.h"
 #include "catalog/schema.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/abstract_executor.h"
 #include "executor/insert_executor.h"

--- a/src/main/tpcc/tpcc_new_order.cpp
+++ b/src/main/tpcc/tpcc_new_order.cpp
@@ -41,7 +41,7 @@
 #include "common/timer.h"
 #include "common/generator.h"
 
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 
 #include "executor/executor_context.h"

--- a/src/main/tpcc/tpcc_order_status.cpp
+++ b/src/main/tpcc/tpcc_order_status.cpp
@@ -41,7 +41,7 @@
 #include "common/timer.h"
 #include "common/generator.h"
 
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 
 #include "executor/executor_context.h"

--- a/src/main/tpcc/tpcc_payment.cpp
+++ b/src/main/tpcc/tpcc_payment.cpp
@@ -41,7 +41,7 @@
 #include "common/timer.h"
 #include "common/generator.h"
 
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 
 #include "executor/executor_context.h"

--- a/src/main/tpcc/tpcc_stock_level.cpp
+++ b/src/main/tpcc/tpcc_stock_level.cpp
@@ -41,7 +41,7 @@
 #include "common/timer.h"
 #include "common/generator.h"
 
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 
 #include "executor/executor_context.h"

--- a/src/main/tpcc/tpcc_workload.cpp
+++ b/src/main/tpcc/tpcc_workload.cpp
@@ -39,7 +39,7 @@
 #include "common/timer.h"
 #include "common/generator.h"
 
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "concurrency/epoch_manager_factory.h"
 

--- a/src/main/ycsb/ycsb_loader.cpp
+++ b/src/main/ycsb/ycsb_loader.cpp
@@ -22,7 +22,7 @@
 #include "benchmark/ycsb/ycsb_configuration.h"
 #include "catalog/catalog.h"
 #include "catalog/schema.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/abstract_executor.h"
 #include "executor/insert_executor.h"

--- a/src/main/ycsb/ycsb_mixed.cpp
+++ b/src/main/ycsb/ycsb_mixed.cpp
@@ -40,7 +40,7 @@
 #include "common/timer.h"
 #include "common/generator.h"
 
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 
 #include "executor/executor_context.h"
@@ -81,7 +81,7 @@ bool RunMixed(const size_t thread_id, ZipfDistribution &zipf, FastRandom &rng) {
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
 
-  concurrency::Transaction *txn = txn_manager.BeginTransaction(thread_id);
+  concurrency::TransactionContext *txn = txn_manager.BeginTransaction(thread_id);
 
   std::unique_ptr<executor::ExecutorContext> context(
       new executor::ExecutorContext(txn));

--- a/src/main/ycsb/ycsb_workload.cpp
+++ b/src/main/ycsb/ycsb_workload.cpp
@@ -40,7 +40,7 @@
 #include "common/platform.h"
 #include "common/container_tuple.h"
 
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 
 #include "executor/executor_context.h"

--- a/src/network/marshal.cpp
+++ b/src/network/marshal.cpp
@@ -143,7 +143,7 @@ void PacketPutString(OutputPacket *pkt, const std::string &str) {
   pkt->len += str.size() + 1;
 }
 
-void PacketPutBytes(OutputPacket *pkt, const std::vector<uchar> &data) {
+void PacketPutBytes(OutputPacket *pkt, const std::string &data) {
   pkt->buf.insert(std::end(pkt->buf), std::begin(data), std::end(data));
   pkt->len += data.size();
 }

--- a/src/network/marshal.cpp
+++ b/src/network/marshal.cpp
@@ -135,7 +135,7 @@ void PacketPutByte(OutputPacket *pkt, const uchar c) {
   pkt->len++;
 }
 
-void PacketPutString(OutputPacket *pkt, const std::string &str) {
+void PacketPutStringWithTerminator(OutputPacket *pkt, const std::string &str) {
   pkt->buf.insert(std::end(pkt->buf), std::begin(str), std::end(str));
   // add null character
   pkt->buf.push_back(0);
@@ -143,7 +143,7 @@ void PacketPutString(OutputPacket *pkt, const std::string &str) {
   pkt->len += str.size() + 1;
 }
 
-void PacketPutBytes(OutputPacket *pkt, const std::string &data) {
+void PacketPutString(OutputPacket *pkt, const std::string &data) {
   pkt->buf.insert(std::end(pkt->buf), std::begin(data), std::end(data));
   pkt->len += data.size();
 }

--- a/src/network/network_manager.cpp
+++ b/src/network/network_manager.cpp
@@ -120,7 +120,12 @@ void NetworkManager::StartServer() {
     SSL_load_error_strings();
     SSL_library_init();
 
-    if ((ssl_context = SSL_CTX_new(TLSv1_server_method())) == nullptr)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    ssl_context = SSL_CTX_new(TLS_server_method());
+#else
+    ssl_context = SSL_CTX_new(SSLv23_server_method());
+#endif
+    if (ssl_context == nullptr)
     {
       throw ConnectionException("Error creating SSL context.");
     }

--- a/src/network/postgres_protocol_handler.cpp
+++ b/src/network/postgres_protocol_handler.cpp
@@ -107,8 +107,8 @@ void PostgresProtocolHandler::MakeHardcodedParameterStatus(
     const std::pair<std::string, std::string> &kv) {
   std::unique_ptr<OutputPacket> response(new OutputPacket());
   response->msg_type = NetworkMessageType::PARAMETER_STATUS;
-  PacketPutString(response.get(), kv.first);
-  PacketPutString(response.get(), kv.second);
+  PacketPutStringWithTerminator(response.get(), kv.first);
+  PacketPutStringWithTerminator(response.get(), kv.second);
   responses.push_back(std::move(response));
 }
 
@@ -122,7 +122,7 @@ void PostgresProtocolHandler::PutTupleDescriptor(
   PacketPutInt(pkt.get(), tuple_descriptor.size(), 2);
 
   for (auto col : tuple_descriptor) {
-    PacketPutString(pkt.get(), std::get<0>(col));
+    PacketPutStringWithTerminator(pkt.get(), std::get<0>(col));
     // TODO: Table Oid (int32)
     PacketPutInt(pkt.get(), 0, 4);
     // TODO: Attr id of column (int16)
@@ -160,7 +160,7 @@ void PostgresProtocolHandler::SendDataRows(std::vector<ResultValue> &results,
         // length of the row attribute
         PacketPutInt(pkt.get(), content.size(), 4);
         // contents of the row attribute
-        PacketPutBytes(pkt.get(), content);
+        PacketPutString(pkt.get(), content);
       }
     }
     responses.push_back(std::move(pkt));
@@ -199,7 +199,7 @@ void PostgresProtocolHandler::CompleteCommand(const std::string &query, const Qu
     default:
       tag += " " + std::to_string(rows);
    }
-   PacketPutString(pkt.get(), tag);
+  PacketPutStringWithTerminator(pkt.get(), tag);
    responses.push_back(std::move(pkt));
 }
 
@@ -1151,7 +1151,7 @@ void PostgresProtocolHandler::SendErrorResponse(
 
   for (auto entry : error_status) {
     PacketPutByte(pkt.get(), static_cast<unsigned char>(entry.first));
-    PacketPutString(pkt.get(), entry.second);
+    PacketPutStringWithTerminator(pkt.get(), entry.second);
   }
 
   // put null terminator

--- a/src/network/service/tcp_connection.cpp
+++ b/src/network/service/tcp_connection.cpp
@@ -12,6 +12,7 @@
 
 
 #include <iostream>
+#include <functional>
 #include <mutex>
 
 #include <pthread.h>

--- a/src/optimizer/child_property_generator.cpp
+++ b/src/optimizer/child_property_generator.cpp
@@ -125,8 +125,9 @@ void ChildPropertyGenerator::ScanHelper() {
   // AbstractExpression -> offset when insert
   ExprMap columns;
   vector<shared_ptr<expression::AbstractExpression>> column_exprs;
-  auto columns_prop = requirements_.GetPropertyOfType(PropertyType::COLUMNS)
-                          ->As<PropertyColumns>();
+  auto columns_prop = requirements_.GetPropertyOfTypeAs<PropertyColumns>(PropertyType::COLUMNS);
+  PL_ASSERT(columns_prop != nullptr);
+
   if (columns_prop->HasStarExpression()) {
     column_exprs.emplace_back(new expression::StarExpression());
   } else {
@@ -140,7 +141,7 @@ void ChildPropertyGenerator::ScanHelper() {
 
     // Add all the columns from PropertySort to column_set
     auto sort_prop =
-        requirements_.GetPropertyOfType(PropertyType::SORT)->As<PropertySort>();
+        requirements_.GetPropertyOfTypeAs<PropertySort>(PropertyType::SORT);
     if (sort_prop != nullptr) {
       for (size_t i = 0; i < sort_prop->GetSortColumnSize(); i++) {
         auto expr = sort_prop->GetSortColumn(i);

--- a/src/optimizer/cost_and_stats_calculator.cpp
+++ b/src/optimizer/cost_and_stats_calculator.cpp
@@ -182,12 +182,10 @@ void CostAndStatsCalculator::Visit(const PhysicalSeqScan *op) {
   }
 
   auto columns_prop =
-      output_properties_->GetPropertyOfType(PropertyType::COLUMNS)
-          ->As<PropertyColumns>();
+      output_properties_->GetPropertyOfTypeAs<PropertyColumns>(PropertyType::COLUMNS);
   auto output_stats = generateOutputStat(table_stats, columns_prop);
   auto predicate_prop =
-      output_properties_->GetPropertyOfType(PropertyType::PREDICATE)
-          ->As<PropertyPredicate>();
+      output_properties_->GetPropertyOfTypeAs<PropertyPredicate>(PropertyType::PREDICATE);
   if (predicate_prop == nullptr) {
     output_cost_ += Cost::NoConditionSeqScanCost(table_stats);
     output_stats_ = output_stats;
@@ -206,9 +204,7 @@ void CostAndStatsCalculator::Visit(const PhysicalIndexScan *op) {
   // TODO : Replace with more accurate cost
   output_cost_ = getCostOfChildren(child_costs_);
   auto predicate_prop =
-      output_properties_->GetPropertyOfType(PropertyType::PREDICATE)
-          ->As<PropertyPredicate>();
-
+      output_properties_->GetPropertyOfTypeAs<PropertyPredicate>(PropertyType::PREDICATE);
   auto stats_storage = StatsStorage::GetInstance();
   auto table_stats =
       std::dynamic_pointer_cast<TableStats>(stats_storage->GetTableStats(
@@ -237,8 +233,7 @@ void CostAndStatsCalculator::Visit(const PhysicalIndexScan *op) {
   }
 
   auto columns_prop =
-      output_properties_->GetPropertyOfType(PropertyType::COLUMNS)
-          ->As<PropertyColumns>();
+      output_properties_->GetPropertyOfTypeAs<PropertyColumns>(PropertyType::COLUMNS);
   auto output_stats = generateOutputStat(table_stats, columns_prop);
 
   if (predicate_prop == nullptr) {
@@ -267,8 +262,7 @@ void CostAndStatsCalculator::Visit(const PhysicalProject *) {
     return;
   }
   auto columns_prop =
-      output_properties_->GetPropertyOfType(PropertyType::COLUMNS)
-          ->As<PropertyColumns>();
+      output_properties_->GetPropertyOfTypeAs<PropertyColumns>(PropertyType::COLUMNS);
   auto output_stats = generateOutputStat(table_stats_ptr, columns_prop);
 
   output_cost_ += Cost::ProjectCost(
@@ -288,8 +282,7 @@ void CostAndStatsCalculator::Visit(const PhysicalOrderBy *) {
   }
 
   auto columns_prop =
-      output_properties_->GetPropertyOfType(PropertyType::COLUMNS)
-          ->As<PropertyColumns>();
+      output_properties_->GetPropertyOfTypeAs<PropertyColumns>(PropertyType::COLUMNS);
   auto output_stats = generateOutputStat(table_stats_ptr, columns_prop);
   auto sort_prop = std::dynamic_pointer_cast<PropertySort>(
       output_properties_->GetPropertyOfType(PropertyType::SORT));
@@ -334,8 +327,7 @@ void CostAndStatsCalculator::Visit(const PhysicalLimit *) {
     return;
   }
   auto columns_prop =
-      output_properties_->GetPropertyOfType(PropertyType::COLUMNS)
-          ->As<PropertyColumns>();
+      output_properties_->GetPropertyOfTypeAs<PropertyColumns>(PropertyType::COLUMNS);
   auto output_stats = generateOutputStat(table_stats_ptr, columns_prop);
 
   size_t limit = (size_t)std::dynamic_pointer_cast<PropertyLimit>(
@@ -388,8 +380,7 @@ void CostAndStatsCalculator::Visit(const PhysicalHashGroupBy *op) {
   }
 
   auto columns_prop =
-      output_properties_->GetPropertyOfType(PropertyType::COLUMNS)
-          ->As<PropertyColumns>();
+      output_properties_->GetPropertyOfTypeAs<PropertyColumns>(PropertyType::COLUMNS);
   auto output_stats = generateOutputStat(table_stats_ptr, columns_prop);
 
   std::vector<oid_t> column_ids;
@@ -417,8 +408,7 @@ void CostAndStatsCalculator::Visit(const PhysicalSortGroupBy *op) {
   }
 
   auto columns_prop =
-      output_properties_->GetPropertyOfType(PropertyType::COLUMNS)
-          ->As<PropertyColumns>();
+      output_properties_->GetPropertyOfTypeAs<PropertyColumns>(PropertyType::COLUMNS);
   auto output_stats = generateOutputStat(table_stats_ptr, columns_prop);
 
   std::vector<oid_t> column_ids;
@@ -458,14 +448,11 @@ void CostAndStatsCalculator::Visit(const PhysicalDistinct *) {
     return;
   }
   auto columns_prop =
-      output_properties_->GetPropertyOfType(PropertyType::COLUMNS)
-          ->As<PropertyColumns>();
+      output_properties_->GetPropertyOfTypeAs<PropertyColumns>(PropertyType::COLUMNS);
   auto output_stats = generateOutputStat(table_stats_ptr, columns_prop);
 
   auto distinct_prop =
-      output_properties_->GetPropertyOfType(PropertyType::DISTINCT)
-          ->As<PropertyDistinct>();
-
+      output_properties_->GetPropertyOfTypeAs<PropertyDistinct>(PropertyType::DISTINCT);
   // TODO: Deal with complex situations like distinct with multiple columns or
   // with complex expressions
   if (distinct_prop->GetSize() == 1 &&

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -380,10 +380,11 @@ void Optimizer::OptimizeExpression(shared_ptr<GroupExpression> gexpr,
 }
 
 Property *Optimizer::GenerateNewPropertyCols(PropertySet requirements) {
-  auto cols_prop = requirements.GetPropertyOfType(PropertyType::COLUMNS)
-                       ->As<PropertyColumns>();
-  auto sort_prop =
-      requirements.GetPropertyOfType(PropertyType::SORT)->As<PropertySort>();
+  auto cols_prop = requirements.GetPropertyOfTypeAs<PropertyColumns>(PropertyType::COLUMNS);
+  auto sort_prop = requirements.GetPropertyOfTypeAs<PropertySort>(PropertyType::SORT);
+
+  PL_ASSERT(cols_prop != nullptr);
+  PL_ASSERT(sort_prop != nullptr);
 
   // Check if there is any missing columns from orderby need to be added
   ExprSet columns_set;

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -81,7 +81,7 @@ Optimizer::Optimizer() {
 
 shared_ptr<planner::AbstractPlan> Optimizer::BuildPelotonPlanTree(
     const unique_ptr<parser::SQLStatementList> &parse_tree_list,
-    const std::string default_database_name, concurrency::Transaction *txn) {
+    const std::string default_database_name, concurrency::TransactionContext *txn) {
   // Base Case
   if (parse_tree_list->GetStatements().size() == 0) return nullptr;
 
@@ -137,7 +137,7 @@ void Optimizer::Reset() {
 
 unique_ptr<planner::AbstractPlan> Optimizer::HandleDDLStatement(
     parser::SQLStatement *tree, bool &is_ddl_stmt,
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   unique_ptr<planner::AbstractPlan> ddl_plan = nullptr;
   is_ddl_stmt = true;
   auto stmt_type = tree->GetType();
@@ -216,7 +216,7 @@ unique_ptr<planner::AbstractPlan> Optimizer::HandleDDLStatement(
 }
 
 shared_ptr<GroupExpression> Optimizer::InsertQueryTree(
-    parser::SQLStatement *tree, concurrency::Transaction *txn) {
+    parser::SQLStatement *tree, concurrency::TransactionContext *txn) {
   QueryToOperatorTransformer converter(txn);
   shared_ptr<OperatorExpression> initial =
       converter.ConvertToOpExpression(tree);

--- a/src/optimizer/query_to_operator_transformer.cpp
+++ b/src/optimizer/query_to_operator_transformer.cpp
@@ -31,7 +31,7 @@ using std::shared_ptr;
 namespace peloton {
 namespace optimizer {
 QueryToOperatorTransformer::QueryToOperatorTransformer(
-  concurrency::Transaction *txn)
+  concurrency::TransactionContext *txn)
   : txn_(txn) {}
 
 

--- a/src/optimizer/stats/stats_storage.cpp
+++ b/src/optimizer/stats/stats_storage.cpp
@@ -56,7 +56,7 @@ void StatsStorage::CreateStatsTableInCatalog() {
  */
 void StatsStorage::InsertOrUpdateTableStats(
     storage::DataTable *table, TableStatsCollector *table_stats_collector,
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   // Add or update column stats sequentially.
   oid_t database_id = table->GetDatabaseOid();
   oid_t table_id = table->GetOid();
@@ -104,7 +104,7 @@ void StatsStorage::InsertOrUpdateColumnStats(
     oid_t database_id, oid_t table_id, oid_t column_id, int num_rows,
     double cardinality, double frac_null, std::string most_common_vals,
     std::string most_common_freqs, std::string histogram_bounds,
-    std::string column_name, bool has_index, concurrency::Transaction *txn) {
+    std::string column_name, bool has_index, concurrency::TransactionContext *txn) {
   LOG_TRACE("InsertOrUpdateColumnStats, %d, %lf, %lf, %s, %s, %s", num_rows,
             cardinality, frac_null, most_common_vals.c_str(),
             most_common_freqs.c_str(), histogram_bounds.c_str());
@@ -267,7 +267,7 @@ std::shared_ptr<TableStats> StatsStorage::GetTableStats(
  * datatables to collect their stats and store them in the column_stats_catalog.
  */
 ResultType StatsStorage::AnalyzeStatsForAllTables(
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   if (txn == nullptr) {
     LOG_TRACE("Do not have transaction to analyze all tables' stats.");
     return ResultType::FAILURE;
@@ -300,7 +300,7 @@ ResultType StatsStorage::AnalyzeStatsForAllTables(
  * sotre the stats in column_stats_catalog.
  */
 ResultType StatsStorage::AnalyzeStatsForTable(storage::DataTable *table,
-                                              concurrency::Transaction *txn) {
+                                              concurrency::TransactionContext *txn) {
   if (txn == nullptr) {
     LOG_TRACE("Do not have transaction to analyze the table stats: %s",
               table->GetName().c_str());

--- a/src/optimizer/stats/tuple_samples_storage.cpp
+++ b/src/optimizer/stats/tuple_samples_storage.cpp
@@ -78,7 +78,7 @@ void TupleSamplesStorage::AddSamplesTable(
 }
 
 ResultType TupleSamplesStorage::DeleteSamplesTable(
-    oid_t database_id, oid_t table_id, concurrency::Transaction *txn) {
+    oid_t database_id, oid_t table_id, concurrency::TransactionContext *txn) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   bool single_statement_txn = false;
   if (txn == nullptr) {
@@ -114,7 +114,7 @@ ResultType TupleSamplesStorage::DeleteSamplesTable(
 
 bool TupleSamplesStorage::InsertSampleTuple(
     storage::DataTable *samples_table, std::unique_ptr<storage::Tuple> tuple,
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   if (txn == nullptr) {
     return false;
   }
@@ -130,7 +130,7 @@ bool TupleSamplesStorage::InsertSampleTuple(
 }
 
 ResultType TupleSamplesStorage::CollectSamplesForTable(
-    storage::DataTable *data_table, concurrency::Transaction *txn) {
+    storage::DataTable *data_table, concurrency::TransactionContext *txn) {
   if (txn == nullptr) {
     LOG_TRACE("Do not have transaction to collect samples for table: %s",
               data_table->GetName().c_str());
@@ -146,7 +146,7 @@ ResultType TupleSamplesStorage::CollectSamplesForTable(
 std::unique_ptr<std::vector<std::unique_ptr<executor::LogicalTile>>>
 TupleSamplesStorage::GetTuplesWithSeqScan(storage::DataTable *data_table,
                                           std::vector<oid_t> column_offsets,
-                                          concurrency::Transaction *txn) {
+                                          concurrency::TransactionContext *txn) {
   if (txn == nullptr) {
     LOG_TRACE("Do not have transaction to perform the sequential scan");
     return nullptr;

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -886,6 +886,7 @@ parser::ColumnDefinition* PostgresParser::ColumnDefTransform(ColumnDef* root) {
         try {
           result->default_value.reset(ExprTransform(constraint->raw_expr));
         } catch (NotImplementedException e) {
+          delete result;
           throw NotImplementedException(StringUtil::Format(
               "Exception thrown in default expr:\n%s", e.what()));
         }
@@ -893,6 +894,7 @@ parser::ColumnDefinition* PostgresParser::ColumnDefTransform(ColumnDef* root) {
         try {
           result->check_expression.reset(ExprTransform(constraint->raw_expr));
         } catch (NotImplementedException e) {
+          delete result;
           throw NotImplementedException(StringUtil::Format(
               "Exception thrown in check expr:\n%s", e.what()));
         }
@@ -926,8 +928,13 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
     Node* node = reinterpret_cast<Node*>(cell->data.ptr_value);
     if ((node->type) == T_ColumnDef) {
       // Transform Regular Column
-      ColumnDefinition* temp =
-          ColumnDefTransform(reinterpret_cast<ColumnDef*>(node));
+      ColumnDefinition* temp = nullptr;
+      try {
+        temp = ColumnDefTransform(reinterpret_cast<ColumnDef*>(node));
+      } catch (NotImplementedException e) {
+        delete result;
+        throw e;
+      }
       result->columns.push_back(std::unique_ptr<ColumnDefinition>(temp));
     } else if (node->type == T_Constraint) {
       // Transform Constraints
@@ -965,6 +972,7 @@ parser::SQLStatement* PostgresParser::CreateTransform(CreateStmt* root) {
 
         result->columns.push_back(std::unique_ptr<ColumnDefinition>(col));
       } else {
+        delete result;
         throw NotImplementedException(StringUtil::Format(
             "Constraint of type %d not supported yet", node->type));
       }
@@ -1413,6 +1421,9 @@ parser::SQLStatementList* PostgresParser::ListTransform(List* root) {
       result->AddStatement(NodeTransform((Node*)cell->data.ptr_value));
     }
   } catch (ParserException& e) {
+    delete result;
+    throw e;
+  } catch (NotImplementedException e) {
     delete result;
     throw e;
   }

--- a/src/planner/analyze_plan.cpp
+++ b/src/planner/analyze_plan.cpp
@@ -23,7 +23,7 @@ AnalyzePlan::AnalyzePlan(storage::DataTable *table) : target_table_(table) {}
 
 AnalyzePlan::AnalyzePlan(std::string table_name,
                          std::string database_name,
-                         concurrency::Transaction *txn)
+                         concurrency::TransactionContext *txn)
     : table_name_(table_name) {
   target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
     database_name, table_name, txn);
@@ -32,14 +32,14 @@ AnalyzePlan::AnalyzePlan(std::string table_name,
 AnalyzePlan::AnalyzePlan(std::string table_name,
                          std::string database_name,
                          std::vector<char *> column_names,
-                         concurrency::Transaction *txn)
+                         concurrency::TransactionContext *txn)
     : table_name_(table_name), column_names_(column_names) {
   target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
     database_name, table_name, txn);
 }
 
 AnalyzePlan::AnalyzePlan(parser::AnalyzeStatement *analyze_stmt,
-                         concurrency::Transaction *txn) {
+                         concurrency::TransactionContext *txn) {
   table_name_ = analyze_stmt->GetTableName();
   column_names_ = std::vector<char*>();
   for (auto& name : analyze_stmt->GetColumnNames())

--- a/src/statistics/access_metric.cpp
+++ b/src/statistics/access_metric.cpp
@@ -17,7 +17,7 @@ namespace peloton {
 namespace stats {
 
 void AccessMetric::Aggregate(AbstractMetric &source) {
-  PL_ASSERT(source.GetType() == ACCESS_METRIC);
+  PL_ASSERT(source.GetType() == MetricType::ACCESS);
 
   auto access_metric = static_cast<AccessMetric &>(source);
   for (size_t i = 0; i < NUM_COUNTERS; ++i) {

--- a/src/statistics/backend_stats_context.cpp
+++ b/src/statistics/backend_stats_context.cpp
@@ -47,7 +47,7 @@ BackendStatsContext* BackendStatsContext::GetInstance() {
 
 BackendStatsContext::BackendStatsContext(size_t max_latency_history,
                                          bool regiser_to_aggregator)
-    : txn_latencies_(LATENCY_METRIC, max_latency_history) {
+    : txn_latencies_(MetricType::LATENCY, max_latency_history) {
   std::thread::id this_id = std::this_thread::get_id();
   thread_id_ = this_id;
 
@@ -69,7 +69,7 @@ TableMetric* BackendStatsContext::GetTableMetric(oid_t database_id,
                                                  oid_t table_id) {
   if (table_metrics_.find(table_id) == table_metrics_.end()) {
     table_metrics_[table_id] = std::unique_ptr<TableMetric>(
-        new TableMetric{TABLE_METRIC, database_id, table_id});
+        new TableMetric{MetricType::TABLE, database_id, table_id});
   }
   return table_metrics_[table_id].get();
 }
@@ -78,7 +78,7 @@ TableMetric* BackendStatsContext::GetTableMetric(oid_t database_id,
 DatabaseMetric* BackendStatsContext::GetDatabaseMetric(oid_t database_id) {
   if (database_metrics_.find(database_id) == database_metrics_.end()) {
     database_metrics_[database_id] = std::unique_ptr<DatabaseMetric>(
-        new DatabaseMetric{DATABASE_METRIC, database_id});
+        new DatabaseMetric{MetricType::DATABASE, database_id});
   }
   return database_metrics_[database_id].get();
 }
@@ -92,7 +92,7 @@ IndexMetric* BackendStatsContext::GetIndexMetric(oid_t database_id,
   // Index metric doesn't exist yet
   if (index_metrics_.Contains(index_id) == false) {
     index_metric.reset(
-        new IndexMetric{INDEX_METRIC, database_id, table_id, index_id});
+        new IndexMetric{MetricType::INDEX, database_id, table_id, index_id});
     index_metrics_.Insert(index_id, index_metric);
     index_id_lock.Lock();
     index_ids_.insert(index_id);
@@ -222,7 +222,7 @@ void BackendStatsContext::InitQueryMetric(
     const std::shared_ptr<QueryMetric::QueryParams> params) {
   // TODO currently all queries belong to DEFAULT_DB
   ongoing_query_metric_.reset(new QueryMetric(
-      QUERY_METRIC, statement->GetQueryString(), params, DEFAULT_DB_ID));
+      MetricType::QUERY, statement->GetQueryString(), params, DEFAULT_DB_ID));
 }
 
 //===--------------------------------------------------------------------===//
@@ -290,7 +290,7 @@ void BackendStatsContext::Reset() {
     // Reset database metrics
     if (database_metrics_.find(database_id) == database_metrics_.end()) {
       database_metrics_[database_id] = std::unique_ptr<DatabaseMetric>(
-          new DatabaseMetric{DATABASE_METRIC, database_id});
+          new DatabaseMetric{MetricType::DATABASE, database_id});
     }
 
     // Reset table metrics
@@ -301,7 +301,7 @@ void BackendStatsContext::Reset() {
 
       if (table_metrics_.find(table_id) == table_metrics_.end()) {
         table_metrics_[table_id] = std::unique_ptr<TableMetric>(
-            new TableMetric{TABLE_METRIC, database_id, table_id});
+            new TableMetric{MetricType::TABLE, database_id, table_id});
       }
 
       // Reset indexes metrics
@@ -312,7 +312,7 @@ void BackendStatsContext::Reset() {
         oid_t index_id = index->GetOid();
         if (index_metrics_.Contains(index_id) == false) {
           std::shared_ptr<IndexMetric> index_metric(
-              new IndexMetric{INDEX_METRIC, database_id, table_id, index_id});
+              new IndexMetric{MetricType::INDEX, database_id, table_id, index_id});
           index_metrics_.Insert(index_id, index_metric);
           index_ids_.insert(index_id);
         }

--- a/src/statistics/counter_metric.cpp
+++ b/src/statistics/counter_metric.cpp
@@ -21,7 +21,7 @@ CounterMetric::CounterMetric(MetricType type) : AbstractMetric(type) {
 }
 
 void CounterMetric::Aggregate(AbstractMetric &source) {
-  PL_ASSERT(source.GetType() == COUNTER_METRIC);
+  PL_ASSERT(source.GetType() == MetricType::COUNTER);
   count_ += static_cast<CounterMetric &>(source).GetCounter();
 }
 

--- a/src/statistics/database_metric.cpp
+++ b/src/statistics/database_metric.cpp
@@ -20,7 +20,7 @@ DatabaseMetric::DatabaseMetric(MetricType type, oid_t database_id)
     : AbstractMetric(type), database_id_(database_id) {}
 
 void DatabaseMetric::Aggregate(AbstractMetric& source) {
-  PL_ASSERT(source.GetType() == DATABASE_METRIC);
+  PL_ASSERT(source.GetType() == MetricType::DATABASE);
 
   DatabaseMetric& db_metric = static_cast<DatabaseMetric&>(source);
   txn_committed_.Aggregate(db_metric.GetTxnCommitted());

--- a/src/statistics/index_metric.cpp
+++ b/src/statistics/index_metric.cpp
@@ -36,7 +36,7 @@ IndexMetric::IndexMetric(MetricType type, oid_t database_id, oid_t table_id,
 }
 
 void IndexMetric::Aggregate(AbstractMetric& source) {
-  assert(source.GetType() == INDEX_METRIC);
+  assert(source.GetType() == MetricType::INDEX);
 
   IndexMetric& index_metric = static_cast<IndexMetric&>(source);
   index_access_.Aggregate(index_metric.GetIndexAccess());

--- a/src/statistics/latency_metric.cpp
+++ b/src/statistics/latency_metric.cpp
@@ -25,7 +25,7 @@ LatencyMetric::LatencyMetric(MetricType type, size_t max_history)
 }
 
 void LatencyMetric::Aggregate(AbstractMetric& source) {
-  PL_ASSERT(source.GetType() == LATENCY_METRIC);
+  PL_ASSERT(source.GetType() == MetricType::LATENCY);
 
   LatencyMetric& latency_metric = static_cast<LatencyMetric&>(source);
   CircularBuffer<double> source_latencies = latency_metric.Copy();

--- a/src/statistics/stats_aggregator.cpp
+++ b/src/statistics/stats_aggregator.cpp
@@ -130,7 +130,7 @@ void StatsAggregator::Aggregate(int64_t &interval_cnt, double &alpha,
 }
 
 void StatsAggregator::UpdateQueryMetrics(int64_t time_stamp,
-                                         concurrency::Transaction *txn) {
+                                         concurrency::TransactionContext *txn) {
   // Get the target query metrics table
   LOG_TRACE("Inserting Query Metric Tuples");
   // auto query_metrics_table = GetMetricTable(QUERY_METRIC_NAME);
@@ -221,7 +221,7 @@ void StatsAggregator::UpdateMetrics() {
 
 void StatsAggregator::UpdateTableMetrics(storage::Database *database,
                                          int64_t time_stamp,
-                                         concurrency::Transaction *txn) {
+                                         concurrency::TransactionContext *txn) {
   // Update table metrics table for each of the indices
   auto database_oid = database->GetOid();
   auto table_count = database->GetTableCount();
@@ -248,7 +248,7 @@ void StatsAggregator::UpdateTableMetrics(storage::Database *database,
 void StatsAggregator::UpdateIndexMetrics(storage::Database *database,
                                          storage::DataTable *table,
                                          int64_t time_stamp,
-                                         concurrency::Transaction *txn) {
+                                         concurrency::TransactionContext *txn) {
   // Update index metrics table for each of the indices
   auto database_oid = database->GetOid();
   auto table_oid = table->GetOid();

--- a/src/statistics/stats_aggregator.cpp
+++ b/src/statistics/stats_aggregator.cpp
@@ -133,7 +133,7 @@ void StatsAggregator::UpdateQueryMetrics(int64_t time_stamp,
                                          concurrency::TransactionContext *txn) {
   // Get the target query metrics table
   LOG_TRACE("Inserting Query Metric Tuples");
-  // auto query_metrics_table = GetMetricTable(QUERY_METRIC_NAME);
+  // auto query_metrics_table = GetMetricTable(MetricType::QUERY_NAME);
 
   std::shared_ptr<QueryMetric> query_metric;
   auto &completed_query_metrics = aggregated_stats_.GetCompletedQueryMetrics();

--- a/src/statistics/table_metric.cpp
+++ b/src/statistics/table_metric.cpp
@@ -30,7 +30,7 @@ TableMetric::TableMetric(MetricType type, oid_t database_id, oid_t table_id)
 }
 
 void TableMetric::Aggregate(AbstractMetric& source) {
-  assert(source.GetType() == TABLE_METRIC);
+  assert(source.GetType() == MetricType::TABLE);
 
   TableMetric& table_metric = static_cast<TableMetric&>(source);
   table_access_.Aggregate(table_metric.GetTableAccess());

--- a/src/storage/abstract_table.cpp
+++ b/src/storage/abstract_table.cpp
@@ -39,25 +39,25 @@ column_map_type AbstractTable::GetTileGroupLayout() const {
   auto col_count = schema->GetColumnCount();
 
   // pure row layout map
-  if (layout_type == LAYOUT_TYPE_ROW) {
+  if (layout_type == LayoutType::ROW) {
     for (oid_t col_itr = 0; col_itr < col_count; col_itr++) {
       column_map[col_itr] = std::make_pair(0, col_itr);
     }
   }
   // pure column layout map
-  else if (layout_type == LAYOUT_TYPE_COLUMN) {
+  else if (layout_type == LayoutType::COLUMN) {
     for (oid_t col_itr = 0; col_itr < col_count; col_itr++) {
       column_map[col_itr] = std::make_pair(col_itr, 0);
     }
   }
   // hybrid layout map
-  else if (layout_type == LAYOUT_TYPE_HYBRID) {
+  else if (layout_type == LayoutType::HYBRID) {
     for (oid_t col_itr = 0; col_itr < col_count; col_itr++) {
       column_map[col_itr] = std::make_pair(0, col_itr);
     }
   } else {
     throw Exception("Unknown tilegroup layout option : " +
-                    std::to_string(layout_type));
+                    LayoutTypeToString(layout_type));
   }
 
   return column_map;

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -21,7 +21,7 @@
 #include "common/exception.h"
 #include "common/logger.h"
 #include "common/platform.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "gc/gc_manager_factory.h"
 #include "index/index.h"
@@ -307,7 +307,7 @@ ItemPointer DataTable::AcquireVersion() {
 
 bool DataTable::InstallVersion(const AbstractTuple *tuple,
                                const TargetList *targets_ptr,
-                               concurrency::Transaction *transaction,
+                               concurrency::TransactionContext *transaction,
                                ItemPointer *index_entry_ptr) {
   if (CheckConstraints(tuple) == false) {
     LOG_TRACE("InsertVersion(): Constraint violated");
@@ -324,7 +324,7 @@ bool DataTable::InstallVersion(const AbstractTuple *tuple,
 }
 
 ItemPointer DataTable::InsertTuple(const storage::Tuple *tuple,
-                                   concurrency::Transaction *transaction,
+                                   concurrency::TransactionContext *transaction,
                                    ItemPointer **index_entry_ptr) {
   ItemPointer location = GetEmptyTupleSlot(tuple);
   if (location.block == INVALID_OID) {
@@ -340,7 +340,7 @@ ItemPointer DataTable::InsertTuple(const storage::Tuple *tuple,
 }
 
 bool DataTable::InsertTuple(const AbstractTuple *tuple,
-    ItemPointer location, concurrency::Transaction *transaction,
+    ItemPointer location, concurrency::TransactionContext *transaction,
     ItemPointer **index_entry_ptr) {
   if (CheckConstraints(tuple) == false) {
     LOG_TRACE("InsertTuple(): Constraint violated");
@@ -410,7 +410,7 @@ ItemPointer DataTable::InsertTuple(const storage::Tuple *tuple) {
  */
 bool DataTable::InsertInIndexes(const AbstractTuple *tuple,
                                 ItemPointer location,
-                                concurrency::Transaction *transaction,
+                                concurrency::TransactionContext *transaction,
                                 ItemPointer **index_entry_ptr) {
   int index_count = GetIndexCount();
 
@@ -490,7 +490,7 @@ bool DataTable::InsertInIndexes(const AbstractTuple *tuple,
 
 bool DataTable::InsertInSecondaryIndexes(const AbstractTuple *tuple,
                                          const TargetList *targets_ptr,
-                                         concurrency::Transaction *transaction,
+                                         concurrency::TransactionContext *transaction,
                                          ItemPointer *index_entry_ptr) {
   int index_count = GetIndexCount();
   // Transform the target list into a hash set
@@ -1206,7 +1206,7 @@ trigger::TriggerList *DataTable::GetTriggerList() {
   return trigger_list_.get();
 }
 
-void DataTable::UpdateTriggerListFromCatalog(concurrency::Transaction *txn) {
+void DataTable::UpdateTriggerListFromCatalog(concurrency::TransactionContext *txn) {
   trigger_list_ =
       catalog::TriggerCatalog::GetInstance().GetTriggers(table_oid, txn);
 }

--- a/src/storage/table_factory.cpp
+++ b/src/storage/table_factory.cpp
@@ -26,10 +26,11 @@ DataTable *TableFactory::GetDataTable(oid_t database_id, oid_t relation_id,
                                       std::string table_name,
                                       size_t tuples_per_tilegroup_count,
                                       bool own_schema, bool adapt_table,
-                                      bool is_catalog) {
+                                      bool is_catalog,
+                                      peloton::LayoutType layout_type) {
   DataTable *table = new DataTable(schema, table_name, database_id, relation_id,
                                    tuples_per_tilegroup_count, own_schema,
-                                   adapt_table, is_catalog);
+                                   adapt_table, is_catalog, layout_type);
 
   return table;
 }

--- a/src/storage/temp_table.cpp
+++ b/src/storage/temp_table.cpp
@@ -37,7 +37,7 @@ TempTable::~TempTable() {
 }
 
 ItemPointer TempTable::InsertTuple(
-    const Tuple *tuple, UNUSED_ATTRIBUTE concurrency::Transaction *transaction,
+    const Tuple *tuple, UNUSED_ATTRIBUTE concurrency::TransactionContext *transaction,
     UNUSED_ATTRIBUTE ItemPointer **index_entry_ptr) {
   PL_ASSERT(tuple != nullptr);
   PL_ASSERT(transaction == nullptr);

--- a/src/storage/tuple.cpp
+++ b/src/storage/tuple.cpp
@@ -312,7 +312,7 @@ bool Tuple::EqualsNoSchemaCheck(const AbstractTuple &other) const {
   for (int column_itr = 0; column_itr < column_count; column_itr++) {
     type::Value lhs = (GetValue(column_itr));
     type::Value rhs = (other.GetValue(column_itr));
-    if (lhs.CompareNotEquals(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareNotEquals(rhs) == type::CmpBool::TRUE) {
       return false;
     }
   }
@@ -325,7 +325,7 @@ bool Tuple::EqualsNoSchemaCheck(const AbstractTuple &other,
   for (auto column_itr : columns) {
     type::Value lhs = (GetValue(column_itr));
     type::Value rhs = (other.GetValue(column_itr));
-    if (lhs.CompareNotEquals(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareNotEquals(rhs) == type::CmpBool::TRUE) {
       return false;
     }
   }
@@ -363,10 +363,10 @@ int Tuple::Compare(const Tuple &other) const {
   for (int column_itr = 0; column_itr < column_count; column_itr++) {
     type::Value lhs = (GetValue(column_itr));
     type::Value rhs = (other.GetValue(column_itr));
-    if (lhs.CompareGreaterThan(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareGreaterThan(rhs) == type::CmpBool::TRUE) {
       return 1;
     }
-    if (lhs.CompareLessThan(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareLessThan(rhs) == type::CmpBool::TRUE) {
       return -1;
     }
   }
@@ -379,10 +379,10 @@ int Tuple::Compare(const Tuple &other,
   for (auto column_itr : columns) {
     type::Value lhs = (GetValue(column_itr));
     type::Value rhs = (other.GetValue(column_itr));
-    if (lhs.CompareGreaterThan(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareGreaterThan(rhs) == type::CmpBool::TRUE) {
       return 1;
     }
-    if (lhs.CompareLessThan(rhs) == type::CMP_TRUE) {
+    if (lhs.CompareLessThan(rhs) == type::CmpBool::TRUE) {
       return -1;
     }
   }

--- a/src/storage/zone_map_manager.cpp
+++ b/src/storage/zone_map_manager.cpp
@@ -96,10 +96,10 @@ void ZoneMapManager::CreateOrUpdateZoneMapForTileGroup(
     oid_t num_tuple_slots = tile_group->GetAllocatedTupleCount();
     for (oid_t tuple_itr = 0; tuple_itr < num_tuple_slots; tuple_itr++) {
       type::Value current_val = tile_group->GetValue(tuple_itr, col_itr);
-      if (current_val.CompareGreaterThan(max)) {
+      if (current_val.CompareGreaterThan(max) == type::CmpBool::TRUE) {
         max = current_val;
       }
-      if (current_val.CompareLessThan(min)) {
+      if (current_val.CompareLessThan(min) == type::CmpBool::TRUE) {
         min = current_val;
       }
     }

--- a/src/storage/zone_map_manager.cpp
+++ b/src/storage/zone_map_manager.cpp
@@ -54,7 +54,7 @@ void ZoneMapManager::CreateZoneMapTableInCatalog() {
  * @param   table ptr and a transaction handle
  */
 void ZoneMapManager::CreateZoneMapsForTable(storage::DataTable *table,
-                                            concurrency::Transaction *txn) {
+                                            concurrency::TransactionContext *txn) {
   PL_ASSERT(table != nullptr);
   // Scan over the tile groups, check for immutable flag to be true
   // and keep adding to the zone map catalog
@@ -79,7 +79,7 @@ void ZoneMapManager::CreateZoneMapsForTable(storage::DataTable *table,
  */
 void ZoneMapManager::CreateOrUpdateZoneMapForTileGroup(
     storage::DataTable *table, oid_t tile_group_idx,
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   LOG_DEBUG("Creating Zone Maps for TileGroupId : %u", tile_group_idx);
   
   oid_t database_id = table->GetDatabaseOid();
@@ -122,7 +122,7 @@ void ZoneMapManager::CreateOrUpdateZoneMapForTileGroup(
 void ZoneMapManager::CreateOrUpdateZoneMapInCatalog(
     oid_t database_id, oid_t table_id, oid_t tile_group_idx, oid_t column_id,
     std::string min, std::string max, std::string type,
-    concurrency::Transaction *txn) {
+    concurrency::TransactionContext *txn) {
   auto stats_catalog = catalog::ZoneMapCatalog::GetInstance(nullptr);
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   // Delete and update in a single commit.

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -141,7 +141,7 @@ executor::ExecuteResult TrafficCop::ExecuteHelper(
     const std::vector<int> &result_format, size_t thread_id) {
   auto &curr_state = GetCurrentTxnState();
 
-  concurrency::Transaction *txn;
+  concurrency::TransactionContext *txn;
   if (!tcop_txn_state_.empty()) {
     txn = curr_state.first;
   } else {
@@ -162,7 +162,7 @@ executor::ExecuteResult TrafficCop::ExecuteHelper(
 
   struct ExecutePlanArg {
     std::shared_ptr<planner::AbstractPlan> plan_;
-    concurrency::Transaction *txn_;
+    concurrency::TransactionContext *txn_;
     const std::vector<type::Value> &params_;
     std::vector<ResultValue> &result_;
     const std::vector<int> &result_format_;

--- a/src/trigger/trigger.cpp
+++ b/src/trigger/trigger.cpp
@@ -15,7 +15,7 @@
 #include "catalog/catalog.h"
 #include "catalog/column_catalog.h"
 #include "catalog/table_catalog.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "expression/comparison_expression.h"
 #include "expression/constant_value_expression.h"
 #include "expression/tuple_value_expression.h"
@@ -58,7 +58,7 @@ Trigger::Trigger(const std::string &name, int16_t type,
  *
  */
 void Trigger::SerializeWhen(SerializeOutput &output, oid_t database_oid,
-                            oid_t table_oid, concurrency::Transaction *txn) {
+                            oid_t table_oid, concurrency::TransactionContext *txn) {
   size_t start = output.Position();
   output.WriteInt(0);  // reserve first 4 bytes for the total tuple size
   if (trigger_when != nullptr) {
@@ -165,7 +165,7 @@ void TriggerList::UpdateTypeSummary(int16_t type) {
 }
 
 bool TriggerList::ExecTriggers(TriggerType exec_type,
-                               concurrency::Transaction *txn,
+                               concurrency::TransactionContext *txn,
                                storage::Tuple *new_tuple,
                                executor::ExecutorContext *executor_context_,
                                storage::Tuple *old_tuple,

--- a/src/type/array_type.cpp
+++ b/src/type/array_type.cpp
@@ -80,7 +80,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
       std::vector<bool>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetBooleanValue(ValueFactory::GetBooleanValue(*it).CompareEquals(object));
-        if (ValueFactory::GetBooleanValue(*it).CompareEquals(object) == CMP_TRUE) return res;
+        if (ValueFactory::GetBooleanValue(*it).CompareEquals(object) == CmpBool::TRUE) return res;
       }
       return ValueFactory::GetBooleanValue(false);
     }

--- a/src/type/bigint_type.cpp
+++ b/src/type/bigint_type.cpp
@@ -187,7 +187,7 @@ CmpBool BigintType::CompareEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   BIGINT_COMPARE_FUNC(==);
 
@@ -199,7 +199,7 @@ CmpBool BigintType::CompareNotEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   BIGINT_COMPARE_FUNC(!=);
 
@@ -211,7 +211,7 @@ CmpBool BigintType::CompareLessThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   BIGINT_COMPARE_FUNC(<);
 
@@ -223,7 +223,7 @@ CmpBool BigintType::CompareLessThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   BIGINT_COMPARE_FUNC(<=);
 
@@ -235,7 +235,7 @@ CmpBool BigintType::CompareGreaterThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   BIGINT_COMPARE_FUNC(>);
 
@@ -247,7 +247,7 @@ CmpBool BigintType::CompareGreaterThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   BIGINT_COMPARE_FUNC(>=);
 

--- a/src/type/boolean_type.cpp
+++ b/src/type/boolean_type.cpp
@@ -29,7 +29,7 @@ CmpBool BooleanType::CompareEquals(const Value& left,
                                    const Value& right) const {
   PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(==);
 }
 
@@ -37,7 +37,7 @@ CmpBool BooleanType::CompareNotEquals(const Value& left,
                                       const Value& right) const {
   PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(!=);
 }
 
@@ -45,7 +45,7 @@ CmpBool BooleanType::CompareLessThan(const Value& left,
                                      const Value& right) const {
   PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(<);
 }
 
@@ -53,7 +53,7 @@ CmpBool BooleanType::CompareLessThanEquals(const Value& left,
                                            const Value& right) const {
   PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(<=);
 }
 
@@ -61,7 +61,7 @@ CmpBool BooleanType::CompareGreaterThan(const Value& left,
                                         const Value& right) const {
   PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(>);
 }
 
@@ -69,21 +69,21 @@ CmpBool BooleanType::CompareGreaterThanEquals(const Value& left,
                                               const Value& right) const {
   PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(>=);
 }
 
 Value BooleanType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value BooleanType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareGreaterThanEquals(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 

--- a/src/type/date_type.cpp
+++ b/src/type/date_type.cpp
@@ -21,55 +21,55 @@ DateType::DateType() : Type(TypeId::DATE) {}
 
 CmpBool DateType::CompareEquals(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() == right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareNotEquals(const Value& left,
                                    const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (right.IsNull()) return CMP_NULL;
+  if (right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() != right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareLessThan(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() < right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareLessThanEquals(const Value& left,
                                         const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() <= right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareGreaterThan(const Value& left,
                                      const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() > right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareGreaterThanEquals(const Value& left,
                                            const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() >= right.GetAs<int32_t>());
 }
 
 Value DateType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value DateType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareGreaterThan(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareGreaterThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 

--- a/src/type/decimal_type.cpp
+++ b/src/type/decimal_type.cpp
@@ -163,7 +163,7 @@ Value DecimalType::Min(const Value& left, const Value &right) const {
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
-  if (left.CompareLessThanEquals(right) == CMP_TRUE)
+  if (left.CompareLessThanEquals(right) == CmpBool::TRUE)
     return left.Copy();
   return right.Copy();
 }
@@ -174,7 +174,7 @@ Value DecimalType::Max(const Value& left, const Value &right) const {
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
-  if (left.CompareGreaterThanEquals(right) == CMP_TRUE)
+  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE)
     return left.Copy();
   return right.Copy();
 }
@@ -198,7 +198,7 @@ CmpBool DecimalType::CompareEquals(const Value& left, const Value &right) const 
   PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
     
   DECIMAL_COMPARE_FUNC(==);
 
@@ -209,7 +209,7 @@ CmpBool DecimalType::CompareNotEquals(const Value& left, const Value &right) con
   PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   DECIMAL_COMPARE_FUNC(!=);
 
@@ -220,7 +220,7 @@ CmpBool DecimalType::CompareLessThan(const Value& left, const Value &right) cons
   PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   DECIMAL_COMPARE_FUNC(<);
 
@@ -231,7 +231,7 @@ CmpBool DecimalType::CompareLessThanEquals(const Value& left, const Value &right
   PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   DECIMAL_COMPARE_FUNC(<=);
 
@@ -242,7 +242,7 @@ CmpBool DecimalType::CompareGreaterThan(const Value& left, const Value &right) c
   PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   DECIMAL_COMPARE_FUNC(>);
 
@@ -253,7 +253,7 @@ CmpBool DecimalType::CompareGreaterThanEquals(const Value& left, const Value &ri
   PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   DECIMAL_COMPARE_FUNC(>=);
 

--- a/src/type/integer_parent_type.cpp
+++ b/src/type/integer_parent_type.cpp
@@ -28,7 +28,7 @@ Value IntegerParentType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
 
-  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
@@ -37,7 +37,7 @@ Value IntegerParentType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
 
-  if (left.CompareGreaterThanEquals(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 

--- a/src/type/integer_type.cpp
+++ b/src/type/integer_type.cpp
@@ -191,7 +191,7 @@ CmpBool IntegerType::CompareEquals(const Value& left, const Value &right) const 
   PL_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   INT_COMPARE_FUNC(==);
 
@@ -203,7 +203,7 @@ CmpBool IntegerType::CompareNotEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   INT_COMPARE_FUNC(!=);
 
@@ -215,7 +215,7 @@ CmpBool IntegerType::CompareLessThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   INT_COMPARE_FUNC(<);
 
@@ -227,7 +227,7 @@ CmpBool IntegerType::CompareLessThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   INT_COMPARE_FUNC(<=);
 
@@ -239,7 +239,7 @@ CmpBool IntegerType::CompareGreaterThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   INT_COMPARE_FUNC(>);
 
@@ -251,7 +251,7 @@ CmpBool IntegerType::CompareGreaterThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   INT_COMPARE_FUNC(>=);
 

--- a/src/type/smallint_type.cpp
+++ b/src/type/smallint_type.cpp
@@ -198,7 +198,7 @@ CmpBool SmallintType::CompareEquals(const Value& left,
   PL_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   SMALLINT_COMPARE_FUNC(==);
 
@@ -210,7 +210,7 @@ CmpBool SmallintType::CompareNotEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   SMALLINT_COMPARE_FUNC(!=);
 
@@ -222,7 +222,7 @@ CmpBool SmallintType::CompareLessThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   SMALLINT_COMPARE_FUNC(<);
 
@@ -234,7 +234,7 @@ CmpBool SmallintType::CompareLessThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   SMALLINT_COMPARE_FUNC(<=);
 
@@ -246,7 +246,7 @@ CmpBool SmallintType::CompareGreaterThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   SMALLINT_COMPARE_FUNC(>);
 
@@ -258,7 +258,7 @@ CmpBool SmallintType::CompareGreaterThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   SMALLINT_COMPARE_FUNC(>=);
 

--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -26,56 +26,56 @@ TimestampType::TimestampType()
 CmpBool TimestampType::CompareEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() == right.GetAs<uint64_t>());
 }
 
 CmpBool TimestampType::CompareNotEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() != right.GetAs<uint64_t>());
 }
 
 CmpBool TimestampType::CompareLessThan(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() < right.GetAs<uint64_t>());
 }
 
 CmpBool TimestampType::CompareLessThanEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() <= right.GetAs<uint64_t>());
 }
 
 CmpBool TimestampType::CompareGreaterThan(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int64_t>() > right.GetAs<int64_t>());
 }
 
 CmpBool TimestampType::CompareGreaterThanEquals(const Value& left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() >= right.GetAs<uint64_t>());
 }
 
 Value TimestampType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value TimestampType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareGreaterThanEquals(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 

--- a/src/type/tinyint_type.cpp
+++ b/src/type/tinyint_type.cpp
@@ -191,7 +191,7 @@ CmpBool TinyintType::CompareEquals(const Value& left, const Value &right) const 
   PL_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   TINYINT_COMPARE_FUNC(==);
 
@@ -203,7 +203,7 @@ CmpBool TinyintType::CompareNotEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   TINYINT_COMPARE_FUNC(!=);
 
@@ -215,7 +215,7 @@ CmpBool TinyintType::CompareLessThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   TINYINT_COMPARE_FUNC(<);
 
@@ -227,7 +227,7 @@ CmpBool TinyintType::CompareLessThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   TINYINT_COMPARE_FUNC(<=);
 
@@ -239,7 +239,7 @@ CmpBool TinyintType::CompareGreaterThan(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   TINYINT_COMPARE_FUNC(>);
 
@@ -251,7 +251,7 @@ CmpBool TinyintType::CompareGreaterThanEquals(const Value& left,
   PL_ASSERT(left.CheckInteger());
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
-    return CMP_NULL;
+    return CmpBool::NULL_;
 
   TINYINT_COMPARE_FUNC(>=);
 

--- a/src/type/types.cpp
+++ b/src/type/types.cpp
@@ -2692,7 +2692,7 @@ std::ostream &operator<<(std::ostream &os, const PropertyType &type) {
 //===--------------------------------------------------------------------===//
 std::string SqlStateErrorCodeToString(SqlStateErrorCode code) {
   switch (code) {
-    case SERIALIZATION_ERROR:
+    case SqlStateErrorCode::SERIALIZATION_ERROR:
       return "40001";
     default:
       return "INVALID";

--- a/src/type/types.cpp
+++ b/src/type/types.cpp
@@ -2352,6 +2352,37 @@ std::ostream &operator<<(std::ostream &os, const CheckpointingType &type) {
   return os;
 }
 
+std::string LayoutTypeToString(LayoutType type) {
+  switch (type) {
+    case LayoutType::INVALID: {
+      return "INVALID";
+    }
+    case LayoutType::ROW: {
+      return "ROW";
+    }
+    case LayoutType::COLUMN: {
+      return "COLUMN";
+    }
+    case LayoutType::HYBRID: {
+      return "HYBRID";
+    }
+    default: {
+      throw ConversionException(StringUtil::Format(
+          "No string conversion for LayoutType value '%d'",
+          static_cast<int>(type)));
+    }
+  }
+  return "INVALID";
+}
+
+std::ostream &operator<<(std::ostream &os, const LayoutType &type) {
+  os << LayoutTypeToString(type);
+  return os;
+}
+
+
+
+
 type::TypeId PostgresValueTypeToPelotonValueType(PostgresValueType type) {
   switch (type) {
     case PostgresValueType::BOOLEAN:

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -59,7 +59,7 @@ char *VarlenType::GetData(char *storage) {
 
 CmpBool VarlenType::CompareEquals(const Value &left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) == GetLength(right));
@@ -71,7 +71,7 @@ CmpBool VarlenType::CompareEquals(const Value &left, const Value &right) const {
 CmpBool VarlenType::CompareNotEquals(const Value &left,
                                      const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) != GetLength(right));
@@ -83,7 +83,7 @@ CmpBool VarlenType::CompareNotEquals(const Value &left,
 CmpBool VarlenType::CompareLessThan(const Value &left,
                                     const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) < GetLength(right));
@@ -95,7 +95,7 @@ CmpBool VarlenType::CompareLessThan(const Value &left,
 CmpBool VarlenType::CompareLessThanEquals(const Value &left,
                                           const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) <= GetLength(right));
@@ -107,7 +107,7 @@ CmpBool VarlenType::CompareLessThanEquals(const Value &left,
 CmpBool VarlenType::CompareGreaterThan(const Value &left,
                                        const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) > GetLength(right));
@@ -119,7 +119,7 @@ CmpBool VarlenType::CompareGreaterThan(const Value &left,
 CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
                                              const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
-  if (left.IsNull() || right.IsNull()) return CMP_NULL;
+  if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
       GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) >= GetLength(right));
@@ -131,14 +131,14 @@ CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
 Value VarlenType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value VarlenType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareGreaterThanEquals(right) == CMP_TRUE) return left.Copy();
+  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -299,7 +299,7 @@ TEST_F(BinderCorrectnessTest, FunctionExpressionTest) {
       dynamic_cast<parser::SelectStatement*>(stmt)->select_list[0].get());
   EXPECT_TRUE(funct_expr->Evaluate(nullptr, nullptr, nullptr)
                   .CompareEquals(type::ValueFactory::GetVarcharValue("est")) ==
-              type::CMP_TRUE);
+              type::CmpBool::TRUE);
 
   txn_manager.CommitTransaction(txn);
 }

--- a/test/codegen/bloom_filter_test.cpp
+++ b/test/codegen/bloom_filter_test.cpp
@@ -57,12 +57,12 @@ class BloomFilterCodegenTest : public PelotonTest {
   int UpDivide(int num1, int num2) { return (num1 + num2 - 1) / num2; }
 
   void InsertTuple(const std::vector<int> &vals, storage::DataTable *table,
-                   concurrency::Transaction *txn);
+                   concurrency::TransactionContext *txn);
 
   void CreateTable(std::string table_name, int tuple_size,
-                   concurrency::Transaction *txn);
+                   concurrency::TransactionContext *txn);
 
-  double ExecuteJoin(std::string query, concurrency::Transaction *txn,
+  double ExecuteJoin(std::string query, concurrency::TransactionContext *txn,
                      int num_iter, unsigned inner_table_cardinality,
                      bool enable_bloom_filter);
 
@@ -275,7 +275,7 @@ TEST_F(BloomFilterCodegenTest, PerformanceTest) {
 }
 
 double BloomFilterCodegenTest::ExecuteJoin(std::string query,
-                                           concurrency::Transaction *txn,
+                                           concurrency::TransactionContext *txn,
                                            int num_iter,
                                            unsigned inner_table_cardinality,
                                            bool enable_bloom_filter) {
@@ -324,7 +324,7 @@ double BloomFilterCodegenTest::ExecuteJoin(std::string query,
 // Create a table where all the columns are BIGINT and each tuple has desired
 // tuple size
 void BloomFilterCodegenTest::CreateTable(std::string table_name, int tuple_size,
-                                         concurrency::Transaction *txn) {
+                                         concurrency::TransactionContext *txn) {
   int curr_size = 0;
   size_t bigint_size = type::Type::GetTypeSize(type::TypeId::BIGINT);
   std::vector<catalog::Column> cols;
@@ -343,7 +343,7 @@ void BloomFilterCodegenTest::CreateTable(std::string table_name, int tuple_size,
 // Insert a tuple to specific table
 void BloomFilterCodegenTest::InsertTuple(const std::vector<int> &vals,
                                          storage::DataTable *table,
-                                         concurrency::Transaction *txn) {
+                                         concurrency::TransactionContext *txn) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   storage::Tuple tuple{table->GetSchema(), true};
   for (unsigned i = 0; i < vals.size(); i++) {

--- a/test/codegen/case_translator_test.cpp
+++ b/test/codegen/case_translator_test.cpp
@@ -90,17 +90,17 @@ TEST_F(CaseTranslatorTest, SimpleCase) {
   const auto &results = buffer.GetOutputTuples();
   EXPECT_EQ(NumRowsInTestTable(), results.size());
   EXPECT_TRUE(results[0].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(0)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(0)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[0].GetValue(1).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(0)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(0)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[1].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(10)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(10)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[1].GetValue(1).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(1)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(1)) == type::CmpBool::TRUE);
 
   for (uint32_t i = 2; i < NumRowsInTestTable(); i++) {
     EXPECT_TRUE(results[i].GetValue(1).CompareEquals(
-                    type::ValueFactory::GetBigIntValue(0)) == type::CMP_TRUE);
+                    type::ValueFactory::GetBigIntValue(0)) == type::CmpBool::TRUE);
   }
 }
 
@@ -156,17 +156,17 @@ TEST_F(CaseTranslatorTest, SimpleCaseMoreWhen) {
   const auto &results = buffer.GetOutputTuples();
   EXPECT_EQ(NumRowsInTestTable(), results.size());
   EXPECT_TRUE(results[0].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(0)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(0)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[0].GetValue(1).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(0)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(0)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[1].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(10)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(10)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[1].GetValue(1).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(1)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(1)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[2].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(20)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(20)) == type::CmpBool::TRUE);
   EXPECT_TRUE(results[2].GetValue(1).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(2)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(2)) == type::CmpBool::TRUE);
 }
 
 }  // namespace test

--- a/test/codegen/group_by_translator_test.cpp
+++ b/test/codegen/group_by_translator_test.cpp
@@ -91,7 +91,7 @@ TEST_F(GroupByTranslatorTest, SingleColumnGrouping) {
   // Each group should have a count of one (since the grouping column is unique)
   type::Value const_one = type::ValueFactory::GetIntegerValue(1);
   for (const auto &tuple : results) {
-    EXPECT_TRUE(tuple.GetValue(1).CompareEquals(const_one) == type::CMP_TRUE);
+    EXPECT_TRUE(tuple.GetValue(1).CompareEquals(const_one) == type::CmpBool::TRUE);
   }
 }
 
@@ -153,7 +153,7 @@ TEST_F(GroupByTranslatorTest, MultiColumnGrouping) {
   type::Value const_one = type::ValueFactory::GetIntegerValue(1);
   for (const auto &tuple : results) {
     type::Value group_count = tuple.GetValue(2);
-    EXPECT_TRUE(group_count.CompareEquals(const_one) == type::CMP_TRUE);
+    EXPECT_TRUE(group_count.CompareEquals(const_one) == type::CmpBool::TRUE);
   }
 }
 
@@ -385,7 +385,7 @@ TEST_F(GroupByTranslatorTest, SingleCountStar) {
   const auto &results = buffer.GetOutputTuples();
   EXPECT_EQ(1, results.size());
   EXPECT_TRUE(results[0].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(10)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(10)) == type::CmpBool::TRUE);
 }
 
 TEST_F(GroupByTranslatorTest, MinAndMax) {
@@ -451,12 +451,12 @@ TEST_F(GroupByTranslatorTest, MinAndMax) {
   // maximum row ID is equal to # inserted - 1. Therefore:
   // MAX(a) = (# inserted - 1) * 10 = (10 - 1) * 10 = 9 * 10 = 90
   EXPECT_TRUE(results[0].GetValue(0).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(90)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(90)) == type::CmpBool::TRUE);
 
   // The values of 'b' are equal to the (zero-indexed) row ID * 10 + 1. The
   // minimum row ID is 0. Therefore: MIN(b) = 0 * 10 + 1 = 1
   EXPECT_TRUE(results[0].GetValue(1).CompareEquals(
-                  type::ValueFactory::GetBigIntValue(1)) == type::CMP_TRUE);
+                  type::ValueFactory::GetBigIntValue(1)) == type::CmpBool::TRUE);
 }
 
 }  // namespace test

--- a/test/codegen/hash_join_translator_test.cpp
+++ b/test/codegen/hash_join_translator_test.cpp
@@ -124,7 +124,7 @@ TEST_F(HashJoinTranslatorTest, SingleHashJoinColumnTest) {
     LOG_DEBUG("=====> Output: %s", tuple.GetInfo().c_str());
 
     // Check that the joins keys are actually equal
-    EXPECT_EQ(type::CMP_TRUE,
+    EXPECT_EQ(type::CmpBool::TRUE,
               tuple.GetValue(0).CompareEquals(tuple.GetValue(1)));
   }
 }

--- a/test/codegen/insert_translator_test.cpp
+++ b/test/codegen/insert_translator_test.cpp
@@ -97,13 +97,13 @@ TEST_F(InsertTranslatorTest, InsertOneTuple) {
   // Check that we got all the results
   auto &results_table1 = buffer_table1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetDecimalValue(2)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("Tuple1")));
 
 }
@@ -158,21 +158,21 @@ TEST_F(InsertTranslatorTest, InsertScanTranslator) {
   // Check that we got all the results
   auto &results_table1 = buffer_table1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("3")));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(90)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(91)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(92)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("93")));
 }
 
@@ -227,19 +227,19 @@ TEST_F(InsertTranslatorTest, InsertScanTranslatorWithNull) {
   // Check that we got all the results
   auto &results_table1 = buffer_table1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(1).IsNull());
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(2).CompareEquals(
+  EXPECT_TRUE(results_table1[0].GetValue(1).IsNull());
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("3")));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(90)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(1).IsNull());
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(2).CompareEquals(
+  EXPECT_TRUE(results_table1[9].GetValue(1).IsNull());
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(92)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("93")));
 }
 
@@ -293,21 +293,21 @@ TEST_F(InsertTranslatorTest, InsertScanColumnTranslator) {
   // Check that we got all the results
   auto &results_table1 = buffer_table1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("3")));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(91)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(90)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(92)));
-  EXPECT_EQ(type::CMP_TRUE, results_table1[9].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_table1[9].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("93")));
 }
 

--- a/test/codegen/insert_translator_test.cpp
+++ b/test/codegen/insert_translator_test.cpp
@@ -12,7 +12,7 @@
 
 #include "codegen/testing_codegen_util.h"
 #include "common/harness.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager.h"
 #include "planner/insert_plan.h"
 #include "planner/seq_scan_plan.h"

--- a/test/codegen/order_by_translator_test.cpp
+++ b/test/codegen/order_by_translator_test.cpp
@@ -61,7 +61,7 @@ TEST_F(OrderByTranslatorTest, SingleIntColAscTest) {
       results.begin(), results.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
         auto is_lte = t1.GetValue(0).CompareLessThanEquals(t2.GetValue(0));
-        return is_lte == type::CMP_TRUE;
+        return is_lte == type::CmpBool::TRUE;
       }));
 }
 
@@ -99,7 +99,7 @@ TEST_F(OrderByTranslatorTest, SingleIntColDescTest) {
       results.begin(), results.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
         auto is_gte = t1.GetValue(0).CompareGreaterThanEquals(t2.GetValue(0));
-        return is_gte == type::CMP_TRUE;
+        return is_gte == type::CmpBool::TRUE;
       }));
 }
 
@@ -137,14 +137,14 @@ TEST_F(OrderByTranslatorTest, MultiIntColAscTest) {
   EXPECT_TRUE(std::is_sorted(
       results.begin(), results.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
-        if (t1.GetValue(1).CompareEquals(t2.GetValue(0)) == type::CMP_TRUE) {
+        if (t1.GetValue(1).CompareEquals(t2.GetValue(0)) == type::CmpBool::TRUE) {
           // t1.b == t2.b => t1.a <= t2.a
           return t1.GetValue(0).CompareLessThanEquals(t2.GetValue(0)) ==
-                 type::CMP_TRUE;
+                 type::CmpBool::TRUE;
         } else {
           // t1.b != t2.b => t1.b < t2.b
           return t1.GetValue(1).CompareLessThan(t2.GetValue(1)) ==
-                 type::CMP_TRUE;
+                 type::CmpBool::TRUE;
         }
       }));
 }
@@ -183,14 +183,14 @@ TEST_F(OrderByTranslatorTest, MultiIntColMixedTest) {
   EXPECT_TRUE(std::is_sorted(
       results.begin(), results.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
-        if (t1.GetValue(1).CompareEquals(t2.GetValue(1)) == type::CMP_TRUE) {
+        if (t1.GetValue(1).CompareEquals(t2.GetValue(1)) == type::CmpBool::TRUE) {
           // t1.b == t2.b => t1.a <= t2.a
           return t1.GetValue(0).CompareLessThanEquals(t2.GetValue(0)) ==
-                 type::CMP_TRUE;
+                 type::CmpBool::TRUE;
         } else {
           // t1.b != t2.b => t1.b > t2.b
           return t1.GetValue(1).CompareGreaterThan(t2.GetValue(1)) ==
-                 type::CMP_TRUE;
+                 type::CmpBool::TRUE;
         }
       }));
 }

--- a/test/codegen/parameterization_test.cpp
+++ b/test/codegen/parameterization_test.cpp
@@ -210,11 +210,11 @@ TEST_F(ParameterizationTest, ConstParameterWithConjunction) {
 
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(1, results.size());
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(21)));
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetDecimalValue(22)));
 
   // SELECT a, b, c FROM table where a >= 30 and b = 31;
@@ -247,11 +247,11 @@ TEST_F(ParameterizationTest, ConstParameterWithConjunction) {
 
   const auto &results_2 = buffer_2.GetOutputTuples();
   ASSERT_EQ(1, results_2.size());
-  EXPECT_EQ(type::CMP_TRUE, results_2[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_2[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(30)));
-  EXPECT_EQ(type::CMP_TRUE, results_2[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_2[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(31)));
-  EXPECT_EQ(type::CMP_TRUE, results_2[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_2[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetDecimalValue(32)));
   EXPECT_TRUE(cached);
 
@@ -328,9 +328,9 @@ TEST_F(ParameterizationTest, ParamParameterWithConjunction) {
 
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(NumRowsInTestTable() - 2, results.size());
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(type::CMP_FALSE, results[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::FALSE, results[0].GetValue(3).CompareEquals(
                                  type::ValueFactory::GetVarcharValue("")));
   EXPECT_FALSE(cached);
 
@@ -368,9 +368,9 @@ TEST_F(ParameterizationTest, ParamParameterWithConjunction) {
 
   const auto &results_2 = buffer_2.GetOutputTuples();
   ASSERT_EQ(NumRowsInTestTable() - 3, results_2.size());
-  EXPECT_EQ(type::CMP_TRUE, results_2[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_2[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(30)));
-  EXPECT_EQ(type::CMP_FALSE, results_2[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::FALSE, results_2[0].GetValue(3).CompareEquals(
                                  type::ValueFactory::GetVarcharValue("empty")));
   EXPECT_TRUE(cached);
 
@@ -408,9 +408,9 @@ TEST_F(ParameterizationTest, ParamParameterWithConjunction) {
 
   const auto &results_3 = buffer_3.GetOutputTuples();
   ASSERT_EQ(NumRowsInTestTable() - 3, results_3.size());
-  EXPECT_EQ(type::CMP_TRUE, results_3[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_3[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(30)));
-  EXPECT_EQ(type::CMP_FALSE, results_3[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::FALSE, results_3[0].GetValue(3).CompareEquals(
                                  type::ValueFactory::GetVarcharValue("empty")));
   EXPECT_TRUE(cached);
 
@@ -448,9 +448,9 @@ TEST_F(ParameterizationTest, ParamParameterWithConjunction) {
 
   const auto &results_4 = buffer_4.GetOutputTuples();
   ASSERT_EQ(NumRowsInTestTable() - 3, results_3.size());
-  EXPECT_EQ(type::CMP_TRUE, results_4[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_4[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(30)));
-  EXPECT_EQ(type::CMP_FALSE, results_4[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::FALSE, results_4[0].GetValue(3).CompareEquals(
                                  type::ValueFactory::GetVarcharValue("empty")));
   EXPECT_TRUE(cached);
 }

--- a/test/codegen/query_cache_test.cpp
+++ b/test/codegen/query_cache_test.cpp
@@ -246,9 +246,9 @@ TEST_F(QueryCacheTest, CacheSeqScanPlan) {
   // Check that we got all the results
   const auto& results_1 = buffer_1.GetOutputTuples();
   EXPECT_EQ(1, results_1.size());
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(21)));
   EXPECT_FALSE(cached);
 
@@ -258,9 +258,9 @@ TEST_F(QueryCacheTest, CacheSeqScanPlan) {
 
   const auto& results_2 = buffer_2.GetOutputTuples();
   EXPECT_EQ(1, results_2.size());
-  EXPECT_EQ(type::CMP_TRUE, results_2[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_2[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(type::CMP_TRUE, results_2[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_2[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(21)));
   EXPECT_TRUE(cached);
   EXPECT_EQ(1, codegen::QueryCache::Instance().GetCount());
@@ -304,7 +304,7 @@ TEST_F(QueryCacheTest, CacheHashJoinPlan) {
 
     // Check that the joins keys are actually equal
     EXPECT_EQ(tuple.GetValue(0).CompareEquals(tuple.GetValue(1)),
-              type::CMP_TRUE);
+              type::CmpBool::TRUE);
   }
 
   // We collect the results of the query into an in-memory buffer
@@ -322,7 +322,7 @@ TEST_F(QueryCacheTest, CacheHashJoinPlan) {
 
     // Check that the joins keys are actually equal
     EXPECT_EQ(tuple.GetValue(0).CompareEquals(tuple.GetValue(1)),
-              type::CMP_TRUE);
+              type::CmpBool::TRUE);
   }
   EXPECT_EQ(1, codegen::QueryCache::Instance().GetCount());
 
@@ -385,7 +385,7 @@ TEST_F(QueryCacheTest, CacheOrderByPlan) {
       results_1.begin(), results_1.end(),
       [](const codegen::WrappedTuple& t1, const codegen::WrappedTuple& t2) {
         auto is_gte = t1.GetValue(0).CompareGreaterThanEquals(t2.GetValue(0));
-        return is_gte == type::CMP_TRUE;
+        return is_gte == type::CmpBool::TRUE;
       }));
 
   CompileAndExecuteCache(order_by_plan_2, buffer_2,
@@ -397,7 +397,7 @@ TEST_F(QueryCacheTest, CacheOrderByPlan) {
       results_2.begin(), results_2.end(),
       [](const codegen::WrappedTuple& t1, const codegen::WrappedTuple& t2) {
         auto is_gte = t1.GetValue(0).CompareGreaterThanEquals(t2.GetValue(0));
-        return is_gte == type::CMP_TRUE;
+        return is_gte == type::CmpBool::TRUE;
       }));
 
   auto found =

--- a/test/codegen/table_scan_translator_test.cpp
+++ b/test/codegen/table_scan_translator_test.cpp
@@ -216,18 +216,18 @@ TEST_F(TableScanTranslatorTest, SimplePredicateWithNull) {
   EXPECT_EQ(2, results.size());
 
   // First tuple should be (0, 1)
-  EXPECT_EQ(type::CmpBool::CMP_TRUE,
+  EXPECT_EQ(type::CmpBool::TRUE,
             results[0].GetValue(0).CompareEquals(
                 type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(type::CmpBool::CMP_TRUE,
+  EXPECT_EQ(type::CmpBool::TRUE,
             results[0].GetValue(1).CompareEquals(
                 type::ValueFactory::GetIntegerValue(1)));
 
   // Second tuple should be (10, 11)
-  EXPECT_EQ(type::CmpBool::CMP_TRUE,
+  EXPECT_EQ(type::CmpBool::TRUE,
             results[1].GetValue(0).CompareEquals(
                 type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_EQ(type::CmpBool::CMP_TRUE,
+  EXPECT_EQ(type::CmpBool::TRUE,
             results[1].GetValue(1).CompareEquals(
                 type::ValueFactory::GetIntegerValue(11)));
 }
@@ -295,9 +295,9 @@ TEST_F(TableScanTranslatorTest, ScanWithConjunctionPredicate) {
   // Check output results
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(1, results.size());
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(21)));
 }
 
@@ -583,9 +583,9 @@ TEST_F(TableScanTranslatorTest, ScanWithModuloPredicate) {
   // Check output results
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(1, results.size());
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
 }
 

--- a/test/codegen/testing_codegen_util.cpp
+++ b/test/codegen/testing_codegen_util.cpp
@@ -86,7 +86,7 @@ std::unique_ptr<catalog::Schema> PelotonCodeGenTest::CreateTestSchema(
 }
 
 // Create all the test tables, but don't load any data
-void PelotonCodeGenTest::CreateTestTables(concurrency::Transaction *txn,
+void PelotonCodeGenTest::CreateTestTables(concurrency::TransactionContext *txn,
                                           oid_t tuples_per_tilegroup) {
   auto *catalog = catalog::Catalog::GetInstance();
   for (int i = 0; i < 4; i++) {

--- a/test/codegen/update_translator_test.cpp
+++ b/test/codegen/update_translator_test.cpp
@@ -115,21 +115,21 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstant) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("3")));
-  EXPECT_EQ(type::CMP_TRUE, results_1[9].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[9].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[9].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[9].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(91)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[9].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[9].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(92)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[9].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[9].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("93")));
 }
 
@@ -209,13 +209,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantAndPredicate) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(40)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(49)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(42)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("43")));
 
 }
@@ -304,13 +304,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAnOperatorExpression) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(40)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(49)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(42)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("43")));
 
 }
@@ -410,13 +410,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAnOperatorExpressionComplex) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(41)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(81)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(42)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("43")));
 
 }
@@ -498,13 +498,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantPrimary) {
   // Check that we got all the results
   auto &results_5 = buffer_5.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_5[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_5[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(type::CMP_TRUE, results_5[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_5[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(11)));
-  EXPECT_EQ(type::CMP_TRUE, results_5[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_5[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(12)));
-  EXPECT_EQ(type::CMP_TRUE, results_5[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_5[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("13")));
 }
 
@@ -583,13 +583,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithCast) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(11)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(type::CMP_TRUE, results_1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_1[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("13")));
 
   // Get the scan plan without a predicate with four columns
@@ -655,13 +655,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithCast) {
   // Check that we got all the results
   auto &results_3 = buffer_3.GetOutputTuples();
 
-  EXPECT_EQ(type::CMP_TRUE, results_3[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_3[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_EQ(type::CMP_TRUE, results_3[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_3[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(11)));
-  EXPECT_EQ(type::CMP_TRUE, results_3[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_3[0].GetValue(2).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(3)));
-  EXPECT_EQ(type::CMP_TRUE, results_3[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results_3[0].GetValue(3).CompareEquals(
                                 type::ValueFactory::GetVarcharValue("13")));
 }
 

--- a/test/codegen/zone_map_scan_test.cpp
+++ b/test/codegen/zone_map_scan_test.cpp
@@ -146,9 +146,9 @@ TEST_F(ZoneMapScanTest, ScanwithConjunctionPredicate) {
   // Check output results
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(1, results.size());
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(type::CMP_TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
                                 type::ValueFactory::GetIntegerValue(21)));
 }
 }

--- a/test/common/container_tuple_test.cpp
+++ b/test/common/container_tuple_test.cpp
@@ -37,7 +37,7 @@ TEST_F(ContainerTupleTests, VectorValue) {
 
   for (size_t i = 0; i < values.size(); i++) {
     LOG_INFO("%s", ctuple.GetValue(i).GetInfo().c_str());
-    EXPECT_TRUE(values[i].CompareEquals(ctuple.GetValue(i)) == type::CMP_TRUE);
+    EXPECT_TRUE(values[i].CompareEquals(ctuple.GetValue(i)) == type::CmpBool::TRUE);
   }
 }
 

--- a/test/common/harness.cpp
+++ b/test/common/harness.cpp
@@ -14,7 +14,7 @@
 #include "common/harness.h"
 
 #include "type/ephemeral_pool.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 
 namespace peloton {

--- a/test/concurrency/anomaly_test.cpp
+++ b/test/concurrency/anomaly_test.cpp
@@ -42,7 +42,7 @@ static std::vector<ConflictAvoidanceType> CONFLICT_AVOIDANCE_TYPES = {
 
 
 // Dirty write:
-// Transaction T1 modifies a data item. Another transaction T2 then further 
+// TransactionContext T1 modifies a data item. Another transaction T2 then further
 // modifies that data item before T1 performs a COMMIT or ROLLBACK.
 // If T1 or T2 then performs a ROLLBACK, it is unclear what the correct 
 // data value should be.
@@ -302,7 +302,7 @@ void DirtyWriteTest(const ProtocolType protocol UNUSED_ATTRIBUTE,
 
 
 // Dirty read:
-// Transaction T1 modifies a data item. Another transaction T2 then reads
+// TransactionContext T1 modifies a data item. Another transaction T2 then reads
 // that data item before T1 performs a COMMIT or ROLLBACK.
 // If T1 then performs a ROLLBACK, T2 has read a data item that was never
 // committed and so never really existed.
@@ -408,7 +408,7 @@ void DirtyReadTest(const ProtocolType protocol UNUSED_ATTRIBUTE,
 
 
 // Fuzzy read:
-// Transaction T1 reads a data item. Another transaction T2 then modifies
+// TransactionContext T1 reads a data item. Another transaction T2 then modifies
 // or deletes that data item and commits. If T1 then attempts to reread
 // the data item, it receives a modified value or discovers that the data
 // item has been deleted.

--- a/test/concurrency/decentralized_epoch_manager_test.cpp
+++ b/test/concurrency/decentralized_epoch_manager_test.cpp
@@ -19,7 +19,7 @@ namespace peloton {
 namespace test {
 
 //===--------------------------------------------------------------------===//
-// Transaction Tests
+// TransactionContext Tests
 //===--------------------------------------------------------------------===//
 
 class DecentralizedEpochManagerTests : public PelotonTest {};

--- a/test/concurrency/local_epoch_test.cpp
+++ b/test/concurrency/local_epoch_test.cpp
@@ -18,7 +18,7 @@ namespace peloton {
 namespace test {
 
 //===--------------------------------------------------------------------===//
-// Transaction Tests
+// TransactionContext Tests
 //===--------------------------------------------------------------------===//
 
 class LocalEpochTests : public PelotonTest {};

--- a/test/concurrency/mvcc_test.cpp
+++ b/test/concurrency/mvcc_test.cpp
@@ -20,7 +20,7 @@ namespace peloton {
 namespace test {
 
 //===--------------------------------------------------------------------===//
-// Transaction Tests
+// TransactionContext Tests
 //===--------------------------------------------------------------------===//
 
 class MVCCTests : public PelotonTest {};

--- a/test/concurrency/serializable_transaction_test.cpp
+++ b/test/concurrency/serializable_transaction_test.cpp
@@ -17,7 +17,7 @@ namespace peloton {
 namespace test {
 
 //===--------------------------------------------------------------------===//
-// Serializable Transaction Tests
+// Serializable TransactionContext Tests
 //===--------------------------------------------------------------------===//
 
 class SerializableTransactionTests : public PelotonTest {};

--- a/test/concurrency/testing_transaction_util.cpp
+++ b/test/concurrency/testing_transaction_util.cpp
@@ -229,7 +229,7 @@ TestingTransactionUtil::MakeProjectInfoFromTuple(const storage::Tuple *tuple) {
 }
 
 bool TestingTransactionUtil::ExecuteInsert(
-    concurrency::Transaction *transaction, storage::DataTable *table, int id,
+    concurrency::TransactionContext *transaction, storage::DataTable *table, int id,
     int value) {
   std::unique_ptr<executor::ExecutorContext> context(
       new executor::ExecutorContext(transaction));
@@ -278,7 +278,7 @@ planner::IndexScanPlan::IndexScanDesc MakeIndexDesc(storage::DataTable *table,
       index, key_column_ids, expr_types, values, runtime_keys);
 }
 
-bool TestingTransactionUtil::ExecuteRead(concurrency::Transaction *transaction,
+bool TestingTransactionUtil::ExecuteRead(concurrency::TransactionContext *transaction,
                                          storage::DataTable *table, int id,
                                          int &result, bool select_for_update) {
   std::unique_ptr<executor::ExecutorContext> context(
@@ -311,7 +311,7 @@ bool TestingTransactionUtil::ExecuteRead(concurrency::Transaction *transaction,
   return true;
 }
 bool TestingTransactionUtil::ExecuteDelete(
-    concurrency::Transaction *transaction, storage::DataTable *table, int id,
+    concurrency::TransactionContext *transaction, storage::DataTable *table, int id,
     bool select_for_update) {
   std::unique_ptr<executor::ExecutorContext> context(
       new executor::ExecutorContext(transaction));
@@ -337,7 +337,7 @@ bool TestingTransactionUtil::ExecuteDelete(
   return delete_executor.Execute();
 }
 bool TestingTransactionUtil::ExecuteUpdate(
-    concurrency::Transaction *transaction, storage::DataTable *table, int id,
+    concurrency::TransactionContext *transaction, storage::DataTable *table, int id,
     int value, bool select_for_update) {
   std::unique_ptr<executor::ExecutorContext> context(
       new executor::ExecutorContext(transaction));
@@ -376,7 +376,7 @@ bool TestingTransactionUtil::ExecuteUpdate(
   return update_executor.Execute();
 }
 
-bool TestingTransactionUtil::ExecuteUpdateByValue(concurrency::Transaction *txn,
+bool TestingTransactionUtil::ExecuteUpdateByValue(concurrency::TransactionContext *txn,
                                                   storage::DataTable *table,
                                                   int old_value, int new_value,
                                                   bool select_for_update) {
@@ -424,7 +424,7 @@ bool TestingTransactionUtil::ExecuteUpdateByValue(concurrency::Transaction *txn,
   return update_executor.Execute();
 }
 
-bool TestingTransactionUtil::ExecuteScan(concurrency::Transaction *transaction,
+bool TestingTransactionUtil::ExecuteScan(concurrency::TransactionContext *transaction,
                                          std::vector<int> &results,
                                          storage::DataTable *table, int id,
                                          bool select_for_update) {

--- a/test/concurrency/timestamp_ordering_transaction_manager_test.cpp
+++ b/test/concurrency/timestamp_ordering_transaction_manager_test.cpp
@@ -19,7 +19,7 @@ namespace peloton {
 namespace test {
 
 //===--------------------------------------------------------------------===//
-// Transaction Tests
+// TransactionContext Tests
 //===--------------------------------------------------------------------===//
 
 class TimestampOrderingTransactionManagerTests : public PelotonTest {};

--- a/test/executor/aggregate_test.cpp
+++ b/test/executor/aggregate_test.cpp
@@ -126,16 +126,16 @@ TEST_F(AggregateTests, SortedDistinctTest) {
   type::Value val = (result_tile->GetValue(0, 2));
   type::CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 3));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(2)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(5, 2));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(51)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(5, 3));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(52)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 }
 
 TEST_F(AggregateTests, SortedSumGroupByTest) {
@@ -227,16 +227,16 @@ TEST_F(AggregateTests, SortedSumGroupByTest) {
   type::Value val = (result_tile->GetValue(0, 0));
   type::CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(105)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(1, 0));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(1, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(355)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 }
 
 TEST_F(AggregateTests, SortedSumMaxGroupByTest) {
@@ -333,16 +333,16 @@ TEST_F(AggregateTests, SortedSumMaxGroupByTest) {
   type::Value val = (result_tile->GetValue(0, 0));
   type::CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(105)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 2));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(42)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(1, 0));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 }
 
 TEST_F(AggregateTests, MinMaxTest) {
@@ -454,16 +454,16 @@ TEST_F(AggregateTests, MinMaxTest) {
   type::Value val = (result_tile->GetValue(0, 0));
   type::CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(91)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 2));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(2)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 3));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(92)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 }
 
 TEST_F(AggregateTests, HashDistinctTest) {
@@ -741,15 +741,15 @@ TEST_F(AggregateTests, HashCountDistinctGroupByTest) {
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(0)));
   type::CmpBool cmp1 =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE || cmp1 == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE || cmp1 == type::CmpBool::TRUE);
 
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(5)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 
   val = (result_tile->GetValue(0, 2));
   cmp = (val.CompareLessThanEquals(type::ValueFactory::GetIntegerValue(3)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 }
 
 TEST_F(AggregateTests, PlainSumCountDistinctTest) {
@@ -854,13 +854,13 @@ TEST_F(AggregateTests, PlainSumCountDistinctTest) {
   type::Value val = (result_tile->GetValue(0, 0));
   type::CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(50)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   val = (result_tile->GetValue(0, 2));
   cmp = (val.CompareLessThanEquals(type::ValueFactory::GetIntegerValue(3)));
-  EXPECT_TRUE(cmp == type::CMP_TRUE);
+  EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 }
 
 }  // namespace test

--- a/test/executor/join_test.cpp
+++ b/test/executor/join_test.cpp
@@ -84,7 +84,7 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, JoinType join_type,
 void ExecuteNestedLoopJoinTest(JoinType join_type, bool IndexScan = false);
 
 void PopulateTable(storage::DataTable *table, int num_rows, bool random,
-                   concurrency::Transaction *current_txn);
+                   concurrency::TransactionContext *current_txn);
 
 oid_t CountTuplesWithNullFields(executor::LogicalTile *logical_tile);
 
@@ -224,7 +224,7 @@ TEST_F(JoinTests, BasicNestedLoopTest) {
 }
 
 void PopulateTable(storage::DataTable *table, int num_rows, bool random,
-                   concurrency::Transaction *current_txn) {
+                   concurrency::TransactionContext *current_txn) {
   // Random values
   if (random) std::srand(std::time(nullptr));
 

--- a/test/executor/limit_test.cpp
+++ b/test/executor/limit_test.cpp
@@ -52,7 +52,9 @@ void RunTest(executor::LimitExecutor &executor, size_t expected_num_tiles,
 
   EXPECT_EQ(expected_num_tiles, result_tiles.size());
 
-  if (result_tiles.size() > 0) EXPECT_EQ(expected_first_oid, *(result_tiles[0]->begin()));
+  if (result_tiles.size() > 0) {
+     EXPECT_EQ(expected_first_oid, *(result_tiles[0]->begin()));
+  }
 
   size_t actual_num_tuples_returned = 0;
   for (auto &tile : result_tiles) {

--- a/test/executor/logical_tile_test.cpp
+++ b/test/executor/logical_tile_test.cpp
@@ -18,7 +18,7 @@
 
 #include "catalog/manager.h"
 #include "catalog/schema.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/logical_tile.h"
 

--- a/test/executor/materialization_test.cpp
+++ b/test/executor/materialization_test.cpp
@@ -81,18 +81,18 @@ TEST_F(MaterializationTests, SingleBaseTileTest) {
     type::Value val1 = (result_base_tile->GetValue(i, 1));
     type::CmpBool cmp = (val0.CompareEquals(
       type::ValueFactory::GetIntegerValue(TestingExecutorUtil::PopulatedValue(i, 0))));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
     cmp = val1.CompareEquals(type::ValueFactory::GetIntegerValue(
         TestingExecutorUtil::PopulatedValue(i, 1)));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 
     // Double check that logical tile is functioning.
     type::Value logic_val0 = (result_logical_tile->GetValue(i, 0));
     type::Value logic_val1 = (result_logical_tile->GetValue(i, 1));
     cmp = (logic_val0.CompareEquals(val0));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
     cmp = (logic_val1.CompareEquals(val1));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   }
 }
 
@@ -154,28 +154,28 @@ TEST_F(MaterializationTests, TwoBaseTilesWithReorderTest) {
     // Output column 2.
     type::CmpBool cmp(val2.CompareEquals(
       type::ValueFactory::GetIntegerValue(TestingExecutorUtil::PopulatedValue(i, 0))));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 
     // Output column 1.
     cmp = (val1.CompareEquals(type::ValueFactory::GetIntegerValue(
         TestingExecutorUtil::PopulatedValue(i, 1))));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 
     // Output column 0.
     cmp = (val0.CompareEquals(type::ValueFactory::GetVarcharValue(
         std::to_string(TestingExecutorUtil::PopulatedValue(i, 3)))));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
 
     // Double check that logical tile is functioning.
     type::Value logic_val0 = (result_logical_tile->GetValue(i, 0));
     type::Value logic_val1 = (result_logical_tile->GetValue(i, 1));
     type::Value logic_val2 = (result_logical_tile->GetValue(i, 2));
     cmp = (logic_val0.CompareEquals(val0));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
     cmp = (logic_val1.CompareEquals(val1));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
     cmp = (logic_val2.CompareEquals(val2));
-    EXPECT_TRUE(cmp == type::CMP_TRUE);
+    EXPECT_TRUE(cmp == type::CmpBool::TRUE);
   }
 }
 

--- a/test/executor/seq_scan_test.cpp
+++ b/test/executor/seq_scan_test.cpp
@@ -22,7 +22,7 @@
 #include "type/types.h"
 #include "type/value.h"
 #include "type/value_factory.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/abstract_executor.h"
 #include "executor/executor_context.h"

--- a/test/executor/seq_scan_test.cpp
+++ b/test/executor/seq_scan_test.cpp
@@ -238,7 +238,7 @@ void RunTest(executor::SeqScanExecutor &executor, int expected_num_tiles,
           (type::ValueFactory::GetVarcharValue(std::to_string(val2)));
       type::Value val =
           (result_tiles[i]->GetValue(new_tuple_id, expected_num_cols - 1));
-      EXPECT_TRUE(val.CompareEquals(string_value) == type::CMP_TRUE);
+      EXPECT_TRUE(val.CompareEquals(string_value) == type::CmpBool::TRUE);
     }
     EXPECT_EQ(0, expected_tuples_left.size());
   }

--- a/test/executor/testing_executor_util.cpp
+++ b/test/executor/testing_executor_util.cpp
@@ -21,7 +21,7 @@
 #include "catalog/schema.h"
 #include "common/exception.h"
 #include "common/harness.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/abstract_executor.h"
 #include "executor/logical_tile.h"
@@ -187,7 +187,7 @@ std::shared_ptr<storage::TileGroup> TestingExecutorUtil::CreateTileGroup(
  */
 void TestingExecutorUtil::PopulateTable(storage::DataTable *table, int num_rows,
                                         bool mutate, bool random, bool group_by,
-                                        concurrency::Transaction *current_txn) {
+                                        concurrency::TransactionContext *current_txn) {
   // Random values
   if (random) std::srand(std::time(nullptr));
 

--- a/test/executor/tile_group_layout_test.cpp
+++ b/test/executor/tile_group_layout_test.cpp
@@ -96,9 +96,10 @@ void ExecuteTileGroupTest(UNUSED_ATTRIBUTE peloton::LayoutType layout_type) {
 
   bool own_schema = true;
   bool adapt_table = true;
+  bool is_catalog = false;
   std::unique_ptr<storage::DataTable> table(storage::TableFactory::GetDataTable(
       INVALID_OID, INVALID_OID, table_schema, table_name,
-      tuples_per_tilegroup_count, own_schema, adapt_table));
+      tuples_per_tilegroup_count, own_schema, adapt_table, is_catalog, layout_type));
 
   // PRIMARY INDEX
   if (indexes == true) {

--- a/test/executor/tile_group_layout_test.cpp
+++ b/test/executor/tile_group_layout_test.cpp
@@ -37,7 +37,7 @@
 #include "storage/tile.h"
 #include "storage/tile_group.h"
 #include "storage/data_table.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/abstract_executor.h"
 #include "executor/seq_scan_executor.h"

--- a/test/executor/tile_group_layout_test.cpp
+++ b/test/executor/tile_group_layout_test.cpp
@@ -60,7 +60,16 @@ namespace test {
 
 class TileGroupLayoutTests : public PelotonTest {};
 
-void ExecuteTileGroupTest(peloton::LayoutType layout_type) {
+// FIXME: PAVLO: 2017-12-21
+// I was going to through and changing LayoutType to be 
+// an 'enum class' instead of just an 'enum'. When I did that,
+// the invocation to TableFactory::GetDataTable() broke because
+// now it didn't like the LayoutType parameter. I looked into it
+// and found that the TableFactory doesn't even take in a LayoutType
+// parameter at all. It was only working because the LayoutType
+// was getting cast to a bool. So as it stands now, this test case
+// does *not* check whether we can have different layouts in a TileGroup. 
+void ExecuteTileGroupTest(UNUSED_ATTRIBUTE peloton::LayoutType layout_type) {
   const int tuples_per_tilegroup_count = 10;
   const int tile_group_count = 5;
   const int tuple_count = tuples_per_tilegroup_count * tile_group_count;
@@ -89,7 +98,7 @@ void ExecuteTileGroupTest(peloton::LayoutType layout_type) {
   bool adapt_table = true;
   std::unique_ptr<storage::DataTable> table(storage::TableFactory::GetDataTable(
       INVALID_OID, INVALID_OID, table_schema, table_name,
-      tuples_per_tilegroup_count, own_schema, adapt_table, layout_type));
+      tuples_per_tilegroup_count, own_schema, adapt_table));
 
   // PRIMARY INDEX
   if (indexes == true) {
@@ -209,11 +218,11 @@ void ExecuteTileGroupTest(peloton::LayoutType layout_type) {
 }
 
 TEST_F(TileGroupLayoutTests, RowLayout) {
-  ExecuteTileGroupTest(LAYOUT_TYPE_ROW);
+  ExecuteTileGroupTest(LayoutType::ROW);
 }
 
 TEST_F(TileGroupLayoutTests, ColumnLayout) {
-  ExecuteTileGroupTest(LAYOUT_TYPE_COLUMN);
+  ExecuteTileGroupTest(LayoutType::COLUMN);
 }
 
 }  // namespace test

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -20,7 +20,7 @@
 #include "catalog/schema.h"
 #include "common/logger.h"
 #include "common/statement.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/abstract_executor.h"
 #include "executor/create_executor.h"

--- a/test/expression/expression_test.cpp
+++ b/test/expression/expression_test.cpp
@@ -213,7 +213,7 @@ TEST_F(ExpressionTests, ExtractDateTests) {
   //    type::Value expected = type::ValueFactory::GetDecimalValue(x.second);
   //    type::Value result = extract_expr->Evaluate(nullptr, nullptr, nullptr);
   //    EXPECT_FALSE(result.IsNull());
-  //    EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  //    EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
   //  }
 }
 
@@ -264,14 +264,14 @@ TEST_F(ExpressionTests, SimpleCase) {
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   type::Value result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   type::Value expected = type::ValueFactory::GetIntegerValue(2);
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 
   // Test with A = 2, should get 3
   tuple->SetValue(0, type::ValueFactory::GetIntegerValue(2), nullptr);
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   expected = type::ValueFactory::GetIntegerValue(3);
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 }
 
 TEST_F(ExpressionTests, SimpleCaseCopyTest) {
@@ -323,14 +323,14 @@ TEST_F(ExpressionTests, SimpleCaseCopyTest) {
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   type::Value result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   type::Value expected = type::ValueFactory::GetIntegerValue(2);
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 
   // Test with A = 2, should get 3
   tuple->SetValue(0, type::ValueFactory::GetIntegerValue(2), nullptr);
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   expected = type::ValueFactory::GetIntegerValue(3);
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 }
 
 TEST_F(ExpressionTests, SimpleCaseWithDefault) {
@@ -377,14 +377,14 @@ TEST_F(ExpressionTests, SimpleCaseWithDefault) {
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   type::Value result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   type::Value expected = type::ValueFactory::GetIntegerValue(2);
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 
   // Test with A = 2, should get 3
   tuple->SetValue(0, type::ValueFactory::GetIntegerValue(2), nullptr);
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   expected = type::ValueFactory::GetIntegerValue(3);
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 }
 
 }  // namespace test

--- a/test/function/date_functions_test.cpp
+++ b/test/function/date_functions_test.cpp
@@ -55,7 +55,7 @@ void ExtractTestHelper(DatePartType part, std::string &date,
   // Then check that it equals our expected value
   LOG_TRACE("COMPARE: %s = %s\n", expected.ToString().c_str(),
             result.ToString().c_str());
-  EXPECT_EQ(type::CmpBool::CMP_TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(type::CmpBool::TRUE, expected.CompareEquals(result));
 }
 
 // Invoke DateFunctions::Extract(NULL)

--- a/test/gc/transaction_level_gc_manager_test.cpp
+++ b/test/gc/transaction_level_gc_manager_test.cpp
@@ -27,7 +27,7 @@ namespace peloton {
 namespace test {
 
 //===--------------------------------------------------------------------===//
-// Transaction-Level GC Manager Tests
+// TransactionContext-Level GC Manager Tests
 //===--------------------------------------------------------------------===//
 
 class TransactionLevelGCManagerTests : public PelotonTest {};

--- a/test/include/catalog/testing_constraints_util.h
+++ b/test/include/catalog/testing_constraints_util.h
@@ -28,7 +28,7 @@
 #include "type/value.h"
 #include "type/value_factory.h"
 #include "common/exception.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/abstract_executor.h"
 #include "executor/logical_tile.h"
@@ -226,7 +226,7 @@ class TestingConstraintsUtil {
   };
 
   /** @brief Insert a tuple with 1 columns' value specified */
-  static bool ExecuteOneInsert(concurrency::Transaction *transaction,
+  static bool ExecuteOneInsert(concurrency::TransactionContext *transaction,
                                storage::DataTable *table,
                                const type::Value &col1) {
     std::unique_ptr<executor::ExecutorContext> context(
@@ -247,7 +247,7 @@ class TestingConstraintsUtil {
   };
 
   /** @brief Delete all tuples from a table */
-//  static bool ExecuteTruncate(concurrency::Transaction *transaction,
+//  static bool ExecuteTruncate(concurrency::TransactionContext *transaction,
 //                              storage::DataTable *table) {
 //    std::unique_ptr<executor::ExecutorContext> context(
 //        new executor::ExecutorContext(transaction));
@@ -258,7 +258,7 @@ class TestingConstraintsUtil {
 //  };
 
   /** @brief Insert a tuple with 1 columns' value specified */
-  static bool ExecuteMultiInsert(concurrency::Transaction *transaction,
+  static bool ExecuteMultiInsert(concurrency::TransactionContext *transaction,
                                  storage::DataTable *table,
                                  std::vector<type::Value> cols) {
     std::unique_ptr<executor::ExecutorContext> context(
@@ -281,7 +281,7 @@ class TestingConstraintsUtil {
   };
 
   /** @brief Insert a tuple with 4 columns' value specified */
-  static bool ExecuteInsert(concurrency::Transaction *transaction,
+  static bool ExecuteInsert(concurrency::TransactionContext *transaction,
                             storage::DataTable *table, const type::Value &col1,
                             const type::Value &col2, const type::Value &col3,
                             const type::Value &col4) {
@@ -307,7 +307,7 @@ class TestingConstraintsUtil {
   };
 
   /** @brief Insert a tuple with 3 columns' value specified */
-  static bool ExecuteInsert(concurrency::Transaction *transaction,
+  static bool ExecuteInsert(concurrency::TransactionContext *transaction,
                             storage::DataTable *table, const type::Value &col1,
                             const type::Value &col2, const type::Value &col3) {
     std::unique_ptr<executor::ExecutorContext> context(
@@ -332,7 +332,7 @@ class TestingConstraintsUtil {
 
 
 
-  static void PopulateTable(concurrency::Transaction *transaction,
+  static void PopulateTable(concurrency::TransactionContext *transaction,
                             storage::DataTable *table, int num_rows) {
     // Ensure that the tile group is as expected.
     UNUSED_ATTRIBUTE const catalog::Schema *schema = table->GetSchema();

--- a/test/include/codegen/testing_codegen_util.h
+++ b/test/include/codegen/testing_codegen_util.h
@@ -63,7 +63,7 @@ class PelotonCodeGenTest : public PelotonTest {
 
   // Create the test tables
   void CreateTestTables(
-      concurrency::Transaction *txn,
+      concurrency::TransactionContext *txn,
       oid_t tuples_per_tilegroup = DEFAULT_TUPLES_PER_TILEGROUP);
 
   // Load the given table with the given number of rows

--- a/test/include/concurrency/testing_transaction_util.h
+++ b/test/include/concurrency/testing_transaction_util.h
@@ -57,7 +57,7 @@
 
 #include "catalog/schema.h"
 #include "common/harness.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "expression/comparison_expression.h"
@@ -131,22 +131,22 @@ class TestingTransactionUtil {
   // Create the same table with combined primary key constraints on (id, value)
   static storage::DataTable *CreateCombinedPrimaryKeyTable();
 
-  static bool ExecuteInsert(concurrency::Transaction *txn,
+  static bool ExecuteInsert(concurrency::TransactionContext *txn,
                             storage::DataTable *table, int id, int value);
-  static bool ExecuteRead(concurrency::Transaction *txn,
+  static bool ExecuteRead(concurrency::TransactionContext *txn,
                           storage::DataTable *table, int id, int &result,
                           bool select_for_update = false);
-  static bool ExecuteDelete(concurrency::Transaction *txn,
+  static bool ExecuteDelete(concurrency::TransactionContext *txn,
                             storage::DataTable *table, int id,
                             bool select_for_update = false);
-  static bool ExecuteUpdate(concurrency::Transaction *txn,
+  static bool ExecuteUpdate(concurrency::TransactionContext *txn,
                             storage::DataTable *table, int id, int value,
                             bool select_for_update = false);
-  static bool ExecuteUpdateByValue(concurrency::Transaction *txn,
+  static bool ExecuteUpdateByValue(concurrency::TransactionContext *txn,
                                    storage::DataTable *table, int old_value,
                                    int new_value,
                                    bool select_for_update = false);
-  static bool ExecuteScan(concurrency::Transaction *txn,
+  static bool ExecuteScan(concurrency::TransactionContext *txn,
                           std::vector<int> &results, storage::DataTable *table,
                           int id, bool select_for_update = false);
 
@@ -340,7 +340,7 @@ class TransactionThread {
   storage::DataTable *table;
   int cur_seq;
   bool go;
-  concurrency::Transaction *txn;
+  concurrency::TransactionContext *txn;
 };
 
 // Transaction scheduler, to make life easier for writing txn test

--- a/test/include/executor/testing_executor_util.h
+++ b/test/include/executor/testing_executor_util.h
@@ -29,7 +29,7 @@ class Manager;
 }
 
 namespace concurrency {
-class Transaction;
+class TransactionContext;
 }
 
 namespace executor {
@@ -80,7 +80,7 @@ class TestingExecutorUtil {
 
   static void PopulateTable(storage::DataTable *table, int num_rows,
                             bool mutate, bool random, bool group_by,
-                            concurrency::Transaction *current_txn);
+                            concurrency::TransactionContext *current_txn);
 
   static void PopulateTiles(std::shared_ptr<storage::TileGroup> tile_group,
                             int num_rows);

--- a/test/include/sql/testing_sql_util.h
+++ b/test/include/sql/testing_sql_util.h
@@ -63,7 +63,7 @@ class TestingSQLUtil {
   // Generate the plan tree for a SQL query with the specific optimizer
   static std::shared_ptr<planner::AbstractPlan> GeneratePlanWithOptimizer(
       std::unique_ptr<optimizer::AbstractOptimizer> &optimizer,
-      const std::string query, concurrency::Transaction *txn);
+      const std::string query, concurrency::TransactionContext *txn);
 
   // A simpler wrapper around ExecuteSQLQuery
   static ResultType ExecuteSQLQuery(const std::string query,

--- a/test/include/statistics/testing_stats_util.h
+++ b/test/include/statistics/testing_stats_util.h
@@ -21,7 +21,7 @@
 #include "catalog/column.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "concurrency/transaction_manager.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "storage/tile_group_factory.h"
 #include "storage/table_factory.h"
 #include "storage/tuple.h"

--- a/test/index/hybrid_index_test.cpp
+++ b/test/index/hybrid_index_test.cpp
@@ -26,7 +26,7 @@
 #include "catalog/manager.h"
 #include "catalog/schema.h"
 #include "common/timer.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/abstract_executor.h"
 #include "executor/executor_context.h"

--- a/test/logging/logging_test.cpp
+++ b/test/logging/logging_test.cpp
@@ -361,7 +361,7 @@
 //   log_manager.WaitForModeTransition(LoggingStatusType::LOGGING, true);
 //   EXPECT_TRUE(log_manager.ContainsFrontendLogger());
 //   log_manager.SetGlobalMaxFlushedCommitId(4);
-//   concurrency::Transaction test_txn;
+//   concurrency::TransactionContext test_txn;
 //   cid_t commit_id = 5;
 //   log_manager.PrepareLogging();
 //   log_manager.LogBeginTransaction(commit_id);

--- a/test/logging/recovery_test.cpp
+++ b/test/logging/recovery_test.cpp
@@ -311,16 +311,16 @@
 
 //   type::Value rval0 = (recovery_table->GetTileGroupById(100)->GetValue(5, 0));
 //   type::CmpBool cmp0 = (val0.CompareEquals(rval0));
-//   EXPECT_TRUE(cmp0 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp0 == type::CmpBool::TRUE);
 //   type::Value rval1 = (recovery_table->GetTileGroupById(100)->GetValue(5, 1));
 //   type::CmpBool cmp1 = (val1.CompareEquals(rval1));
-//   EXPECT_TRUE(cmp1 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp1 == type::CmpBool::TRUE);
 //   type::Value rval2 = (recovery_table->GetTileGroupById(100)->GetValue(5, 2));
 //   type::CmpBool cmp2 = (val2.CompareEquals(rval2));
-//   EXPECT_TRUE(cmp2 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp2 == type::CmpBool::TRUE);
 //   type::Value rval3 = (recovery_table->GetTileGroupById(100)->GetValue(5, 3));
 //   type::CmpBool cmp3 = (val3.CompareEquals(rval3));
-//   EXPECT_TRUE(cmp3 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp3 == type::CmpBool::TRUE);
 
 //   EXPECT_EQ(recovery_table->GetTupleCount(), 1);
 //   EXPECT_EQ(recovery_table->GetTileGroupCount(), 2);
@@ -365,16 +365,16 @@
 
 //   type::Value rval0 = (recovery_table->GetTileGroupById(100)->GetValue(5, 0));
 //   type::CmpBool cmp0 = (val0.CompareEquals(rval0));
-//   EXPECT_TRUE(cmp0 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp0 == type::CmpBool::TRUE);
 //   type::Value rval1 = (recovery_table->GetTileGroupById(100)->GetValue(5, 1));
 //   type::CmpBool cmp1 = (val1.CompareEquals(rval1));
-//   EXPECT_TRUE(cmp1 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp1 == type::CmpBool::TRUE);
 //   type::Value rval2 = (recovery_table->GetTileGroupById(100)->GetValue(5, 2));
 //   type::CmpBool cmp2 = (val2.CompareEquals(rval2));
-//   EXPECT_TRUE(cmp2 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp2 == type::CmpBool::TRUE);
 //   type::Value rval3 = (recovery_table->GetTileGroupById(100)->GetValue(5, 3));
 //   type::CmpBool cmp3 = (val3.CompareEquals(rval3));
-//   EXPECT_TRUE(cmp3 == type::CMP_TRUE);
+//   EXPECT_TRUE(cmp3 == type::CmpBool::TRUE);
 
 //   EXPECT_EQ(recovery_table->GetTupleCount(), 0);
 //   EXPECT_EQ(recovery_table->GetTileGroupCount(), 2);

--- a/test/optimizer/cost_test.cpp
+++ b/test/optimizer/cost_test.cpp
@@ -55,7 +55,7 @@ void CreateAndLoadTable() {
 }
 
 std::shared_ptr<TableStats> GetTableStatsWithName(
-    std::string table_name, concurrency::Transaction *txn) {
+    std::string table_name, concurrency::TransactionContext *txn) {
   auto catalog = catalog::Catalog::GetInstance();
   auto database = catalog->GetDatabaseWithName(DEFAULT_DB_NAME, txn);
   auto table = catalog->GetTableWithName(DEFAULT_DB_NAME, table_name, txn);

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -389,7 +389,7 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   EXPECT_EQ(update_stmt->updates.at(0)->column, "s_quantity");
   auto constant =
       (expression::ConstantValueExpression *)update_stmt->updates.at(0)->value.get();
-  EXPECT_TRUE(constant->GetValue().CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, constant->GetValue().CompareEquals(
       type::ValueFactory::GetDecimalValue(48)));
 
   // Test Second Set Condition
@@ -399,7 +399,7 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   auto child1 = (expression::TupleValueExpression *)op_expr->GetChild(0);
   EXPECT_EQ(child1->GetColumnName(), "s_ytd");
   auto child2 = (expression::ConstantValueExpression *)op_expr->GetChild(1);
-  EXPECT_TRUE(
+  EXPECT_EQ(type::CmpBool::TRUE, 
       child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
 
   // Test Where clause
@@ -410,14 +410,14 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   auto column = (expression::TupleValueExpression *)cond1->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_i_id");
   constant = (expression::ConstantValueExpression *)cond1->GetChild(1);
-  EXPECT_TRUE(constant->GetValue().CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, constant->GetValue().CompareEquals(
       type::ValueFactory::GetIntegerValue(68999)));
   auto cond2 = (expression::OperatorExpression *)where->GetChild(1);
   EXPECT_EQ(cond2->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
   column = (expression::TupleValueExpression *)cond2->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_w_id");
   constant = (expression::ConstantValueExpression *)cond2->GetChild(1);
-  EXPECT_TRUE(constant->GetValue().CompareEquals(
+  EXPECT_EQ(type::CmpBool::TRUE, constant->GetValue().CompareEquals(
       type::ValueFactory::GetIntegerValue(4)));
 }
 
@@ -582,7 +582,7 @@ TEST_F(PostgresParserTests, InsertTest) {
     type::CmpBool res = five.CompareEquals(
         ((expression::ConstantValueExpression *)
              insert_stmt->insert_values.at(1).at(1).get())->GetValue());
-    EXPECT_EQ(1, res);
+    EXPECT_EQ(type::CmpBool::TRUE, res);
 
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
@@ -759,8 +759,10 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_TRUE(child1 != nullptr);
   auto child2 = (expression::ConstantValueExpression*)default_expr->GetChild(1);
   EXPECT_TRUE(child2 != nullptr);
-  EXPECT_TRUE(child1->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_TRUE(child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            child1->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
 
   // Check Second column
   column = create_stmt->columns.at(1).get();
@@ -800,10 +802,12 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   EXPECT_EQ("d", plus_child1->GetColumnName());
   auto plus_child2 = (expression::ConstantValueExpression*)check_child1->GetChild(1);
   EXPECT_TRUE(plus_child2 != nullptr);
-  EXPECT_TRUE(plus_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            plus_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
   auto check_child2 = (expression::ConstantValueExpression*)column->check_expression->GetChild(1);
   EXPECT_TRUE(check_child2 != nullptr);
-  EXPECT_TRUE(check_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(0)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            check_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(0)));
 
   // Check Fifth column
   column = create_stmt->columns.at(4).get();
@@ -975,7 +979,8 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ(2, fun_expr->GetChildrenSize());
   auto const_expr = (expression::ConstantValueExpression*) fun_expr->GetChild(0);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_TRUE(const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
   auto tv_expr = (expression::TupleValueExpression*) fun_expr->GetChild(1);
   EXPECT_TRUE(tv_expr != nullptr);
   EXPECT_EQ("a", tv_expr->GetColumnName());
@@ -987,7 +992,8 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ(1, fun_expr->GetChildrenSize());
   const_expr = (expression::ConstantValueExpression*) fun_expr->GetChild(0);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_TRUE(const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(99)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(99)));
 
   // Check FUN(b) > 2
   auto op_expr = (expression::OperatorExpression*)select_stmt->where_clause.get();
@@ -1001,7 +1007,8 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ("b", tv_expr->GetColumnName());
   const_expr = (expression::ConstantValueExpression*) op_expr->GetChild(1);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_TRUE(const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
+  EXPECT_EQ(type::CmpBool::TRUE, 
+            const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
 }
 
 TEST_F(PostgresParserTests, CaseTest) {

--- a/test/planner/planner_equality_test.cpp
+++ b/test/planner/planner_equality_test.cpp
@@ -63,7 +63,7 @@ class PlannerEqualityTest : public PelotonTest {
 
   std::shared_ptr<planner::AbstractPlan> GeneratePlanWithOptimizer(
       std::unique_ptr<optimizer::AbstractOptimizer> &optimizer,
-      const std::string query, concurrency::Transaction *txn) {
+      const std::string query, concurrency::TransactionContext *txn) {
     auto &peloton_parser = parser::PostgresParser::GetInstance();
   
     auto parsed_stmt = peloton_parser.BuildParseTree(query);

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -133,7 +133,7 @@ ResultType TestingSQLUtil::ExecuteSQLQueryWithOptimizer(
 std::shared_ptr<planner::AbstractPlan>
 TestingSQLUtil::GeneratePlanWithOptimizer(
     std::unique_ptr<optimizer::AbstractOptimizer> &optimizer,
-    const std::string query, concurrency::Transaction *txn) {
+    const std::string query, concurrency::TransactionContext *txn) {
   auto &peloton_parser = parser::PostgresParser::GetInstance();
 
   auto parsed_stmt = peloton_parser.BuildParseTree(query);

--- a/test/storage/masked_tuple_test.cpp
+++ b/test/storage/masked_tuple_test.cpp
@@ -41,7 +41,7 @@ void MaskedTupleTestHelper(storage::MaskedTuple *masked_tuple,
         v.CompareEquals(type::ValueFactory::GetIntegerValue(expected));
     LOG_TRACE("mask[%d]->%d ==> (Expected=%d / Result=%s)", i, mask[i],
               expected, v.GetInfo().c_str());
-    EXPECT_EQ(type::CmpBool::CMP_TRUE, result);
+    EXPECT_EQ(type::CmpBool::TRUE, result);
   }
 }
 
@@ -80,7 +80,7 @@ TEST_F(MaskedTupleTests, BasicTest) {
     int expected = values[i];
     auto result =
         v.CompareEquals(type::ValueFactory::GetIntegerValue(expected));
-    EXPECT_EQ(type::CmpBool::CMP_TRUE, result);
+    EXPECT_EQ(type::CmpBool::TRUE, result);
   }
 
   // CREATE MASKED TUPLE

--- a/test/storage/temp_table_test.cpp
+++ b/test/storage/temp_table_test.cpp
@@ -90,7 +90,7 @@ TEST_F(TempTableTests, InsertTest) {
         // I have to do this because we can't put type::Value into a std::set
         bool found = false;
         for (auto val : values) {
-          found = val.CompareEquals(tupleVal) == type::CMP_TRUE;
+          found = val.CompareEquals(tupleVal) == type::CmpBool::TRUE;
           if (found) break;
         }  // FOR
         EXPECT_TRUE(found);

--- a/test/storage/tile_group_test.cpp
+++ b/test/storage/tile_group_test.cpp
@@ -14,7 +14,7 @@
 #include "common/harness.h"
 
 #include "type/value_factory.h"
-#include "concurrency/transaction.h"
+#include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "storage/tile_group.h"
 #include "storage/tile_group_factory.h"

--- a/test/type/array_value_test.cpp
+++ b/test/type/array_value_test.cpp
@@ -274,49 +274,49 @@ TEST_F(ArrayValueTests, InListTest) {
 void CheckEqual(type::Value v1, type::Value v2) {
   type::CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE(result[0] == type::CMP_TRUE);
+  EXPECT_TRUE(result[0] == type::CmpBool::TRUE);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE(result[1] == type::CMP_FALSE);
+  EXPECT_TRUE(result[1] == type::CmpBool::FALSE);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE(result[2] == type::CMP_FALSE);
+  EXPECT_TRUE(result[2] == type::CmpBool::FALSE);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE(result[3] == type::CMP_TRUE);
+  EXPECT_TRUE(result[3] == type::CmpBool::TRUE);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE(result[4] == type::CMP_FALSE);
+  EXPECT_TRUE(result[4] == type::CmpBool::FALSE);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE(result[5] == type::CMP_TRUE);
+  EXPECT_TRUE(result[5] == type::CmpBool::TRUE);
 }
 
 void CheckLessThan(type::Value v1, type::Value v2) {
   type::CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE(result[0] == type::CMP_FALSE);
+  EXPECT_TRUE(result[0] == type::CmpBool::FALSE);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE(result[1] == type::CMP_TRUE);
+  EXPECT_TRUE(result[1] == type::CmpBool::TRUE);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE(result[2] == type::CMP_TRUE);
+  EXPECT_TRUE(result[2] == type::CmpBool::TRUE);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE(result[3] == type::CMP_TRUE);
+  EXPECT_TRUE(result[3] == type::CmpBool::TRUE);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE(result[4] == type::CMP_FALSE);
+  EXPECT_TRUE(result[4] == type::CmpBool::FALSE);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE(result[5] == type::CMP_FALSE);
+  EXPECT_TRUE(result[5] == type::CmpBool::FALSE);
 }
 
 void CheckGreaterThan(type::Value v1, type::Value v2) {
   type::CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE(result[0] == type::CMP_FALSE);
+  EXPECT_TRUE(result[0] == type::CmpBool::FALSE);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE(result[1] == type::CMP_TRUE);
+  EXPECT_TRUE(result[1] == type::CmpBool::TRUE);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE(result[2] == type::CMP_FALSE);
+  EXPECT_TRUE(result[2] == type::CmpBool::FALSE);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE(result[3] == type::CMP_FALSE);
+  EXPECT_TRUE(result[3] == type::CmpBool::FALSE);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE(result[4] == type::CMP_TRUE);
+  EXPECT_TRUE(result[4] == type::CmpBool::TRUE);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE(result[5] == type::CMP_TRUE);
+  EXPECT_TRUE(result[5] == type::CmpBool::TRUE);
 }
 
 TEST_F(ArrayValueTests, CompareTest) {
@@ -340,7 +340,7 @@ TEST_F(ArrayValueTests, CompareTest) {
   type::Value v = type::ValueFactory::GetVarcharValue("");
 
   // Test null varchar
-  EXPECT_TRUE(v.CompareEquals(type::ValueFactory::GetVarcharValue(nullptr, 0)) == type::CMP_NULL);
+  EXPECT_TRUE(v.CompareEquals(type::ValueFactory::GetVarcharValue(nullptr, 0)) == type::CmpBool::NULL_);
 }
 }
 }

--- a/test/type/boolean_value_test.cpp
+++ b/test/type/boolean_value_test.cpp
@@ -115,9 +115,9 @@ TEST_F(BooleanValueTests, ComparisonTest) {
 
         if (expected_null) expected = false;
 
-        EXPECT_EQ(expected, result == type::CMP_TRUE);
-        EXPECT_EQ(!expected, result == type::CMP_FALSE);
-        EXPECT_EQ(expected_null, result == type::CMP_NULL);
+        EXPECT_EQ(expected, result == type::CmpBool::TRUE);
+        EXPECT_EQ(!expected, result == type::CmpBool::FALSE);
+        EXPECT_EQ(expected_null, result == type::CmpBool::NULL_);
       }
     }
   }
@@ -167,7 +167,7 @@ TEST_F(BooleanValueTests, HashTest) {
       auto hash0 = val0.Hash();
       auto hash1 = val1.Hash();
 
-      if (result == type::CMP_TRUE) {
+      if (result == type::CmpBool::TRUE) {
         EXPECT_EQ(hash0, hash1);
       } else {
         EXPECT_NE(hash0, hash1);

--- a/test/type/date_value_test.cpp
+++ b/test/type/date_value_test.cpp
@@ -100,10 +100,10 @@ TEST_F(DateValueTests, ComparisonTest) {
                   val1.ToString().c_str(), expected, result);
 
         if (expected_null) {
-          EXPECT_EQ(expected_null, result == type::CMP_NULL);
+          EXPECT_EQ(expected_null, result == type::CmpBool::NULL_);
         } else {
-          EXPECT_EQ(expected, result == type::CMP_TRUE);
-          EXPECT_EQ(!expected, result == type::CMP_FALSE);
+          EXPECT_EQ(expected, result == type::CmpBool::TRUE);
+          EXPECT_EQ(!expected, result == type::CmpBool::FALSE);
         }
       }
     }
@@ -155,7 +155,7 @@ TEST_F(DateValueTests, CopyTest) {
   type::Value val0 =
       type::ValueFactory::GetDateValue(static_cast<int32_t>(1000000));
   type::Value val1 = val0.Copy();
-  EXPECT_TRUE(val0.CompareEquals(val1) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, val0.CompareEquals(val1));
 }
 
 TEST_F(DateValueTests, CastTest) {
@@ -166,12 +166,12 @@ TEST_F(DateValueTests, CastTest) {
 
   result = val_null.CastAs(type::TypeId::DATE);
   EXPECT_TRUE(result.IsNull());
-  EXPECT_TRUE(result.CompareEquals(val_null) == type::CMP_NULL);
+  EXPECT_EQ(type::CmpBool::NULL_, result.CompareEquals(val_null));
   EXPECT_EQ(result.GetTypeId(), val_null.GetTypeId());
 
   result = val_null.CastAs(type::TypeId::VARCHAR);
   EXPECT_TRUE(result.IsNull());
-  EXPECT_TRUE(result.CompareEquals(str_null) == type::CMP_NULL);
+  EXPECT_EQ(type::CmpBool::NULL_, result.CompareEquals(str_null));
   EXPECT_EQ(result.GetTypeId(), str_null.GetTypeId());
 
   EXPECT_THROW(val_null.CastAs(type::TypeId::BOOLEAN), peloton::Exception);

--- a/test/type/numeric_value_test.cpp
+++ b/test/type/numeric_value_test.cpp
@@ -56,49 +56,49 @@ int64_t RANDOM64() {
 void CheckEqual(type::Value &v1, type::Value &v2) {
   type::CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE((result[0]) );
+  EXPECT_EQ(type::CmpBool::TRUE, result[0]);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE((result[1]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[1]);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE((result[2]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[2]);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE((result[3]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[3]);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE((result[4]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[4]);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE((result[5]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[5]);
 }
 
 void CheckLessThan(type::Value &v1, type::Value &v2) {
   type::CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE((result[0]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[0]);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE((result[1]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[1]);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE((result[2]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[2]);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE((result[3]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[3]);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE((result[4]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[4]);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE((result[5]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[5]);
 }
 
 void CheckGreaterThan(type::Value &v1, type::Value &v2) {
   type::CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE((result[0]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[0]);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE((result[1]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[1]);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE((result[2]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[2]);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE((result[3]) == type::CMP_FALSE);
+  EXPECT_EQ(type::CmpBool::FALSE, result[3]);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE((result[4]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[4]);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE((result[5]) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, result[5]);
 }
 
 // Compare two integers
@@ -664,7 +664,7 @@ TEST_F(NumericValueTests, NullValueTest) {
   bool_result[4] = type::ValueFactory::GetIntegerValue(rand()).CompareEquals(
     type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL));
   for (int i = 0; i < 5; i++) {
-    EXPECT_TRUE(bool_result[i] == type::CMP_NULL);
+    EXPECT_TRUE(bool_result[i] == type::CmpBool::NULL_);
   }
 
   bool_result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL).CompareEquals(
@@ -678,7 +678,7 @@ TEST_F(NumericValueTests, NullValueTest) {
   bool_result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL).CompareEquals(
     type::ValueFactory::GetIntegerValue(rand()));
   for (int i = 0; i < 5; i++) {
-    EXPECT_TRUE(bool_result[i] == type::CMP_NULL);
+    EXPECT_TRUE(bool_result[i] == type::CmpBool::NULL_);
   }
 
   type::Value result[5];

--- a/test/type/numeric_value_test.cpp
+++ b/test/type/numeric_value_test.cpp
@@ -185,13 +185,15 @@ void CheckMath1(T1 x, T2 y, type::TypeId xtype, type::TypeId ytype) {
     EXPECT_THROW(type::Value(xtype, x).Add(type::Value(ytype, y)),
       peloton::Exception);
   else if (sizeof(x) >= sizeof(y)) {
-    if ((x > 0 && y > 0 && sum1 < 0) || (x < 0 && y < 0 && sum1 > 0))
+    if ((x > 0 && y > 0 && sum1 < 0) || (x < 0 && y < 0 && sum1 > 0)) {
       EXPECT_THROW(type::Value(xtype, x).Add(type::Value(ytype, y)),
         peloton::Exception);
+    }
   }
-  else if ((x > 0 && y > 0 && sum2 < 0) || (x < 0 && y < 0 && sum2 > 0))
+  else if ((x > 0 && y > 0 && sum2 < 0) || (x < 0 && y < 0 && sum2 > 0)) {
     EXPECT_THROW(type::Value(xtype, x).Add(type::Value(ytype, y)),
       peloton::Exception);
+  }
   else {
     v1 = type::Value(xtype, x).Add(type::Value(ytype, y));
     CheckEqual(v1, v2);
@@ -201,17 +203,20 @@ void CheckMath1(T1 x, T2 y, type::TypeId xtype, type::TypeId ytype) {
   T1 diff1 = (T1)(x - y);
   T2 diff2 = (T2)(x - y);
   // Out of range detection
-  if ((x - y) != diff1 && (x - y) != diff2)
+  if ((x - y) != diff1 && (x - y) != diff2) {
     EXPECT_THROW(type::Value(xtype, x).Subtract(type::Value(ytype, y)),
       peloton::Exception);
+  }
   else if (sizeof(x) >= sizeof(y)) {
-    if ((x > 0 && y < 0 && diff1 < 0) || (x < 0 && y > 0 && diff1 > 0))
+    if ((x > 0 && y < 0 && diff1 < 0) || (x < 0 && y > 0 && diff1 > 0)) {
       EXPECT_THROW(type::Value(xtype, x).Subtract(type::Value(ytype, y)),
         peloton::Exception);
+    }
   }
-  else if ((x > 0 && y < 0 && diff2 < 0) || (x < 0 && y > 0 && diff2 > 0))
+  else if ((x > 0 && y < 0 && diff2 < 0) || (x < 0 && y > 0 && diff2 > 0)) {
     EXPECT_THROW(type::Value(xtype, x).Subtract(type::Value(ytype, y)),
       peloton::Exception);
+  }
   else {
     v1 = type::Value(xtype, x).Subtract(type::Value(ytype, y));
     CheckEqual(v1, v2);
@@ -222,17 +227,20 @@ void CheckMath1(T1 x, T2 y, type::TypeId xtype, type::TypeId ytype) {
   T1 prod1 = (T1)(x * y);
   T2 prod2 = (T2)(x * y);
   // Out of range detection
-  if ((x * y) != prod1 && (x * y) != prod2)
+  if ((x * y) != prod1 && (x * y) != prod2) {
     EXPECT_THROW(type::Value(xtype, x).Multiply(type::Value(ytype, y)),
       peloton::Exception);
+  }
   else if (sizeof(x) >= sizeof(y)) {
-    if (y != 0 && prod1 / y != x)
+    if (y != 0 && prod1 / y != x) {
       EXPECT_THROW(type::Value(xtype, x).Multiply(type::Value(ytype, y)),
         peloton::Exception);
+    }
   }
-  else if (y != 0 && prod2 / y != x)
+  else if (y != 0 && prod2 / y != x) {
     EXPECT_THROW(type::Value(xtype, x).Multiply(type::Value(ytype, y)),
       peloton::Exception);
+  }
   else {
     v1 = type::Value(xtype, x).Multiply(type::Value(ytype, y));
     CheckEqual(v1, v2);
@@ -240,9 +248,10 @@ void CheckMath1(T1 x, T2 y, type::TypeId xtype, type::TypeId ytype) {
 
   // Test x / y
   // Divide by zero detection
-  if (y == 0)
+  if (y == 0) {
     EXPECT_THROW(type::Value(xtype, x).Divide(type::Value(ytype, y)),
       peloton::Exception);
+  }
   else {
     v1 = type::Value(xtype, x).Divide(type::Value(ytype, y));
     v2 = type::Value(maxtype, x / y);
@@ -251,9 +260,10 @@ void CheckMath1(T1 x, T2 y, type::TypeId xtype, type::TypeId ytype) {
 
   // Test x % y
   // Divide by zero detection
-  if (y == 0)
+  if (y == 0) {
     EXPECT_THROW(type::Value(xtype, x).Modulo(type::Value(ytype, y)),
       peloton::Exception);
+  }
   else {
     v1 = type::Value(xtype, x).Modulo(type::Value(ytype, y));
     v2 = type::Value(maxtype, x % y);
@@ -261,9 +271,10 @@ void CheckMath1(T1 x, T2 y, type::TypeId xtype, type::TypeId ytype) {
   }
 
   // Test sqrt(x)
-  if (x < 0)
+  if (x < 0) {
     EXPECT_THROW(type::Value(xtype, x).Sqrt(),
       peloton::Exception);
+  }
   else {
     v1 = type::Value(xtype, x).Sqrt();
     v2 = type::ValueFactory::GetDecimalValue(sqrt(x));

--- a/test/type/timestamp_value_test.cpp
+++ b/test/type/timestamp_value_test.cpp
@@ -100,10 +100,10 @@ TEST_F(TimestampValueTests, ComparisonTest) {
                   val1.ToString().c_str(), expected, result);
 
         if (expected_null) {
-          EXPECT_EQ(expected_null, result == type::CMP_NULL);
+          EXPECT_EQ(expected_null, result == type::CmpBool::NULL_);
         } else {
-          EXPECT_EQ(expected, result == type::CMP_TRUE);
-          EXPECT_EQ(!expected, result == type::CMP_FALSE);
+          EXPECT_EQ(expected, result == type::CmpBool::TRUE);
+          EXPECT_EQ(!expected, result == type::CmpBool::FALSE);
         }
       }
     }
@@ -155,7 +155,7 @@ TEST_F(TimestampValueTests, CopyTest) {
   type::Value val0 =
       type::ValueFactory::GetTimestampValue(static_cast<uint64_t>(1000000));
   type::Value val1 = val0.Copy();
-  EXPECT_TRUE(val0.CompareEquals(val1) == type::CMP_TRUE);
+  EXPECT_EQ(type::CmpBool::TRUE, val0.CompareEquals(val1));
 }
 
 TEST_F(TimestampValueTests, CastTest) {
@@ -166,12 +166,12 @@ TEST_F(TimestampValueTests, CastTest) {
 
   result = valNull.CastAs(type::TypeId::TIMESTAMP);
   EXPECT_TRUE(result.IsNull());
-  EXPECT_TRUE(result.CompareEquals(valNull) == type::CMP_NULL);
+  EXPECT_EQ(type::CmpBool::NULL_, result.CompareEquals(valNull));
   EXPECT_EQ(result.GetTypeId(), valNull.GetTypeId());
 
   result = valNull.CastAs(type::TypeId::VARCHAR);
   EXPECT_TRUE(result.IsNull());
-  EXPECT_TRUE(result.CompareEquals(strNull) == type::CMP_NULL);
+  EXPECT_EQ(type::CmpBool::NULL_, result.CompareEquals(strNull));
   EXPECT_EQ(result.GetTypeId(), strNull.GetTypeId());
 
   EXPECT_THROW(valNull.CastAs(type::TypeId::BOOLEAN), peloton::Exception);

--- a/test/type/type_util_test.cpp
+++ b/test/type/type_util_test.cpp
@@ -128,14 +128,16 @@ TEST_F(TypeUtilTests, CompareEqualsRawTest) {
 
   const int num_cols = (int)schema->GetColumnCount();
   for (int tuple_idx = 1; tuple_idx < 3; tuple_idx++) {
-    bool expected = (tuple_idx == 2);
+    type::CmpBool expected = (tuple_idx == 2 ?
+                                type::CmpBool::TRUE :
+                                type::CmpBool::FALSE);
 
     for (int i = 0; i < num_cols; i++) {
       const char* val0 = tuples[0]->GetDataPtr(i);
       const char* val1 = tuples[tuple_idx]->GetDataPtr(i);
       auto type = schema->GetColumn(i).GetType();
       bool inlined = schema->IsInlined(i);
-      bool result = type::TypeUtil::CompareEqualsRaw(type, val0, val1, inlined);
+      type::CmpBool result = type::TypeUtil::CompareEqualsRaw(type, val0, val1, inlined);
 
       LOG_TRACE(
           "'%s'=='%s' => Expected:%s / Result:%s",
@@ -164,13 +166,12 @@ TEST_F(TypeUtilTests, CompareLessThanRawTest) {
       const char* val1 = tuples[tuple_idx]->GetDataPtr(i);
       auto type = schema->GetColumn(i).GetType();
       bool inlined = schema->IsInlined(i);
-      bool result =
+      type::CmpBool result =
           type::TypeUtil::CompareLessThanRaw(type, val0, val1, inlined);
 
       auto fullVal0 = tuples[0]->GetValue(i);
       auto fullVal1 = tuples[tuple_idx]->GetValue(i);
-      bool expected =
-          (fullVal0.CompareLessThan(fullVal1) == type::CmpBool::CMP_TRUE);
+      type::CmpBool expected = fullVal0.CompareLessThan(fullVal1);
 
       EXPECT_EQ(expected, result);
     }  // FOR (columns)
@@ -192,13 +193,12 @@ TEST_F(TypeUtilTests, CompareGreaterThanRawTest) {
       const char* val1 = tuples[tuple_idx]->GetDataPtr(i);
       auto type = schema->GetColumn(i).GetType();
       bool inlined = schema->IsInlined(i);
-      bool result =
+      type::CmpBool result =
           type::TypeUtil::CompareGreaterThanRaw(type, val0, val1, inlined);
 
       auto fullVal0 = tuples[0]->GetValue(i);
       auto fullVal1 = tuples[tuple_idx]->GetValue(i);
-      bool expected =
-          (fullVal0.CompareGreaterThan(fullVal1) == type::CmpBool::CMP_TRUE);
+      type::CmpBool expected = fullVal0.CompareGreaterThan(fullVal1);
 
       EXPECT_EQ(expected, result);
     }  // FOR (columns)
@@ -229,10 +229,10 @@ TEST_F(TypeUtilTests, CompareStringsTest) {
           type::CmpBool result = type::GetCmpBool(
               type::TypeUtil::CompareStrings(str1.c_str(), i,
                                              str2.c_str(), j) < 0);
-          if (result != type::CmpBool::CMP_TRUE) {
+          if (result != type::CmpBool::TRUE) {
             LOG_ERROR("INVALID '%s' < '%s'", str1.c_str(), str2.c_str());
           }
-          EXPECT_EQ(type::CmpBool::CMP_TRUE, result);
+          EXPECT_EQ(type::CmpBool::TRUE, result);
         } // FOR (upper2)
       } // FOR (str2)
     } // FOR (upper1)

--- a/test/type/value_factory_test.cpp
+++ b/test/type/value_factory_test.cpp
@@ -109,7 +109,7 @@ TEST_F(ValueFactoryTests, CastTest) {
   EXPECT_EQ(v3.GetTypeId(), type::TypeId::VARCHAR);
 
   type::Value v4(type::ValueFactory::Clone(v3));
-  EXPECT_TRUE(v3.CompareEquals(v4) == type::CMP_TRUE);
+  EXPECT_TRUE(v3.CompareEquals(v4) == type::CmpBool::TRUE);
 
   type::Value v5(type::ValueFactory::CastAsVarchar(type::Value(type::TypeId::TINYINT, (int8_t)type::PELOTON_INT8_MAX)));
   EXPECT_EQ(v5.ToString(), "127");
@@ -161,7 +161,7 @@ TEST_F(ValueFactoryTests, SerializationTest) {
       type::Value expected = (expect_min ?
                                 type::Type::GetMinValue(col_type) :
                                 type::Type::GetMaxValue(col_type));
-      EXPECT_EQ(type::CMP_TRUE, v.CompareEquals(expected));
+      EXPECT_EQ(type::CmpBool::TRUE, v.CompareEquals(expected));
     }
   }
 }

--- a/test/type/value_test.cpp
+++ b/test/type/value_test.cpp
@@ -45,7 +45,7 @@ TEST_F(ValueTests, HashTest) {
               max_val.ToString().c_str(), min_val.ToString().c_str());
 
     // They should not be equal
-    EXPECT_EQ(type::CmpBool::CMP_FALSE, max_val.CompareEquals(min_val));
+    EXPECT_EQ(type::CmpBool::FALSE, max_val.CompareEquals(min_val));
 
     // Nor should their hash values be equal
     auto max_hash = max_val.Hash();
@@ -55,7 +55,7 @@ TEST_F(ValueTests, HashTest) {
     // But if I copy the first value then the hashes should be the same
     auto copyVal = max_val.Copy();
     auto copyHash = copyVal.Hash();
-    EXPECT_EQ(type::CmpBool::CMP_TRUE, max_val.CompareEquals(copyVal));
+    EXPECT_EQ(type::CmpBool::TRUE, max_val.CompareEquals(copyVal));
     EXPECT_EQ(max_hash, copyHash);
   }  // FOR
 }
@@ -69,8 +69,8 @@ TEST_F(ValueTests, MinMaxTest) {
     if (col_type == type::TypeId::VARCHAR) {
       max_val = type::ValueFactory::GetVarcharValue(std::string("AAA"), nullptr);
       min_val = type::ValueFactory::GetVarcharValue(std::string("ZZZ"), nullptr);
-      EXPECT_EQ(type::CMP_FALSE, min_val.CompareLessThan(max_val));
-      EXPECT_EQ(type::CMP_FALSE, max_val.CompareGreaterThan(min_val));
+      EXPECT_EQ(type::CmpBool::FALSE, min_val.CompareLessThan(max_val));
+      EXPECT_EQ(type::CmpBool::FALSE, max_val.CompareGreaterThan(min_val));
     }
 
     // FIXME: Broken types!!!
@@ -78,14 +78,14 @@ TEST_F(ValueTests, MinMaxTest) {
     LOG_DEBUG("MinMax: %s", TypeIdToString(col_type).c_str());
 
     // Check that we always get the correct MIN value
-    EXPECT_EQ(type::CMP_TRUE, min_val.Min(min_val).CompareEquals(min_val));
-    EXPECT_EQ(type::CMP_TRUE, min_val.Min(max_val).CompareEquals(min_val));
-    EXPECT_EQ(type::CMP_TRUE, min_val.Min(min_val).CompareEquals(min_val));
+    EXPECT_EQ(type::CmpBool::TRUE, min_val.Min(min_val).CompareEquals(min_val));
+    EXPECT_EQ(type::CmpBool::TRUE, min_val.Min(max_val).CompareEquals(min_val));
+    EXPECT_EQ(type::CmpBool::TRUE, min_val.Min(min_val).CompareEquals(min_val));
 
     // Check that we always get the correct MAX value
-    EXPECT_EQ(type::CMP_TRUE, max_val.Max(min_val).CompareEquals(max_val));
-    EXPECT_EQ(type::CMP_TRUE, min_val.Max(max_val).CompareEquals(max_val));
-    EXPECT_EQ(type::CMP_TRUE, max_val.Max(min_val).CompareEquals(max_val));
+    EXPECT_EQ(type::CmpBool::TRUE, max_val.Max(min_val).CompareEquals(max_val));
+    EXPECT_EQ(type::CmpBool::TRUE, min_val.Max(max_val).CompareEquals(max_val));
+    EXPECT_EQ(type::CmpBool::TRUE, max_val.Max(min_val).CompareEquals(max_val));
   } // FOR
 }
 
@@ -106,7 +106,7 @@ TEST_F(ValueTests, VarcharCopyTest) {
 
     // But their underlying data should be equal
     auto result = val1.CompareEquals(val2);
-    EXPECT_EQ(type::CmpBool::CMP_TRUE, result);
+    EXPECT_EQ(type::CmpBool::TRUE, result);
   }  // FOR
 }
 }


### PR DESCRIPTION
Fix Issue #983 
In the tile group layout test we were missing a parameter in the GetDataTable() function call because of which the next parameter was being cast to bool. This PR fixes that and we now check for both row and column layout.

We were doing:-
 `std::unique_ptr<storage::DataTable> table(storage::TableFactory::GetDataTable(
        INVALID_OID, INVALID_OID, table_schema, table_name,
        tuples_per_tilegroup_count, own_schema, adapt_table, layout_type));`

Changed it to : 
  `std::unique_ptr<storage::DataTable> table(storage::TableFactory::GetDataTable(
        INVALID_OID, INVALID_OID, table_schema, table_name,
        tuples_per_tilegroup_count, own_schema, adapt_table, is_catalog, layout_type));`