### PR TITLE
Improved source validation

### DIFF
--- a/script/git-hooks/pre-commit
+++ b/script/git-hooks/pre-commit
@@ -13,7 +13,7 @@ if [ -n "$files" ]; then
   python script/validators/source_validator.py --files $files
   result=$?
   if [ $result -ne 0 ]; then
-    echo "Use `./script/formatter/formatter.py -c -f` to format all staged files or `--no-verify` to temporarily bypass the pre-commit hook. Be aware that changed files have to be staged again!"
+    echo "Use './script/formatter/formatter.py -c -f' to format all staged files or '--no-verify' to temporarily bypass the pre-commit hook. Be aware that changed files have to be staged again!"
   fi
   exit $result
 fi

--- a/script/validators/source_validator.py
+++ b/script/validators/source_validator.py
@@ -142,8 +142,9 @@ def check_format(file_path):
             if code in ("  ", "- "):
                 line_num += 1
             if code == '- ':
-                LOG.info("Invalid formatting in file: " + file_path)
-                LOG.info("Line %d: %s" % (line_num, line[2:]))
+                if status:
+                    LOG.info("Invalid formatting in file: " + file_path)
+                LOG.info("Line %d: %s" % (line_num, line[2:].strip()))
                 status = False
         return status
     except OSError as e:

--- a/script/validators/source_validator.py
+++ b/script/validators/source_validator.py
@@ -109,7 +109,8 @@ def check_common_patterns(file_path):
             for validator_pattern in VALIDATOR_PATTERNS:
                 # Check for patterns one at a time
                 if validator_pattern.search(line):
-                    LOG.info("Invalid pattern -- " + validator_pattern.pattern + " -- found in : " + file_path)
+                    if status:
+                        LOG.info("Invalid pattern -- " + validator_pattern.pattern + " -- found in : " + file_path)
                     LOG.info("Line #%d :: %s" % (line_ctr, line))
                     status = False
             line_ctr += 1


### PR DESCRIPTION
Since validator patterns are used repeatedly in a nested loop, it's better to compile them before for improved performance. Apart from these, at some places, source files were left open and not closed. I have fixed that security bug.

Lastly, I've tried to improve validator output, which till now gives redundant  and not much useful output when a format is violated.

Consider the old output:
```
12-23-2017 00:16:26 [<module>:222] INFO : Running source validator ...
12-23-2017 00:16:26 [<module>:223] INFO : Peloton root : /Users/binaryboy/Desktop/peloton
12-23-2017 00:16:26 [<module>:242] INFO : Scanning file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_common_patterns:112] INFO : Invalid pattern --  free\( -- found in : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_common_patterns:113] INFO : Line #32 :: // free()

12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [check_format:138] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:16:26 [<module>:245] INFO : Validation NOT successful
```

vs. the new one:
```
12-23-2017 00:38:47 [<module>:232] INFO : Running source validator ...
12-23-2017 00:38:47 [<module>:233] INFO : Peloton root : /Users/binaryboy/Desktop/peloton
12-23-2017 00:38:47 [<module>:252] INFO : Scanning file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:38:47 [check_common_patterns:112] INFO : Invalid pattern --  free\( -- found in : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:38:47 [check_common_patterns:113] INFO : Line #32 :: // free()

12-23-2017 00:38:48 [check_format:148] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:38:48 [check_format:149] INFO : Line:     ::google::SetUsageMessage("Usage Info: \n");::google::HandleCommandLineHelpFlags();}

12-23-2017 00:38:48 [check_format:148] INFO : Invalid formatting in file : /Users/binaryboy/Desktop/peloton/src/main/peloton/peloton.cpp
12-23-2017 00:38:48 [check_format:149] INFO : Line: // free()

12-23-2017 00:38:48 [<module>:255] INFO : Validation NOT successful
``` 
for the same format anomaly.