### PR TITLE
[Cleanup] Fix formatter script

### DIFF
--- a/script/formatting/formatter.py
+++ b/script/formatting/formatter.py
@@ -32,7 +32,8 @@ DEFAULT_DIRS = []
 DEFAULT_DIRS.append(PELOTON_SRC_DIR)
 DEFAULT_DIRS.append(PELOTON_TESTS_DIR)
 
-CLANG_FORMAT = "clang-format-3.6"
+CLANG_FORMAT = "clang-format"
+CLANG_FORMAT_FILE = os.path.join(PELOTON_DIR, ".clang-format")
 
 ## ==============================================
 ##             HEADER CONFIGURATION
@@ -111,9 +112,13 @@ def format_file(file_path, update_header, clang_format_code):
             fd.write(file_data)
 
         elif clang_format_code:
-            formatting_command = CLANG_FORMAT + " -style=file " + " -i " + file_path
-            LOG.info(formatting_command)
-            subprocess.call([CLANG_FORMAT, "-style=file", "-i", file_path])
+            try:
+                formatting_command = CLANG_FORMAT + " -style=file -i " + file_path
+                LOG.info(formatting_command)
+                subprocess.call([CLANG_FORMAT, "-style=file", "-i", file_path])
+            except OSError as e:
+                LOG.error("clang-format seems not installed")
+                exit("clang-format seems not installed")
 
     #END WITH
 

--- a/script/git-hooks/pre-commit
+++ b/script/git-hooks/pre-commit
@@ -13,7 +13,7 @@ if [ -n "$files" ]; then
   python script/validators/source_validator.py --files $files
   result=$?
   if [ $result -ne 0 ]; then
-    echo "Use `./script/formatter/formatter.py -c -f` to format all staged files or `--no-verify` to temporarily bypass the pre-commit hook. Be aware that changed files have to be staged again!"
+    echo "[peloton pre-commit hook] Use \"./script/formatting/formatter.py -c -f\" to format all staged files or \"--no-verify\" to temporarily bypass the pre-commit hook. Be aware that changed files have to be staged again!"
   fi
   exit $result
 fi


### PR DESCRIPTION
Small fixes that came up during a conversation with @dengyuchenkit  and @haoxianghua. 

  * use any clang-format version
  * catch error if clang-format is not installed
    (similar to source validator changed in #941)
  * fix wrong path in pre-commit hook fail message