### PR TITLE
Print out stack trace when throws an exception

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -73,6 +73,11 @@ list(APPEND Peloton_LINKER_LIBS ${LLVM_LIBRARIES})
 
 # --[ IWYU
 
+# ---[ Liblzma
+find_package(Liblzma)
+include_directories(SYSTEM ${LIBLZMA_INCLUDE_DIR})
+list(APPEND Peloton_LINKER_LIBS ${LIBLZMA_LIBRARIES})
+
 # ---[ Libunwind
 find_package(Libunwind)
 include_directories(SYSTEM ${LIBUNWIND_INCLUDE_DIR})

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -73,6 +73,11 @@ list(APPEND Peloton_LINKER_LIBS ${LLVM_LIBRARIES})
 
 # --[ IWYU
 
+# ---[ Libunwind
+find_package(Libunwind)
+include_directories(SYSTEM ${LIBUNWIND_INCLUDE_DIR})
+list(APPEND Peloton_LINKER_LIBS ${LIBUNWIND_LIBRARIES})
+
 # Generate clang compilation database
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -73,14 +73,11 @@ list(APPEND Peloton_LINKER_LIBS ${LLVM_LIBRARIES})
 
 # --[ IWYU
 
-<<<<<<< HEAD
 # ---[ Liblzma
 find_package(Liblzma)
 include_directories(SYSTEM ${LIBLZMA_INCLUDE_DIR})
 list(APPEND Peloton_LINKER_LIBS ${LIBLZMA_LIBRARIES})
 
-=======
->>>>>>> 2f09c62... using libunwind to print out stack trace info when throw out exception
 # ---[ Libunwind
 find_package(Libunwind)
 include_directories(SYSTEM ${LIBUNWIND_INCLUDE_DIR})

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -73,11 +73,14 @@ list(APPEND Peloton_LINKER_LIBS ${LLVM_LIBRARIES})
 
 # --[ IWYU
 
+<<<<<<< HEAD
 # ---[ Liblzma
 find_package(Liblzma)
 include_directories(SYSTEM ${LIBLZMA_INCLUDE_DIR})
 list(APPEND Peloton_LINKER_LIBS ${LIBLZMA_LIBRARIES})
 
+=======
+>>>>>>> 2f09c62... using libunwind to print out stack trace info when throw out exception
 # ---[ Libunwind
 find_package(Libunwind)
 include_directories(SYSTEM ${LIBUNWIND_INCLUDE_DIR})

--- a/cmake/Modules/FindLiblzma.cmake
+++ b/cmake/Modules/FindLiblzma.cmake
@@ -1,44 +1,33 @@
-# - Try to find Liblzma
+# Try to find LibLZMA library and include path.
+# Once done this will define
 #
-#
-# Usage:
-# LIBLZMA_INCLUDE_DIRS, where to find LibLzma headers
-# LIBLZMA_LIBRARIES, LibLzma libraries
-# Liblzma_FOUND, If false, do not try to use Liblzma
+# LIBLZMA_INCLUDE_DIRS - where to find lzma/version.h, etc.
+# LIBLZMA_LIBRARIES - List of libraries when using liblzma.
+# LIBLZMA_FOUND - True if liblzma found.
 
-set(LIBLZMA_ROOT CACHE PATH "Root directory of Liblzma installation")
-set(LibLzma_EXTRA_PREFIXES /usr/local /opt/local "$ENV{HOME}" ${LIBLZMA_ROOT})
-foreach(prefix ${LibLzma_EXTRA_PREFIXES})
-  list(APPEND LibLzma_INCLUDE_PATHS "${prefix}/include")
-  list(APPEND LibLzma_LIBRARIES_PATHS "${prefix}/lib")
-endforeach()
+if(LIBLZMA_INCLUDE_DIR AND LIBLZMA_LIBRARY)
+  set(LIBLZMA_FOUND 1)
+  set(LIBLZMA_LIBRARIES ${LIBLZMA_LIBRARY})
+  set(LIBLZMA_INCLUDE_DIRS ${LIBLZMA_INCLUDE_DIR})
+else(LIBLZMA_INCLUDE_DIR AND LIBLZMA_LIBRARY)
+    set(LIBLZMA_FOUND 0)
+    set(LIBLZMA_LIBRARIES)
+    set(LIBLZMA_INCLUDE_DIRS)
+endif(LIBLZMA_INCLUDE_DIR AND LIBLZMA_LIBRARY)
 
-find_path(LIBLZMA_INCLUDE_DIRS event.h PATHS ${LibLzma_INCLUDE_PATHS})
-# "lib" prefix is needed on Windows
-find_library(LIBLZMA_LIBRARIES NAMES event Liblzma PATHS ${LibLzma_LIBRARIES_PATHS})
-find_library(LIBLZMA_PTHREAD_LIBRARIES NAMES Liblzma_pthreads event_pthreads PATHS ${LibLzma_LIBRARIES_PATHS})
+mark_as_advanced(LIBLZMA_INCLUDE_DIR)
+mark_as_advanced(LIBLZMA_LIBRARY)
+mark_as_advanced(LIBLZMA_FOUND)
 
-if (LIBLZMA_LIBRARIES AND LIBLZMA_INCLUDE_DIRS AND LIBLZMA_PTHREAD_LIBRARIES)
-  set(Liblzma_FOUND TRUE)
-  set(LIBLZMA_LIBRARIES ${LIBLZMA_LIBRARIES})
-  set(LIBLZMA_PTHREAD_LIBRARIES ${LIBLZMA_PTHREAD_LIBRARIES})
-  message(STATUS "Found Liblzma pthread (include: ${LIBLZMA_INCLUDE_DIRS}, library: ${LIBLZMA_PTHREAD_LIBRARIES})")
-else ()
-  set(Liblzma_FOUND FALSE)
-endif ()
-
-if (Liblzma_FOUND)
-  if (NOT Liblzma_FIND_QUIETLY)
-    message(STATUS "Found Liblzma (include: ${LIBLZMA_INCLUDE_DIRS}, library: ${LIBLZMA_LIBRARIES})")
-  endif ()
-else ()
-  if (LibLzma_FIND_REQUIRED)
-    message(FATAL_ERROR "Could NOT find Liblzma.")
-  endif ()
-  message(STATUS "Liblzma NOT found.")
-endif ()
-
-mark_as_advanced(
-    LIBLZMA_LIBRARIES
-    LIBLZMA_INCLUDE_DIRS
-  )
+if(NOT LIBLZMA_FOUND)
+  set(LIBLZMA_DIR_MESSAGE "liblzma was not found. Make sure LIBLZMA_LIBRARY and LIBLZMA_INCLUDE_DIR are set.")
+  if(NOT LIBLZMA_FIND_QUIETLY)
+    message(STATUS "${LIBLZMA_DIR_MESSAGE}")
+  else(NOT LIBLZMA_FIND_QUIETLY)
+    if(LIBLZMA_FIND_REQUIRED)
+      message(FATAL_ERROR "${LIBLZMA_DIR_MESSAGE}")
+    endif(LIBLZMA_FIND_REQUIRED)
+  endif(NOT LIBLZMA_FIND_QUIETLY)
+else(NOT LIBLZMA_FOUND)
+  message(STATUS "Found liblzma: ${LIBLZMA_LIBRARY}")
+endif(NOT LIBLZMA_FOUND)

--- a/cmake/Modules/FindLiblzma.cmake
+++ b/cmake/Modules/FindLiblzma.cmake
@@ -1,0 +1,44 @@
+# - Try to find Liblzma
+#
+#
+# Usage:
+# LIBLZMA_INCLUDE_DIRS, where to find LibLzma headers
+# LIBLZMA_LIBRARIES, LibLzma libraries
+# Liblzma_FOUND, If false, do not try to use Liblzma
+
+set(LIBLZMA_ROOT CACHE PATH "Root directory of Liblzma installation")
+set(LibLzma_EXTRA_PREFIXES /usr/local /opt/local "$ENV{HOME}" ${LIBLZMA_ROOT})
+foreach(prefix ${LibLzma_EXTRA_PREFIXES})
+  list(APPEND LibLzma_INCLUDE_PATHS "${prefix}/include")
+  list(APPEND LibLzma_LIBRARIES_PATHS "${prefix}/lib")
+endforeach()
+
+find_path(LIBLZMA_INCLUDE_DIRS event.h PATHS ${LibLzma_INCLUDE_PATHS})
+# "lib" prefix is needed on Windows
+find_library(LIBLZMA_LIBRARIES NAMES event Liblzma PATHS ${LibLzma_LIBRARIES_PATHS})
+find_library(LIBLZMA_PTHREAD_LIBRARIES NAMES Liblzma_pthreads event_pthreads PATHS ${LibLzma_LIBRARIES_PATHS})
+
+if (LIBLZMA_LIBRARIES AND LIBLZMA_INCLUDE_DIRS AND LIBLZMA_PTHREAD_LIBRARIES)
+  set(Liblzma_FOUND TRUE)
+  set(LIBLZMA_LIBRARIES ${LIBLZMA_LIBRARIES})
+  set(LIBLZMA_PTHREAD_LIBRARIES ${LIBLZMA_PTHREAD_LIBRARIES})
+  message(STATUS "Found Liblzma pthread (include: ${LIBLZMA_INCLUDE_DIRS}, library: ${LIBLZMA_PTHREAD_LIBRARIES})")
+else ()
+  set(Liblzma_FOUND FALSE)
+endif ()
+
+if (Liblzma_FOUND)
+  if (NOT Liblzma_FIND_QUIETLY)
+    message(STATUS "Found Liblzma (include: ${LIBLZMA_INCLUDE_DIRS}, library: ${LIBLZMA_LIBRARIES})")
+  endif ()
+else ()
+  if (LibLzma_FIND_REQUIRED)
+    message(FATAL_ERROR "Could NOT find Liblzma.")
+  endif ()
+  message(STATUS "Liblzma NOT found.")
+endif ()
+
+mark_as_advanced(
+    LIBLZMA_LIBRARIES
+    LIBLZMA_INCLUDE_DIRS
+  )

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -20,6 +20,48 @@ unset UNAME
 DISTRO=$(echo $DISTRO | tr "[:lower:]" "[:upper:]")
 TMPDIR=/tmp
 
+<<<<<<< HEAD
+=======
+function install_repo_package() {
+    if [ "$#" -ne 1 ]; then
+        echo "The download path is required."
+        exit 1
+    else
+        dpath=$(basename "$1")
+    fi
+    pushd $TMPDIR
+    wget -nc --no-check-certificate "$1"
+    sudo yum install -y "$dpath"
+    popd
+    return 0
+}
+
+function install_package() {
+    if [ "$#" -lt 1 ]; then
+        echo "The download path is required."
+        exit 1
+    fi
+
+    pushd $TMPDIR
+    wget -nc --no-check-certificate "$1"
+    tpath=$(basename "$1")
+    dpath=$(tar --exclude='*/*' -tf "$tpath")
+    tar xzf $tpath
+    pushd $dpath
+    if [ -e "bootstrap.sh" ]; then
+        ./bootstrap.sh
+        sudo ./b2 install
+    else
+        ./configure
+        make
+        sudo make install
+    fi
+    popd; popd
+    return 0
+}
+
+
+>>>>>>> 2f09c62... using libunwind to print out stack trace info when throw out exception
 ## ------------------------------------------------
 ## UBUNTU
 ## ------------------------------------------------
@@ -60,8 +102,12 @@ if [ "$DISTRO" = "UBUNTU" ]; then
         libboost-thread-dev \
         libboost-filesystem-dev \
         libjemalloc-dev \
+<<<<<<< HEAD
         libunwind8-dev \
         liblzma-dev \
+=======
+        libunwind-dev \
+>>>>>>> 2f09c62... using libunwind to print out stack trace info when throw out exception
         valgrind \
         lcov \
         libpqxx-dev \

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -104,7 +104,7 @@ elif [[ "$DISTRO" == *"REDHAT"* ]] && [[ "${DISTRO_VER%.*}" == "7" ]]; then
             echo "The download path is required."
             exit 1
         fi
-    
+
         pushd $TMPDIR
         wget -nc --no-check-certificate "$1"
         tpath=$(basename "$1")

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -20,48 +20,6 @@ unset UNAME
 DISTRO=$(echo $DISTRO | tr "[:lower:]" "[:upper:]")
 TMPDIR=/tmp
 
-<<<<<<< HEAD
-=======
-function install_repo_package() {
-    if [ "$#" -ne 1 ]; then
-        echo "The download path is required."
-        exit 1
-    else
-        dpath=$(basename "$1")
-    fi
-    pushd $TMPDIR
-    wget -nc --no-check-certificate "$1"
-    sudo yum install -y "$dpath"
-    popd
-    return 0
-}
-
-function install_package() {
-    if [ "$#" -lt 1 ]; then
-        echo "The download path is required."
-        exit 1
-    fi
-
-    pushd $TMPDIR
-    wget -nc --no-check-certificate "$1"
-    tpath=$(basename "$1")
-    dpath=$(tar --exclude='*/*' -tf "$tpath")
-    tar xzf $tpath
-    pushd $dpath
-    if [ -e "bootstrap.sh" ]; then
-        ./bootstrap.sh
-        sudo ./b2 install
-    else
-        ./configure
-        make
-        sudo make install
-    fi
-    popd; popd
-    return 0
-}
-
-
->>>>>>> 2f09c62... using libunwind to print out stack trace info when throw out exception
 ## ------------------------------------------------
 ## UBUNTU
 ## ------------------------------------------------
@@ -102,12 +60,8 @@ if [ "$DISTRO" = "UBUNTU" ]; then
         libboost-thread-dev \
         libboost-filesystem-dev \
         libjemalloc-dev \
-<<<<<<< HEAD
         libunwind8-dev \
         liblzma-dev \
-=======
-        libunwind-dev \
->>>>>>> 2f09c62... using libunwind to print out stack trace info when throw out exception
         valgrind \
         lcov \
         libpqxx-dev \

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -61,6 +61,7 @@ if [ "$DISTRO" = "UBUNTU" ]; then
         libboost-filesystem-dev \
         libjemalloc-dev \
         libunwind8-dev \
+        liblzma-dev \
         valgrind \
         lcov \
         libpqxx-dev \

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -60,6 +60,7 @@ if [ "$DISTRO" = "UBUNTU" ]; then
         libboost-thread-dev \
         libboost-filesystem-dev \
         libjemalloc-dev \
+        libunwind8-dev \
         valgrind \
         lcov \
         libpqxx-dev \

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -31,7 +31,7 @@ if [ "$DISTRO" = "UBUNTU" ]; then
         sudo apt-get update -qq
     fi
 
-    # Fix for cmake3 name change in Ubuntu 15.x and 16.x plus --force-yes deprecation 
+    # Fix for cmake3 name change in Ubuntu 15.x and 16.x plus --force-yes deprecation
     CMAKE_NAME="cmake3"
     FORCE_Y="--force-yes"
     MAJOR_VER=$(echo "$DISTRO_VER" | cut -d '.' -f 1)
@@ -189,6 +189,7 @@ elif [ "$DISTRO" = "DARWIN" ]; then
     brew install libedit
     brew install llvm@3.7
     brew install postgresql
+    brew install libunwind-headers
 
 ## ------------------------------------------------
 ## UNKNOWN

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -189,6 +189,7 @@ elif [ "$DISTRO" = "DARWIN" ]; then
     brew install libedit
     brew install llvm@3.7
     brew install postgresql
+    brew install xz
     brew install libunwind-headers
 
 ## ------------------------------------------------

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -14,7 +14,7 @@
 
 #include <cxxabi.h>
 #include <errno.h>
-#include <execinfo.h>
+#include <libunwind.h>
 #include <signal.h>
 #include <cstdio>
 #include <cstdlib>
@@ -22,8 +22,8 @@
 #include <memory>
 #include <stdexcept>
 
-#include "type/type.h"
 #include "internal_types.h"
+#include "type/type.h"
 
 namespace peloton {
 
@@ -68,9 +68,9 @@ class Exception : public std::runtime_error {
 
   Exception(ExceptionType exception_type, std::string message)
       : std::runtime_error(message), type(exception_type) {
-    exception_message_ = "Exception Type :: " +
-                                    ExpectionTypeToString(exception_type) +
-                                    "\nMessage :: " + message;
+    exception_message_ =
+        "Exception Type :: " + ExpectionTypeToString(exception_type) +
+        "\nMessage :: " + message;
   }
 
   std::string ExpectionTypeToString(ExceptionType type) {
@@ -128,76 +128,43 @@ class Exception : public std::runtime_error {
     }
   }
 
-  // Based on :: http://panthema.net/2008/0901-stacktrace-demangled/
-  static void PrintStackTrace(FILE *out = ::stderr,
-                              unsigned int max_frames = 63) {
-    ::fprintf(out, "Stack Trace:\n");
+  static void PrintStackTrace(FILE *out = ::stderr) {
+    unw_cursor_t cursor;
+    unw_context_t context;
 
-    /// storage array for stack trace address data
-    void *addrlist[max_frames + 1];
+    unw_getcontext(&context);
+    unw_init_local(&cursor, &context);
 
-    /// retrieve current stack addresses
-    int addrlen = backtrace(addrlist, max_frames + 1);
-
-    if (addrlen == 0) {
-      ::fprintf(out, "  <empty, possibly corrupt>\n");
-      return;
-    }
-
-    /// resolve addresses into strings containing "filename(function+address)",
-    char **symbol_list = backtrace_symbols(addrlist, addrlen);
-
-    /// allocate string which will be filled with the demangled function name
-    size_t func_name_size = 1024;
-    std::unique_ptr<char> func_name(new char[func_name_size]);
-
-    /// iterate over the returned symbol lines. skip the first, it is the
-    /// address of this function.
-    for (int i = 1; i < addrlen; i++) {
-      char *begin_name = 0, *begin_offset = 0, *end_offset = 0;
-
-      /// find parentheses and +address offset surrounding the mangled name:
-      /// ./module(function+0x15c) [0x8048a6d]
-      for (char *p = symbol_list[i]; *p; ++p) {
-        if (*p == '(')
-          begin_name = p;
-        else if (*p == '+')
-          begin_offset = p;
-        else if (*p == ')' && begin_offset) {
-          end_offset = p;
-          break;
-        }
+    int count = 0;
+    while (unw_step(&cursor)) {
+      unw_word_t ip, off;
+      // get program counter register info
+      unw_get_reg(&cursor, UNW_REG_IP, &ip);
+      if (ip == 0) {
+        break;
       }
 
-      if (begin_name && begin_offset && end_offset &&
-          begin_name < begin_offset) {
-        *begin_name++ = '\0';
-        *begin_offset++ = '\0';
-        *end_offset = '\0';
-
-        /// mangled name is now in [begin_name, begin_offset) and caller
-        /// offset in [begin_offset, end_offset). now apply  __cxa_demangle():
+      char sym[256] = "Unknown";
+      if (unw_get_proc_name(&cursor, sym, sizeof(sym), &off) == 0) {
+        char *nameptr = sym;
         int status;
-        char *ret = abi::__cxa_demangle(begin_name, func_name.get(),
-                                        &func_name_size, &status);
+        // demangle c++ function name
+        char *demangled = abi::__cxa_demangle(sym, nullptr, nullptr, &status);
         if (status == 0) {
-          func_name.reset(ret);  // use possibly realloc()-ed string
-          ::fprintf(out, "  %s : %s+%s\n", symbol_list[i], func_name.get(),
-                    begin_offset);
-        } else {
-          /// demangling failed. Output function name as a C function with
-          /// no arguments.
-          ::fprintf(out, "  %s : %s()+%s\n", symbol_list[i], begin_name,
-                    begin_offset);
+          nameptr = demangled;
         }
+        ::fprintf(out, "#%-2d pc = 0x%lx %s + 0x%lx\n", ++count,
+                  static_cast<uintptr_t>(ip), nameptr,
+                  static_cast<uintptr_t>(off));
+        std::free(demangled);
       } else {
-        /// couldn't parse the line ? print the whole line.
-        ::fprintf(out, "  %s\n", symbol_list[i]);
+        ::fprintf(out,
+                  " -- error: unable to obtain symbol name for this frame\n");
       }
     }
   }
 
-  friend std::ostream& operator<<(std::ostream& os, const Exception& e);
+  friend std::ostream &operator<<(std::ostream &os, const Exception &e);
 
  private:
   // type

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -129,41 +129,40 @@ class Exception : public std::runtime_error {
   }
 
   static void PrintStackTrace(FILE *out = ::stderr) {
-    (void)out;
-    // unw_cursor_t cursor;
-    // unw_context_t context;
-    //
-    // unw_getcontext(&context);
-    // unw_init_local(&cursor, &context);
-    //
-    // int count = 0;
-    // while (unw_step(&cursor) && count < 8) {
-    //   unw_word_t ip, off;
-    //   // get program counter register info
-    //   unw_get_reg(&cursor, UNW_REG_IP, &ip);
-    //   if (ip == 0) {
-    //     break;
-    //   }
-    //
-    //   char sym[256] = "Unknown";
-    //   if (unw_get_proc_name(&cursor, sym, sizeof(sym), &off) == 0) {
-    //     char *nameptr = sym;
-    //     int status;
-    //     // demangle c++ function name
-    //     char *demangled = abi::__cxa_demangle(sym, nullptr, nullptr,
-    //     &status); if (status == 0) {
-    //       nameptr = demangled;
-    //     }
-    //     ::fprintf(out, "#%-2d pc = 0x%lx %s + 0x%lx\n", ++count,
-    //               static_cast<uintptr_t>(ip), nameptr,
-    //               static_cast<uintptr_t>(off));
-    //     std::free(demangled);
-    //   } else {
-    //     ::fprintf(out,
-    //               " -- error: unable to obtain symbol name for this
-    //               frame\n");
-    //   }
-    // }
+    unw_cursor_t cursor;
+    unw_context_t context;
+
+    unw_getcontext(&context);
+    unw_init_local(&cursor, &context);
+
+    int count = 0;
+    while (unw_step(&cursor) && count < 8) {
+      unw_word_t ip, off;
+      // get program counter register info
+      unw_get_reg(&cursor, UNW_REG_IP, &ip);
+      if (ip == 0) {
+        break;
+      }
+
+      char sym[256] = "Unknown";
+      if (unw_get_proc_name(&cursor, sym, sizeof(sym), &off) == 0) {
+        char *nameptr = sym;
+        int status;
+        // demangle c++ function name
+        char *demangled = abi::__cxa_demangle(sym, nullptr, nullptr, &status);
+        if (status == 0) {
+          nameptr = demangled;
+        }
+        ::fprintf(out, "#%-2d pc = 0x%lx %s + 0x%lx\n", ++count,
+                  static_cast<uintptr_t>(ip), nameptr,
+                  static_cast<uintptr_t>(off));
+        std::free(demangled);
+      } else {
+        ::fprintf(out,
+                  " -- error: unable to obtain symbol name for this
+                  frame\n");
+      }
+    }
   }
 
   friend std::ostream &operator<<(std::ostream &os, const Exception &e);

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -159,8 +159,7 @@ class Exception : public std::runtime_error {
         std::free(demangled);
       } else {
         ::fprintf(out,
-                  " -- error: unable to obtain symbol name for this
-                  frame\n");
+                  "-- error: unable to obtain symbol name for this frame\n");
       }
     }
   }

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -128,11 +128,7 @@ class Exception : public std::runtime_error {
     }
   }
 
-<<<<<<< HEAD
   static void PrintStackTrace(FILE *out = ::stderr) {
-=======
-  static void PrintStackTrace(FILE *out = ::stderr) {
->>>>>>> 2f09c62... using libunwind to print out stack trace info when throw out exception
     unw_cursor_t cursor;
     unw_context_t context;
 
@@ -140,11 +136,7 @@ class Exception : public std::runtime_error {
     unw_init_local(&cursor, &context);
 
     int count = 0;
-<<<<<<< HEAD
     while (unw_step(&cursor) && count < 8) {
-=======
-    while (unw_step(&cursor)) {
->>>>>>> 2f09c62... using libunwind to print out stack trace info when throw out exception
       unw_word_t ip, off;
       // get program counter register info
       unw_get_reg(&cursor, UNW_REG_IP, &ip);
@@ -154,17 +146,10 @@ class Exception : public std::runtime_error {
 
       char sym[256] = "Unknown";
       if (unw_get_proc_name(&cursor, sym, sizeof(sym), &off) == 0) {
-<<<<<<< HEAD
         char *nameptr = sym;
         int status;
         // demangle c++ function name
         char *demangled = abi::__cxa_demangle(sym, nullptr, nullptr, &status);
-=======
-        char *nameptr = sym;
-        int status;
-        // demangle c++ function name
-        char *demangled = abi::__cxa_demangle(sym, nullptr, nullptr, &status);
->>>>>>> 2f09c62... using libunwind to print out stack trace info when throw out exception
         if (status == 0) {
           nameptr = demangled;
         }

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -136,7 +136,7 @@ class Exception : public std::runtime_error {
     unw_init_local(&cursor, &context);
 
     int count = 0;
-    while (unw_step(&cursor)) {
+    while (unw_step(&cursor) && count < 8) {
       unw_word_t ip, off;
       // get program counter register info
       unw_get_reg(&cursor, UNW_REG_IP, &ip);

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -128,7 +128,11 @@ class Exception : public std::runtime_error {
     }
   }
 
+<<<<<<< HEAD
   static void PrintStackTrace(FILE *out = ::stderr) {
+=======
+  static void PrintStackTrace(FILE *out = ::stderr) {
+>>>>>>> 2f09c62... using libunwind to print out stack trace info when throw out exception
     unw_cursor_t cursor;
     unw_context_t context;
 
@@ -136,7 +140,11 @@ class Exception : public std::runtime_error {
     unw_init_local(&cursor, &context);
 
     int count = 0;
+<<<<<<< HEAD
     while (unw_step(&cursor) && count < 8) {
+=======
+    while (unw_step(&cursor)) {
+>>>>>>> 2f09c62... using libunwind to print out stack trace info when throw out exception
       unw_word_t ip, off;
       // get program counter register info
       unw_get_reg(&cursor, UNW_REG_IP, &ip);
@@ -146,10 +154,17 @@ class Exception : public std::runtime_error {
 
       char sym[256] = "Unknown";
       if (unw_get_proc_name(&cursor, sym, sizeof(sym), &off) == 0) {
+<<<<<<< HEAD
         char *nameptr = sym;
         int status;
         // demangle c++ function name
         char *demangled = abi::__cxa_demangle(sym, nullptr, nullptr, &status);
+=======
+        char *nameptr = sym;
+        int status;
+        // demangle c++ function name
+        char *demangled = abi::__cxa_demangle(sym, nullptr, nullptr, &status);
+>>>>>>> 2f09c62... using libunwind to print out stack trace info when throw out exception
         if (status == 0) {
           nameptr = demangled;
         }

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -129,39 +129,41 @@ class Exception : public std::runtime_error {
   }
 
   static void PrintStackTrace(FILE *out = ::stderr) {
-    unw_cursor_t cursor;
-    unw_context_t context;
-
-    unw_getcontext(&context);
-    unw_init_local(&cursor, &context);
-
-    int count = 0;
-    while (unw_step(&cursor) && count < 8) {
-      unw_word_t ip, off;
-      // get program counter register info
-      unw_get_reg(&cursor, UNW_REG_IP, &ip);
-      if (ip == 0) {
-        break;
-      }
-
-      char sym[256] = "Unknown";
-      if (unw_get_proc_name(&cursor, sym, sizeof(sym), &off) == 0) {
-        char *nameptr = sym;
-        int status;
-        // demangle c++ function name
-        char *demangled = abi::__cxa_demangle(sym, nullptr, nullptr, &status);
-        if (status == 0) {
-          nameptr = demangled;
-        }
-        ::fprintf(out, "#%-2d pc = 0x%lx %s + 0x%lx\n", ++count,
-                  static_cast<uintptr_t>(ip), nameptr,
-                  static_cast<uintptr_t>(off));
-        std::free(demangled);
-      } else {
-        ::fprintf(out,
-                  " -- error: unable to obtain symbol name for this frame\n");
-      }
-    }
+    (void)out;
+    // unw_cursor_t cursor;
+    // unw_context_t context;
+    //
+    // unw_getcontext(&context);
+    // unw_init_local(&cursor, &context);
+    //
+    // int count = 0;
+    // while (unw_step(&cursor) && count < 8) {
+    //   unw_word_t ip, off;
+    //   // get program counter register info
+    //   unw_get_reg(&cursor, UNW_REG_IP, &ip);
+    //   if (ip == 0) {
+    //     break;
+    //   }
+    //
+    //   char sym[256] = "Unknown";
+    //   if (unw_get_proc_name(&cursor, sym, sizeof(sym), &off) == 0) {
+    //     char *nameptr = sym;
+    //     int status;
+    //     // demangle c++ function name
+    //     char *demangled = abi::__cxa_demangle(sym, nullptr, nullptr,
+    //     &status); if (status == 0) {
+    //       nameptr = demangled;
+    //     }
+    //     ::fprintf(out, "#%-2d pc = 0x%lx %s + 0x%lx\n", ++count,
+    //               static_cast<uintptr_t>(ip), nameptr,
+    //               static_cast<uintptr_t>(off));
+    //     std::free(demangled);
+    //   } else {
+    //     ::fprintf(out,
+    //               " -- error: unable to obtain symbol name for this
+    //               frame\n");
+    //   }
+    // }
   }
 
   friend std::ostream &operator<<(std::ostream &os, const Exception &e);

--- a/test/codegen/value_integrity_test.cpp
+++ b/test/codegen/value_integrity_test.cpp
@@ -69,12 +69,7 @@ void DivideByZeroTest(const codegen::type::Type &data_type, ExpressionType op) {
   typedef void (*func)(CType);
   func f = (func)code_context.GetRawFunctionPointer(function.GetFunction());
 
-  try {
-    f(0);
-  } catch (Exception &e) {
-    e.PrintStackTrace();
-  }
-  // EXPECT_THROW(, DivideByZeroException);
+  EXPECT_THROW(, DivideByZeroException);
 }
 
 template <typename CType>

--- a/test/codegen/value_integrity_test.cpp
+++ b/test/codegen/value_integrity_test.cpp
@@ -69,7 +69,7 @@ void DivideByZeroTest(const codegen::type::Type &data_type, ExpressionType op) {
   typedef void (*func)(CType);
   func f = (func)code_context.GetRawFunctionPointer(function.GetFunction());
 
-  EXPECT_THROW(, DivideByZeroException);
+  EXPECT_THROW(f(0), DivideByZeroException);
 }
 
 template <typename CType>

--- a/test/codegen/value_integrity_test.cpp
+++ b/test/codegen/value_integrity_test.cpp
@@ -13,10 +13,10 @@
 #include "codegen/testing_codegen_util.h"
 
 #include "codegen/function_builder.h"
-#include "codegen/type/tinyint_type.h"
-#include "codegen/type/smallint_type.h"
-#include "codegen/type/integer_type.h"
 #include "codegen/type/bigint_type.h"
+#include "codegen/type/integer_type.h"
+#include "codegen/type/smallint_type.h"
+#include "codegen/type/tinyint_type.h"
 
 namespace peloton {
 namespace test {
@@ -68,7 +68,13 @@ void DivideByZeroTest(const codegen::type::Type &data_type, ExpressionType op) {
 
   typedef void (*func)(CType);
   func f = (func)code_context.GetRawFunctionPointer(function.GetFunction());
-  EXPECT_THROW(f(0), DivideByZeroException);
+
+  try {
+    f(0);
+  } catch (Exception &e) {
+    e.PrintStackTrace();
+  }
+  // EXPECT_THROW(, DivideByZeroException);
 }
 
 template <typename CType>


### PR DESCRIPTION
Using libunwind to print out stack trace whenever throw an exception. 
The following is a basic example.

**Client Terminal:** 
```
postgres=# select * from foo1;
Table foo1 is not found
```

**Server side**
```
Exception Type :: Catalog
Message :: Table foo1 is not found
#1  pc = 0x7fb2c866cdaf peloton::CatalogException::CatalogException(std::string) + 0x14f
#2  pc = 0x7fb2c86986f6 peloton::catalog::Catalog::GetTableObject(std::string const&, std::string const&, peloton::concurrency::Transaction*) + 0x176
#3  pc = 0x7fb2c85cc7ed peloton::binder::BinderContext::AddTable(peloton::parser::TableRef*, std::string, peloton::concurrency::Transaction*) + 0x9d
#4  pc = 0x7fb2c85c790c peloton::binder::BindNodeVisitor::Visit(peloton::parser::TableRef*) + 0x10c
#5  pc = 0x7fb2c85c8f3c peloton::binder::BindNodeVisitor::Visit(peloton::parser::SelectStatement*) + 0x13c
.....
```