### PR TITLE
Fix for #954 : Refactor Garbage Collector

### DIFF
--- a/src/concurrency/transaction_manager.cpp
+++ b/src/concurrency/transaction_manager.cpp
@@ -81,7 +81,12 @@ void TransactionManager::EndTransaction(TransactionContext *current_txn) {
     current_txn->ExecOnCommitTriggers();
   }
 
-  gc::GCManagerFactory::GetInstance().RecycleTransaction(current_txn);
+  if(gc::GCManagerFactory::GetGCType() == GarbageCollectionType::ON) {
+    gc::GCManagerFactory::GetInstance().RecycleTransaction(current_txn);
+  } else {
+    delete current_txn;
+  }
+
   current_txn = nullptr;
 
   if (static_cast<StatsType>(settings::SettingsManager::GetInt(

--- a/src/concurrency/transaction_manager.cpp
+++ b/src/concurrency/transaction_manager.cpp
@@ -65,8 +65,8 @@ TransactionContext *TransactionManager::BeginTransaction(
     txn = new TransactionContext(thread_id, type, read_id);
   }
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-      StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+      settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()
         ->GetTxnLatencyMetric()
         .StartTimer();
@@ -84,9 +84,8 @@ void TransactionManager::EndTransaction(TransactionContext *current_txn) {
   gc::GCManagerFactory::GetInstance().RecycleTransaction(current_txn);
   current_txn = nullptr;
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-      StatsType::INVALID) {
-
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+      settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()
         ->GetTxnLatencyMetric()
         .RecordLatency();

--- a/src/gc/gc_manager.cpp
+++ b/src/gc/gc_manager.cpp
@@ -13,6 +13,7 @@
 
 #include "catalog/schema.h"
 #include "common/internal_types.h"
+#include "concurrency/transaction_context.h"
 #include "type/value.h"
 #include "type/abstract_pool.h"
 #include "storage/tile.h"

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -136,18 +136,9 @@ int TransactionLevelGCManager::Unlink(const int &thread_id,
     // involve any garbage collection
     if (garbage_ctx->GetIsolationLevel() != IsolationLevelType::READ_ONLY) {
 
-      if (garbage_ctx->GetResult() == ResultType::SUCCESS) {
-
-        if (garbage_ctx->IsGCSetEmpty()) {
-          delete garbage_ctx;
-          continue;
-        }
-      } else {
-
-        if (garbage_ctx->IsGCSetEmpty()) {
-          delete garbage_ctx;
-          continue;
-        }
+      if (garbage_ctx->IsGCSetEmpty()) {
+        delete garbage_ctx;
+        continue;
       }
     } else {
       delete garbage_ctx;
@@ -223,6 +214,7 @@ void TransactionLevelGCManager::AddToRecycleMap(
     // During the resetting, a table may be deconstructed because of the DROP
     // TABLE request
     if (tile_group == nullptr) {
+      delete garbage_ctx;
       return;
     }
 

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -88,14 +88,9 @@ void TransactionLevelGCManager::RecycleTransaction(
   epoch_manager.ExitEpoch(txn->GetThreadId(),
                           txn->GetEpochId());
 
-  if (txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY) {
-
-    if (txn->GetResult() != ResultType::SUCCESS) {
-
-      if (txn->IsGCSetEmpty() != true) {
+  if (txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY && \
+      txn->GetResult() != ResultType::SUCCESS && txn->IsGCSetEmpty() != true) {
         txn->SetEpochId(epoch_manager.GetNextEpochId());
-      }
-    }
   }
 
   // Add the transaction context to the lock-free queue

--- a/src/include/concurrency/transaction_context.h
+++ b/src/include/concurrency/transaction_context.h
@@ -75,6 +75,8 @@ class TransactionContext : public Printable {
 
   inline void SetCommitId(const cid_t commit_id) { commit_id_ = commit_id; }
 
+  inline void SetEpochId(const eid_t epoch_id) { epoch_id_ = epoch_id; }
+
   void RecordCreate(oid_t database_oid, oid_t table_oid, oid_t index_oid) {
     rw_object_set_.emplace_back(database_oid, table_oid, index_oid,
                                 DDLType::CREATE);

--- a/src/include/gc/gc_manager.h
+++ b/src/include/gc/gc_manager.h
@@ -20,9 +20,12 @@
 #include "common/logger.h"
 #include "common/macros.h"
 #include "common/internal_types.h"
-#include "concurrency/transaction_context.h"
 
 namespace peloton {
+
+namespace concurrency {
+class TransactionContext;
+}
 
 namespace storage {
 class TileGroup;

--- a/src/include/gc/gc_manager.h
+++ b/src/include/gc/gc_manager.h
@@ -20,6 +20,7 @@
 #include "common/logger.h"
 #include "common/macros.h"
 #include "common/internal_types.h"
+#include "concurrency/transaction_context.h"
 
 namespace peloton {
 
@@ -72,7 +73,7 @@ class GCManager {
   virtual size_t GetTableCount() { return 0; }
 
   virtual void RecycleTransaction(
-                            concurrency::Transaction *txn UNUSED_ATTRIBUTE) {}
+                      concurrency::TransactionContext *txn UNUSED_ATTRIBUTE) {}
 
  protected:
   void CheckAndReclaimVarlenColumns(storage::TileGroup *tg, oid_t tuple_id);

--- a/src/include/gc/gc_manager.h
+++ b/src/include/gc/gc_manager.h
@@ -72,10 +72,7 @@ class GCManager {
   virtual size_t GetTableCount() { return 0; }
 
   virtual void RecycleTransaction(
-      std::shared_ptr<GCSet> gc_set UNUSED_ATTRIBUTE,
-      std::shared_ptr<GCObjectSet> gc_object_set UNUSED_ATTRIBUTE,
-      const eid_t &epoch_id UNUSED_ATTRIBUTE,
-      const size_t &thread_id UNUSED_ATTRIBUTE) {}
+                            concurrency::Transaction *txn UNUSED_ATTRIBUTE) {}
 
  protected:
   void CheckAndReclaimVarlenColumns(storage::TileGroup *tg, oid_t tuple_id);

--- a/src/include/gc/transaction_level_gc_manager.h
+++ b/src/include/gc/transaction_level_gc_manager.h
@@ -101,7 +101,8 @@ class TransactionLevelGCManager : public GCManager {
    */
   virtual void StopGC() override;
 
-  virtual void RecycleTransaction(concurrency::Transaction *txn) override;
+  virtual void RecycleTransaction(
+      concurrency::TransactionContext *txn) override;
 
   virtual ItemPointer ReturnFreeSlot(const oid_t &table_id) override;
 
@@ -142,14 +143,14 @@ class TransactionLevelGCManager : public GCManager {
 
   void Running(const int &thread_id);
 
-  void AddToRecycleMap(concurrency::Transaction *txn_ctx);
+  void AddToRecycleMap(concurrency::TransactionContext *txn_ctx);
 
   bool ResetTuple(const ItemPointer &);
 
   // this function iterates the gc context and unlinks every version
   // from the indexes.
   // this function will call the UnlinkVersion() function.
-  void UnlinkVersions(concurrency::Transaction *txn_ctx);
+  void UnlinkVersions(concurrency::TransactionContext *txn_ctx);
 
   // this function unlinks a specified version from the index.
   void UnlinkVersion(const ItemPointer location, const GCVersionType type);
@@ -163,13 +164,14 @@ class TransactionLevelGCManager : public GCManager {
 
   // queues for to-be-unlinked tuples.
   // # unlink_queues == # gc_threads
-  std::vector<
-      std::shared_ptr<peloton::LockFreeQueue<concurrency::TransactionContext* >>>
+  std::vector<std::shared_ptr<
+      peloton::LockFreeQueue<concurrency::TransactionContext* >>>
       unlink_queues_;
 
   // local queues for to-be-unlinked tuples.
   // # local_unlink_queues == # gc_threads
-  std::vector<std::list<concurrency::TransactionContext* >> local_unlink_queues_;
+  std::vector<
+      std::list<concurrency::TransactionContext* >> local_unlink_queues_;
 
   // multimaps for to-be-reclaimed tuples.
   // The key is the timestamp when the garbage is identified, value is the

--- a/src/include/gc/transaction_level_gc_manager.h
+++ b/src/include/gc/transaction_level_gc_manager.h
@@ -32,26 +32,14 @@ namespace gc {
 #define MAX_QUEUE_LENGTH 100000
 #define MAX_ATTEMPT_COUNT 100000
 
-struct GarbageContext {
-  GarbageContext() : epoch_id_(INVALID_EID) {}
-  GarbageContext(std::shared_ptr<GCSet> gc_set,
-                 std::shared_ptr<GCObjectSet> gc_object_set,
-                 const eid_t &epoch_id)
-      : gc_set_(gc_set), gc_object_set_(gc_object_set), epoch_id_(epoch_id) {}
-
-  std::shared_ptr<GCSet> gc_set_;
-  std::shared_ptr<GCObjectSet> gc_object_set_;
-  eid_t epoch_id_;
-};
-
 class TransactionLevelGCManager : public GCManager {
  public:
   TransactionLevelGCManager(const int thread_count)
       : gc_thread_count_(thread_count), reclaim_maps_(thread_count) {
     unlink_queues_.reserve(thread_count);
     for (int i = 0; i < gc_thread_count_; ++i) {
-      std::shared_ptr<LockFreeQueue<std::shared_ptr<GarbageContext>>>
-          unlink_queue(new LockFreeQueue<std::shared_ptr<GarbageContext>>(
+      std::shared_ptr<LockFreeQueue<concurrency::TransactionContext* >>
+          unlink_queue(new LockFreeQueue<concurrency::TransactionContext* >(
               MAX_QUEUE_LENGTH));
       unlink_queues_.push_back(unlink_queue);
       local_unlink_queues_.emplace_back();
@@ -67,8 +55,8 @@ class TransactionLevelGCManager : public GCManager {
 
     unlink_queues_.reserve(gc_thread_count_);
     for (int i = 0; i < gc_thread_count_; ++i) {
-      std::shared_ptr<LockFreeQueue<std::shared_ptr<GarbageContext>>>
-          unlink_queue(new LockFreeQueue<std::shared_ptr<GarbageContext>>(
+      std::shared_ptr<LockFreeQueue<concurrency::TransactionContext* >>
+          unlink_queue(new LockFreeQueue<concurrency::TransactionContext* >(
               MAX_QUEUE_LENGTH));
       unlink_queues_.push_back(unlink_queue);
       local_unlink_queues_.emplace_back();
@@ -113,10 +101,7 @@ class TransactionLevelGCManager : public GCManager {
    */
   virtual void StopGC() override;
 
-  virtual void RecycleTransaction(std::shared_ptr<GCSet> gc_set,
-                                  std::shared_ptr<GCObjectSet> gc_object_set,
-                                  const eid_t &epoch_id,
-                                  const size_t &thread_id) override;
+  virtual void RecycleTransaction(concurrency::Transaction *txn) override;
 
   virtual ItemPointer ReturnFreeSlot(const oid_t &table_id) override;
 
@@ -157,14 +142,14 @@ class TransactionLevelGCManager : public GCManager {
 
   void Running(const int &thread_id);
 
-  void AddToRecycleMap(std::shared_ptr<GarbageContext> gc_ctx);
+  void AddToRecycleMap(concurrency::Transaction *txn_ctx);
 
   bool ResetTuple(const ItemPointer &);
 
   // this function iterates the gc context and unlinks every version
   // from the indexes.
   // this function will call the UnlinkVersion() function.
-  void UnlinkVersions(const std::shared_ptr<GarbageContext> &garbage_ctx);
+  void UnlinkVersions(concurrency::Transaction *txn_ctx);
 
   // this function unlinks a specified version from the index.
   void UnlinkVersion(const ItemPointer location, const GCVersionType type);
@@ -178,18 +163,19 @@ class TransactionLevelGCManager : public GCManager {
 
   // queues for to-be-unlinked tuples.
   // # unlink_queues == # gc_threads
-  std::vector<std::shared_ptr<
-      peloton::LockFreeQueue<std::shared_ptr<GarbageContext>>>> unlink_queues_;
+  std::vector<
+      std::shared_ptr<peloton::LockFreeQueue<concurrency::TransactionContext* >>>
+      unlink_queues_;
 
   // local queues for to-be-unlinked tuples.
   // # local_unlink_queues == # gc_threads
-  std::vector<std::list<std::shared_ptr<GarbageContext>>> local_unlink_queues_;
+  std::vector<std::list<concurrency::TransactionContext* >> local_unlink_queues_;
 
   // multimaps for to-be-reclaimed tuples.
   // The key is the timestamp when the garbage is identified, value is the
   // metadata of the garbage.
   // # reclaim_maps == # gc_threads
-  std::vector<std::multimap<cid_t, std::shared_ptr<GarbageContext>>>
+  std::vector<std::multimap<cid_t, concurrency::TransactionContext* >>
       reclaim_maps_;
 
   // queues for to-be-reused tuples.

--- a/src/include/gc/transaction_level_gc_manager.h
+++ b/src/include/gc/transaction_level_gc_manager.h
@@ -21,6 +21,7 @@
 #include "common/init.h"
 #include "common/logger.h"
 #include "common/thread_pool.h"
+#include "concurrency/transaction_context.h"
 #include "gc/gc_manager.h"
 #include "common/internal_types.h"
 

--- a/test/gc/garbage_collection_test.cpp
+++ b/test/gc/garbage_collection_test.cpp
@@ -192,6 +192,7 @@ TEST_F(GarbageCollectionTests, UpdateTest) {
   EXPECT_EQ(1, recycle_num);
 
   gc_manager.StopGC();
+  gc::GCManagerFactory::Configure(0);
 
   table.release();
 
@@ -289,6 +290,7 @@ TEST_F(GarbageCollectionTests, DeleteTest) {
   EXPECT_EQ(1, recycle_num);
 
   gc_manager.StopGC();
+  gc::GCManagerFactory::Configure(0);
 
   table.release();
 

--- a/test/gc/transaction_level_gc_manager_test.cpp
+++ b/test/gc/transaction_level_gc_manager_test.cpp
@@ -194,6 +194,8 @@ TEST_F(TransactionLevelGCManagerTests, UpdateDeleteTest) {
 
   EXPECT_EQ(0, unlinked_count);
 
+  gc::GCManagerFactory::Configure(0);
+
   table.release();
 
   // DROP!
@@ -354,6 +356,8 @@ TEST_F(TransactionLevelGCManagerTests, ReInsertTest) {
   EXPECT_TRUE(ret == ResultType::SUCCESS);
   EXPECT_TRUE(results[0] != -1);
 
+  gc::GCManagerFactory::Configure(0);
+
   table.release();
 
   // DROP!
@@ -464,6 +468,8 @@ TEST_F(TransactionLevelGCManagerTests, ImmutabilityTest) {
   // mutable tilegroup.
   location = gc_manager.ReturnFreeSlot((table.get())->GetOid());
   EXPECT_EQ(location.IsNull(), false);
+
+  gc::GCManagerFactory::Configure(0);
 
   table.release();
   // DROP!

--- a/test/gc/transaction_level_gc_manager_test.cpp
+++ b/test/gc/transaction_level_gc_manager_test.cpp
@@ -194,6 +194,7 @@ TEST_F(TransactionLevelGCManagerTests, UpdateDeleteTest) {
 
   EXPECT_EQ(0, unlinked_count);
 
+  gc_manager.StopGC();
   gc::GCManagerFactory::Configure(0);
 
   table.release();
@@ -356,6 +357,7 @@ TEST_F(TransactionLevelGCManagerTests, ReInsertTest) {
   EXPECT_TRUE(ret == ResultType::SUCCESS);
   EXPECT_TRUE(results[0] != -1);
 
+  gc_manager.StopGC();
   gc::GCManagerFactory::Configure(0);
 
   table.release();
@@ -469,6 +471,7 @@ TEST_F(TransactionLevelGCManagerTests, ImmutabilityTest) {
   location = gc_manager.ReturnFreeSlot((table.get())->GetOid());
   EXPECT_EQ(location.IsNull(), false);
 
+  gc_manager.StopGC();
   gc::GCManagerFactory::Configure(0);
 
   table.release();

--- a/test/include/common/harness.h
+++ b/test/include/common/harness.h
@@ -108,6 +108,7 @@ class PelotonTest : public ::testing::Test {
   virtual void SetUp() {
 
     // turn off gc under test mode
+    gc::GCManagerFactory::GetInstance().StopGC();
     gc::GCManagerFactory::Configure(0);
 
   }


### PR DESCRIPTION
Fix for #954: This PR moves deallocation of TransactionContext to the GarbageCollector. This also gets rid of the garbage collection context and maintains a pointer to the TransactionContext in the queue till recycling. 
  