### PR TITLE
Fix return type for floor

### DIFF
--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -178,7 +178,7 @@ struct Floor : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val) const override {
     llvm::Value *raw_ret =
         codegen.Call(DecimalFunctionsProxy::Floor, {val.GetValue()});
-    return Value{Integer::Instance(), raw_ret};
+    return Value{Decimal::Instance(), raw_ret};
   }
 };
 


### PR DESCRIPTION
Looks like the return type of the floor function as set incorrectly. This PR fixes it.

@saatviks Since this was your function, you can review the fix :)