### PR TITLE
Fix for #983

### DIFF
--- a/src/include/storage/table_factory.h
+++ b/src/include/storage/table_factory.h
@@ -35,7 +35,8 @@ class TableFactory {
                                  std::string table_name,
                                  size_t tuples_per_tile_group_count,
                                  bool own_schema, bool adapt_table,
-                                 bool is_catalog = false);
+                                 bool is_catalog = false,
+                                 peloton::LayoutType layout_type = peloton::LayoutType::ROW);
 
   static TempTable *GetTempTable(catalog::Schema *schema, bool own_schema);
 

--- a/src/storage/table_factory.cpp
+++ b/src/storage/table_factory.cpp
@@ -26,10 +26,11 @@ DataTable *TableFactory::GetDataTable(oid_t database_id, oid_t relation_id,
                                       std::string table_name,
                                       size_t tuples_per_tilegroup_count,
                                       bool own_schema, bool adapt_table,
-                                      bool is_catalog) {
+                                      bool is_catalog,
+                                      peloton::LayoutType layout_type) {
   DataTable *table = new DataTable(schema, table_name, database_id, relation_id,
                                    tuples_per_tilegroup_count, own_schema,
-                                   adapt_table, is_catalog);
+                                   adapt_table, is_catalog, layout_type);
 
   return table;
 }

--- a/test/executor/tile_group_layout_test.cpp
+++ b/test/executor/tile_group_layout_test.cpp
@@ -60,16 +60,7 @@ namespace test {
 
 class TileGroupLayoutTests : public PelotonTest {};
 
-// FIXME: PAVLO: 2017-12-21
-// I was going to through and changing LayoutType to be 
-// an 'enum class' instead of just an 'enum'. When I did that,
-// the invocation to TableFactory::GetDataTable() broke because
-// now it didn't like the LayoutType parameter. I looked into it
-// and found that the TableFactory doesn't even take in a LayoutType
-// parameter at all. It was only working because the LayoutType
-// was getting cast to a bool. So as it stands now, this test case
-// does *not* check whether we can have different layouts in a TileGroup. 
-void ExecuteTileGroupTest(UNUSED_ATTRIBUTE peloton::LayoutType layout_type) {
+void ExecuteTileGroupTest(peloton::LayoutType layout_type) {
   const int tuples_per_tilegroup_count = 10;
   const int tile_group_count = 5;
   const int tuple_count = tuples_per_tilegroup_count * tile_group_count;
@@ -96,9 +87,10 @@ void ExecuteTileGroupTest(UNUSED_ATTRIBUTE peloton::LayoutType layout_type) {
 
   bool own_schema = true;
   bool adapt_table = true;
+  bool is_catalog = false;
   std::unique_ptr<storage::DataTable> table(storage::TableFactory::GetDataTable(
       INVALID_OID, INVALID_OID, table_schema, table_name,
-      tuples_per_tilegroup_count, own_schema, adapt_table));
+      tuples_per_tilegroup_count, own_schema, adapt_table, is_catalog, layout_type));
 
   // PRIMARY INDEX
   if (indexes == true) {


### PR DESCRIPTION
This fixes the Tile Group Layout Test.

In the tile group layout test we were missing a parameter in the GetDataTable() function call because of which the next parameter was being cast to bool. This PR fixes that and we now check for both row and column layout.

We were doing:-
 `std::unique_ptr<storage::DataTable> table(storage::TableFactory::GetDataTable(
        INVALID_OID, INVALID_OID, table_schema, table_name,
        tuples_per_tilegroup_count, own_schema, adapt_table, layout_type));`

Changed it to : 
  `std::unique_ptr<storage::DataTable> table(storage::TableFactory::GetDataTable(
        INVALID_OID, INVALID_OID, table_schema, table_name,
        tuples_per_tilegroup_count, own_schema, adapt_table, is_catalog, layout_type));`