### PR TITLE
Codegen (Block) Nested Loop Joins

### DIFF
--- a/src/codegen/buffering_consumer.cpp
+++ b/src/codegen/buffering_consumer.cpp
@@ -76,11 +76,6 @@ void BufferingConsumer::Prepare(CompilationContext &ctx) {
   auto &runtime_state = ctx.GetRuntimeState();
   consumer_state_id_ =
       runtime_state.RegisterState("consumerState", codegen.CharPtrType());
-
-  // Introduce our output tuple buffer as local (on stack)
-  auto *value_type = ValueProxy::GetType(codegen);
-  tuple_output_state_id_ = runtime_state.RegisterState(
-      "output", codegen.ArrayType(value_type, output_ais_.size()), true);
 }
 
 // For each output attribute, we write out the attribute's value into the
@@ -89,7 +84,9 @@ void BufferingConsumer::Prepare(CompilationContext &ctx) {
 void BufferingConsumer::ConsumeResult(ConsumerContext &ctx,
                                       RowBatch::Row &row) const {
   auto &codegen = ctx.GetCodeGen();
-  auto *tuple_buffer_ = GetStateValue(ctx, tuple_output_state_id_);
+  auto *tuple_buffer_ = codegen.AllocateBuffer(
+      ValueProxy::GetType(codegen), static_cast<uint32_t>(output_ais_.size()),
+      "output");
   tuple_buffer_ =
       codegen->CreatePointerCast(tuple_buffer_, codegen.CharPtrType());
 

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -32,23 +32,27 @@ llvm::Type *CodeGen::ArrayType(llvm::Type *type, uint32_t num_elements) const {
 
 /// Constant wrappers for bool, int8, int16, int32, int64, strings and NULL
 llvm::Constant *CodeGen::ConstBool(bool val) const {
-  return llvm::ConstantInt::get(BoolType(), val, true);
+  if (val) {
+    return llvm::ConstantInt::getTrue(GetContext());
+  } else {
+    return llvm::ConstantInt::getFalse(GetContext());
+  }
 }
 
-llvm::Constant *CodeGen::Const8(int8_t val) const {
-  return llvm::ConstantInt::get(Int8Type(), val, true);
+llvm::Constant *CodeGen::Const8(uint8_t val) const {
+  return llvm::ConstantInt::get(Int8Type(), val, false);
 }
 
-llvm::Constant *CodeGen::Const16(int16_t val) const {
-  return llvm::ConstantInt::get(Int16Type(), val, true);
+llvm::Constant *CodeGen::Const16(uint16_t val) const {
+  return llvm::ConstantInt::get(Int16Type(), val, false);
 }
 
-llvm::Constant *CodeGen::Const32(int32_t val) const {
-  return llvm::ConstantInt::get(Int32Type(), val, true);
+llvm::Constant *CodeGen::Const32(uint32_t val) const {
+  return llvm::ConstantInt::get(Int32Type(), val, false);
 }
 
-llvm::Constant *CodeGen::Const64(int64_t val) const {
-  return llvm::ConstantInt::get(Int64Type(), val, true);
+llvm::Constant *CodeGen::Const64(uint64_t val) const {
+  return llvm::ConstantInt::get(Int64Type(), val, false);
 }
 
 llvm::Constant *CodeGen::ConstDouble(double val) const {
@@ -109,6 +113,7 @@ llvm::Value *CodeGen::AllocateBuffer(llvm::Type *element_type,
   auto *arr = llvm::GetElementPtrInst::CreateInBounds(
       arr_type, alloc, {Const32(0), Const32(0)}, name);
   arr->insertAfter(llvm::cast<llvm::AllocaInst>(alloc));
+
   return arr;
 }
 

--- a/src/codegen/compilation_context.cpp
+++ b/src/codegen/compilation_context.cpp
@@ -189,9 +189,6 @@ llvm::Function *CompilationContext::GeneratePlanFunction(
       codegen_.VoidType(),
       {{"runtimeState", runtime_state.FinalizeType(codegen_)->getPointerTo()}}};
 
-  // Create all local state
-  runtime_state.CreateLocalState(codegen_);
-
   // Load the query parameter values
   parameter_cache_.Populate(codegen_, GetQueryParametersPtr());
 

--- a/src/codegen/compilation_context.cpp
+++ b/src/codegen/compilation_context.cpp
@@ -24,6 +24,7 @@ namespace codegen {
 
 namespace {
 
+// Reset the cache (if already loaded), the populate the cache
 void InitializeParameterCache(CodeGen &codegen, ParameterCache &cache,
                               llvm::Value *runtime_query_parameters) {
   cache.Reset();
@@ -271,12 +272,12 @@ OperatorTranslator *CompilationContext::GetTranslator(
   return iter == op_translators_.end() ? nullptr : iter->second.get();
 }
 
-llvm::Function *CompilationContext::DeclareAuxiliaryProducer(
+AuxiliaryProducerFunction CompilationContext::DeclareAuxiliaryProducer(
     const planner::AbstractPlan &plan, const std::string &provided_name) {
   auto iter = auxiliary_producers_.find(&plan);
   if (iter != auxiliary_producers_.end()) {
     const auto &declaration = iter->second;
-    return declaration.GetDeclaredFunction();
+    return AuxiliaryProducerFunction(declaration);
   }
 
   auto &cc = query_.GetCodeContext();
@@ -301,7 +302,7 @@ llvm::Function *CompilationContext::DeclareAuxiliaryProducer(
   // Save the function declaration for later definition
   auxiliary_producers_.emplace(&plan, declaration);
 
-  return declaration.GetDeclaredFunction();
+  return AuxiliaryProducerFunction(declaration);
 }
 
 }  // namespace codegen

--- a/src/codegen/function_builder.cpp
+++ b/src/codegen/function_builder.cpp
@@ -18,36 +18,103 @@
 namespace peloton {
 namespace codegen {
 
-// We preserve the state of any ongoing function construction in order to be
-// able to restore it after this function has been fully completed. Thus,
-// FunctionBuilders are nestable, allowing the definition of a function to begin
-// while in midst of defining another function.
-FunctionBuilder::FunctionBuilder(
-    CodeContext &code_context, std::string name, llvm::Type *ret_type,
-    const std::vector<std::pair<std::string, llvm::Type *>> &args)
-    : finished_(false),
-      code_context_(code_context),
-      previous_function_(code_context_.GetCurrentFunction()),
-      previous_insert_point_(code_context_.GetBuilder().GetInsertBlock()),
-      overflow_bb_(nullptr),
-      divide_by_zero_bb_(nullptr) {
-  // Collect function argument types
+namespace {
+
+llvm::Function *ConstructFunction(
+    CodeContext &cc, const std::string &name,
+    FunctionSignature::Visibility visibility, llvm::Type *ret_type,
+    const std::vector<FunctionSignature::ArgumentInfo> &args) {
+  // Collect the function argument types
   std::vector<llvm::Type *> arg_types;
   for (auto &arg : args) {
-    arg_types.push_back(arg.second);
+    arg_types.push_back(arg.type);
+  }
+
+  // Determine function visibility
+  llvm::Function::LinkageTypes linkage;
+  switch (visibility) {
+    case FunctionSignature::Visibility::External:
+      linkage = llvm::Function::LinkageTypes::ExternalLinkage;
+      break;
+    case FunctionSignature::Visibility::ExternalAvailable:
+      linkage = llvm::Function::LinkageTypes::AvailableExternallyLinkage;
+      break;
+    case FunctionSignature::Visibility::Internal:
+      linkage = llvm::Function::LinkageTypes::InternalLinkage;
+      break;
   }
 
   // Declare the function
   auto *fn_type = llvm::FunctionType::get(ret_type, arg_types, false);
-  func_ = llvm::Function::Create(fn_type, llvm::Function::ExternalLinkage, name,
-                                 &code_context_.GetModule());
+  auto *func_decl =
+      llvm::Function::Create(fn_type, linkage, name, &cc.GetModule());
 
   // Set the argument names
   auto arg_iter = args.begin();
-  for (auto iter = func_->arg_begin(), end = func_->arg_end(); iter != end;
-       iter++, arg_iter++) {
-    iter->setName(arg_iter->first);
+  for (auto iter = func_decl->arg_begin(), end = func_decl->arg_end();
+       iter != end; iter++, arg_iter++) {
+    iter->setName(arg_iter->name);
   }
+
+  return func_decl;
+}
+
+}  // anonymous namespace
+
+//===----------------------------------------------------------------------===//
+//
+// FunctionSignature
+//
+//===----------------------------------------------------------------------===//
+
+FunctionSignature::FunctionSignature(
+    const std::string &name, FunctionSignature::Visibility visibility,
+    llvm::Type *ret_type,
+    std::initializer_list<FunctionSignature::ArgumentInfo> args)
+    : name_(name),
+      visibility_(visibility),
+      ret_type_(ret_type),
+      args_info_(args) {}
+
+FunctionSignature::FunctionSignature(
+    const std::string &name, FunctionSignature::Visibility visibility,
+    llvm::Type *ret_type,
+    const std::vector<FunctionSignature::ArgumentInfo> &args)
+    : name_(name),
+      visibility_(visibility),
+      ret_type_(ret_type),
+      args_info_(args) {}
+
+llvm::Function *FunctionSignature::MakeDeclaration(CodeContext &cc) const {
+  return ConstructFunction(cc, name_, visibility_, ret_type_, args_info_);
+}
+
+//===----------------------------------------------------------------------===//
+//
+// FunctionBuilder
+//
+//===----------------------------------------------------------------------===//
+
+// We preserve the state of any ongoing function construction in order to be
+// able to restore it after this function has been fully completed. Thus,
+// FunctionBuilders are nestable, allowing the definition of a function to begin
+// while in midst of defining another function.
+FunctionBuilder::FunctionBuilder(CodeContext &code_context,
+                                 const FunctionSignature &signature)
+    : finished_(false),
+      code_context_(code_context),
+      previous_function_(code_context_.GetCurrentFunction()),
+      previous_insert_point_(code_context_.GetBuilder().GetInsertBlock()),
+      func_(signature.MakeDeclaration(code_context)),
+      overflow_bb_(nullptr),
+      divide_by_zero_bb_(nullptr) {
+  // At this point, we've saved the current position during code generation and
+  // we have a function declaration. Now:
+  //  1. We define the "entry" block and attach it to the function. At this
+  //     point, it transitions from being a declaration to a full definition.
+  //  2. We switch the insertion position into the entry block. The function is
+  //     being built after the constructor completes.
+  //  3. We register the function into the context.
 
   // Set the entry point of the function
   entry_bb_ =
@@ -58,6 +125,14 @@ FunctionBuilder::FunctionBuilder(
   // Register the function we're creating with the code context
   code_context_.RegisterFunction(func_);
 }
+
+FunctionBuilder::FunctionBuilder(
+    CodeContext &code_context, std::string name, llvm::Type *ret_type,
+    const std::vector<FunctionSignature::ArgumentInfo> &args)
+    : FunctionBuilder(
+          code_context,
+          FunctionSignature{name, FunctionSignature::Visibility::External,
+                            ret_type, args}) {}
 
 // When we destructing the FunctionBuilder, we just do a sanity check to ensure
 // that the user actually finished constructing the function. This is because we
@@ -72,7 +147,6 @@ llvm::Value *FunctionBuilder::GetArgumentByName(std::string name) {
       return &arg;
     }
   }
-  PL_ASSERT(false);
   return nullptr;
 }
 
@@ -85,7 +159,6 @@ llvm::Value *FunctionBuilder::GetArgumentByPosition(uint32_t index) {
       return &*arg_iter;
     }
   }
-  PL_ASSERT(false);
   return nullptr;
 }
 
@@ -152,33 +225,35 @@ llvm::BasicBlock *FunctionBuilder::GetDivideByZeroBB() {
 
 // Return the given value from the function and finish it
 void FunctionBuilder::ReturnAndFinish(llvm::Value *ret) {
-  if (!finished_) {
-    if (ret != nullptr) {
-      code_context_.GetBuilder().CreateRet(ret);
-    } else {
-      code_context_.GetBuilder().CreateRetVoid();
-    }
-
-    // Add the overflow error block if it exists
-    if (overflow_bb_ != nullptr) {
-      overflow_bb_->insertInto(func_);
-    }
-
-    // Add the divide-by-zero error block if it exists
-    if (divide_by_zero_bb_ != nullptr) {
-      divide_by_zero_bb_->insertInto(func_);
-    }
-
-    // Restore previous function construction state in the code context
-    if (previous_insert_point_ != nullptr) {
-      PL_ASSERT(previous_function_ != nullptr);
-      code_context_.GetBuilder().SetInsertPoint(previous_insert_point_);
-      code_context_.SetCurrentFunction(previous_function_);
-    }
-
-    // Now we're done
-    finished_ = true;
+  if (finished_) {
+    return;
   }
+
+  if (ret != nullptr) {
+    code_context_.GetBuilder().CreateRet(ret);
+  } else {
+    code_context_.GetBuilder().CreateRetVoid();
+  }
+
+  // Add the overflow error block if it exists
+  if (overflow_bb_ != nullptr) {
+    overflow_bb_->insertInto(func_);
+  }
+
+  // Add the divide-by-zero error block if it exists
+  if (divide_by_zero_bb_ != nullptr) {
+    divide_by_zero_bb_->insertInto(func_);
+  }
+
+  // Restore previous function construction state in the code context
+  if (previous_insert_point_ != nullptr) {
+    PL_ASSERT(previous_function_ != nullptr);
+    code_context_.GetBuilder().SetInsertPoint(previous_insert_point_);
+    code_context_.SetCurrentFunction(previous_function_);
+  }
+
+  // Now we're done
+  finished_ = true;
 }
 
 }  // namespace codegen

--- a/src/codegen/operator/block_nested_loop_join_translator.cpp
+++ b/src/codegen/operator/block_nested_loop_join_translator.cpp
@@ -1,0 +1,208 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// block_nested_loop_join_translator.cpp
+//
+// Identification:
+// src/codegen/operator/block_nested_loop_join_translator.cpp
+//
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "codegen/operator/block_nested_loop_join_translator.h"
+
+#include "codegen/compilation_context.h"
+#include "codegen/function_builder.h"
+#include "codegen/proxy/sorter_proxy.h"
+#include "planner/nested_loop_join_plan.h"
+
+namespace peloton {
+namespace codegen {
+
+BlockNestedLoopJoinTranslator::BlockNestedLoopJoinTranslator(
+    const planner::NestedLoopJoinPlan &nlj_plan, CompilationContext &context,
+    Pipeline &pipeline)
+    : OperatorTranslator(context, pipeline),
+      nlj_plan_(nlj_plan),
+      left_pipeline_(this),
+      max_buf_rows_(256) {
+  // Prepare children
+  PL_ASSERT(nlj_plan.GetChildrenSize() == 2 &&
+            "NLJ must have only two children");
+  context.Prepare(*nlj_plan.GetChild(0), left_pipeline_);
+  context.Prepare(*nlj_plan.GetChild(1), pipeline);
+
+  auto *predicate = nlj_plan.GetPredicate();
+  PL_ASSERT(predicate != nullptr && "NLJ predicate cannot be NULL");
+  context.Prepare(*predicate);
+
+  auto &runtime_state = context.GetRuntimeState();
+  sorter_id_ =
+      runtime_state.RegisterState("sorter", SorterProxy::GetType(GetCodeGen()));
+
+  std::vector<type::Type> left_input_desc;
+  for (const auto *ai : nlj_plan.GetJoinAIsLeft()) {
+    left_input_desc.push_back(ai->type);
+  }
+  for (const auto *ai : nlj_plan.GetLeftAttributes()) {
+    left_input_desc.push_back(ai->type);
+  }
+  sorter_ = Sorter{GetCodeGen(), left_input_desc};
+}
+
+void BlockNestedLoopJoinTranslator::InitializeState() {
+  auto &codegen = GetCodeGen();
+  auto *null_func = codegen.Null(
+      proxy::TypeBuilder<util::Sorter::ComparisonFunction>::GetType(codegen));
+  sorter_.Init(codegen, LoadStatePtr(sorter_id_), null_func);
+}
+
+void BlockNestedLoopJoinTranslator::DefineAuxiliaryFunctions() {
+  auto &codegen = GetCodeGen();
+
+  auto &runtime_state = GetCompilationContext().GetRuntimeState();
+  std::vector<std::pair<std::string, llvm::Type *>> args = {
+      {"runtimeState", runtime_state.FinalizeType(codegen)->getPointerTo()}};
+  FunctionBuilder joinBuffer{codegen.GetCodeContext(), "joinBuffer",
+                             codegen.VoidType(), args};
+  {
+    // All this function does it call produce on the right child
+    GetCompilationContext().Produce(*nlj_plan_.GetChild(1));
+  }
+  joinBuffer.ReturnAndFinish();
+  join_buffer_func_ = joinBuffer.GetFunction();
+}
+
+void BlockNestedLoopJoinTranslator::TearDownState() {
+  sorter_.Destroy(GetCodeGen(), LoadStatePtr(sorter_id_));
+}
+
+std::string BlockNestedLoopJoinTranslator::GetName() const {
+  return "BlockNestedLoopJoin";
+}
+
+void BlockNestedLoopJoinTranslator::Produce() const {
+  GetCompilationContext().Produce(*nlj_plan_.GetChild(0));
+
+  // Flush any remaining tuples in buffer
+  auto &codegen = GetCodeGen();
+  auto *num_buffered_tuples =
+      sorter_.GetNumberOfStoredTuples(codegen, LoadStatePtr(sorter_id_));
+  lang::If has_tuples{
+      codegen, codegen->CreateICmpUGT(num_buffered_tuples, codegen.Const32(0))};
+  {
+    // Flush remaining
+    codegen.CallFunc(join_buffer_func_, {codegen.GetState()});
+  }
+  has_tuples.EndIf();
+}
+
+void BlockNestedLoopJoinTranslator::Consume(ConsumerContext &ctx,
+                                            RowBatch::Row &row) const {
+  if (IsFromLeftChild(ctx.GetPipeline())) {
+    ConsumeFromLeft(ctx, row);
+  } else {
+    ConsumeFromRight(ctx, row);
+  }
+}
+
+bool BlockNestedLoopJoinTranslator::IsFromLeftChild(
+    const Pipeline &pipeline) const {
+  return pipeline.GetChild() == left_pipeline_.GetChild();
+}
+
+void BlockNestedLoopJoinTranslator::ConsumeFromLeft(
+    UNUSED_ATTRIBUTE ConsumerContext &context, RowBatch::Row &row) const {
+  auto &codegen = GetCodeGen();
+
+  // Construct tuple
+  std::vector<Value> tuple;
+  for (const auto &left_key_col : nlj_plan_.GetJoinAIsLeft()) {
+    tuple.push_back(row.DeriveValue(codegen, left_key_col));
+  }
+  for (const auto &left_non_key_col : nlj_plan_.GetLeftAttributes()) {
+    tuple.push_back(row.DeriveValue(codegen, left_non_key_col));
+  }
+  // Append tuple to buffer
+  auto *sorter_ptr = LoadStatePtr(sorter_id_);
+  sorter_.Append(codegen, sorter_ptr, tuple);
+
+  // Check if we should process the filled buffer
+  auto *buf_size = sorter_.GetNumberOfStoredTuples(codegen, sorter_ptr);
+  auto *flush_buffer_cond =
+      codegen->CreateICmpUGE(buf_size, codegen.Const32(max_buf_rows_));
+  lang::If flush_buffer{codegen, flush_buffer_cond};
+  {
+    // Flush
+    codegen.CallFunc(join_buffer_func_, {codegen.GetState()});
+  }
+  flush_buffer.EndIf();
+}
+
+namespace {
+
+class BufferedTupleCallback : public Sorter::IterateCallback {
+ public:
+  // Constructor
+  BufferedTupleCallback(const planner::NestedLoopJoinPlan &plan,
+                        ConsumerContext &ctx, RowBatch::Row &row);
+
+  // The callback invoked for each tuple in the sorter/buffer
+  void ProcessEntry(
+      CodeGen &codegen,
+      const std::vector<codegen::Value> &left_tuple) const override;
+
+ private:
+  // The plan
+  const planner::NestedLoopJoinPlan &plan_;
+  // The consumer context
+  ConsumerContext &ctx_;
+  // The current "outer" row
+  RowBatch::Row &row_;
+};
+
+inline BufferedTupleCallback::BufferedTupleCallback(
+    const planner::NestedLoopJoinPlan &plan, ConsumerContext &ctx,
+    RowBatch::Row &row)
+    : plan_(plan), ctx_(ctx), row_(row) {}
+
+inline void BufferedTupleCallback::ProcessEntry(
+    CodeGen &codegen, const std::vector<codegen::Value> &left_tuple) const {
+  const auto &left_join_key_cols = plan_.GetJoinAIsLeft();
+  const auto &left_non_key_cols = plan_.GetLeftAttributes();
+  PL_ASSERT(left_tuple.size() ==
+            (left_join_key_cols.size() + left_non_key_cols.size()));
+
+  // Add join keys to row first to check the predicate
+  for (size_t i = 0; i < left_join_key_cols.size(); i++) {
+    row_.RegisterAttributeValue(left_join_key_cols[i], left_tuple[i]);
+  }
+
+  // Check if the predicate passes now
+  const auto &valid = row_.DeriveValue(codegen, *plan_.GetPredicate());
+  lang::If valid_match{codegen, valid};
+  {
+    // We have a valid row, add the remaining non-join-key columns
+    for (uint32_t i = 0; i < left_non_key_cols.size(); i++) {
+      row_.RegisterAttributeValue(left_non_key_cols[i],
+                                  left_tuple[i + left_join_key_cols.size()]);
+    }
+    ctx_.Consume(row_);
+  }
+  valid_match.EndIf();
+}
+
+}  // anonymous namespace
+
+void BlockNestedLoopJoinTranslator::ConsumeFromRight(ConsumerContext &context,
+                                                     RowBatch::Row &row) const {
+  // At this point, the sorter instance has a buffer full of tuples. Let's
+  // generate an inner loop.
+  BufferedTupleCallback callback{nlj_plan_, context, row};
+  sorter_.Iterate(GetCodeGen(), LoadStatePtr(sorter_id_), callback);
+}
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/codegen/operator/delete_translator.cpp
+++ b/src/codegen/operator/delete_translator.cpp
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "codegen/operator/delete_translator.h"
+
+#include "codegen/compilation_context.h"
 #include "codegen/proxy/deleter_proxy.h"
 #include "codegen/proxy/storage_manager_proxy.h"
 #include "planner/delete_plan.h"

--- a/src/codegen/operator/global_group_by_translator.cpp
+++ b/src/codegen/operator/global_group_by_translator.cpp
@@ -12,6 +12,7 @@
 
 #include "codegen/operator/global_group_by_translator.h"
 
+#include "codegen/compilation_context.h"
 #include "codegen/lang/if.h"
 #include "common/logger.h"
 #include "planner/aggregate_plan.h"

--- a/src/codegen/operator/global_group_by_translator.cpp
+++ b/src/codegen/operator/global_group_by_translator.cpp
@@ -58,8 +58,6 @@ GlobalGroupByTranslator::GlobalGroupByTranslator(
   // Allocate state in the function argument for our materialization buffer
   auto &runtime_state = context.GetRuntimeState();
   mat_buffer_id_ = runtime_state.RegisterState("buf", mat_buffer_type);
-  output_vector_id_ = runtime_state.RegisterState(
-      "ggbSelVec", codegen.ArrayType(codegen.Int32Type(), 1), true);
 
   LOG_DEBUG("Finished constructing GlobalGroupByTranslator ...");
 }
@@ -92,9 +90,13 @@ void GlobalGroupByTranslator::Produce() const {
   }
 
   // Create a row-batch of one row, place all the attributes into the row
-  Vector v{LoadStateValue(output_vector_id_), 1, codegen.Int32Type()};
+  auto *raw_vec =
+      codegen.AllocateBuffer(codegen.Int32Type(), 1, "globalGroupBySelVector");
+  Vector selection_vector{raw_vec, 1, codegen.Int32Type()};
+  selection_vector.SetValue(codegen, codegen.Const32(0), codegen.Const32(0));
+
   RowBatch batch{GetCompilationContext(), codegen.Const32(0),
-                 codegen.Const32(1), v, false};
+                 codegen.Const32(1), selection_vector, false};
 
   for (size_t i = 0; i < agg_terms.size(); i++) {
     batch.AddAttribute(&agg_terms[i].agg_ai, &buffer_accessors[i]);

--- a/src/codegen/operator/hash_group_by_translator.cpp
+++ b/src/codegen/operator/hash_group_by_translator.cpp
@@ -45,19 +45,7 @@ HashGroupByTranslator::HashGroupByTranslator(
   // of input tuples
   if (UsePrefetching()) {
     child_pipeline_.InstallBoundaryAtInput(this);
-
-    // Allocate slot for prefetch array
-    prefetch_vector_id_ = runtime_state.RegisterState(
-        "gpPrefetchVec",
-        codegen.ArrayType(codegen.Int64Type(),
-                          OAHashTable::kDefaultGroupPrefetchSize),
-        true);
   }
-
-  // Allocate local stage for the output vector we produce
-  output_vector_id_ = runtime_state.RegisterState(
-      "hgbSelVec",
-      codegen.ArrayType(codegen.Int32Type(), Vector::kDefaultVectorSize), true);
 
   // Register the hash-table instance in the runtime state
   hash_table_id_ = runtime_state.RegisterState(
@@ -117,9 +105,13 @@ void HashGroupByTranslator::Produce() const {
 
   LOG_DEBUG("HashGroupBy starting to produce results ...");
 
+  auto &codegen = GetCodeGen();
+
   // Iterate over the hash table, sending tuples up the tree
-  Vector selection_vec{LoadStateValue(output_vector_id_),
-                       Vector::kDefaultVectorSize, GetCodeGen().Int32Type()};
+  auto *raw_vec = codegen.AllocateBuffer(
+      codegen.Int32Type(), Vector::kDefaultVectorSize, "hashGroupBySelVector");
+  Vector selection_vec{raw_vec, Vector::kDefaultVectorSize,
+                       GetCodeGen().Int32Type()};
   ProduceResults producer{*this};
   hash_table_.VectorizedIterate(GetCodeGen(), LoadStatePtr(hash_table_id_),
                                 selection_vec, producer);
@@ -137,8 +129,10 @@ void HashGroupByTranslator::Consume(ConsumerContext &context,
   auto &codegen = GetCodeGen();
 
   // The vector holding the hash values for the group
-  Vector hashes{LoadStateValue(prefetch_vector_id_),
-                OAHashTable::kDefaultGroupPrefetchSize, codegen.Int64Type()};
+  auto *raw_vec = codegen.AllocateBuffer(
+      codegen.Int64Type(), OAHashTable::kDefaultGroupPrefetchSize, "pfVector");
+  Vector hashes{raw_vec, OAHashTable::kDefaultGroupPrefetchSize,
+                codegen.Int64Type()};
 
   auto group_prefetch = [&](
       RowBatch::VectorizedIterateCallback::IterationInstance &iter_instance) {

--- a/src/codegen/operator/hash_group_by_translator.cpp
+++ b/src/codegen/operator/hash_group_by_translator.cpp
@@ -12,6 +12,7 @@
 
 #include "codegen/operator/hash_group_by_translator.h"
 
+#include "codegen/compilation_context.h"
 #include "codegen/proxy/oa_hash_table_proxy.h"
 #include "codegen/operator/projection_translator.h"
 #include "codegen/lang/vectorized_loop.h"

--- a/src/codegen/operator/order_by_translator.cpp
+++ b/src/codegen/operator/order_by_translator.cpp
@@ -99,11 +99,6 @@ OrderByTranslator::OrderByTranslator(const planner::OrderByPlan &plan,
   // Create the sorter
   sorter_ = Sorter{codegen, tuple_desc};
 
-  // Create the output selection vector
-  output_vector_id_ = runtime_state.RegisterState(
-      "obSelVec",
-      codegen.ArrayType(codegen.Int32Type(), Vector::kDefaultVectorSize), true);
-
   LOG_DEBUG("Finished constructing OrderByTranslator ...");
 }
 
@@ -233,8 +228,10 @@ void OrderByTranslator::Produce() const {
   LOG_DEBUG("OrderBy sort complete, iterating over results ...");
 
   // Now iterate over the sorted list
-  Vector selection_vector{LoadStateValue(output_vector_id_),
-                          Vector::kDefaultVectorSize, codegen.Int32Type()};
+  auto *raw_vec = codegen.AllocateBuffer(
+      codegen.Int32Type(), Vector::kDefaultVectorSize, "orderBySelVec");
+  Vector selection_vector{raw_vec, Vector::kDefaultVectorSize,
+                          codegen.Int32Type()};
 
   ProduceResults callback{*this, selection_vector};
   sorter_.VectorizedIterate(codegen, sorter_ptr, selection_vector.GetCapacity(),

--- a/src/codegen/operator/order_by_translator.cpp
+++ b/src/codegen/operator/order_by_translator.cpp
@@ -138,7 +138,7 @@ void OrderByTranslator::DefineAuxiliaryFunctions() {
   auto &storage_format = sorter_.GetStorageFormat();
 
   // The comparison function builder
-  std::vector<std::pair<std::string, llvm::Type *>> args = {
+  std::vector<FunctionSignature::ArgumentInfo> args = {
       {"leftTuple", codegen.CharPtrType()},
       {"rightTuple", codegen.CharPtrType()}};
   FunctionBuilder compare{codegen.GetCodeContext(), "compare",

--- a/src/codegen/operator/order_by_translator.cpp
+++ b/src/codegen/operator/order_by_translator.cpp
@@ -138,7 +138,7 @@ void OrderByTranslator::DefineAuxiliaryFunctions() {
   auto &storage_format = sorter_.GetStorageFormat();
 
   // The comparison function builder
-  std::vector<FunctionSignature::ArgumentInfo> args = {
+  std::vector<FunctionDeclaration::ArgumentInfo> args = {
       {"leftTuple", codegen.CharPtrType()},
       {"rightTuple", codegen.CharPtrType()}};
   FunctionBuilder compare{codegen.GetCodeContext(), "compare",

--- a/src/codegen/operator/projection_translator.cpp
+++ b/src/codegen/operator/projection_translator.cpp
@@ -46,7 +46,7 @@ void ProjectionTranslator::Consume(ConsumerContext &context,
 }
 
 std::string ProjectionTranslator::GetName() const {
-  bool non_trivial = plan_.GetProjectInfo()->isNonTrivial();
+  bool non_trivial = plan_.GetProjectInfo()->IsNonTrivial();
   std::string ret = "Projection";
   ret.append(non_trivial ? "(non-trivial)" : "(trivial)");
   return ret;
@@ -56,7 +56,7 @@ void ProjectionTranslator::PrepareProjection(
     CompilationContext &context, const planner::ProjectInfo &projection_info) {
   // If the projection is non-trivial, we need to prepare translators for every
   // target expression
-  if (projection_info.isNonTrivial()) {
+  if (projection_info.IsNonTrivial()) {
     for (const auto &target : projection_info.GetTargetList()) {
       const auto &derived_attribute = target.second;
       PL_ASSERT(derived_attribute.expr != nullptr);
@@ -70,7 +70,7 @@ void ProjectionTranslator::AddNonTrivialAttributes(
     std::vector<RowBatch::ExpressionAccess> &accessors) {
   // If the projection is non-trivial, we need to add attribute accessors for
   // all targets
-  if (projection_info.isNonTrivial()) {
+  if (projection_info.IsNonTrivial()) {
     // Construct an accessor for each target
     const auto &target_list = projection_info.GetTargetList();
     for (uint32_t i = 0; i < target_list.size(); i++) {

--- a/src/codegen/operator/projection_translator.cpp
+++ b/src/codegen/operator/projection_translator.cpp
@@ -12,6 +12,7 @@
 
 #include "codegen/operator/projection_translator.h"
 
+#include "codegen/compilation_context.h"
 #include "common/logger.h"
 #include "planner/projection_plan.h"
 

--- a/src/codegen/parameter_cache.cpp
+++ b/src/codegen/parameter_cache.cpp
@@ -38,6 +38,10 @@ codegen::Value ParameterCache::GetValue(uint32_t index) const {
   return values_[index];
 }
 
+void ParameterCache::Reset() {
+  values_.clear();
+}
+
 codegen::Value ParameterCache::DeriveParameterValue(CodeGen &codegen,
     llvm::Value *query_parameters_ptr, uint32_t index,
     peloton::type::TypeId type_id, bool is_nullable) {
@@ -92,7 +96,10 @@ codegen::Value ParameterCache::DeriveParameterValue(CodeGen &codegen,
                       TypeIdToString(type_id)};
     }
   }
-  llvm::Value *is_null = codegen.Call(QueryParametersProxy::IsNull, args);
+  llvm::Value *is_null = nullptr;
+  if (is_nullable) {
+    is_null = codegen.Call(QueryParametersProxy::IsNull, args);
+  }
   return Value{type::Type{type_id, is_nullable}, val, len, is_null};
 }
 

--- a/src/codegen/proxy/sorter_proxy.cpp
+++ b/src/codegen/proxy/sorter_proxy.cpp
@@ -16,12 +16,13 @@ namespace peloton {
 namespace codegen {
 
 DEFINE_TYPE(Sorter, "peloton::util::Sorter", MEMBER(buffer_start),
-            MEMBER(buffer_pos), MEMBER(buffer_end), MEMBER(tuple_size),
-            MEMBER(comp_fn));
+            MEMBER(buffer_pos), MEMBER(buffer_end), MEMBER(num_tuples),
+            MEMBER(tuple_size), MEMBER(comp_fn));
 
 DEFINE_METHOD(peloton::codegen::util, Sorter, Init);
 DEFINE_METHOD(peloton::codegen::util, Sorter, StoreInputTuple);
 DEFINE_METHOD(peloton::codegen::util, Sorter, Sort);
+DEFINE_METHOD(peloton::codegen::util, Sorter, Clear);
 DEFINE_METHOD(peloton::codegen::util, Sorter, Destroy);
 
 }  // namespace codegen

--- a/src/codegen/query_cache.cpp
+++ b/src/codegen/query_cache.cpp
@@ -95,10 +95,11 @@ oid_t QueryCache::GetOidFromPlan(const planner::AbstractPlan &plan) const {
     }
     default: { break; }
   }
-  if (plan.GetChildren().size() == 0)
+  if (plan.GetChildren().size() == 0) {
     return INVALID_OID;
-  else
+  } else {
     return GetOidFromPlan(*plan.GetChild(0));
+  }
 }
 
 }  // namespace codegen

--- a/src/codegen/query_compiler.cpp
+++ b/src/codegen/query_compiler.cpp
@@ -67,6 +67,7 @@ bool QueryCompiler::IsSupported(const planner::AbstractPlan &plan) {
       }
       break;
     }
+    case PlanNodeType::NESTLOOP:
     case PlanNodeType::HASHJOIN: {
       const auto &join = static_cast<const planner::AbstractJoinPlan &>(plan);
       // Right now, only support inner joins

--- a/src/codegen/query_compiler.cpp
+++ b/src/codegen/query_compiler.cpp
@@ -68,9 +68,9 @@ bool QueryCompiler::IsSupported(const planner::AbstractPlan &plan) {
       break;
     }
     case PlanNodeType::HASHJOIN: {
-      const auto &hjp = static_cast<const planner::HashJoinPlan &>(plan);
+      const auto &join = static_cast<const planner::AbstractJoinPlan &>(plan);
       // Right now, only support inner joins
-      if (hjp.GetJoinType() == JoinType::INNER) {
+      if (join.GetJoinType() == JoinType::INNER) {
         break;
       }
     }

--- a/src/codegen/row_batch.cpp
+++ b/src/codegen/row_batch.cpp
@@ -130,7 +130,7 @@ codegen::Value RowBatch::Row::DeriveValue(
 }
 
 void RowBatch::Row::RegisterAttributeValue(const planner::AttributeInfo *ai,
-                                           codegen::Value &val) {
+                                           const codegen::Value &val) {
   // Here the caller wants to register a temporary attribute value for the row
   // that overrides any attribute accessor available for the underlying batch
   // We place the value in the cache to ensure we don't go through the normal

--- a/src/codegen/runtime_state.cpp
+++ b/src/codegen/runtime_state.cpp
@@ -23,14 +23,12 @@ RuntimeState::RuntimeState() : constructed_type_(nullptr) {}
 // argument indicates whether this state is local (i.e., lives on the stack) or
 // whether the requesting operator wants to manage the memory.
 RuntimeState::StateID RuntimeState::RegisterState(std::string name,
-                                                  llvm::Type *type,
-                                                  bool is_on_stack) {
+                                                  llvm::Type *type) {
   PL_ASSERT(constructed_type_ == nullptr);
   RuntimeState::StateID state_id = state_slots_.size();
   RuntimeState::StateInfo state_info;
   state_info.name = name;
   state_info.type = type;
-  state_info.local = is_on_stack;
   state_slots_.push_back(state_info);
   return state_id;
 }
@@ -45,8 +43,6 @@ llvm::Value *RuntimeState::LoadStatePtr(CodeGen &codegen,
 
   auto &state_info = state_slots_[state_id];
 
-  PL_ASSERT(!state_info.local);
-
   // We index into the runtime state to get a pointer to the state
   std::string ptr_name{state_info.name + "Ptr"};
   llvm::Value *runtime_state = codegen.GetState();
@@ -58,9 +54,6 @@ llvm::Value *RuntimeState::LoadStatePtr(CodeGen &codegen,
 llvm::Value *RuntimeState::LoadStateValue(
     CodeGen &codegen, RuntimeState::StateID state_id) const {
   auto &state_info = state_slots_[state_id];
-  if (state_info.local) {
-    return state_info.val;
-  }
 
   llvm::Value *state_ptr = LoadStatePtr(codegen, state_id);
   llvm::Value *state = codegen->CreateLoad(state_ptr);
@@ -82,46 +75,17 @@ llvm::Type *RuntimeState::FinalizeType(CodeGen &codegen) {
     return constructed_type_;
   }
 
-  // Construct a type capturing all non-local state
+  // Construct a type capturing all state
   std::vector<llvm::Type *> types;
   for (uint32_t i = 0, index = 0; i < state_slots_.size(); i++) {
-    if (!state_slots_[i].local) {
-      // We set the index in the overall state where this instance is found
-      state_slots_[i].index = index++;
-      types.push_back(state_slots_[i].type);
-    }
+    // We set the index in the overall state where this instance is found
+    state_slots_[i].index = index++;
+    types.push_back(state_slots_[i].type);
   }
 
   constructed_type_ =
       llvm::StructType::create(codegen.GetContext(), types, "RuntimeState");
   return constructed_type_;
-}
-
-void RuntimeState::CreateLocalState(CodeGen &codegen) {
-  for (auto &state_info : state_slots_) {
-    if (state_info.local) {
-      if (auto *arr_type = llvm::dyn_cast<llvm::ArrayType>(state_info.type)) {
-        // Do the stack allocation of the array
-        llvm::AllocaInst *arr = codegen->CreateAlloca(
-            arr_type->getArrayElementType(),
-            codegen.Const32(arr_type->getArrayNumElements()));
-
-        // Set the alignment
-        arr->setAlignment(Vector::kDefaultVectorAlignment);
-
-        // Zero-out the allocated space
-        uint64_t sz = codegen.SizeOf(state_info.type);
-        codegen->CreateMemSet(arr, codegen.Const8(0), sz, arr->getAlignment());
-
-        state_info.val = arr;
-      } else {
-        state_info.val = codegen->CreateAlloca(state_info.type);
-      }
-
-      // Set the name of the local state to what the client wants
-      state_info.val->setName(state_info.name);
-    }
-  }
 }
 
 }  // namespace codegen

--- a/src/codegen/runtime_state.cpp
+++ b/src/codegen/runtime_state.cpp
@@ -53,11 +53,10 @@ llvm::Value *RuntimeState::LoadStatePtr(CodeGen &codegen,
 
 llvm::Value *RuntimeState::LoadStateValue(
     CodeGen &codegen, RuntimeState::StateID state_id) const {
-  auto &state_info = state_slots_[state_id];
-
   llvm::Value *state_ptr = LoadStatePtr(codegen, state_id);
   llvm::Value *state = codegen->CreateLoad(state_ptr);
 #ifndef NDEBUG
+  auto &state_info = state_slots_[state_id];
   PL_ASSERT(state->getType() == state_info.type);
   if (state->getType()->isStructTy()) {
     PL_ASSERT(state_info.type->isStructTy());

--- a/src/codegen/sorter.cpp
+++ b/src/codegen/sorter.cpp
@@ -173,6 +173,10 @@ llvm::Value *Sorter::GetEndPosition(CodeGen &codegen,
       codegen->CreateConstInBoundsGEP2_32(sorter_type, sorter_ptr, 0, 1));
 }
 
+llvm::Value *Sorter::GetTupleSize(CodeGen &codegen) const {
+  return codegen.Const32(storage_format_.GetStorageSize());
+}
+
 //===----------------------------------------------------------------------===//
 // SORTER ACCESS
 //===----------------------------------------------------------------------===//

--- a/src/codegen/sorter.cpp
+++ b/src/codegen/sorter.cpp
@@ -68,6 +68,10 @@ void Sorter::Sort(CodeGen &codegen, llvm::Value *sorter_ptr) const {
   codegen.Call(SorterProxy::Sort, {sorter_ptr});
 }
 
+void Sorter::Reset(CodeGen &codegen, llvm::Value *sorter_ptr) const {
+  codegen.Call(SorterProxy::Clear, {sorter_ptr});
+}
+
 void Sorter::Iterate(CodeGen &codegen, llvm::Value *sorter_ptr,
                      Sorter::IterateCallback &callback) const {
   struct TaatIterateCallback : VectorizedIterateCallback {
@@ -112,18 +116,10 @@ void Sorter::VectorizedIterate(
     CodeGen &codegen, llvm::Value *sorter_ptr, uint32_t vector_size,
     Sorter::VectorizedIterateCallback &callback) const {
   llvm::Value *start_pos = GetStartPosition(codegen, sorter_ptr);
-
   llvm::Value *num_tuples = GetNumberOfStoredTuples(codegen, sorter_ptr);
-
-  // Determine the number of bytes to skip per vector
-  llvm::Value *vec_sz = codegen.Const32(vector_size);
-  llvm::Value *tuple_size = GetTupleSize(codegen);
-  llvm::Value *skip = codegen->CreateMul(vec_sz, tuple_size);
-
-  lang::VectorizedLoop loop{
-      codegen, num_tuples, vector_size, {{"pos", start_pos}}};
+  lang::VectorizedLoop loop{codegen, num_tuples, vector_size, {}};
   {
-    llvm::Value *curr_pos = loop.GetLoopVar(0);
+    // Current loop range
     auto curr_range = loop.GetCurrentRange();
 
     // Provide an accessor into the sorted space
@@ -133,9 +129,8 @@ void Sorter::VectorizedIterate(
     callback.ProcessEntries(codegen, curr_range.start, curr_range.end,
                             sorter_access);
 
-    // Bump the pointer by the size of a tuple
-    llvm::Value *next_pos = codegen->CreateInBoundsGEP(curr_pos, skip);
-    loop.LoopEnd(codegen, {next_pos});
+    // That's it
+    loop.LoopEnd(codegen, {});
   }
 }
 
@@ -146,15 +141,9 @@ void Sorter::Destroy(CodeGen &codegen, llvm::Value *sorter_ptr) const {
 
 llvm::Value *Sorter::GetNumberOfStoredTuples(CodeGen &codegen,
                                              llvm::Value *sorter_ptr) const {
-  // TODO: util::Sorter has a function to handle this ...
-  llvm::Value *start_pos = GetStartPosition(codegen, sorter_ptr);
-  llvm::Value *end_pos = GetEndPosition(codegen, sorter_ptr);
-  llvm::Value *tuple_size =
-      codegen->CreateZExt(GetTupleSize(codegen), codegen.Int64Type());
-
-  llvm::Value *diff_bytes = codegen->CreatePtrDiff(end_pos, start_pos);
-  llvm::Value *num_tuples = codegen->CreateUDiv(diff_bytes, tuple_size);
-  return codegen->CreateTruncOrBitCast(num_tuples, codegen.Int32Type());
+  auto *sorter_type = SorterProxy::GetType(codegen);
+  return codegen->CreateLoad(
+      codegen->CreateConstInBoundsGEP2_32(sorter_type, sorter_ptr, 0, 3));
 }
 
 // Pull out the 'start_pos_' instance member from the provided Sorter instance
@@ -163,14 +152,6 @@ llvm::Value *Sorter::GetStartPosition(CodeGen &codegen,
   auto *sorter_type = SorterProxy::GetType(codegen);
   return codegen->CreateLoad(
       codegen->CreateConstInBoundsGEP2_32(sorter_type, sorter_ptr, 0, 0));
-}
-
-// Pull out the 'end_pos_' instance member from the provided Sorter instance
-llvm::Value *Sorter::GetEndPosition(CodeGen &codegen,
-                                    llvm::Value *sorter_ptr) const {
-  auto *sorter_type = SorterProxy::GetType(codegen);
-  return codegen->CreateLoad(
-      codegen->CreateConstInBoundsGEP2_32(sorter_type, sorter_ptr, 0, 1));
 }
 
 llvm::Value *Sorter::GetTupleSize(CodeGen &codegen) const {

--- a/src/codegen/table.cpp
+++ b/src/codegen/table.cpp
@@ -19,8 +19,6 @@
 #include "codegen/proxy/runtime_functions_proxy.h"
 #include "codegen/proxy/zone_map_proxy.h"
 #include "storage/data_table.h"
-#include "codegen/type/integer_type.h"
-#include "codegen/operator/table_scan_translator.h"
 
 namespace peloton {
 namespace codegen {
@@ -41,6 +39,7 @@ llvm::Value *Table::GetTileGroup(CodeGen &codegen, llvm::Value *table_ptr,
   return codegen.Call(RuntimeFunctionsProxy::GetTileGroup,
                       {table_ptr, tile_group_id});
 }
+
 // We acquire a Zone Map manager instance
 llvm::Value *Table::GetZoneMapManager(CodeGen &codegen) const {
   return codegen.Call(ZoneMapManagerProxy::GetInstance, {});
@@ -58,10 +57,11 @@ llvm::Value *Table::GetZoneMapManager(CodeGen &codegen) const {
 // num_tile_groups = GetTileGroupCount(table_ptr)
 //
 // for (; tile_group_idx < num_tile_groups; ++tile_group_idx) {
-//   if (ShouldScanTileGroup(predicate_array, tile_group_idx) == true) {
+//   if (ShouldScanTileGroup(predicate_array, tile_group_idx)) {
 //      tile_group_ptr := GetTileGroup(table_ptr, tile_group_idx)
 //      consumer.TileGroupStart(tile_group_ptr);
-//      tile_group.TidScan(tile_group_ptr, column_layouts, vector_size, consumer);
+//      tile_group.TidScan(tile_group_ptr, column_layouts, vector_size,
+//                         consumer);
 //      consumer.TileGroupEnd(tile_group_ptr);
 //   }
 // }
@@ -71,63 +71,61 @@ void Table::GenerateScan(CodeGen &codegen, llvm::Value *table_ptr,
                          uint32_t batch_size, ScanCallback &consumer,
                          llvm::Value *predicate_ptr,
                          size_t num_predicates) const {
-  // First get the columns from the table the consumer needs. For every column,
-  // we'll need to have a ColumnInfoLayout struct
-  const uint32_t num_columns =
+  // Allocate some space for the column layouts
+  const auto num_columns =
       static_cast<uint32_t>(table_.GetSchema()->GetColumnCount());
+  llvm::Value *column_layouts = codegen.AllocateBuffer(
+      ColumnLayoutInfoProxy::GetType(codegen), num_columns, "columnLayout");
 
-  llvm::Value *column_layouts = codegen->CreateAlloca(
-      ColumnLayoutInfoProxy::GetType(codegen), codegen.Const32(num_columns));
-
-  llvm::Value *predicate_array = codegen->CreateAlloca(
-      PredicateInfoProxy::GetType(codegen), codegen.Const32(num_predicates));
+  // Allocate some space for the parsed predicates (if need be!)
+  llvm::Value *predicate_array =
+      codegen.NullPtr(PredicateInfoProxy::GetType(codegen)->getPointerTo());
   if (num_predicates != 0) {
+    predicate_array = codegen.AllocateBuffer(
+        PredicateInfoProxy::GetType(codegen), num_predicates, "predicateInfo");
     codegen.Call(RuntimeFunctionsProxy::FillPredicateArray,
                  {predicate_ptr, predicate_array});
   }
+
   // Get the number of tile groups in the given table
-  llvm::Value *scanned_tiles = codegen.Const64(0);
   llvm::Value *tile_group_idx = codegen.Const64(0);
   llvm::Value *num_tile_groups = GetTileGroupCount(codegen, table_ptr);
-  LOG_INFO("Begin Looping over all tile groups");
-  lang::Loop loop{
-      codegen,
-      codegen->CreateICmpULT(tile_group_idx, num_tile_groups),
-      {{"tileGroupIdx", tile_group_idx}, {"scanned_tiles", scanned_tiles}}};
+
+  lang::Loop loop{codegen,
+                  codegen->CreateICmpULT(tile_group_idx, num_tile_groups),
+                  {{"tileGroupIdx", tile_group_idx}}};
   {
     // Get the tile group with the given tile group ID
     tile_group_idx = loop.GetLoopVar(0);
-    scanned_tiles = loop.GetLoopVar(1);
-    llvm::Value *zone_map_manager = GetZoneMapManager(codegen);
     llvm::Value *tile_group_ptr =
         GetTileGroup(codegen, table_ptr, tile_group_idx);
     llvm::Value *tile_group_id =
         tile_group_.GetTileGroupId(codegen, tile_group_ptr);
-    llvm::Value *new_scanned_tiles = nullptr;
-    codegen::lang::If cond{
-        codegen,
-        codegen.Call(
-            ZoneMapManagerProxy::ShouldScanTileGroup,
-            {zone_map_manager, predicate_array, codegen.Const32(num_predicates),
-             table_ptr, tile_group_idx})};
+
+    // Check zone map
+    llvm::Value *cond = codegen.Call(
+        ZoneMapManagerProxy::ShouldScanTileGroup,
+        {GetZoneMapManager(codegen), predicate_array,
+         codegen.Const32(num_predicates), table_ptr, tile_group_idx});
+
+    codegen::lang::If should_scan_tilegroup{codegen, cond};
     {
-      // Invoke the consumer to let her know that we're starting to iterate over
-      // the tile group now
+      // Inform the consumer that we're starting iteration over the tile group
       consumer.TileGroupStart(codegen, tile_group_id, tile_group_ptr);
+
       // Generate the scan cover over the given tile group
       tile_group_.GenerateTidScan(codegen, tile_group_ptr, column_layouts,
                                   batch_size, consumer);
-      // Invoke the consumer to let her know that we're done with this tile
-      // group
+
+      // Inform the consumer that we've finished iteration over the tile group
       consumer.TileGroupFinish(codegen, tile_group_ptr);
-      new_scanned_tiles = codegen->CreateAdd(scanned_tiles, codegen.Const64(1));
     }
-    cond.EndIf();
-    scanned_tiles = cond.BuildPHI(new_scanned_tiles, scanned_tiles);
+    should_scan_tilegroup.EndIf();
+
     // Move to next tile group in the table
     tile_group_idx = codegen->CreateAdd(tile_group_idx, codegen.Const64(1));
     loop.LoopEnd(codegen->CreateICmpULT(tile_group_idx, num_tile_groups),
-                 {tile_group_idx, scanned_tiles});
+                 {tile_group_idx});
   }
 }
 

--- a/src/codegen/translator_factory.cpp
+++ b/src/codegen/translator_factory.cpp
@@ -6,7 +6,7 @@
 //
 // Identification: src/codegen/translator_factory.cpp
 //
-// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -22,6 +22,7 @@
 #include "codegen/expression/null_check_translator.h"
 #include "codegen/expression/parameter_translator.h"
 #include "codegen/expression/tuple_value_translator.h"
+#include "codegen/operator/block_nested_loop_join_translator.h"
 #include "codegen/operator/delete_translator.h"
 #include "codegen/operator/global_group_by_translator.h"
 #include "codegen/operator/hash_group_by_translator.h"
@@ -44,6 +45,7 @@
 #include "planner/hash_join_plan.h"
 #include "planner/hash_plan.h"
 #include "planner/insert_plan.h"
+#include "planner/nested_loop_join_plan.h"
 #include "planner/order_by_plan.h"
 #include "planner/projection_plan.h"
 #include "planner/seq_scan_plan.h"
@@ -74,6 +76,11 @@ std::unique_ptr<OperatorTranslator> TranslatorFactory::CreateTranslator(
     case PlanNodeType::HASHJOIN: {
       auto &join = static_cast<const planner::HashJoinPlan &>(plan_node);
       translator = new HashJoinTranslator(join, context, pipeline);
+      break;
+    }
+    case PlanNodeType::NESTLOOP: {
+      auto &join = static_cast<const planner::NestedLoopJoinPlan &>(plan_node);
+      translator = new BlockNestedLoopJoinTranslator(join, context, pipeline);
       break;
     }
     case PlanNodeType::HASH: {

--- a/src/codegen/value.cpp
+++ b/src/codegen/value.cpp
@@ -33,7 +33,7 @@ Value::Value(const type::Type &type, llvm::Value *val, llvm::Value *length,
 // Return a boolean value indicating whether this value is NULL
 llvm::Value *Value::IsNull(CodeGen &codegen) const {
   if (IsNullable()) {
-    PL_ASSERT(null_ != nullptr);
+    PL_ASSERT(null_ != nullptr && null_->getType() == codegen.BoolType());
     return null_;
   } else {
     return codegen.ConstBool(false);

--- a/src/codegen/values_runtime.cpp
+++ b/src/codegen/values_runtime.cpp
@@ -12,6 +12,7 @@
 
 #include "codegen/values_runtime.h"
 
+#include "type/value.h"
 #include "type/type_util.h"
 #include "type/value_factory.h"
 #include "type/value_peeker.h"
@@ -19,62 +20,72 @@
 namespace peloton {
 namespace codegen {
 
+namespace {
+
+inline void SetValue(type::Value *val_ptr, type::Value &&val) {
+  new (val_ptr) type::Value(val);
+}
+
+}  // namespace
+
 void ValuesRuntime::OutputBoolean(char *values, uint32_t idx, bool val,
                                   bool is_null) {
-  type::Value *vals = reinterpret_cast<type::Value *>(values);
+  auto *vals = reinterpret_cast<type::Value *>(values);
   if (is_null) {
-    vals[idx] = type::ValueFactory::GetNullValueByType(type::TypeId::BOOLEAN);
+    SetValue(&vals[idx],
+             type::ValueFactory::GetNullValueByType(type::TypeId::BOOLEAN));
   } else {
-    vals[idx] = type::ValueFactory::GetBooleanValue(val);
+    SetValue(&vals[idx], type::ValueFactory::GetBooleanValue(val));
   }
 }
 
 void ValuesRuntime::OutputTinyInt(char *values, uint32_t idx, int8_t val) {
-  type::Value *vals = reinterpret_cast<type::Value *>(values);
-  vals[idx] = type::ValueFactory::GetTinyIntValue(val);
+  auto *vals = reinterpret_cast<type::Value *>(values);
+  SetValue(&vals[idx], type::ValueFactory::GetTinyIntValue(val));
 }
 
 void ValuesRuntime::OutputSmallInt(char *values, uint32_t idx, int16_t val) {
-  type::Value *vals = reinterpret_cast<type::Value *>(values);
-  vals[idx] = type::ValueFactory::GetSmallIntValue(val);
+  auto *vals = reinterpret_cast<type::Value *>(values);
+  SetValue(&vals[idx], type::ValueFactory::GetSmallIntValue(val));
 }
 
 void ValuesRuntime::OutputInteger(char *values, uint32_t idx, int32_t val) {
-  type::Value *vals = reinterpret_cast<type::Value *>(values);
-  vals[idx] = type::ValueFactory::GetIntegerValue(val);
+  auto *vals = reinterpret_cast<type::Value *>(values);
+  SetValue(&vals[idx], type::ValueFactory::GetIntegerValue(val));
 }
 
 void ValuesRuntime::OutputBigInt(char *values, uint32_t idx, int64_t val) {
-  type::Value *vals = reinterpret_cast<type::Value *>(values);
-  vals[idx] = type::ValueFactory::GetBigIntValue(val);
+  auto *vals = reinterpret_cast<type::Value *>(values);
+  SetValue(&vals[idx], type::ValueFactory::GetBigIntValue(val));
 }
 
 void ValuesRuntime::OutputDate(char *values, uint32_t idx, int32_t val) {
-  type::Value *vals = reinterpret_cast<type::Value *>(values);
-  vals[idx] = type::ValueFactory::GetDateValue(val);
+  auto *vals = reinterpret_cast<type::Value *>(values);
+  SetValue(&vals[idx], type::ValueFactory::GetDateValue(val));
 }
 
 void ValuesRuntime::OutputTimestamp(char *values, uint32_t idx, int64_t val) {
-  type::Value *vals = reinterpret_cast<type::Value *>(values);
-  vals[idx] = type::ValueFactory::GetTimestampValue(val);
+  auto *vals = reinterpret_cast<type::Value *>(values);
+  SetValue(&vals[idx], type::ValueFactory::GetTimestampValue(val));
 }
 
 void ValuesRuntime::OutputDecimal(char *values, uint32_t idx, double val) {
-  type::Value *vals = reinterpret_cast<type::Value *>(values);
-  vals[idx] = type::ValueFactory::GetDecimalValue(val);
+  auto *vals = reinterpret_cast<type::Value *>(values);
+  SetValue(&vals[idx], type::ValueFactory::GetDecimalValue(val));
 }
 
-void ValuesRuntime::OutputVarchar(char *values, uint32_t idx, char *str,
-                                  UNUSED_ATTRIBUTE uint32_t len) {
-  type::Value *vals = reinterpret_cast<type::Value *>(values);
-  vals[idx] = type::ValueFactory::GetVarcharValue(str, len, false);
+void ValuesRuntime::OutputVarchar(char *values, uint32_t idx, const char *str,
+                                  uint32_t len) {
+  auto *vals = reinterpret_cast<type::Value *>(values);
+  SetValue(&vals[idx], type::ValueFactory::GetVarcharValue(str, len, false));
 }
 
-void ValuesRuntime::OutputVarbinary(char *values, uint32_t idx, char *ptr,
+void ValuesRuntime::OutputVarbinary(char *values, uint32_t idx, const char *ptr,
                                     uint32_t len) {
-  type::Value *vals = reinterpret_cast<type::Value *>(values);
-  const auto *bin_ptr = reinterpret_cast<unsigned char *>(ptr);
-  vals[idx] = type::ValueFactory::GetVarbinaryValue(bin_ptr, len, false);
+  auto *vals = reinterpret_cast<type::Value *>(values);
+  const auto *bin_ptr = reinterpret_cast<const unsigned char *>(ptr);
+  SetValue(&vals[idx],
+           type::ValueFactory::GetVarbinaryValue(bin_ptr, len, false));
 }
 
 int32_t ValuesRuntime::CompareStrings(const char *str1, uint32_t len1,

--- a/src/codegen/vector.cpp
+++ b/src/codegen/vector.cpp
@@ -16,7 +16,7 @@ namespace peloton {
 namespace codegen {
 
 // The default vector size is 2048 elements
-std::atomic<uint32_t> Vector::kDefaultVectorSize{2048};
+std::atomic<uint32_t> Vector::kDefaultVectorSize{1024};
 
 // The default byte-alignment of all vectors is 32 bytes
 uint32_t Vector::kDefaultVectorAlignment = 32;

--- a/src/codegen/vector.cpp
+++ b/src/codegen/vector.cpp
@@ -15,7 +15,7 @@
 namespace peloton {
 namespace codegen {
 
-// The default vector size is 2048 elements
+// The default vector size is 1024 elements
 std::atomic<uint32_t> Vector::kDefaultVectorSize{1024};
 
 // The default byte-alignment of all vectors is 32 bytes

--- a/src/executor/abstract_join_executor.cpp
+++ b/src/executor/abstract_join_executor.cpp
@@ -68,7 +68,7 @@ std::vector<LogicalTile::ColumnInfo> AbstractJoinExecutor::BuildSchema(
     schema.assign(left.begin(), left.end());
     schema.insert(schema.end(), right.begin(), right.end());
   } else {
-    PL_ASSERT(!proj_info_->isNonTrivial());
+    PL_ASSERT(!proj_info_->IsNonTrivial());
     auto &direct_map_list = proj_info_->GetDirectMapList();
     schema.resize(direct_map_list.size());
 
@@ -113,7 +113,7 @@ AbstractJoinExecutor::BuildSchemaFromLeftTile(
     }
   } else {
     // non trivial projection. construct from direct map list
-    PL_ASSERT(!proj_info_->isNonTrivial());
+    PL_ASSERT(!proj_info_->IsNonTrivial());
     auto &direct_map_list = proj_info_->GetDirectMapList();
     schema.resize(direct_map_list.size());
 
@@ -163,7 +163,7 @@ AbstractJoinExecutor::BuildSchemaFromRightTile(
     schema.insert(schema.end(), right_schema->begin(), right_schema->end());
   } else {
     // non trivial projection. construct from direct map list
-    PL_ASSERT(!proj_info_->isNonTrivial());
+    PL_ASSERT(!proj_info_->IsNonTrivial());
     auto &direct_map_list = proj_info_->GetDirectMapList();
     schema.resize(direct_map_list.size());
 

--- a/src/include/codegen/aggregation.h
+++ b/src/include/codegen/aggregation.h
@@ -18,8 +18,8 @@
 #include "codegen/codegen.h"
 #include "codegen/updateable_storage.h"
 #include "codegen/value.h"
-#include "codegen/compilation_context.h"
 #include "codegen/oa_hash_table.h"
+#include "codegen/runtime_state.h"
 #include "planner/aggregate_plan.h"
 
 namespace peloton {

--- a/src/include/codegen/auxiliary_producer_function.h
+++ b/src/include/codegen/auxiliary_producer_function.h
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// auxiliary_producer_function.h
+//
+// Identification: src/include/codegen/auxiliary_producer_function.h
+//
+// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "codegen/codegen.h"
+#include "codegen/function_builder.h"
+
+namespace peloton {
+namespace codegen {
+
+class AuxiliaryProducerFunction {
+ public:
+  // Constructor
+  explicit AuxiliaryProducerFunction();
+  explicit AuxiliaryProducerFunction(const FunctionDeclaration &declaration);
+
+  // Call the function
+  llvm::Value *Call(CodeGen &codegen) const;
+
+ private:
+  // The function
+  llvm::Function *function_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Implementation
+///
+////////////////////////////////////////////////////////////////////////////////
+
+inline AuxiliaryProducerFunction::AuxiliaryProducerFunction()
+    : function_(nullptr) {}
+
+inline AuxiliaryProducerFunction::AuxiliaryProducerFunction(
+    const FunctionDeclaration &declaration)
+    : function_(declaration.GetDeclaredFunction()) {}
+
+inline llvm::Value *AuxiliaryProducerFunction::Call(CodeGen &codegen) const {
+  // At this point, the function cannot be NULL!
+  PL_ASSERT(function_ != nullptr);
+  auto *runtime_state_ptr = codegen.GetState();
+  return codegen.CallFunc(function_, {runtime_state_ptr});
+}
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/include/codegen/buffering_consumer.h
+++ b/src/include/codegen/buffering_consumer.h
@@ -92,9 +92,6 @@ class BufferingConsumer : public QueryResultConsumer {
 
   // The slot in the runtime state to find our state context
   RuntimeState::StateID consumer_state_id_;
-
-  // The ID of our output tuple buffer state
-  RuntimeState::StateID tuple_output_state_id_;
 };
 
 }  // namespace codegen

--- a/src/include/codegen/code_context.h
+++ b/src/include/codegen/code_context.h
@@ -15,7 +15,7 @@
 #include <string>
 #include <unordered_map>
 
-#include <llvm/IR/IRBuilder.h>
+#include "llvm/IR/IRBuilder.h"
 
 #include "common/macros.h"
 

--- a/src/include/codegen/codegen.h
+++ b/src/include/codegen/codegen.h
@@ -81,6 +81,10 @@ class CodeGen {
   /// Wrapper for pointer for constant string
   llvm::Value *ConstStringPtr(const std::string &s) const;
 
+  llvm::Value *AllocateVariable(llvm::Type *type, const std::string &name);
+  llvm::Value *AllocateBuffer(llvm::Type *element_type, uint32_t num_elems,
+                              const std::string &name);
+
   // /Generate a call to the function with the provided name and arguments
   llvm::Value *CallFunc(llvm::Value *fn,
                         std::initializer_list<llvm::Value *> args);

--- a/src/include/codegen/codegen.h
+++ b/src/include/codegen/codegen.h
@@ -70,10 +70,10 @@ class CodeGen {
 
   /// Constant wrappers for bool, int8, int16, int32, int64, strings, and null
   llvm::Constant *ConstBool(bool val) const;
-  llvm::Constant *Const8(int8_t val) const;
-  llvm::Constant *Const16(int16_t val) const;
-  llvm::Constant *Const32(int32_t val) const;
-  llvm::Constant *Const64(int64_t val) const;
+  llvm::Constant *Const8(uint8_t val) const;
+  llvm::Constant *Const16(uint16_t val) const;
+  llvm::Constant *Const32(uint32_t val) const;
+  llvm::Constant *Const64(uint64_t val) const;
   llvm::Constant *ConstDouble(double val) const;
   llvm::Constant *ConstString(const std::string &s) const;
   llvm::Constant *Null(llvm::Type *type) const;

--- a/src/include/codegen/compilation_context.h
+++ b/src/include/codegen/compilation_context.h
@@ -18,6 +18,7 @@
 #include "codegen/code_context.h"
 #include "codegen/codegen.h"
 #include "codegen/expression/expression_translator.h"
+#include "codegen/function_builder.h"
 #include "codegen/operator/operator_translator.h"
 #include "codegen/query.h"
 #include "codegen/query_compiler.h"
@@ -63,6 +64,9 @@ class CompilationContext {
   // construct a compilation context, then invoke this method to compile
   // the plan and prepare the provided query statement.
   void GeneratePlan(QueryCompiler::CompileStats *stats);
+
+  llvm::Function *DeclareAuxiliaryProducer(const planner::AbstractPlan &plan,
+                                           const std::string &provided_name);
 
   //===--------------------------------------------------------------------===//
   // ACCESSORS
@@ -145,6 +149,10 @@ class CompilationContext {
   // The mapping of an expression somewhere in the tree to its translator
   std::unordered_map<const expression::AbstractExpression *,
                      std::unique_ptr<ExpressionTranslator>> exp_translators_;
+
+  // Pre-declared producer functions and their root plan nodes
+  std::unordered_map<const planner::AbstractPlan *, FunctionDeclaration>
+      auxiliary_producers_;
 };
 
 }  // namespace codegen

--- a/src/include/codegen/compilation_context.h
+++ b/src/include/codegen/compilation_context.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <unordered_map>
 
+#include "codegen/auxiliary_producer_function.h"
 #include "codegen/code_context.h"
 #include "codegen/codegen.h"
 #include "codegen/expression/expression_translator.h"
@@ -65,8 +66,10 @@ class CompilationContext {
   // the plan and prepare the provided query statement.
   void GeneratePlan(QueryCompiler::CompileStats *stats);
 
-  llvm::Function *DeclareAuxiliaryProducer(const planner::AbstractPlan &plan,
-                                           const std::string &provided_name);
+  // Declare an extra function that produces tuples outside of the main plan
+  // function. The primary producer in this function is the provided plan node.
+  AuxiliaryProducerFunction DeclareAuxiliaryProducer(
+      const planner::AbstractPlan &plan, const std::string &provided_name);
 
   //===--------------------------------------------------------------------===//
   // ACCESSORS

--- a/src/include/codegen/function_builder.h
+++ b/src/include/codegen/function_builder.h
@@ -86,12 +86,9 @@ class FunctionBuilder {
   friend class CodeGen;
 
  public:
-  // Constructor
-  FunctionBuilder(CodeContext &cc,
-                  const FunctionDeclaration &declaration);
+  FunctionBuilder(CodeContext &cc, const FunctionDeclaration &declaration);
 
-  FunctionBuilder(CodeContext &cc, std::string name,
-                  llvm::Type *ret_type,
+  FunctionBuilder(CodeContext &cc, std::string name, llvm::Type *ret_type,
                   const std::vector<FunctionDeclaration::ArgumentInfo> &args);
 
   // Destructor

--- a/src/include/codegen/function_builder.h
+++ b/src/include/codegen/function_builder.h
@@ -22,6 +22,7 @@ namespace codegen {
 // "complete" the function when the user wants to.
 //===----------------------------------------------------------------------===//
 class FunctionBuilder {
+  friend class CodeGen;
  public:
   // Constructor
   FunctionBuilder(
@@ -36,17 +37,20 @@ class FunctionBuilder {
   llvm::Value *GetArgumentByPosition(uint32_t index);
   size_t GetNumArguments() const { return func_->arg_size(); }
 
-  // Get the basic block where the function throws an overflow exception
-  llvm::BasicBlock *GetOverflowBB();
-
-  // Get the basic block where the function throws a divide by zero exception
-  llvm::BasicBlock *GetDivideByZeroBB();
-
   // Finish the current function
   void ReturnAndFinish(llvm::Value *res = nullptr);
 
   // Return the function we created in the code context
   llvm::Function *GetFunction() const { return func_; }
+
+ private:
+  llvm::BasicBlock *GetEntryBlock() const { return entry_bb_; }
+
+  // Get the basic block where the function throws an overflow exception
+  llvm::BasicBlock *GetOverflowBB();
+
+  // Get the basic block where the function throws a divide by zero exception
+  llvm::BasicBlock *GetDivideByZeroBB();
 
  private:
   // Has this function finished construction

--- a/src/include/codegen/operator/block_nested_loop_join_translator.h
+++ b/src/include/codegen/operator/block_nested_loop_join_translator.h
@@ -62,6 +62,9 @@ class BlockNestedLoopJoinTranslator : public OperatorTranslator {
   // The pipeline the left subtree of the plan belongs to
   Pipeline left_pipeline_;
 
+  // All the attributes from the left side that are materialized
+  std::vector<const planner::AttributeInfo *> unique_left_attributes_;
+
   // The memory space we use to buffer left input tuples. We use a util::Sorter
   // instance because it provides a simple API to append tuples into a buffer.
   // We **DO NOT** actually sort the input at all.

--- a/src/include/codegen/operator/block_nested_loop_join_translator.h
+++ b/src/include/codegen/operator/block_nested_loop_join_translator.h
@@ -14,7 +14,6 @@
 #pragma once
 
 #include "codegen/operator/operator_translator.h"
-#include "codegen/function_builder.h"
 #include "codegen/sorter.h"
 
 namespace peloton {
@@ -52,7 +51,8 @@ class BlockNestedLoopJoinTranslator : public OperatorTranslator {
   void ConsumeFromLeft(ConsumerContext &context, RowBatch::Row &row) const;
   void ConsumeFromRight(ConsumerContext &context, RowBatch::Row &row) const;
 
- private:
+  void FindMatchesForRow(ConsumerContext &ctx, RowBatch::Row &row) const;
+
   const planner::NestedLoopJoinPlan &GetPlan() const { return nlj_plan_; }
 
  private:

--- a/src/include/codegen/operator/block_nested_loop_join_translator.h
+++ b/src/include/codegen/operator/block_nested_loop_join_translator.h
@@ -53,6 +53,9 @@ class BlockNestedLoopJoinTranslator : public OperatorTranslator {
   void ConsumeFromRight(ConsumerContext &context, RowBatch::Row &row) const;
 
  private:
+  const planner::NestedLoopJoinPlan &GetPlan() const { return nlj_plan_; }
+
+ private:
   // The plan
   const planner::NestedLoopJoinPlan &nlj_plan_;
 

--- a/src/include/codegen/operator/block_nested_loop_join_translator.h
+++ b/src/include/codegen/operator/block_nested_loop_join_translator.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "codegen/auxiliary_producer_function.h"
 #include "codegen/operator/operator_translator.h"
 #include "codegen/sorter.h"
 
@@ -25,7 +26,7 @@ class NestedLoopJoinPlan;
 namespace codegen {
 
 //===----------------------------------------------------------------------===//
-// The translator for a blockwise nested loop joins
+// The translator for a blockwise nested loop join
 //===----------------------------------------------------------------------===//
 class BlockNestedLoopJoinTranslator : public OperatorTranslator {
  public:
@@ -59,27 +60,27 @@ class BlockNestedLoopJoinTranslator : public OperatorTranslator {
   // The plan
   const planner::NestedLoopJoinPlan &nlj_plan_;
 
-  // The pipeline the left subtree of the plan belongs to
+  // The pipeline for the left subtree of the plan
   Pipeline left_pipeline_;
 
-  // All the attributes from the left side that are materialized
+  // All the attributes from the left input that are materialized
   std::vector<const planner::AttributeInfo *> unique_left_attributes_;
 
   // The memory space we use to buffer left input tuples. We use a util::Sorter
   // instance because it provides a simple API to append tuples into a buffer.
   // We **DO NOT** actually sort the input at all.
-  RuntimeState::StateID sorter_id_;
-  Sorter sorter_;
+  RuntimeState::StateID buffer_id_;
+  Sorter buffer_;
 
   // This controls the number of tuples we buffer before performing the nested
   // loop join. Ideally, we want the buffer to always be, at least, L2 cache
-  // resident. Knowing the tuple layout coming form the left child, we calculate
+  // resident. Knowing the tuple layout coming from the left child, we calculate
   // this value accurately.
   uint32_t max_buf_rows_;
 
   // This is the function called when enough tuples from the left side have been
   // buffered and we want to perform the BNLJ against the right input.
-  llvm::Function *join_buffer_func_;
+  AuxiliaryProducerFunction join_buffer_func_;
 };
 
 }  // namespace codegen

--- a/src/include/codegen/operator/block_nested_loop_join_translator.h
+++ b/src/include/codegen/operator/block_nested_loop_join_translator.h
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// block_nested_loop_join_translator.h
+//
+// Identification:
+// src/include/codegen/operator/block_nested_loop_join_translator.h
+//
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "codegen/operator/operator_translator.h"
+#include "codegen/function_builder.h"
+#include "codegen/sorter.h"
+
+namespace peloton {
+
+namespace planner {
+class NestedLoopJoinPlan;
+}  // namespace planner
+
+namespace codegen {
+
+//===----------------------------------------------------------------------===//
+// The translator for a blockwise nested loop joins
+//===----------------------------------------------------------------------===//
+class BlockNestedLoopJoinTranslator : public OperatorTranslator {
+ public:
+  BlockNestedLoopJoinTranslator(const planner::NestedLoopJoinPlan &nlj_plan,
+                                CompilationContext &context,
+                                Pipeline &pipeline);
+
+  void InitializeState() override;
+
+  void DefineAuxiliaryFunctions() override;
+
+  void TearDownState() override;
+
+  std::string GetName() const override;
+
+  void Produce() const override;
+
+  void Consume(ConsumerContext &context, RowBatch::Row &row) const override;
+
+ private:
+  bool IsFromLeftChild(const Pipeline &pipeline) const;
+
+  void ConsumeFromLeft(ConsumerContext &context, RowBatch::Row &row) const;
+  void ConsumeFromRight(ConsumerContext &context, RowBatch::Row &row) const;
+
+ private:
+  // The plan
+  const planner::NestedLoopJoinPlan &nlj_plan_;
+
+  // The pipeline the left subtree of the plan belongs to
+  Pipeline left_pipeline_;
+
+  // The memory space we use to buffer left input tuples. We use a util::Sorter
+  // instance because it provides a simple API to append tuples into a buffer.
+  // We **DO NOT** actually sort the input at all.
+  RuntimeState::StateID sorter_id_;
+  Sorter sorter_;
+
+  // This controls the number of tuples we buffer before performing the nested
+  // loop join. Ideally, we want the buffer to always be, at least, L2 cache
+  // resident. Knowing the tuple layout coming form the left child, we calculate
+  // this value accurately.
+  uint32_t max_buf_rows_;
+
+  // This is the function called when enough tuples from the left side have been
+  // buffered and we want to perform the BNLJ against the right input.
+  llvm::Function *join_buffer_func_;
+};
+
+}  // namespace codegen
+}  // namespace peloton

--- a/src/include/codegen/operator/delete_translator.h
+++ b/src/include/codegen/operator/delete_translator.h
@@ -12,9 +12,7 @@
 
 #pragma once
 
-#include "codegen/compilation_context.h"
 #include "codegen/operator/operator_translator.h"
-#include "codegen/consumer_context.h"
 #include "codegen/table.h"
 
 namespace peloton {

--- a/src/include/codegen/operator/global_group_by_translator.h
+++ b/src/include/codegen/operator/global_group_by_translator.h
@@ -13,7 +13,6 @@
 #pragma once
 
 #include "codegen/aggregation.h"
-#include "codegen/compilation_context.h"
 #include "codegen/operator/operator_translator.h"
 #include "codegen/pipeline.h"
 

--- a/src/include/codegen/operator/global_group_by_translator.h
+++ b/src/include/codegen/operator/global_group_by_translator.h
@@ -88,9 +88,6 @@ class GlobalGroupByTranslator : public OperatorTranslator {
 
   // The ID of our materialization buffer in the runtime state
   RuntimeState::StateID mat_buffer_id_;
-
-  // The ID of our output vector in the runtime state
-  RuntimeState::StateID output_vector_id_;
 };
 
 }  // namespace codegen

--- a/src/include/codegen/operator/hash_group_by_translator.h
+++ b/src/include/codegen/operator/hash_group_by_translator.h
@@ -13,8 +13,6 @@
 #pragma once
 
 #include "codegen/aggregation.h"
-#include "codegen/compilation_context.h"
-#include "codegen/consumer_context.h"
 #include "codegen/oa_hash_table.h"
 #include "codegen/operator/operator_translator.h"
 #include "codegen/updateable_storage.h"

--- a/src/include/codegen/operator/hash_group_by_translator.h
+++ b/src/include/codegen/operator/hash_group_by_translator.h
@@ -195,12 +195,6 @@ class HashGroupByTranslator : public OperatorTranslator {
   // The hash table
   OAHashTable hash_table_;
 
-  // The ID of the output vector (for vectorized result production)
-  RuntimeState::StateID output_vector_id_;
-
-  // The ID of the group-prefetch vector, if we're prefetching
-  RuntimeState::StateID prefetch_vector_id_;
-
   // The aggregation handler
   Aggregation aggregation_;
 };

--- a/src/include/codegen/operator/hash_join_translator.h
+++ b/src/include/codegen/operator/hash_join_translator.h
@@ -161,9 +161,6 @@ class HashJoinTranslator : public OperatorTranslator {
   // The storage format used to store build-attributes in hash-table
   CompactStorage left_value_storage_;
 
-  // The ID of the prefetch vector, if we're prefetching
-  RuntimeState::StateID prefetch_vector_id_;
-
   // Does this join need an output vector
   bool needs_output_vector_;
 };

--- a/src/include/codegen/operator/order_by_translator.h
+++ b/src/include/codegen/operator/order_by_translator.h
@@ -98,9 +98,6 @@ class OrderByTranslator : public OperatorTranslator {
   // The comparison function
   llvm::Function *compare_func_;
 
-  // The ID of the output vector (for vectorized scans) in the runtime state
-  RuntimeState::StateID output_vector_id_;
-
   struct SortKeyInfo {
     // The sort key
     const planner::AttributeInfo *sort_key;

--- a/src/include/codegen/operator/projection_translator.h
+++ b/src/include/codegen/operator/projection_translator.h
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include "codegen/compilation_context.h"
 #include "codegen/operator/operator_translator.h"
 #include "codegen/pipeline.h"
 

--- a/src/include/codegen/operator/table_scan_translator.h
+++ b/src/include/codegen/operator/table_scan_translator.h
@@ -149,9 +149,6 @@ class TableScanTranslator : public OperatorTranslator {
   // The scan
   const planner::SeqScanPlan &scan_;
 
-  // The ID of the selection vector in runtime state
-  RuntimeState::StateID selection_vector_id_;
-
   // The code-generating table instance
   codegen::Table table_;
 };

--- a/src/include/codegen/operator/update_translator.h
+++ b/src/include/codegen/operator/update_translator.h
@@ -6,7 +6,7 @@
 //
 // Identification: src/include/codegen/update_translator.h
 //
-// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -18,9 +18,13 @@
 #include "codegen/runtime_state.h"
 #include "codegen/table.h"
 #include "codegen/table_storage.h"
-#include "planner/update_plan.h"
 
 namespace peloton {
+
+namespace planner {
+class UpdatePlan;
+}  // namespace planner
+
 namespace codegen {
 
 class UpdateTranslator : public OperatorTranslator {

--- a/src/include/codegen/parameter_cache.h
+++ b/src/include/codegen/parameter_cache.h
@@ -27,7 +27,8 @@ namespace codegen {
 class ParameterCache {
  public:
   // Constructor
-  ParameterCache(const QueryParametersMap &map) : parameters_map_(map) {}
+  explicit ParameterCache(const QueryParametersMap &map)
+      : parameters_map_(map) {}
 
   // Set the parameter values
   void Populate(CodeGen &codegen, llvm::Value *query_parameters_ptr);
@@ -35,10 +36,15 @@ class ParameterCache {
   // Get the codegen value for the specific index
   codegen::Value GetValue(uint32_t index) const;
 
+  // Clear all cache parameter values
+  void Reset();
+
  private:
-  codegen::Value DeriveParameterValue(CodeGen &codegen,
-      llvm::Value *query_parameters_ptr, uint32_t index,
-      peloton::type::TypeId type_id, bool is_nullable);
+  static codegen::Value DeriveParameterValue(CodeGen &codegen,
+                                             llvm::Value *query_parameters_ptr,
+                                             uint32_t index,
+                                             peloton::type::TypeId type_id,
+                                             bool is_nullable);
 
  private:
   // Parameter information

--- a/src/include/codegen/proxy/sorter_proxy.h
+++ b/src/include/codegen/proxy/sorter_proxy.h
@@ -23,14 +23,16 @@ PROXY(Sorter) {
   DECLARE_MEMBER(0, char *, buffer_start);
   DECLARE_MEMBER(1, char *, buffer_pos);
   DECLARE_MEMBER(2, char *, buffer_end);
-  DECLARE_MEMBER(3, uint32_t, tuple_size);
-  DECLARE_MEMBER(4, char *, comp_fn);
+  DECLARE_MEMBER(3, uint32_t, num_tuples);
+  DECLARE_MEMBER(4, uint32_t, tuple_size);
+  DECLARE_MEMBER(5, char *, comp_fn);
   DECLARE_TYPE;
 
-  // Proxy Init(), StoreInputTuple(), Sort(), and Destroy()
+  // Proxy methods in util::Sorter
   DECLARE_METHOD(Init);
   DECLARE_METHOD(StoreInputTuple);
   DECLARE_METHOD(Sort);
+  DECLARE_METHOD(Clear);
   DECLARE_METHOD(Destroy);
 };
 

--- a/src/include/codegen/query_cache.h
+++ b/src/include/codegen/query_cache.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <list>
+
 #include "codegen/query.h"
 #include "common/platform.h"
 #include "common/singleton.h"
@@ -34,7 +35,7 @@ namespace codegen {
 class QueryCache : public Singleton<QueryCache> {
  public:
   // Find the cached query object with the given plan
-  Query* Find(const std::shared_ptr<planner::AbstractPlan> &key);
+  Query *Find(const std::shared_ptr<planner::AbstractPlan> &key);
 
   // Add a plan and a query object to the cache
   void Add(const std::shared_ptr<planner::AbstractPlan> &key,
@@ -71,8 +72,8 @@ class QueryCache : public Singleton<QueryCache> {
                       std::unique_ptr<Query>>> query_list_;
 
   std::unordered_map<std::shared_ptr<planner::AbstractPlan>,
-           decltype(query_list_.begin()),
-           planner::Hash, planner::Equal> cache_map_;
+                     decltype(query_list_.begin()), planner::Hash,
+                     planner::Equal> cache_map_;
 
   RWLock cache_lock_;
 
@@ -80,4 +81,4 @@ class QueryCache : public Singleton<QueryCache> {
 };
 
 }  // namespace codegen
-}  // namespace peloton 
+}  // namespace peloton

--- a/src/include/codegen/query_parameters.h
+++ b/src/include/codegen/query_parameters.h
@@ -19,11 +19,6 @@
 #include "type/value_peeker.h"
 
 namespace peloton {
-
-namespace type {
-class Value;
-}
-
 namespace codegen {
 
 class QueryParameters {
@@ -78,62 +73,50 @@ class QueryParameters {
     return parameters_map_.GetParameters();
   }
 
-  // Get the boolean value for the index
   bool GetBoolean(uint32_t index) const {
     return peloton::type::ValuePeeker::PeekBoolean(parameters_values_[index]);
   }
 
-  // Get the tinyint value for the index
   int8_t GetTinyInt(uint32_t index) const {
     return peloton::type::ValuePeeker::PeekTinyInt(parameters_values_[index]);
   }
 
-  // Get the smallint value for the index
   int16_t GetSmallInt(uint32_t index) const {
     return peloton::type::ValuePeeker::PeekSmallInt(parameters_values_[index]);
   }
 
-  // Get the integer value for the index
   int32_t GetInteger(uint32_t index) const {
     return peloton::type::ValuePeeker::PeekInteger(parameters_values_[index]);
   }
 
-  // Get the bigint value for the index
   int64_t GetBigInt(uint32_t index) const {
     return peloton::type::ValuePeeker::PeekBigInt(parameters_values_[index]);
   }
 
-  // Get the double value for the index
   double GetDouble(uint32_t index) const {
     return peloton::type::ValuePeeker::PeekDouble(parameters_values_[index]);
   }
 
-  // Get the date value for the index
   int32_t GetDate(uint32_t index) const {
     return peloton::type::ValuePeeker::PeekDate(parameters_values_[index]);
   }
 
-  // Get the timestamp value for the index
   uint64_t GetTimestamp(uint32_t index) const {
     return peloton::type::ValuePeeker::PeekTimestamp(parameters_values_[index]);
   }
 
-  // Get the valrchar value for the index
   const char *GetVarcharVal(uint32_t index) const {
     return peloton::type::ValuePeeker::PeekVarchar(parameters_values_[index]);
   }
 
-  // Get the valrchar length for the index
   uint32_t GetVarcharLen(uint32_t index) const {
     return parameters_values_[index].GetLength();
   }
 
-  // Get the valrbinary value for the index
   const char *GetVarbinaryVal(uint32_t index) const {
     return peloton::type::ValuePeeker::PeekVarbinary(parameters_values_[index]);
   }
 
-  // Get the valrbinary length for the index
   uint32_t GetVarbinaryLen(uint32_t index) const {
     return parameters_values_[index].GetLength();
   }

--- a/src/include/codegen/row_batch.h
+++ b/src/include/codegen/row_batch.h
@@ -96,7 +96,7 @@ class RowBatch {
 
     // Register the temporary availability of an attribute in this row
     void RegisterAttributeValue(const planner::AttributeInfo *ai,
-                                codegen::Value &val);
+                                const codegen::Value &val);
 
     RowBatch &GetBatch() const { return batch_; }
 

--- a/src/include/codegen/runtime_state.h
+++ b/src/include/codegen/runtime_state.h
@@ -54,8 +54,7 @@ class RuntimeState {
 
   // Register a parameter with the given name and type in this state. Callers
   // can specify whether the state is local (i.e., on the stack) or global.
-  RuntimeState::StateID RegisterState(std::string name, llvm::Type *type,
-                                      bool is_on_stack = false);
+  RuntimeState::StateID RegisterState(std::string name, llvm::Type *type);
 
   // Get the pointer to the given state information with the given ID
   llvm::Value *LoadStatePtr(CodeGen &codegen,
@@ -68,18 +67,12 @@ class RuntimeState {
   // Construct the equivalent LLVM type that represents this runtime state
   llvm::Type *FinalizeType(CodeGen &codegen);
 
-  // Create/initialize all registered state that is stack-local
-  void CreateLocalState(CodeGen &codegen);
-
  private:
   // Little struct to track information of elements in the runtime state
   struct StateInfo {
     // The name and type of the variable
     std::string name;
     llvm::Type *type;
-
-    // Is this state allocated on the stack (local) or as a function parameter
-    bool local;
 
     // This is the index into the runtime state type that this state is stored
     uint32_t index;

--- a/src/include/codegen/sorter.h
+++ b/src/include/codegen/sorter.h
@@ -73,7 +73,8 @@ class Sorter {
   //===--------------------------------------------------------------------===//
   struct IterateCallback {
     // Destructor
-    virtual ~IterateCallback() {}
+    virtual ~IterateCallback() = default;
+
     // Process the range of rows between the given start and end indices
     virtual void ProcessEntry(
         CodeGen &codegen, const std::vector<codegen::Value> &vals) const = 0;
@@ -84,7 +85,8 @@ class Sorter {
   //===--------------------------------------------------------------------===//
   struct VectorizedIterateCallback {
     // Destructor
-    virtual ~VectorizedIterateCallback() {}
+    virtual ~VectorizedIterateCallback() = default;
+
     // Process the range of rows between the given start and end indices
     virtual void ProcessEntries(CodeGen &codegen, llvm::Value *start_index,
                                 llvm::Value *end_index,
@@ -105,6 +107,9 @@ class Sorter {
 
   // Sort all the data that has been inserted into the sorter instance
   void Sort(CodeGen &codegen, llvm::Value *sorter_ptr) const;
+
+  // Reset the sorter
+  void Reset(CodeGen &codegen, llvm::Value *sorter_ptr) const;
 
   void Iterate(CodeGen &codegen, llvm::Value *sorter_ptr,
                IterateCallback &callback) const;
@@ -129,8 +134,6 @@ class Sorter {
 
   llvm::Value *GetStartPosition(CodeGen &codegen,
                                 llvm::Value *sorter_ptr) const;
-  llvm::Value *GetEndPosition(CodeGen &codegen, llvm::Value *sorter_ptr) const;
-
   llvm::Value *GetTupleSize(CodeGen &codegen) const;
 
  private:

--- a/src/include/codegen/sorter.h
+++ b/src/include/codegen/sorter.h
@@ -122,8 +122,7 @@ class Sorter {
 
  private:
   //===--------------------------------------------------------------------===//
-  // SORTER INSTANCE ACCESSORS
-  //
+  // ACCESSORS
   // TODO: We should codify access to instance memory variables using templates
   //       to something like: codegen.LoadMember<SorterProxy::start_pos>(...)
   //===--------------------------------------------------------------------===//
@@ -132,10 +131,7 @@ class Sorter {
                                 llvm::Value *sorter_ptr) const;
   llvm::Value *GetEndPosition(CodeGen &codegen, llvm::Value *sorter_ptr) const;
 
-  llvm::Value *GetTupleSize(CodeGen &codegen) const {
-    // TODO: Why 64-bit?
-    return codegen.Const32(storage_format_.GetStorageSize());
-  }
+  llvm::Value *GetTupleSize(CodeGen &codegen) const;
 
  private:
   // Compact storage to materialize things

--- a/src/include/codegen/values_runtime.h
+++ b/src/include/codegen/values_runtime.h
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include "type/value.h"
+#include <cstdint>
 
 namespace peloton {
 namespace codegen {
@@ -44,11 +44,11 @@ class ValuesRuntime {
   static void OutputDecimal(char *values, uint32_t idx, double val);
 
   // Write out the given varchar value into the array at the provided index
-  static void OutputVarchar(char *values, uint32_t idx, char *str,
+  static void OutputVarchar(char *values, uint32_t idx, const char *str,
                             uint32_t len);
 
   // Write out the given varbinary value into the array at the provided index
-  static void OutputVarbinary(char *values, uint32_t idx, char *str,
+  static void OutputVarbinary(char *values, uint32_t idx, const char *str,
                               uint32_t len);
 
   static int32_t CompareStrings(const char *str1, uint32_t len1,

--- a/src/include/expression/comparison_expression.h
+++ b/src/include/expression/comparison_expression.h
@@ -25,9 +25,6 @@ namespace expression {
 
 class ComparisonExpression : public AbstractExpression {
  public:
-  // TODO: Should we delete left and right if they are not nullptr?
-  ~ComparisonExpression() {}
-
   ComparisonExpression(ExpressionType type)
       : AbstractExpression(type, type::TypeId::BOOLEAN) {}
 

--- a/src/include/expression/comparison_expression.h
+++ b/src/include/expression/comparison_expression.h
@@ -22,62 +22,89 @@ namespace expression {
 //===----------------------------------------------------------------------===//
 // ComparisonExpression
 //===----------------------------------------------------------------------===//
-
 class ComparisonExpression : public AbstractExpression {
  public:
-  ComparisonExpression(ExpressionType type)
-      : AbstractExpression(type, type::TypeId::BOOLEAN) {}
-
+  /**
+   * Comparison expression constructor
+   *
+   * @param type The exact type of comparison (e.g., less-than, greater-than)
+   * @param left The left side of the comparison
+   * @param right The right side of the comparison
+   */
   ComparisonExpression(ExpressionType type, AbstractExpression *left,
-                       AbstractExpression *right)
-      : AbstractExpression(type, type::TypeId::BOOLEAN, left, right) {}
+                       AbstractExpression *right);
 
-  type::Value Evaluate(
-      const AbstractTuple *tuple1,
-      const AbstractTuple *tuple2,
-      executor::ExecutorContext *context) const override {
-    PL_ASSERT(children_.size() == 2);
-    auto vl = children_[0]->Evaluate(tuple1, tuple2, context);
-    auto vr = children_[1]->Evaluate(tuple1, tuple2, context);
-    switch (exp_type_) {
-      case (ExpressionType::COMPARE_EQUAL):
-        return type::ValueFactory::GetBooleanValue(vl.CompareEquals(vr));
-      case (ExpressionType::COMPARE_NOTEQUAL):
-        return type::ValueFactory::GetBooleanValue(vl.CompareNotEquals(vr));
-      case (ExpressionType::COMPARE_LESSTHAN):
-        return type::ValueFactory::GetBooleanValue(vl.CompareLessThan(vr));
-      case (ExpressionType::COMPARE_GREATERTHAN):
-        return type::ValueFactory::GetBooleanValue(vl.CompareGreaterThan(vr));
-      case (ExpressionType::COMPARE_LESSTHANOREQUALTO):
-        return type::ValueFactory::GetBooleanValue(
-            vl.CompareLessThanEquals(vr));
-      case (ExpressionType::COMPARE_GREATERTHANOREQUALTO):
-        return type::ValueFactory::GetBooleanValue(
-            vl.CompareGreaterThanEquals(vr));
-      case (ExpressionType::COMPARE_DISTINCT_FROM): {
-        if (vl.IsNull() && vr.IsNull()) {
-          return type::ValueFactory::GetBooleanValue(false);
-        }
-        else if (!vl.IsNull() && !vr.IsNull()) {
-          return type::ValueFactory::GetBooleanValue(vl.CompareNotEquals(vr));
-        }
-        return type::ValueFactory::GetBooleanValue(true);
-      }
-      default:
-        throw Exception("Invalid comparison expression type.");
-    }
-  }
+  /**
+   * Perform the comparison of the first and second provided input tuples.
+   *
+   * @param tuple1 The left tuple
+   * @param tuple2 The right tuple
+   * @param context A context object
+   * @return The result of the comparison
+   */
+  type::Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                       executor::ExecutorContext *context) const override;
 
-  AbstractExpression *Copy() const override {
-    return new ComparisonExpression(*this);
-  }
+  /**
+   * Copy this comparison expression into a new expression object. This method
+   * relinquishes ownership of the object after creation. It is the caller's
+   * responsibility to clean up what is returned.
+   *
+   * @return An exact copy of this comparison expression
+   */
+  AbstractExpression *Copy() const override;
 
-  virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
-
- protected:
-  ComparisonExpression(const ComparisonExpression &other)
-      : AbstractExpression(other) {}
+  void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Implementation below
+///
+////////////////////////////////////////////////////////////////////////////////
+
+inline ComparisonExpression::ComparisonExpression(ExpressionType type,
+                                                  AbstractExpression *left,
+                                                  AbstractExpression *right)
+    : AbstractExpression(type, type::TypeId::BOOLEAN, left, right) {}
+
+inline type::Value ComparisonExpression::Evaluate(
+    const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+    executor::ExecutorContext *context) const {
+  PL_ASSERT(children_.size() == 2);
+  auto vl = children_[0]->Evaluate(tuple1, tuple2, context);
+  auto vr = children_[1]->Evaluate(tuple1, tuple2, context);
+  switch (exp_type_) {
+    case (ExpressionType::COMPARE_EQUAL):
+      return type::ValueFactory::GetBooleanValue(vl.CompareEquals(vr));
+    case (ExpressionType::COMPARE_NOTEQUAL):
+      return type::ValueFactory::GetBooleanValue(vl.CompareNotEquals(vr));
+    case (ExpressionType::COMPARE_LESSTHAN):
+      return type::ValueFactory::GetBooleanValue(vl.CompareLessThan(vr));
+    case (ExpressionType::COMPARE_GREATERTHAN):
+      return type::ValueFactory::GetBooleanValue(vl.CompareGreaterThan(vr));
+    case (ExpressionType::COMPARE_LESSTHANOREQUALTO):
+      return type::ValueFactory::GetBooleanValue(vl.CompareLessThanEquals(vr));
+    case (ExpressionType::COMPARE_GREATERTHANOREQUALTO):
+      return type::ValueFactory::GetBooleanValue(
+          vl.CompareGreaterThanEquals(vr));
+    case (ExpressionType::COMPARE_DISTINCT_FROM): {
+      if (vl.IsNull() && vr.IsNull()) {
+        return type::ValueFactory::GetBooleanValue(false);
+      } else if (!vl.IsNull() && !vr.IsNull()) {
+        return type::ValueFactory::GetBooleanValue(vl.CompareNotEquals(vr));
+      }
+      return type::ValueFactory::GetBooleanValue(true);
+    }
+    default:
+      throw Exception("Invalid comparison expression type.");
+  }
+}
+
+inline AbstractExpression *ComparisonExpression::Copy() const {
+  return new ComparisonExpression(GetExpressionType(), GetChild(0)->Copy(),
+                                  GetChild(1)->Copy());
+}
 
 }  // namespace expression
 }  // namespace peloton

--- a/src/include/expression/constant_value_expression.h
+++ b/src/include/expression/constant_value_expression.h
@@ -27,96 +27,128 @@ namespace expression {
 
 class ConstantValueExpression : public AbstractExpression {
  public:
-  ConstantValueExpression(const type::Value &value)
-      : AbstractExpression(ExpressionType::VALUE_CONSTANT, value.GetTypeId()),
-        value_(value.Copy()) {}
+  explicit ConstantValueExpression(const type::Value &value);
 
-  type::Value Evaluate(
-      UNUSED_ATTRIBUTE const AbstractTuple *tuple1,
-      UNUSED_ATTRIBUTE const AbstractTuple *tuple2,
-      UNUSED_ATTRIBUTE executor::ExecutorContext *context) const override {
-    return value_;
-  }
+  // Evaluate this expression
+  type::Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
+                       executor::ExecutorContext *context) const override;
 
-  virtual void DeduceExpressionName() override {
-    if (!alias.empty())
-      return;
-    expr_name_ = value_.ToString();
-  }
-  
-  virtual bool ExactlyEquals(const AbstractExpression &other) const override {
-    if (exp_type_ != other.GetExpressionType())
-      return false;
-    auto const_expr = static_cast<const ConstantValueExpression &>(other);
-    return value_.CompareEquals(const_expr.value_) == CmpBool::TRUE;
-  }
+  void DeduceExpressionName() override;
 
-  virtual hash_t HashForExactMatch() const override {
-    hash_t hash = HashUtil::Hash(&exp_type_);
-    return HashUtil::CombineHashes(hash, value_.Hash());
-  }
+  // Hashing
+  hash_t HashForExactMatch() const override;
+  hash_t Hash() const override;
 
-  virtual bool operator==(const AbstractExpression &rhs) const override {
-    auto type = rhs.GetExpressionType();
-
-    if ((type != ExpressionType::VALUE_PARAMETER) &&
-        (exp_type_ != type || return_value_type_ != rhs.GetValueType())) {
-      return false;
-    }
-
-    auto &other = static_cast<const expression::ConstantValueExpression &>(rhs);
-    // Do not check value since we are going to parameterize and cache
-    // but, check the nullability to optimize the non-nullable cases
-    if (value_.IsNull() != other.IsNullable()) {
-      return false;
-    }
-
-    return true;
-  }
-
-  virtual bool operator!=(const AbstractExpression &rhs) const override {
+  // Equality checks
+  bool ExactlyEquals(const AbstractExpression &other) const override;
+  bool operator==(const AbstractExpression &rhs) const override;
+  bool operator!=(const AbstractExpression &rhs) const override {
     return !(*this == rhs);
   }
 
-  virtual hash_t Hash() const override {
-    // Use VALUE_PARAMTER for parameterization with the compiled query cache
-    auto val = ExpressionType::VALUE_PARAMETER;
-    hash_t hash = HashUtil::Hash(&val);
-
-    // Do not check value since we are going to parameterize and cache
-    // but, check the nullability to optimize the non-nullable cases
-    auto is_nullable = value_.IsNull();
-    return HashUtil::CombineHashes(hash, HashUtil::Hash(&is_nullable));
-  }
-
-  virtual void VisitParameters(codegen::QueryParametersMap &map,
+  void VisitParameters(
+      codegen::QueryParametersMap &map,
       std::vector<peloton::type::Value> &values,
-      UNUSED_ATTRIBUTE const std::vector<peloton::type::Value>
-          &values_from_user) override {
-    auto is_nullable = value_.IsNull();
-    map.Insert(Parameter::CreateConstParameter(value_.GetTypeId(), is_nullable),
-               this);
-    values.push_back(value_);
-  };
+      const std::vector<peloton::type::Value> &values_from_user) override;
 
+  // Copy this constant expression
+  AbstractExpression *Copy() const override;
+
+  void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
+
+  // Value accessor
   type::Value GetValue() const { return value_; }
 
+  // Constant value expressions do not have a parameter
   bool HasParameter() const override { return false; }
 
-  AbstractExpression *Copy() const override {
-    return new ConstantValueExpression(*this);
-  }
-
-  virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
-
+  // Is the expression nullable? In this case, it's whether the constnat value
+  // is null or not.
   bool IsNullable() const override { return value_.IsNull(); }
 
- protected:
-  ConstantValueExpression(const ConstantValueExpression &other)
-      : AbstractExpression(other), value_(other.value_) {}
-
+ private:
+  // The constant
   type::Value value_;
 };
+
+////////////////////////////////////////////////////////////////////////////////
+///
+/// Implementation below
+///
+////////////////////////////////////////////////////////////////////////////////
+
+inline ConstantValueExpression::ConstantValueExpression(
+    const type::Value &value)
+    : AbstractExpression(ExpressionType::VALUE_CONSTANT, value.GetTypeId()),
+      value_(value.Copy()) {}
+
+inline type::Value ConstantValueExpression::Evaluate(
+    UNUSED_ATTRIBUTE const AbstractTuple *tuple1,
+    UNUSED_ATTRIBUTE const AbstractTuple *tuple2,
+    UNUSED_ATTRIBUTE executor::ExecutorContext *context) const {
+  return value_;
+}
+
+inline void ConstantValueExpression::DeduceExpressionName() {
+  if (!alias.empty()) return;
+  expr_name_ = value_.ToString();
+}
+
+inline bool ConstantValueExpression::ExactlyEquals(
+    const AbstractExpression &other) const {
+  if (exp_type_ != other.GetExpressionType()) return false;
+  auto &const_expr = static_cast<const ConstantValueExpression &>(other);
+  return value_.CompareEquals(const_expr.value_) == CmpBool::TRUE;
+}
+
+inline hash_t ConstantValueExpression::HashForExactMatch() const {
+  hash_t hash = HashUtil::Hash(&exp_type_);
+  return HashUtil::CombineHashes(hash, value_.Hash());
+}
+
+inline hash_t ConstantValueExpression::Hash() const {
+  // Use VALUE_PARAMETER for parameterization with the compiled query cache
+  auto val = ExpressionType::VALUE_PARAMETER;
+  hash_t hash = HashUtil::Hash(&val);
+
+  // Do not check value since we are going to parameterize and cache
+  // but, check the nullability to optimize the non-nullable cases
+  auto is_nullable = value_.IsNull();
+  return HashUtil::CombineHashes(hash, HashUtil::Hash(&is_nullable));
+}
+
+inline bool ConstantValueExpression::operator==(
+    const AbstractExpression &rhs) const {
+  auto type = rhs.GetExpressionType();
+
+  if ((type != ExpressionType::VALUE_PARAMETER) &&
+      (exp_type_ != type || return_value_type_ != rhs.GetValueType())) {
+    return false;
+  }
+
+  auto &other = static_cast<const expression::ConstantValueExpression &>(rhs);
+  // Do not check value since we are going to parameterize and cache
+  // but, check the nullability to optimize the non-nullable cases
+  if (value_.IsNull() != other.IsNullable()) {
+    return false;
+  }
+
+  return true;
+}
+
+inline void ConstantValueExpression::VisitParameters(
+    codegen::QueryParametersMap &map, std::vector<peloton::type::Value> &values,
+    UNUSED_ATTRIBUTE const std::vector<peloton::type::Value> &
+        values_from_user) {
+  auto is_nullable = value_.IsNull();
+  map.Insert(Parameter::CreateConstParameter(value_.GetTypeId(), is_nullable),
+             this);
+  values.push_back(value_);
+}
+
+inline AbstractExpression* ConstantValueExpression::Copy() const {
+  return new ConstantValueExpression(GetValue());
+}
 
 }  // namespace expression
 }  // namespace peloton

--- a/src/include/planner/abstract_join_plan.h
+++ b/src/include/planner/abstract_join_plan.h
@@ -51,7 +51,7 @@ class AbstractJoinPlan : public AbstractPlan {
 
   hash_t Hash() const override;
 
-  bool operator==(const AbstractPlan &rhs) const;
+  bool operator==(const AbstractPlan &rhs) const override;
 
   void VisitParameters(
       codegen::QueryParametersMap &map,

--- a/src/include/planner/abstract_join_plan.h
+++ b/src/include/planner/abstract_join_plan.h
@@ -45,7 +45,13 @@ class AbstractJoinPlan : public AbstractPlan {
     // Fuck off!
   }
 
+  void GetOutputColumns(std::vector<oid_t> &columns) const override;
+
   void PerformBinding(BindingContext &context) override;
+
+  hash_t Hash() const override;
+
+  bool operator==(const AbstractPlan &rhs) const;
 
   void VisitParameters(
       codegen::QueryParametersMap &map,

--- a/src/include/planner/abstract_join_plan.h
+++ b/src/include/planner/abstract_join_plan.h
@@ -47,6 +47,11 @@ class AbstractJoinPlan : public AbstractPlan {
 
   void PerformBinding(BindingContext &context) override;
 
+  void VisitParameters(
+      codegen::QueryParametersMap &map,
+      std::vector<peloton::type::Value> &values,
+      const std::vector<peloton::type::Value> &values_from_user) override;
+
   //===--------------------------------------------------------------------===//
   // Accessors
   //===--------------------------------------------------------------------===//

--- a/src/include/planner/abstract_plan.h
+++ b/src/include/planner/abstract_plan.h
@@ -6,7 +6,7 @@
 //
 // Identification: src/include/planner/abstract_plan.h
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -28,19 +28,19 @@
 
 namespace peloton {
 
+namespace catalog {
+class Schema;
+}  // namespace catalog
+
 namespace executor {
 class AbstractExecutor;
 class LogicalTile;
-}
-
-namespace catalog {
-class Schema;
-}
+}  // namespace executor
 
 namespace expression {
 class AbstractExpression;
 class Parameter;
-}
+}  // namespace expression
 
 namespace planner {
 
@@ -79,7 +79,7 @@ class AbstractPlan : public Printable {
   // Setting values of the parameters in the prepare statement
   virtual void SetParameterValues(std::vector<type::Value> *values);
   
-  // Get the estimated cardinalities of this plan
+  // Get the estimated cardinality of this plan
   int GetCardinality() const { return estimated_cardinality_; }
   
   // TODO: This is only for testing now. When the optimizer is ready, we should
@@ -101,10 +101,10 @@ class AbstractPlan : public Printable {
   }
 
   virtual void GetOutputColumns(std::vector<oid_t> &columns UNUSED_ATTRIBUTE)
-      const { return; }
+      const { }
 
   // Get a string representation for debugging
-  const std::string GetInfo() const;
+  const std::string GetInfo() const override;
 
   virtual std::unique_ptr<AbstractPlan> Copy() const = 0;
 

--- a/src/include/planner/nested_loop_join_plan.h
+++ b/src/include/planner/nested_loop_join_plan.h
@@ -36,6 +36,10 @@ class NestedLoopJoinPlan : public AbstractJoinPlan {
 
   void HandleSubplanBinding(bool from_left, const BindingContext &ctx) override;
 
+  hash_t Hash() const override;
+
+  bool operator==(const AbstractPlan &rhs) const override;
+
   PlanNodeType GetPlanNodeType() const override {
     return PlanNodeType::NESTLOOP;
   }

--- a/src/include/planner/nested_loop_join_plan.h
+++ b/src/include/planner/nested_loop_join_plan.h
@@ -48,8 +48,16 @@ class NestedLoopJoinPlan : public AbstractJoinPlan {
     return join_column_ids_left_;
   }
 
+  const std::vector<const planner::AttributeInfo *> GetJoinAIsLeft() const {
+    return join_ais_left_;
+  }
+
   const std::vector<oid_t> &GetJoinColumnsRight() const {
     return join_column_ids_right_;
+  }
+
+  const std::vector<const planner::AttributeInfo *> GetJoinAIsRight() const {
+    return join_ais_right_;
   }
 
  private:
@@ -58,6 +66,7 @@ class NestedLoopJoinPlan : public AbstractJoinPlan {
   // corresponding column id in the result is column 3, then the value should
   // be 3 in  join_column_ids_left. The is specified when creating the plan.
   std::vector<oid_t> join_column_ids_left_;
+  std::vector<const planner::AttributeInfo *> join_ais_left_;
 
   // columns in right table for join predicate. This is also the columns in the
   // result. For example, you wan to do i_id = s_id, s_id must be in the output
@@ -66,6 +75,7 @@ class NestedLoopJoinPlan : public AbstractJoinPlan {
   // physical column id and pass this physical column id to SetTupleColumnValue
   // to update the corresponding column in the index predicate
   std::vector<oid_t> join_column_ids_right_;
+  std::vector<const planner::AttributeInfo *> join_ais_right_;
 
  private:
   DISALLOW_COPY_AND_MOVE(NestedLoopJoinPlan);

--- a/src/include/planner/project_info.h
+++ b/src/include/planner/project_info.h
@@ -30,16 +30,16 @@ namespace planner {
 /**
  * @brief A class for representing projection information.
  *
- * The information is stored in two parts.
+ * The information is stored in two parts:
  * 1) A target_list stores non-trivial projections that can be calculated from
- *expressions.
+ *    expressions.
  * 2) A direct_map_list stores projections that is simply reorder of attributes
- *in the input.
+ *    in the input.
  *
  * We separate it in this way for two reasons:
- * i) Postgres does the same thing;
+ * i)  Postgres does the same thing;
  * ii) It makes it possible to use a more efficient executor to handle pure
- * direct map projections.
+ *     direct map projections.
  *
  * NB: in case of a constant-valued projection, it is still under the umbrella
  * of \b target_list, though it sounds simple enough.
@@ -72,7 +72,7 @@ class ProjectInfo {
 
   const DirectMapList &GetDirectMapList() const { return direct_map_list_; }
 
-  bool isNonTrivial() const { return target_list_.size() > 0; };
+  bool IsNonTrivial() const { return !target_list_.empty(); };
 
   bool Evaluate(storage::Tuple *dest, const AbstractTuple *tuple1,
                 const AbstractTuple *tuple2,

--- a/src/include/settings/settings.h
+++ b/src/include/settings/settings.h
@@ -58,6 +58,11 @@ SETTING_string(certificate_file,
 // RESOURCE USAGE
 //===----------------------------------------------------------------------===//
 
+SETTING_double(bnlj_buffer_size,
+             "The default buffer size to use for blockwise nested loop joins (default: 1 MB)",
+             1.0 * 1024.0 * 1024.0,
+             true, true)
+
 //===----------------------------------------------------------------------===//
 // WRITE AHEAD LOG
 //===----------------------------------------------------------------------===//

--- a/src/include/settings/settings_macro.h
+++ b/src/include/settings/settings_macro.h
@@ -24,6 +24,9 @@
   #ifdef SETTING_int
     #undef SETTING_int
   #endif
+  #ifdef SETTING_double
+    #undef SETTING_double
+  #endif
   #ifdef SETTING_bool
     #undef SETTING_bool
   #endif
@@ -32,6 +35,9 @@
   #endif
   #define SETTING_int(name, description, default_value, is_mutable, is_persistent)     \
     DEFINE_int32(name, default_value, description);
+
+  #define SETTING_double(name, description, default_value, is_mutable, is_persistent)     \
+    DEFINE_double(name, default_value, description);
 
   #define SETTING_bool(name, description, default_value, is_mutable, is_persistent)    \
     DEFINE_bool(name, default_value, description);
@@ -44,6 +50,9 @@
   #ifdef SETTING_int
     #undef SETTING_int
   #endif
+  #ifdef SETTING_double
+    #undef SETTING_double
+  #endif
   #ifdef SETTING_bool
     #undef SETTING_bool
   #endif
@@ -52,6 +61,9 @@
   #endif
   #define SETTING_int(name, description, default_value, is_mutable, is_persistent)     \
     DECLARE_int32(name);
+
+  #define SETTING_double(name, description, default_value, is_mutable, is_persistent)     \
+    DECLARE_double(name);
 
   #define SETTING_bool(name, description, default_value, is_mutable, is_persistent)    \
     DECLARE_bool(name);
@@ -64,6 +76,9 @@
   #ifdef SETTING_int
     #undef SETTING_int
   #endif
+  #ifdef SETTING_double
+    #undef SETTING_double
+  #endif
   #ifdef SETTING_bool
     #undef SETTING_bool
   #endif
@@ -75,6 +90,13 @@
         peloton::settings::SettingId::name,                                            \
         #name, type::ValueFactory::GetIntegerValue(FLAGS_##name),                      \
         description, type::ValueFactory::GetIntegerValue(default_value),               \
+        is_mutable, is_persistent);
+
+  #define SETTING_double(name, description, default_value, is_mutable, is_persistent)  \
+      DefineSetting(                                                                   \
+        peloton::settings::SettingId::name,                                            \
+        #name, type::ValueFactory::GetDecimalValue(FLAGS_##name),                      \
+        description, type::ValueFactory::GetDecimalValue(default_value),               \
         is_mutable, is_persistent);
 
   #define SETTING_bool(name, description, default_value, is_mutable, is_persistent)    \
@@ -96,6 +118,9 @@
   #ifdef SETTING_int
     #undef SETTING_int
   #endif
+  #ifdef SETTING_double
+    #undef SETTING_double
+  #endif
   #ifdef SETTING_bool
     #undef SETTING_bool
   #endif
@@ -103,6 +128,9 @@
     #undef SETTING_string
   #endif
   #define SETTING_int(name, description, default_value, is_mutable, is_persistent)     \
+    name,
+
+  #define SETTING_double(name, description, default_value, is_mutable, is_persistent)     \
     name,
 
   #define SETTING_bool(name, description, default_value, is_mutable, is_persistent)    \

--- a/src/include/settings/settings_manager.h
+++ b/src/include/settings/settings_manager.h
@@ -29,6 +29,7 @@ namespace settings {
 class SettingsManager : public Printable {
  public:
   static int32_t GetInt(SettingId id);
+  static double GetDouble(SettingId id);
   static bool GetBool(SettingId id);
   static std::string GetString(SettingId id);
 

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -745,7 +745,8 @@ static void JoinQueryHelper(
   std::shared_ptr<const catalog::Schema> schema(nullptr);
 
   planner::NestedLoopJoinPlan nested_loop_join_node(
-      join_type, std::move(join_predicate), std::move(project_info), schema);
+      join_type, std::move(join_predicate), std::move(project_info), schema,
+      {left_table_join_column}, {right_table_join_column});
 
   // Run the nested loop join executor
   executor::NestedLoopJoinExecutor nested_loop_join_executor(

--- a/src/planner/abstract_join_plan.cpp
+++ b/src/planner/abstract_join_plan.cpp
@@ -12,8 +12,15 @@
 
 #include "planner/abstract_join_plan.h"
 
+#include <numeric>
+
 namespace peloton {
 namespace planner {
+
+void AbstractJoinPlan::GetOutputColumns(std::vector<oid_t> &columns) const {
+  columns.resize(GetSchema()->GetColumnCount());
+  std::iota(columns.begin(), columns.end(), 0);
+}
 
 void AbstractJoinPlan::PerformBinding(BindingContext &context) {
   const auto &children = GetChildren();
@@ -73,6 +80,61 @@ void AbstractJoinPlan::VisitParameters(
       derived_attr_expr->VisitParameters(map, values, values_from_user);
     }
   }
+}
+
+bool AbstractJoinPlan::operator==(const AbstractPlan &rhs) const {
+  if (GetPlanNodeType() != rhs.GetPlanNodeType()) {
+    return false;
+  }
+
+  // Check join type
+  auto &other = static_cast<const planner::AbstractJoinPlan &>(rhs);
+  if (GetJoinType() != other.GetJoinType()) {
+    return false;
+  }
+
+  // Check predicate
+  auto *pred = GetPredicate();
+  auto *other_pred = other.GetPredicate();
+  if ((pred == nullptr && other_pred != nullptr) ||
+      (pred != nullptr && other_pred == nullptr)) {
+    return false;
+  }
+  if (pred != nullptr && *pred != *other_pred) {
+    return false;
+  }
+
+  // Check projection information
+  auto *proj_info = GetProjInfo();
+  auto *other_proj_info = other.GetProjInfo();
+  if ((proj_info == nullptr && other_proj_info != nullptr) ||
+      (proj_info != nullptr && other_proj_info == nullptr)) {
+    return false;
+  }
+  if (proj_info != nullptr && *proj_info != *other_proj_info) {
+    return false;
+  }
+
+  // Looks okay, but let subclass make sure
+  return true;
+}
+
+hash_t AbstractJoinPlan::Hash() const {
+  auto type = GetPlanNodeType();
+  hash_t hash = HashUtil::Hash(&type);
+
+  auto join_type = GetJoinType();
+  hash = HashUtil::CombineHashes(hash, HashUtil::Hash(&join_type));
+
+  if (GetPredicate() != nullptr) {
+    hash = HashUtil::CombineHashes(hash, GetPredicate()->Hash());
+  }
+
+  if (GetProjInfo() != nullptr) {
+    hash = HashUtil::CombineHashes(hash, GetProjInfo()->Hash());
+  }
+
+  return hash;
 }
 
 }  // namespace planner

--- a/src/planner/hash_join_plan.cpp
+++ b/src/planner/hash_join_plan.cpp
@@ -23,38 +23,32 @@
 namespace peloton {
 namespace planner {
 
-HashJoinPlan::HashJoinPlan(
-    JoinType join_type,
-    std::unique_ptr<const expression::AbstractExpression> &&predicate,
-    std::unique_ptr<const ProjectInfo> &&proj_info,
-    std::shared_ptr<const catalog::Schema> &proj_schema, bool build_bloomfilter)
+HashJoinPlan::HashJoinPlan(JoinType join_type, ExpressionPtr &&predicate,
+                           std::unique_ptr<const ProjectInfo> &&proj_info,
+                           std::shared_ptr<const catalog::Schema> &proj_schema,
+                           bool build_bloomfilter)
     : AbstractJoinPlan(join_type, std::move(predicate), std::move(proj_info),
                        proj_schema),
       build_bloomfilter_(build_bloomfilter) {}
 
 // outer_hashkeys is added for IN-subquery
-HashJoinPlan::HashJoinPlan(
-    JoinType join_type,
-    std::unique_ptr<const expression::AbstractExpression> &&predicate,
-    std::unique_ptr<const ProjectInfo> &&proj_info,
-    std::shared_ptr<const catalog::Schema> &proj_schema,
-    const std::vector<oid_t> &outer_hashkeys, bool build_bloomfilter)
+HashJoinPlan::HashJoinPlan(JoinType join_type, ExpressionPtr &&predicate,
+                           std::unique_ptr<const ProjectInfo> &&proj_info,
+                           std::shared_ptr<const catalog::Schema> &proj_schema,
+                           const std::vector<oid_t> &outer_hashkeys,
+                           bool build_bloomfilter)
     : AbstractJoinPlan(join_type, std::move(predicate), std::move(proj_info),
                        proj_schema),
       build_bloomfilter_(build_bloomfilter) {
   outer_column_ids_ = outer_hashkeys;  // added for IN-subquery
 }
 
-HashJoinPlan::HashJoinPlan(
-    JoinType join_type,
-    std::unique_ptr<const expression::AbstractExpression> &&predicate,
-    std::unique_ptr<const ProjectInfo> &&proj_info,
-    std::shared_ptr<const catalog::Schema> &proj_schema,
-    std::vector<std::unique_ptr<const expression::AbstractExpression>>
-        &left_hash_keys,
-    std::vector<std::unique_ptr<const expression::AbstractExpression>>
-        &right_hash_keys,
-    bool build_bloomfilter)
+HashJoinPlan::HashJoinPlan(JoinType join_type, ExpressionPtr &&predicate,
+                           std::unique_ptr<const ProjectInfo> &&proj_info,
+                           std::shared_ptr<const catalog::Schema> &proj_schema,
+                           std::vector<ExpressionPtr> &left_hash_keys,
+                           std::vector<ExpressionPtr> &right_hash_keys,
+                           bool build_bloomfilter)
     : AbstractJoinPlan(join_type, std::move(predicate), std::move(proj_info),
                        proj_schema),
       left_hash_keys_(std::move(left_hash_keys)),
@@ -71,19 +65,7 @@ void HashJoinPlan::HandleSubplanBinding(bool is_left,
 }
 
 hash_t HashJoinPlan::Hash() const {
-  auto type = GetPlanNodeType();
-  hash_t hash = HashUtil::Hash(&type);
-
-  auto join_type = GetJoinType();
-  hash = HashUtil::CombineHashes(hash, HashUtil::Hash(&join_type));
-
-  if (GetPredicate() != nullptr) {
-    hash = HashUtil::CombineHashes(hash, GetPredicate()->Hash());
-  }
-
-  if (GetProjInfo() != nullptr) {
-    hash = HashUtil::CombineHashes(hash, GetProjInfo()->Hash());
-  }
+  hash_t hash = AbstractJoinPlan::Hash();
 
   std::vector<const expression::AbstractExpression *> keys;
   GetLeftHashKeys(keys);
@@ -101,30 +83,11 @@ hash_t HashJoinPlan::Hash() const {
 }
 
 bool HashJoinPlan::operator==(const AbstractPlan &rhs) const {
-  if (GetPlanNodeType() != rhs.GetPlanNodeType())
+  if (!AbstractJoinPlan::operator==(rhs)) {
     return false;
+  }
 
-  auto &other = static_cast<const planner::HashJoinPlan &>(rhs);
-  if (GetJoinType() != other.GetJoinType())
-    return false;
-
-  // Prodicate
-  auto *pred = GetPredicate();
-  auto *other_pred = other.GetPredicate();
-  if ((pred == nullptr && other_pred != nullptr) ||
-      (pred != nullptr && other_pred == nullptr))
-    return false;
-  if (pred && *pred != *other_pred)
-    return false;
-
-  // Project Info
-  auto *proj_info = GetProjInfo();
-  auto *other_proj_info = other.GetProjInfo();
-  if ((proj_info == nullptr && other_proj_info != nullptr) ||
-      (proj_info != nullptr && other_proj_info == nullptr))
-    return false;
-  if (proj_info && *proj_info != *other_proj_info)
-    return false;
+  const auto &other = static_cast<const HashJoinPlan &>(rhs);
 
   std::vector<const expression::AbstractExpression *> keys, other_keys;
 
@@ -132,12 +95,14 @@ bool HashJoinPlan::operator==(const AbstractPlan &rhs) const {
   GetLeftHashKeys(keys);
   other.GetLeftHashKeys(other_keys);
   size_t keys_count = keys.size();
-  if (keys_count != other_keys.size())
+  if (keys_count != other_keys.size()) {
     return false;
+  }
 
   for (size_t i = 0; i < keys_count; i++) {
-    if (*keys[i] != *other_keys[i])
+    if (*keys[i] != *other_keys[i]) {
       return false;
+    }
   }
 
   keys.clear();
@@ -147,12 +112,14 @@ bool HashJoinPlan::operator==(const AbstractPlan &rhs) const {
   GetRightHashKeys(keys);
   other.GetRightHashKeys(other_keys);
   keys_count = keys.size();
-  if (keys_count != other_keys.size())
+  if (keys_count != other_keys.size()) {
     return false;
+  }
 
   for (size_t i = 0; i < keys_count; i++) {
-    if (*keys[i] != *other_keys[i])
+    if (*keys[i] != *other_keys[i]) {
       return false;
+    }
   }
 
   return AbstractPlan::operator==(rhs);

--- a/src/planner/nested_loop_join_plan.cpp
+++ b/src/planner/nested_loop_join_plan.cpp
@@ -11,14 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "planner/nested_loop_join_plan.h"
-
-#include "common/internal_types.h"
-#include "expression/abstract_expression.h"
-#include "planner/project_info.h"
 
 namespace peloton {
 namespace planner {
@@ -27,21 +22,31 @@ NestedLoopJoinPlan::NestedLoopJoinPlan(
     JoinType join_type,
     std::unique_ptr<const expression::AbstractExpression> &&predicate,
     std::unique_ptr<const ProjectInfo> &&proj_info,
-    std::shared_ptr<const catalog::Schema> &proj_schema)
-    : AbstractJoinPlan(join_type, std::move(predicate), std::move(proj_info),
-                       proj_schema) {}
-
-NestedLoopJoinPlan::NestedLoopJoinPlan(
-    JoinType join_type,
-    std::unique_ptr<const expression::AbstractExpression> &&predicate,
-    std::unique_ptr<const ProjectInfo> &&proj_info,
     std::shared_ptr<const catalog::Schema> &proj_schema,
-    std::vector<oid_t> &join_column_ids_left,
-    std::vector<oid_t> &join_column_ids_right)
+    const std::vector<oid_t> &join_column_ids_left,
+    const std::vector<oid_t> &join_column_ids_right)
     : AbstractJoinPlan(join_type, std::move(predicate), std::move(proj_info),
                        proj_schema) {
   join_column_ids_left_ = join_column_ids_left;
   join_column_ids_right_ = join_column_ids_right;
+}
+
+void NestedLoopJoinPlan::HandleSubplanBinding(
+    UNUSED_ATTRIBUTE bool from_left,
+    UNUSED_ATTRIBUTE const BindingContext &ctx) {}
+
+std::unique_ptr<AbstractPlan> NestedLoopJoinPlan::Copy() const {
+  std::unique_ptr<const expression::AbstractExpression> predicate_copy(
+      GetPredicate()->Copy());
+
+  std::shared_ptr<const catalog::Schema> schema_copy(
+      catalog::Schema::CopySchema(GetSchema()));
+
+  NestedLoopJoinPlan *new_plan = new NestedLoopJoinPlan(
+      GetJoinType(), std::move(predicate_copy), GetProjInfo()->Copy(),
+      schema_copy, join_column_ids_left_, join_column_ids_right_);
+
+  return std::unique_ptr<AbstractPlan>(new_plan);
 }
 
 }  // namespace planner

--- a/src/planner/nested_loop_join_plan.cpp
+++ b/src/planner/nested_loop_join_plan.cpp
@@ -62,5 +62,31 @@ std::unique_ptr<AbstractPlan> NestedLoopJoinPlan::Copy() const {
   return std::unique_ptr<AbstractPlan>(new_plan);
 }
 
+hash_t NestedLoopJoinPlan::Hash() const {
+  hash_t hash = AbstractJoinPlan::Hash();
+
+  // In addition to everything, hash the left and right join columns
+  for (const auto &left_col_id : GetJoinColumnsLeft()) {
+    hash = HashUtil::CombineHashes(hash, HashUtil::Hash(&left_col_id));
+  }
+  for (const auto &right_col_id : GetJoinColumnsRight()) {
+    hash = HashUtil::CombineHashes(hash, HashUtil::Hash(&right_col_id));
+  }
+
+  return HashUtil::CombineHashes(hash, AbstractPlan::Hash());
+}
+
+bool NestedLoopJoinPlan::operator==(const AbstractPlan &rhs) const {
+  if (!AbstractJoinPlan::operator==(rhs)) {
+    return false;
+  }
+
+  const auto &other = static_cast<const NestedLoopJoinPlan &>(rhs);
+
+  return GetJoinColumnsLeft() == other.GetJoinColumnsLeft() &&
+         GetJoinColumnsRight() == other.GetJoinColumnsRight() &&
+         AbstractPlan::operator==(rhs);
+}
+
 }  // namespace planner
 }  // namespace peloton

--- a/src/planner/nested_loop_join_plan.cpp
+++ b/src/planner/nested_loop_join_plan.cpp
@@ -31,9 +31,22 @@ NestedLoopJoinPlan::NestedLoopJoinPlan(
   join_column_ids_right_ = join_column_ids_right;
 }
 
-void NestedLoopJoinPlan::HandleSubplanBinding(
-    UNUSED_ATTRIBUTE bool from_left,
-    UNUSED_ATTRIBUTE const BindingContext &ctx) {}
+void NestedLoopJoinPlan::HandleSubplanBinding(bool from_left,
+                                              const BindingContext &ctx) {
+  if (from_left) {
+    for (const auto left_col_id : join_column_ids_left_) {
+      const auto *ai = ctx.Find(left_col_id);
+      PL_ASSERT(ai != nullptr);
+      join_ais_left_.push_back(ai);
+    }
+  } else {
+    for (const auto right_col_id : join_column_ids_right_) {
+      const auto *ai = ctx.Find(right_col_id);
+      PL_ASSERT(ai != nullptr);
+      join_ais_right_.push_back(ai);
+    }
+  }
+}
 
 std::unique_ptr<AbstractPlan> NestedLoopJoinPlan::Copy() const {
   std::unique_ptr<const expression::AbstractExpression> predicate_copy(

--- a/src/planner/project_info.cpp
+++ b/src/planner/project_info.cpp
@@ -257,7 +257,7 @@ bool ProjectInfo::operator==(const ProjectInfo &rhs) const {
 void ProjectInfo::VisitParameters(
     codegen::QueryParametersMap &map, std::vector<peloton::type::Value> &values,
     const std::vector<peloton::type::Value> &values_from_user) {
-  if (isNonTrivial()) {
+  if (IsNonTrivial()) {
 
     for (auto &target : GetTargetList()) {
       const auto &derived_attribute = target.second;

--- a/src/settings/settings_manager.cpp
+++ b/src/settings/settings_manager.cpp
@@ -34,6 +34,10 @@ int32_t SettingsManager::GetInt(SettingId id) {
   return GetInstance().GetValue(id).GetAs<int32_t>();
 }
 
+double SettingsManager::GetDouble(SettingId id) {
+  return GetInstance().GetValue(id).GetAs<double>();
+}
+
 bool SettingsManager::GetBool(SettingId id) {
   return GetInstance().GetValue(id).GetAs<bool>();
 }

--- a/test/codegen/block_nested_loop_join_translator_test.cpp
+++ b/test/codegen/block_nested_loop_join_translator_test.cpp
@@ -150,7 +150,6 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, SingleColumnEqualityJoin) {
     EXPECT_EQ(0, results.size());
   }
 
-#if 0
   {
     //
     // Join condition: table1.A == table2.B + 1
@@ -159,11 +158,11 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, SingleColumnEqualityJoin) {
     bool left_side = true;
     auto left_a_col = ColRefExpr(type::TypeId::INTEGER, left_side, 0);
     auto right_b_col = ColRefExpr(type::TypeId::INTEGER, !left_side, 1);
-    auto b_col_pl_1 =
-        OpExpr(ExpressionType::OPERATOR_PLUS, type::TypeId::INTEGER,
+    auto b_col_minus_1 =
+        OpExpr(ExpressionType::OPERATOR_MINUS, type::TypeId::INTEGER,
                std::move(right_b_col), std::move(ConstIntExpr(1)));
     auto left_a_eq_right_b =
-        CmpEqExpr(std::move(left_a_col), std::move(b_col_pl_1));
+        CmpEqExpr(std::move(left_a_col), std::move(b_col_minus_1));
 
     std::vector<codegen::WrappedTuple> results;
     PerformTest(std::move(left_a_eq_right_b), {0}, {1}, results);
@@ -171,7 +170,6 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, SingleColumnEqualityJoin) {
     // Check results
     EXPECT_EQ(20, results.size());
   }
-#endif
 }
 
 TEST_F(BlockNestedLoopJoinTranslatorTest, NonEqualityJoin) {

--- a/test/codegen/block_nested_loop_join_translator_test.cpp
+++ b/test/codegen/block_nested_loop_join_translator_test.cpp
@@ -160,7 +160,7 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, SingleColumnEqualityJoin) {
     auto right_b_col = ColRefExpr(type::TypeId::INTEGER, !left_side, 1);
     auto b_col_minus_1 =
         OpExpr(ExpressionType::OPERATOR_MINUS, type::TypeId::INTEGER,
-               std::move(right_b_col), std::move(ConstIntExpr(1)));
+               std::move(right_b_col), ConstIntExpr(1));
     auto left_a_eq_right_b =
         CmpEqExpr(std::move(left_a_col), std::move(b_col_minus_1));
 
@@ -194,7 +194,7 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, NonEqualityJoin) {
     //
     // The cross-product would have 20 x 80 = 1600 results total, but many are
     // removed by the join predicate. The first left tuple doesn't match with
-    // any tuples from the right side because it's A value is 0, less than all
+    // any tuples from the right side because its A value is 0, less than all
     // B values from the right side. The second left tuple matches only one -
     // the first tuple from the right side whose B value is 1. The # of matches
     // is thus: 0, 1, 2, 3, ... , n where n is the number of tuples in the left

--- a/test/codegen/block_nested_loop_join_translator_test.cpp
+++ b/test/codegen/block_nested_loop_join_translator_test.cpp
@@ -1,0 +1,154 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// block_nested_loop_join_translator_test.cpp
+//
+// Identification: test/codegen/block_nested_loop_join_translator_test.cpp
+//
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "codegen/query_compiler.h"
+#include "common/harness.h"
+#include "concurrency/transaction_manager_factory.h"
+#include "planner/nested_loop_join_plan.h"
+#include "planner/seq_scan_plan.h"
+
+#include "codegen/testing_codegen_util.h"
+
+namespace peloton {
+namespace test {
+
+class BlockNestedLoopJoinTranslatorTest : public PelotonCodeGenTest {
+ public:
+  BlockNestedLoopJoinTranslatorTest() : PelotonCodeGenTest() {
+    // Load the test table
+    uint32_t num_rows = 10;
+    LoadTestTable(LeftTableId(), 2 * num_rows);
+    LoadTestTable(RightTableId(), 8 * num_rows);
+  }
+
+  oid_t LeftTableId() const { return test_table_oids[0]; }
+
+  oid_t RightTableId() const { return test_table_oids[1]; }
+
+  storage::DataTable &GetLeftTable() const {
+    return GetTestTable(LeftTableId());
+  }
+
+  storage::DataTable &GetRightTable() const {
+    return GetTestTable(RightTableId());
+  }
+
+  void PerformTest(ExpressionPtr &&predicate,
+                   const std::vector<oid_t> &left_join_cols,
+                   const std::vector<oid_t> &right_join_cols,
+                   std::vector<codegen::WrappedTuple> &results);
+};
+
+void BlockNestedLoopJoinTranslatorTest::PerformTest(
+    ExpressionPtr &&predicate, const std::vector<oid_t> &left_join_cols,
+    const std::vector<oid_t> &right_join_cols,
+    std::vector<codegen::WrappedTuple> &results) {
+  DirectMap dm1 = std::make_pair(0, std::make_pair(0, 0));
+  DirectMap dm2 = std::make_pair(1, std::make_pair(0, 1));
+  DirectMap dm3 = std::make_pair(2, std::make_pair(1, 0));
+  DirectMap dm4 = std::make_pair(3, std::make_pair(1, 1));
+  DirectMapList direct_map_list = {dm1, dm2, dm3, dm4};
+  std::unique_ptr<planner::ProjectInfo> projection{
+      new planner::ProjectInfo(TargetList{}, std::move(direct_map_list))};
+
+  // Output schema
+  auto schema = std::shared_ptr<const catalog::Schema>(
+      new catalog::Schema({GetTestColumn(0), GetTestColumn(1), GetTestColumn(0),
+                           GetTestColumn(1)}));
+
+  AbstractPlanPtr nlj_plan{new planner::NestedLoopJoinPlan(
+      JoinType::INNER, std::move(predicate), std::move(projection), schema,
+      left_join_cols, right_join_cols)};
+
+  AbstractPlanPtr left_scan{
+      new planner::SeqScanPlan(&GetLeftTable(), nullptr, {0, 1, 2})};
+  AbstractPlanPtr right_scan{
+      new planner::SeqScanPlan(&GetRightTable(), nullptr, {0, 1, 2})};
+
+  nlj_plan->AddChild(std::move(left_scan));
+  nlj_plan->AddChild(std::move(right_scan));
+
+  // Do binding
+  planner::BindingContext context;
+  nlj_plan->PerformBinding(context);
+
+  // We collect the results of the query into an in-memory buffer
+  codegen::BufferingConsumer buffer{{0, 1}, context};
+
+  // COMPILE and run
+  CompileAndExecute(*nlj_plan, buffer);
+
+  // Return results
+  results = buffer.GetOutputTuples();
+}
+
+TEST_F(BlockNestedLoopJoinTranslatorTest, SingleColumnEqualityJoin) {
+  {
+    //
+    // Join condition: table1.A == table2.A
+    //
+
+    bool left_side = true;
+    auto left_a_col = ColRefExpr(type::TypeId::INTEGER, left_side, 0);
+    auto right_a_col = ColRefExpr(type::TypeId::INTEGER, !left_side, 0);
+    auto left_a_eq_right_a =
+        CmpEqExpr(std::move(left_a_col), std::move(right_a_col));
+
+    std::vector<codegen::WrappedTuple> results;
+    PerformTest(std::move(left_a_eq_right_a), {0}, {0}, results);
+
+    // Check results
+    EXPECT_EQ(20, results.size());
+  }
+
+  {
+    //
+    // Join condition: table1.A == table2.B
+    //
+
+    bool left_side = true;
+    auto left_a_col = ColRefExpr(type::TypeId::INTEGER, left_side, 0);
+    auto right_b_col = ColRefExpr(type::TypeId::INTEGER, !left_side, 1);
+    auto left_a_eq_right_b =
+        CmpEqExpr(std::move(left_a_col), std::move(right_b_col));
+
+    std::vector<codegen::WrappedTuple> results;
+    PerformTest(std::move(left_a_eq_right_b), {0}, {1}, results);
+
+    // Check results
+    EXPECT_EQ(0, results.size());
+  }
+
+  {
+    //
+    // Join condition: table1.A == table2.B + 1
+    //
+
+    bool left_side = true;
+    auto left_a_col = ColRefExpr(type::TypeId::INTEGER, left_side, 0);
+    auto right_b_col = ColRefExpr(type::TypeId::INTEGER, !left_side, 1);
+    auto b_col_pl_1 =
+        OpExpr(ExpressionType::OPERATOR_PLUS, type::TypeId::INTEGER,
+               std::move(right_b_col), ConstIntExpr(1));
+    auto left_a_eq_right_b =
+        CmpEqExpr(std::move(left_a_col), std::move(b_col_pl_1));
+
+    std::vector<codegen::WrappedTuple> results;
+    PerformTest(std::move(left_a_eq_right_b), {0}, {1}, results);
+
+    // Check results
+    EXPECT_EQ(20, results.size());
+  }
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/codegen/block_nested_loop_join_translator_test.cpp
+++ b/test/codegen/block_nested_loop_join_translator_test.cpp
@@ -129,7 +129,7 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, SingleColumnEqualityJoin) {
     for (const auto &t : results) {
       auto a1 = GetCol(t, JoinOutputColPos::Table1_ColA);
       auto a2 = GetCol(t, JoinOutputColPos::Table1_ColA);
-      EXPECT_TRUE(a1.CompareEquals(a2) == type::CmpBool::TRUE);
+      EXPECT_TRUE(a1.CompareEquals(a2) == CmpBool::TRUE);
     }
   }
 
@@ -204,7 +204,7 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, NonEqualityJoin) {
     for (const auto &t : results) {
       auto a = GetCol(t, JoinOutputColPos::Table1_ColA);
       auto b = GetCol(t, JoinOutputColPos::Table2_ColB);
-      EXPECT_TRUE(a.CompareGreaterThan(b) == type::CmpBool::TRUE);
+      EXPECT_TRUE(a.CompareGreaterThan(b) == CmpBool::TRUE);
     }
   }
 
@@ -233,7 +233,7 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, NonEqualityJoin) {
     for (const auto &t : results) {
       auto a = GetCol(t, JoinOutputColPos::Table1_ColA);
       auto b = GetCol(t, JoinOutputColPos::Table2_ColB);
-      EXPECT_TRUE(a.CompareLessThanEquals(b) == type::CmpBool::TRUE);
+      EXPECT_TRUE(a.CompareLessThanEquals(b) == CmpBool::TRUE);
     }
   }
 
@@ -263,7 +263,7 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, NonEqualityJoin) {
       auto a1_pl_b1 = a1.Add(b1);
 
       auto a2 = GetCol(t, JoinOutputColPos::Table2_ColA);
-      EXPECT_TRUE(a1_pl_b1.CompareGreaterThan(a2) == type::CmpBool::TRUE);
+      EXPECT_TRUE(a1_pl_b1.CompareGreaterThan(a2) == CmpBool::TRUE);
     }
   }
 }

--- a/test/codegen/block_nested_loop_join_translator_test.cpp
+++ b/test/codegen/block_nested_loop_join_translator_test.cpp
@@ -30,6 +30,15 @@ class BlockNestedLoopJoinTranslatorTest : public PelotonCodeGenTest {
     LoadTestTable(RightTableId(), 8 * num_rows);
   }
 
+  enum class JoinOutputColPos : oid_t {
+    Table1_ColA = 0,
+    Table1_ColB = 1,
+    Table1_ColC = 2,
+    Table2_ColA = 3,
+    Table2_ColB = 4,
+    Table2_ColC = 5,
+  };
+
   oid_t LeftTableId() const { return test_table_oids[0]; }
 
   oid_t RightTableId() const { return test_table_oids[1]; }
@@ -46,32 +55,36 @@ class BlockNestedLoopJoinTranslatorTest : public PelotonCodeGenTest {
                    const std::vector<oid_t> &left_join_cols,
                    const std::vector<oid_t> &right_join_cols,
                    std::vector<codegen::WrappedTuple> &results);
+
+  type::Value GetCol(const AbstractTuple &t, JoinOutputColPos p);
 };
 
 void BlockNestedLoopJoinTranslatorTest::PerformTest(
     ExpressionPtr &&predicate, const std::vector<oid_t> &left_join_cols,
     const std::vector<oid_t> &right_join_cols,
     std::vector<codegen::WrappedTuple> &results) {
-  DirectMap dm1 = std::make_pair(0, std::make_pair(0, 0));
-  DirectMap dm2 = std::make_pair(1, std::make_pair(0, 1));
-  DirectMap dm3 = std::make_pair(2, std::make_pair(1, 0));
-  DirectMap dm4 = std::make_pair(3, std::make_pair(1, 1));
-  DirectMapList direct_map_list = {dm1, dm2, dm3, dm4};
+  // Output all columns
+  DirectMapList direct_map_list = {{0, std::make_pair(0, 0)},
+                                   {1, std::make_pair(0, 1)},
+                                   {2, std::make_pair(0, 2)},
+                                   {3, std::make_pair(1, 0)},
+                                   {4, std::make_pair(1, 1)},
+                                   {5, std::make_pair(1, 2)}};
   std::unique_ptr<planner::ProjectInfo> projection{
       new planner::ProjectInfo(TargetList{}, std::move(direct_map_list))};
 
   // Output schema
-  auto schema = std::shared_ptr<const catalog::Schema>(
-      new catalog::Schema({GetTestColumn(0), GetTestColumn(1), GetTestColumn(0),
-                           GetTestColumn(1)}));
+  auto schema = std::shared_ptr<const catalog::Schema>(new catalog::Schema(
+      {GetTestColumn(0), GetTestColumn(1), GetTestColumn(2), GetTestColumn(0),
+       GetTestColumn(1), GetTestColumn(2)}));
 
-  AbstractPlanPtr nlj_plan{new planner::NestedLoopJoinPlan(
+  PlanPtr nlj_plan{new planner::NestedLoopJoinPlan(
       JoinType::INNER, std::move(predicate), std::move(projection), schema,
       left_join_cols, right_join_cols)};
 
-  AbstractPlanPtr left_scan{
+  PlanPtr left_scan{
       new planner::SeqScanPlan(&GetLeftTable(), nullptr, {0, 1, 2})};
-  AbstractPlanPtr right_scan{
+  PlanPtr right_scan{
       new planner::SeqScanPlan(&GetRightTable(), nullptr, {0, 1, 2})};
 
   nlj_plan->AddChild(std::move(left_scan));
@@ -82,7 +95,7 @@ void BlockNestedLoopJoinTranslatorTest::PerformTest(
   nlj_plan->PerformBinding(context);
 
   // We collect the results of the query into an in-memory buffer
-  codegen::BufferingConsumer buffer{{0, 1}, context};
+  codegen::BufferingConsumer buffer{{0, 1, 2, 3, 4, 5}, context};
 
   // COMPILE and run
   CompileAndExecute(*nlj_plan, buffer);
@@ -91,11 +104,16 @@ void BlockNestedLoopJoinTranslatorTest::PerformTest(
   results = buffer.GetOutputTuples();
 }
 
+type::Value BlockNestedLoopJoinTranslatorTest::GetCol(const AbstractTuple &t,
+                                                      JoinOutputColPos p) {
+  return t.GetValue(static_cast<oid_t>(p));
+}
+
 TEST_F(BlockNestedLoopJoinTranslatorTest, SingleColumnEqualityJoin) {
   {
-    //
-    // Join condition: table1.A == table2.A
-    //
+    LOG_INFO(
+        "Testing: "
+        "SELECT A,B FROM table1 INNER JOIN table2 ON table1.A = table2.A");
 
     bool left_side = true;
     auto left_a_col = ColRefExpr(type::TypeId::INTEGER, left_side, 0);
@@ -108,13 +126,17 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, SingleColumnEqualityJoin) {
 
     // Check results
     EXPECT_EQ(20, results.size());
+    for (const auto &t : results) {
+      auto a1 = GetCol(t, JoinOutputColPos::Table1_ColA);
+      auto a2 = GetCol(t, JoinOutputColPos::Table1_ColA);
+      EXPECT_TRUE(a1.CompareEquals(a2) == type::CmpBool::TRUE);
+    }
   }
 
   {
-    //
-    // Join condition: table1.A == table2.B
-    //
-
+    LOG_INFO(
+        "Testing: "
+        "SELECT A,B FROM table1 INNER JOIN table2 ON table1.A = table2.B");
     bool left_side = true;
     auto left_a_col = ColRefExpr(type::TypeId::INTEGER, left_side, 0);
     auto right_b_col = ColRefExpr(type::TypeId::INTEGER, !left_side, 1);
@@ -128,6 +150,7 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, SingleColumnEqualityJoin) {
     EXPECT_EQ(0, results.size());
   }
 
+#if 0
   {
     //
     // Join condition: table1.A == table2.B + 1
@@ -138,7 +161,7 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, SingleColumnEqualityJoin) {
     auto right_b_col = ColRefExpr(type::TypeId::INTEGER, !left_side, 1);
     auto b_col_pl_1 =
         OpExpr(ExpressionType::OPERATOR_PLUS, type::TypeId::INTEGER,
-               std::move(right_b_col), ConstIntExpr(1));
+               std::move(right_b_col), std::move(ConstIntExpr(1)));
     auto left_a_eq_right_b =
         CmpEqExpr(std::move(left_a_col), std::move(b_col_pl_1));
 
@@ -147,6 +170,103 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, SingleColumnEqualityJoin) {
 
     // Check results
     EXPECT_EQ(20, results.size());
+  }
+#endif
+}
+
+TEST_F(BlockNestedLoopJoinTranslatorTest, NonEqualityJoin) {
+  // The left and right input tables have the same schema and data distribution.
+  // The test table has four columns: A, B, D, E. The values in column B, D, E
+  // are 1, 2, and 3 more than the values in the A column, respectively. Values
+  // in the A column increase by 10.
+  {
+    LOG_INFO(
+        "Testing: "
+        "SELECT A,B FROM table1 INNER JOIN table2 ON table1.A > table2.B");
+    bool left_side = true;
+    auto left_a_col = ColRefExpr(type::TypeId::INTEGER, left_side, 0);
+    auto right_a_col = ColRefExpr(type::TypeId::INTEGER, !left_side, 0);
+    auto left_a_eq_right_a =
+        CmpGtExpr(std::move(left_a_col), std::move(right_a_col));
+
+    std::vector<codegen::WrappedTuple> results;
+    PerformTest(std::move(left_a_eq_right_a), {0}, {1}, results);
+
+    // Check results
+    //
+    // The cross-product would have 20 x 80 = 1600 results total, but many are
+    // removed by the join predicate. The first left tuple doesn't match with
+    // any tuples from the right side because it's A value is 0, less than all
+    // B values from the right side. The second left tuple matches only one -
+    // the first tuple from the right side whose B value is 1. The # of matches
+    // is thus: 0, 1, 2, 3, ... , n where n is the number of tuples in the left
+    // table. Then, the total number of matches is ((n-1)*n)/2. For 20 tuples,
+    // there should be 190 matches.
+    EXPECT_EQ(190, results.size());
+    for (const auto &t : results) {
+      auto a = GetCol(t, JoinOutputColPos::Table1_ColA);
+      auto b = GetCol(t, JoinOutputColPos::Table2_ColB);
+      EXPECT_TRUE(a.CompareGreaterThan(b) == type::CmpBool::TRUE);
+    }
+  }
+
+  {
+    LOG_INFO(
+        "Testing: "
+        "SELECT A,B FROM table1 INNER JOIN table2 ON table1.A <= table2.B");
+    bool left_side = true;
+    auto left_a_col = ColRefExpr(type::TypeId::INTEGER, left_side, 0);
+    auto right_a_col = ColRefExpr(type::TypeId::INTEGER, !left_side, 0);
+    auto left_a_eq_right_a =
+        CmpLteExpr(std::move(left_a_col), std::move(right_a_col));
+
+    std::vector<codegen::WrappedTuple> results;
+    PerformTest(std::move(left_a_eq_right_a), {0}, {1}, results);
+
+    // Check results
+    // The number of matches follow logic similar to the previous test. The
+    // first left tuple matches 80 tuples from the right side. The second row
+    // matches 79, etc. The progression for matched rows is
+    // s,(s-1),(s-2),...,(s-r), where s is the number of right tuples and
+    // r is the number of left tuples. Then, the total number of matches is
+    // (s*(s+1))/2 - ((s-r)*(s-r+1))/2). For r = 20 and s = 80, the number of
+    // matches is
+    EXPECT_EQ(1410, results.size());
+    for (const auto &t : results) {
+      auto a = GetCol(t, JoinOutputColPos::Table1_ColA);
+      auto b = GetCol(t, JoinOutputColPos::Table2_ColB);
+      EXPECT_TRUE(a.CompareLessThanEquals(b) == type::CmpBool::TRUE);
+    }
+  }
+
+  {
+    LOG_INFO(
+        "Testing: "
+        "SELECT A,B FROM table1 INNER JOIN table2 ON table1.A + table1.B > "
+        "table2.A");
+    bool left_side = true;
+    auto left_a_col = ColRefExpr(type::TypeId::INTEGER, left_side, 0);
+    auto left_b_col = ColRefExpr(type::TypeId::INTEGER, left_side, 1);
+    auto left_a_pl_b =
+        OpExpr(ExpressionType::OPERATOR_PLUS, type::TypeId::INTEGER,
+               std::move(left_a_col), std::move(left_b_col));
+
+    auto right_a_col = ColRefExpr(type::TypeId::INTEGER, !left_side, 0);
+    auto left_a_eq_right_a =
+        CmpGtExpr(std::move(left_a_pl_b), std::move(right_a_col));
+
+    std::vector<codegen::WrappedTuple> results;
+    PerformTest(std::move(left_a_eq_right_a), {0, 1}, {0}, results);
+
+    // Check results
+    for (const auto &t : results) {
+      auto a1 = GetCol(t, JoinOutputColPos::Table1_ColA);
+      auto b1 = GetCol(t, JoinOutputColPos::Table1_ColB);
+      auto a1_pl_b1 = a1.Add(b1);
+
+      auto a2 = GetCol(t, JoinOutputColPos::Table2_ColA);
+      EXPECT_TRUE(a1_pl_b1.CompareGreaterThan(a2) == type::CmpBool::TRUE);
+    }
   }
 }
 

--- a/test/codegen/delete_translator_test.cpp
+++ b/test/codegen/delete_translator_test.cpp
@@ -155,10 +155,9 @@ TEST_F(DeleteTranslatorTest, DeleteWithModuloPredicate) {
 
   auto b_col_exp = ColRefExpr(type::TypeId::INTEGER, 1);
   auto const_1_exp = ConstIntExpr(1);
-  auto b_mod_1 = std::unique_ptr<expression::AbstractExpression>{
-      new expression::OperatorExpression(
-          ExpressionType::OPERATOR_MOD, type::TypeId::DECIMAL,
-          b_col_exp.release(), const_1_exp.release())};
+  auto b_mod_1 = ExpressionPtr{new expression::OperatorExpression(
+      ExpressionType::OPERATOR_MOD, type::TypeId::DECIMAL, b_col_exp.release(),
+      const_1_exp.release())};
 
   // a = b % 1
   auto a_eq_b_mod_1 =

--- a/test/codegen/group_by_translator_test.cpp
+++ b/test/codegen/group_by_translator_test.cpp
@@ -239,7 +239,7 @@ TEST_F(GroupByTranslatorTest, AggregationWithOutputPredicate) {
       new expression::TupleValueExpression(type::TypeId::DECIMAL, 1, 0);
   auto *const_50 = new expression::ConstantValueExpression(
       type::ValueFactory::GetDecimalValue(50.0));
-  std::unique_ptr<expression::AbstractExpression> x_gt_50{
+  ExpressionPtr x_gt_50{
       new expression::ComparisonExpression(ExpressionType::COMPARE_GREATERTHAN,
                                            x_exp, const_50)};
 

--- a/test/codegen/hash_join_translator_test.cpp
+++ b/test/codegen/hash_join_translator_test.cpp
@@ -25,8 +25,6 @@
 namespace peloton {
 namespace test {
 
-typedef std::unique_ptr<const expression::AbstractExpression> AbstractExprPtr;
-
 class HashJoinTranslatorTest : public PelotonCodeGenTest {
  public:
   HashJoinTranslatorTest() : PelotonCodeGenTest() {
@@ -76,13 +74,13 @@ TEST_F(HashJoinTranslatorTest, SingleHashJoinColumnTest) {
                            TestingExecutorUtil::GetColumnInfo(2)}));
 
   // Left and right hash keys
-  std::vector<AbstractExprPtr> left_hash_keys;
+  std::vector<ConstExpressionPtr> left_hash_keys;
   left_hash_keys.emplace_back(ColRefExpr(type::TypeId::INTEGER, 0));
 
-  std::vector<AbstractExprPtr> right_hash_keys;
+  std::vector<ConstExpressionPtr> right_hash_keys;
   right_hash_keys.emplace_back(ColRefExpr(type::TypeId::INTEGER, 0));
 
-  std::vector<AbstractExprPtr> hash_keys;
+  std::vector<ConstExpressionPtr> hash_keys;
   hash_keys.emplace_back(ColRefExpr(type::TypeId::INTEGER, 0));
 
   // Finally, the fucking join node

--- a/test/codegen/insert_translator_test.cpp
+++ b/test/codegen/insert_translator_test.cpp
@@ -45,19 +45,13 @@ TEST_F(InsertTranslatorTest, InsertOneTuple) {
       type::ValueFactory::GetDecimalValue(2));
   auto constant_expr_3 = new expression::ConstantValueExpression(
       type::ValueFactory::GetVarcharValue("Tuple1", true));
-  std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>>
-      tuples;
-  tuples.push_back(
-      std::vector<std::unique_ptr<expression::AbstractExpression>>());
+  std::vector<std::vector<ExpressionPtr>> tuples;
+  tuples.push_back(std::vector<ExpressionPtr>());
   auto &values = tuples[0];
-  values.push_back(
-      std::unique_ptr<expression::AbstractExpression>(constant_expr_0));
-  values.push_back(
-      std::unique_ptr<expression::AbstractExpression>(constant_expr_1));
-  values.push_back(
-      std::unique_ptr<expression::AbstractExpression>(constant_expr_2));
-  values.push_back(
-      std::unique_ptr<expression::AbstractExpression>(constant_expr_3));
+  values.push_back(ExpressionPtr(constant_expr_0));
+  values.push_back(ExpressionPtr(constant_expr_1));
+  values.push_back(ExpressionPtr(constant_expr_2));
+  values.push_back(ExpressionPtr(constant_expr_3));
 
   std::vector<std::string> columns;
   std::unique_ptr<planner::InsertPlan> insert_plan(

--- a/test/codegen/query_cache_test.cpp
+++ b/test/codegen/query_cache_test.cpp
@@ -32,8 +32,6 @@
 namespace peloton {
 namespace test {
 
-typedef std::unique_ptr<const expression::AbstractExpression> AbstractExprPtr;
-
 class QueryCacheTest : public PelotonCodeGenTest {
  public:
   QueryCacheTest() : PelotonCodeGenTest(), num_rows_to_insert(64) {
@@ -96,15 +94,15 @@ class QueryCacheTest : public PelotonCodeGenTest {
                              TestingExecutorUtil::GetColumnInfo(1),
                              TestingExecutorUtil::GetColumnInfo(2)}));
     // Left and right hash keys
-    std::vector<AbstractExprPtr> left_hash_keys;
+    std::vector<ConstExpressionPtr> left_hash_keys;
     left_hash_keys.emplace_back(
         new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 0));
 
-    std::vector<AbstractExprPtr> right_hash_keys;
+    std::vector<ConstExpressionPtr> right_hash_keys;
     right_hash_keys.emplace_back(
         new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 0));
 
-    std::vector<AbstractExprPtr> hash_keys;
+    std::vector<ConstExpressionPtr> hash_keys;
     hash_keys.emplace_back(
         new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 0));
 

--- a/test/codegen/sorter_test.cpp
+++ b/test/codegen/sorter_test.cpp
@@ -62,8 +62,8 @@ class SorterTest : public PelotonTest {
     }
 
     timer.Stop();
-    LOG_INFO("Loading %llu tuples into sort took %.2f ms", (unsigned long long) num_tuples_to_insert,
-             timer.GetDuration());
+    LOG_INFO("Loading %llu tuples into sort took %.2f ms",
+             (unsigned long long)num_tuples_to_insert, timer.GetDuration());
     timer.Reset();
     timer.Start();
 
@@ -71,8 +71,8 @@ class SorterTest : public PelotonTest {
     sorter.Sort();
 
     timer.Stop();
-    LOG_INFO("Sorting %llu tuples took %.2f ms", (unsigned long long) num_tuples_to_insert,
-             timer.GetDuration());
+    LOG_INFO("Sorting %llu tuples took %.2f ms",
+             (unsigned long long)num_tuples_to_insert, timer.GetDuration());
 
     // Check sorted results
     uint64_t res_tuples = 0;

--- a/test/codegen/table_scan_translator_test.cpp
+++ b/test/codegen/table_scan_translator_test.cpp
@@ -162,7 +162,7 @@ TEST_F(TableScanTranslatorTest, SimplePredicate) {
   //
 
   // Setup the predicate
-  std::unique_ptr<expression::AbstractExpression> a_gt_20 =
+  ExpressionPtr a_gt_20 =
       CmpGteExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(20));
 
   // Setup the scan plan node
@@ -194,7 +194,7 @@ TEST_F(TableScanTranslatorTest, SimplePredicateWithNull) {
   //
 
   // Setup the predicate
-  std::unique_ptr<expression::AbstractExpression> b_lt_20 =
+  ExpressionPtr b_lt_20 =
       CmpLtExpr(ColRefExpr(type::TypeId::INTEGER, 1), ConstIntExpr(20));
 
   // Setup the scan plan node
@@ -234,7 +234,7 @@ TEST_F(TableScanTranslatorTest, PredicateOnNonOutputColumn) {
   //
 
   // 1) Setup the predicate
-  std::unique_ptr<expression::AbstractExpression> a_gt_40 =
+  ExpressionPtr a_gt_40 =
       CmpGteExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(40));
 
   // 2) Setup the scan plan node
@@ -264,11 +264,11 @@ TEST_F(TableScanTranslatorTest, ScanWithConjunctionPredicate) {
   // 1) Construct the components of the predicate
 
   // a >= 20
-  std::unique_ptr<expression::AbstractExpression> a_gt_20 =
+  ExpressionPtr a_gt_20 =
       CmpGteExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(20));
 
   // b = 21
-  std::unique_ptr<expression::AbstractExpression> b_eq_21 =
+  ExpressionPtr b_eq_21 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 1), ConstIntExpr(21));
 
   // a >= 20 AND b = 21

--- a/test/codegen/testing_codegen_util.cpp
+++ b/test/codegen/testing_codegen_util.cpp
@@ -284,6 +284,12 @@ ExpressionPtr PelotonCodeGenTest::CmpLtExpr(ExpressionPtr &&left,
                  std::move(right));
 }
 
+ExpressionPtr PelotonCodeGenTest::CmpLteExpr(ExpressionPtr &&left,
+                                             ExpressionPtr &&right) {
+  return CmpExpr(ExpressionType::COMPARE_LESSTHANOREQUALTO, std::move(left),
+                 std::move(right));
+}
+
 ExpressionPtr PelotonCodeGenTest::CmpGtExpr(ExpressionPtr &&left,
                                             ExpressionPtr &&right) {
   return CmpExpr(ExpressionType::COMPARE_GREATERTHAN, std::move(left),

--- a/test/codegen/update_translator_test.cpp
+++ b/test/codegen/update_translator_test.cpp
@@ -143,7 +143,7 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantAndPredicate) {
   // Pre-condition
   EXPECT_EQ(NumRowsInTestTable(), table->GetTupleCount());
 
-  std::unique_ptr<expression::AbstractExpression> b_eq_41 =
+  ExpressionPtr b_eq_41 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 1), ConstIntExpr(41));
 
   // Get the scan plan without a predicate with four columns
@@ -188,7 +188,7 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantAndPredicate) {
   EXPECT_EQ(NumRowsInTestTable() + 1, table->GetTupleCount());
 
   // Setup the scan plan node
-  std::unique_ptr<expression::AbstractExpression> b_eq_49 =
+  ExpressionPtr b_eq_49 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 1), ConstIntExpr(49));
   std::unique_ptr<planner::SeqScanPlan> scan_plan_2(new planner::SeqScanPlan(
       &GetTestTable(TestTableId2()), b_eq_49.release(), {0, 1, 2, 3}));
@@ -228,7 +228,7 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAnOperatorExpression) {
   // Pre-condition
   EXPECT_EQ(NumRowsInTestTable(), table->GetTupleCount());
 
-  std::unique_ptr<expression::AbstractExpression> b_eq_41 =
+  ExpressionPtr b_eq_41 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 1), ConstIntExpr(41));
 
   // Get the scan plan without a predicate with four columns
@@ -280,7 +280,7 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAnOperatorExpression) {
   EXPECT_EQ(NumRowsInTestTable() + 1, table->GetTupleCount());
 
   // Setup the scan plan node
-  std::unique_ptr<expression::AbstractExpression> b_eq_49 =
+  ExpressionPtr b_eq_49 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 1), ConstIntExpr(49));
   std::unique_ptr<planner::SeqScanPlan> scan_plan_2(new planner::SeqScanPlan(
       &GetTestTable(TestTableId2()), b_eq_49.release(), {0, 1, 2, 3}));
@@ -320,7 +320,7 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAnOperatorExpressionComplex) {
   // Pre-condition
   EXPECT_EQ(NumRowsInTestTable(), table->GetTupleCount());
 
-  std::unique_ptr<expression::AbstractExpression> b_eq_41 =
+  ExpressionPtr b_eq_41 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 1), ConstIntExpr(41));
 
   // Get the scan plan without a predicate with four columns
@@ -382,7 +382,7 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAnOperatorExpressionComplex) {
   EXPECT_EQ(NumRowsInTestTable() + 1, table->GetTupleCount());
 
   // Setup the scan plan node
-  std::unique_ptr<expression::AbstractExpression> a_eq_41 =
+  ExpressionPtr a_eq_41 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(41));
   std::unique_ptr<planner::SeqScanPlan> scan_plan_2(new planner::SeqScanPlan(
       &GetTestTable(TestTableId2()), a_eq_41.release(), {0, 1, 2, 3}));
@@ -422,7 +422,7 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantPrimary) {
   // Pre-condition
   EXPECT_EQ(NumRowsInTestTable(), table->GetTupleCount());
 
-  std::unique_ptr<expression::AbstractExpression> a_eq_10 =
+  ExpressionPtr a_eq_10 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(10));
 
   // Get the scan plan without a predicate with four columns
@@ -467,7 +467,7 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantPrimary) {
   EXPECT_EQ(NumRowsInTestTable() + 2, table->GetTupleCount());
 
   // Setup the scan plan node
-  std::unique_ptr<expression::AbstractExpression> a_eq_1 =
+  ExpressionPtr a_eq_1 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(1));
   std::unique_ptr<planner::SeqScanPlan> scan_plan_5(new planner::SeqScanPlan(
       &GetTestTable(TestTableId5()), a_eq_1.release(), {0, 1, 2, 3}));
@@ -508,7 +508,7 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithCast) {
   EXPECT_EQ(NumRowsInTestTable(), table->GetTupleCount());
 
   // Get the scan plan without a predicate with four columns
-  std::unique_ptr<expression::AbstractExpression> a_eq_10 =
+  ExpressionPtr a_eq_10 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(10));
   std::unique_ptr<planner::SeqScanPlan> scan_plan(new planner::SeqScanPlan(
       &GetTestTable(TestTableId1()), a_eq_10.release(), {0, 1, 2, 3}));
@@ -551,7 +551,7 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithCast) {
   EXPECT_EQ(NumRowsInTestTable() + 1, table->GetTupleCount());
 
   // Setup the scan plan node
-  std::unique_ptr<expression::AbstractExpression> a_eq_10_1 =
+  ExpressionPtr a_eq_10_1 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(10));
   std::unique_ptr<planner::SeqScanPlan> scan_plan_1(new planner::SeqScanPlan(
       &GetTestTable(TestTableId1()), a_eq_10_1.release(), {0, 1, 2, 3}));
@@ -580,7 +580,7 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithCast) {
                 type::ValueFactory::GetVarcharValue("13")));
 
   // Get the scan plan without a predicate with four columns
-  std::unique_ptr<expression::AbstractExpression> a_eq_10_2 =
+  ExpressionPtr a_eq_10_2 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(10));
   std::unique_ptr<planner::SeqScanPlan> scan_plan_2(new planner::SeqScanPlan(
       &GetTestTable(TestTableId1()), a_eq_10_2.release(), {0, 1, 2, 3}));
@@ -623,7 +623,7 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithCast) {
   EXPECT_EQ(NumRowsInTestTable() + 2, table->GetTupleCount());
 
   // Setup the scan plan node
-  std::unique_ptr<expression::AbstractExpression> a_eq_10_3 =
+  ExpressionPtr a_eq_10_3 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(10));
   std::unique_ptr<planner::SeqScanPlan> scan_plan_3(new planner::SeqScanPlan(
       &GetTestTable(TestTableId1()), a_eq_10_3.release(), {0, 1, 2, 3}));

--- a/test/codegen/zone_map_scan_test.cpp
+++ b/test/codegen/zone_map_scan_test.cpp
@@ -84,7 +84,7 @@ TEST_F(ZoneMapScanTest, ScanNoPredicates) {
 TEST_F(ZoneMapScanTest, SimplePredicate) {
   // SELECT a, b, c FROM table where a >= 20;
   // 1) Setup the predicate
-  std::unique_ptr<expression::AbstractExpression> a_gt_20 =
+  ExpressionPtr a_gt_20 =
       CmpGteExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(20));
   // 2) Setup the scan plan node
   auto &table = GetTestTable(TestTableId());
@@ -104,7 +104,7 @@ TEST_F(ZoneMapScanTest, SimplePredicate) {
 TEST_F(ZoneMapScanTest, PredicateOnNonOutputColumn) {
   // SELECT b FROM table where a >= 40;
   // 1) Setup the predicate
-  std::unique_ptr<expression::AbstractExpression> a_gt_40 =
+  ExpressionPtr a_gt_40 =
       CmpGteExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(40));
   // 2) Setup the scan plan node
   auto &table = GetTestTable(TestTableId());
@@ -125,10 +125,10 @@ TEST_F(ZoneMapScanTest, ScanwithConjunctionPredicate) {
   // SELECT a, b, c FROM table where a >= 20 and b = 21;
   // 1) Construct the components of the predicate
   // a >= 20
-  std::unique_ptr<expression::AbstractExpression> a_gt_20 =
+  ExpressionPtr a_gt_20 =
       CmpGteExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(20));
   // b = 21
-  std::unique_ptr<expression::AbstractExpression> b_eq_21 =
+  ExpressionPtr b_eq_21 =
       CmpEqExpr(ColRefExpr(type::TypeId::INTEGER, 1), ConstIntExpr(21));
   // a >= 20 AND b = 21
   auto *conj_eq = new expression::ConjunctionExpression(

--- a/test/executor/join_test.cpp
+++ b/test/executor/join_test.cpp
@@ -56,20 +56,21 @@ class JoinTests : public PelotonTest {};
 
 std::vector<planner::MergeJoinPlan::JoinClause> CreateJoinClauses() {
   std::vector<planner::MergeJoinPlan::JoinClause> join_clauses;
-  auto left =
-      expression::ExpressionUtil::TupleValueFactory(type::TypeId::INTEGER, 0, 1);
-  auto right =
-      expression::ExpressionUtil::TupleValueFactory(type::TypeId::INTEGER, 1, 1);
+  auto left = expression::ExpressionUtil::TupleValueFactory(
+      type::TypeId::INTEGER, 0, 1);
+  auto right = expression::ExpressionUtil::TupleValueFactory(
+      type::TypeId::INTEGER, 1, 1);
   bool reversed = false;
   join_clauses.emplace_back(left, right, reversed);
   return join_clauses;
 }
 
 std::shared_ptr<const peloton::catalog::Schema> CreateJoinSchema() {
-  return std::shared_ptr<const peloton::catalog::Schema>(new catalog::Schema(
-      {TestingExecutorUtil::GetColumnInfo(1), TestingExecutorUtil::GetColumnInfo(1),
-       TestingExecutorUtil::GetColumnInfo(0),
-       TestingExecutorUtil::GetColumnInfo(0)}));
+  return std::shared_ptr<const peloton::catalog::Schema>(
+      new catalog::Schema({TestingExecutorUtil::GetColumnInfo(1),
+                           TestingExecutorUtil::GetColumnInfo(1),
+                           TestingExecutorUtil::GetColumnInfo(0),
+                           TestingExecutorUtil::GetColumnInfo(0)}));
 }
 
 // PlanNodeType::NESTLOOP is picked out as a separated test
@@ -95,13 +96,13 @@ void ExpectEmptyTileResult(MockExecutor *table_scan_executor);
 
 void ExpectMoreThanOneTileResults(
     MockExecutor *table_scan_executor,
-    std::vector<std::unique_ptr<executor::LogicalTile>>
-        &table_logical_tile_ptrs);
+    std::vector<std::unique_ptr<executor::LogicalTile>> &
+        table_logical_tile_ptrs);
 
-void ExpectNormalTileResults(size_t table_tile_group_count,
-                             MockExecutor *table_scan_executor,
-                             std::vector<std::unique_ptr<executor::LogicalTile>>
-                                 &table_logical_tile_ptrs);
+void ExpectNormalTileResults(
+    size_t table_tile_group_count, MockExecutor *table_scan_executor,
+    std::vector<std::unique_ptr<executor::LogicalTile>> &
+        table_logical_tile_ptrs);
 
 enum JOIN_TEST_TYPE {
   BASIC_TEST = 0,
@@ -334,20 +335,21 @@ void ExecuteNestedLoopJoinTest(JoinType join_type, bool IndexScan) {
         index, key_column_ids, expr_types, values, runtime_keys);
 
     // Create plan node.
-    left_table_node.reset(new planner::IndexScanPlan(left_table.get(), predicate_scan,
-                                           column_ids, index_scan_desc));
+    left_table_node.reset(new planner::IndexScanPlan(
+        left_table.get(), predicate_scan, column_ids, index_scan_desc));
 
     // executor
     left_table_scan_executor.reset(
         new executor::IndexScanExecutor(left_table_node.get(), context.get()));
-  }
-  else {
+  } else {
     LOG_INFO("Construct Left Seq Scan Node");
     // Create sequential scan plan node
-    left_table_node.reset(new planner::SeqScanPlan(left_table.get(), predicate_scan, column_ids));
+    left_table_node.reset(
+        new planner::SeqScanPlan(left_table.get(), predicate_scan, column_ids));
 
     // Executor
-    left_table_scan_executor.reset(new executor::SeqScanExecutor(left_table_node.get(), context.get()));
+    left_table_scan_executor.reset(
+        new executor::SeqScanExecutor(left_table_node.get(), context.get()));
   }
 
   // Right ATTR 0 =
@@ -361,7 +363,6 @@ void ExecuteNestedLoopJoinTest(JoinType join_type, bool IndexScan) {
   expr_types_right.push_back(ExpressionType::COMPARE_EQUAL);
   // values_right.push_back(type::ValueFactory::GetIntegerValue(100).Copy());
   values_right.push_back(type::ValueFactory::GetParameterOffsetValue(0).Copy());
-
 
   expression::AbstractExpression *predicate_scan_right = nullptr;
   std::vector<oid_t> column_ids_right({0, 1});
@@ -377,22 +378,22 @@ void ExecuteNestedLoopJoinTest(JoinType join_type, bool IndexScan) {
         runtime_keys_right);
 
     // Create plan node.
-    right_table_node.reset(new planner::IndexScanPlan(
-        right_table.get(), predicate_scan_right, column_ids_right,
-        index_scan_desc_right));
+    right_table_node.reset(
+        new planner::IndexScanPlan(right_table.get(), predicate_scan_right,
+                                   column_ids_right, index_scan_desc_right));
 
     // executor
     right_table_scan_executor.reset(
         new executor::IndexScanExecutor(right_table_node.get(), context.get()));
-  }
-  else {
+  } else {
     LOG_INFO("Construct Right Seq Scan Node");
     // Create sequential scan plan node
-    right_table_node.reset(
-        new planner::SeqScanPlan(right_table.get(), predicate_scan_right, column_ids_right));
+    right_table_node.reset(new planner::SeqScanPlan(
+        right_table.get(), predicate_scan_right, column_ids_right));
 
     // Executor
-    right_table_scan_executor.reset(new executor::SeqScanExecutor(right_table_node.get(), context.get()));
+    right_table_scan_executor.reset(
+        new executor::SeqScanExecutor(right_table_node.get(), context.get()));
   }
 
   //===--------------------------------------------------------------------===//
@@ -625,8 +626,11 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, JoinType join_type,
   switch (join_algorithm) {
     case PlanNodeType::NESTLOOP: {
       // Create nested loop join plan node.
+      std::vector<oid_t> left_join_cols = {1};
+      std::vector<oid_t> right_join_cols = {1};
       planner::NestedLoopJoinPlan nested_loop_join_node(
-          join_type, std::move(predicate), std::move(projection), schema);
+          join_type, std::move(predicate), std::move(projection), schema,
+          left_join_cols, right_join_cols);
 
       // Run the nested loop join executor
       executor::NestedLoopJoinExecutor nested_loop_join_executor(
@@ -702,13 +706,15 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, JoinType join_type,
           left_hash_keys;
       left_hash_keys.emplace_back(
           std::unique_ptr<expression::AbstractExpression>{
-              new expression::TupleValueExpression(type::TypeId::INTEGER, 0, 1)});
+              new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                                   1)});
 
       std::vector<std::unique_ptr<const expression::AbstractExpression>>
           right_hash_keys;
       right_hash_keys.emplace_back(
           std::unique_ptr<expression::AbstractExpression>{
-              new expression::TupleValueExpression(type::TypeId::INTEGER, 1, 1)});
+              new expression::TupleValueExpression(type::TypeId::INTEGER, 1,
+                                                   1)});
 
       // Create hash plan node
       planner::HashPlan hash_plan_node(hash_keys);
@@ -717,11 +723,9 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, JoinType join_type,
       executor::HashExecutor hash_executor(&hash_plan_node, nullptr);
 
       // Create hash join plan node.
-      planner::HashJoinPlan hash_join_plan_node(join_type, std::move(predicate),
-                                                std::move(projection), schema,
-                                                left_hash_keys,
-                                                right_hash_keys,
-                                                false);
+      planner::HashJoinPlan hash_join_plan_node(
+          join_type, std::move(predicate), std::move(projection), schema,
+          left_hash_keys, right_hash_keys, false);
 
       // Construct the hash join executor
       executor::HashJoinExecutor hash_join_executor(&hash_join_plan_node,
@@ -784,7 +788,8 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, JoinType join_type,
         break;
 
       default:
-        throw Exception("Unsupported join type : " + JoinTypeToString(join_type));
+        throw Exception("Unsupported join type : " +
+                        JoinTypeToString(join_type));
         break;
     }
 
@@ -812,7 +817,8 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, JoinType join_type,
         break;
 
       default:
-        throw Exception("Unsupported join type : " + JoinTypeToString(join_type));
+        throw Exception("Unsupported join type : " +
+                        JoinTypeToString(join_type));
         break;
     }
 
@@ -840,7 +846,8 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, JoinType join_type,
         break;
 
       default:
-        throw Exception("Unsupported join type : " + JoinTypeToString(join_type));
+        throw Exception("Unsupported join type : " +
+                        JoinTypeToString(join_type));
         break;
     }
 
@@ -868,7 +875,8 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, JoinType join_type,
         break;
 
       default:
-        throw Exception("Unsupported join type : " + JoinTypeToString(join_type));
+        throw Exception("Unsupported join type : " +
+                        JoinTypeToString(join_type));
         break;
     }
   } else if (join_test_type == RIGHT_TABLE_EMPTY) {
@@ -895,7 +903,8 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, JoinType join_type,
         break;
 
       default:
-        throw Exception("Unsupported join type : " + JoinTypeToString(join_type));
+        throw Exception("Unsupported join type : " +
+                        JoinTypeToString(join_type));
         break;
     }
   }
@@ -910,8 +919,8 @@ oid_t CountTuplesWithNullFields(executor::LogicalTile *logical_tile) {
 
   // Go over the tile
   for (auto logical_tile_itr : *logical_tile) {
-    const ContainerTuple<executor::LogicalTile> join_tuple(
-        logical_tile, logical_tile_itr);
+    const ContainerTuple<executor::LogicalTile> join_tuple(logical_tile,
+                                                           logical_tile_itr);
 
     // Go over all the fields and check for null values
     for (oid_t col_itr = 0; col_itr < column_count; col_itr++) {
@@ -938,8 +947,8 @@ void ValidateJoinLogicalTile(executor::LogicalTile *logical_tile) {
   // Check the attribute values
   // Go over the tile
   for (auto logical_tile_itr : *logical_tile) {
-    const ContainerTuple<executor::LogicalTile> join_tuple(
-        logical_tile, logical_tile_itr);
+    const ContainerTuple<executor::LogicalTile> join_tuple(logical_tile,
+                                                           logical_tile_itr);
 
     // Check the join fields
     type::Value left_tuple_join_attribute_val = (join_tuple.GetValue(0));
@@ -963,8 +972,8 @@ void ValidateNestedLoopJoinLogicalTile(executor::LogicalTile *logical_tile) {
   // Check the attribute values
   // Go over the tile
   for (auto logical_tile_itr : *logical_tile) {
-    const ContainerTuple<executor::LogicalTile> join_tuple(
-        logical_tile, logical_tile_itr);
+    const ContainerTuple<executor::LogicalTile> join_tuple(logical_tile,
+                                                           logical_tile_itr);
 
     // Check the join fields
     type::Value left_tuple_join_attribute_val = (join_tuple.GetValue(2));
@@ -983,18 +992,18 @@ void ExpectEmptyTileResult(MockExecutor *table_scan_executor) {
 
 void ExpectMoreThanOneTileResults(
     MockExecutor *table_scan_executor,
-    std::vector<std::unique_ptr<executor::LogicalTile>>
-        &table_logical_tile_ptrs) {
+    std::vector<std::unique_ptr<executor::LogicalTile>> &
+        table_logical_tile_ptrs) {
   // Expect more than one result tiles from the child, but only get one of them
   EXPECT_CALL(*table_scan_executor, DExecute()).WillOnce(Return(true));
   EXPECT_CALL(*table_scan_executor, GetOutput())
       .WillOnce(Return(table_logical_tile_ptrs[0].release()));
 }
 
-void ExpectNormalTileResults(size_t table_tile_group_count,
-                             MockExecutor *table_scan_executor,
-                             std::vector<std::unique_ptr<executor::LogicalTile>>
-                                 &table_logical_tile_ptrs) {
+void ExpectNormalTileResults(
+    size_t table_tile_group_count, MockExecutor *table_scan_executor,
+    std::vector<std::unique_ptr<executor::LogicalTile>> &
+        table_logical_tile_ptrs) {
   // Return true for the first table_tile_group_count times
   // Then return false after that
   {

--- a/test/include/codegen/testing_codegen_util.h
+++ b/test/include/codegen/testing_codegen_util.h
@@ -37,7 +37,8 @@ using ExpressionPtr = std::unique_ptr<expression::AbstractExpression>;
 using ConstExpressionPtr =
     std::unique_ptr<const expression::AbstractExpression>;
 
-using AbstractPlanPtr = std::unique_ptr<planner::AbstractPlan>;
+using PlanPtr = std::unique_ptr<planner::AbstractPlan>;
+using ConstPlanPtr = std::unique_ptr<const planner::AbstractPlan>;
 
 //===----------------------------------------------------------------------===//
 // Common base class for all codegen tests. This class four test tables that all

--- a/test/include/codegen/testing_codegen_util.h
+++ b/test/include/codegen/testing_codegen_util.h
@@ -33,6 +33,12 @@
 namespace peloton {
 namespace test {
 
+using ExpressionPtr = std::unique_ptr<expression::AbstractExpression>;
+using ConstExpressionPtr =
+    std::unique_ptr<const expression::AbstractExpression>;
+
+using AbstractPlanPtr = std::unique_ptr<planner::AbstractPlan>;
+
 //===----------------------------------------------------------------------===//
 // Common base class for all codegen tests. This class four test tables that all
 // the codegen components use. Their ID's are available through the oid_t
@@ -58,6 +64,8 @@ class PelotonCodeGenTest : public PelotonTest {
   }
 
   // Create the schema (common among all tables)
+  catalog::Column GetTestColumn(uint32_t col_id) const;
+
   std::unique_ptr<catalog::Schema> CreateTestSchema(
       bool add_primary = false) const;
 
@@ -87,32 +95,19 @@ class PelotonCodeGenTest : public PelotonTest {
   //===--------------------------------------------------------------------===//
   // Helpers
   //===--------------------------------------------------------------------===//
-  std::unique_ptr<expression::AbstractExpression> ConstIntExpr(int64_t val);
+  ExpressionPtr ConstIntExpr(int64_t val);
 
-  std::unique_ptr<expression::AbstractExpression> ConstDecimalExpr(double val);
+  ExpressionPtr ConstDecimalExpr(double val);
 
-  std::unique_ptr<expression::AbstractExpression> ColRefExpr(type::TypeId type,
-                                                             uint32_t col_id);
+  ExpressionPtr ColRefExpr(type::TypeId type, uint32_t col_id);
 
-  std::unique_ptr<expression::AbstractExpression> CmpExpr(
-      ExpressionType cmp_type,
-      std::unique_ptr<expression::AbstractExpression> &&left,
-      std::unique_ptr<expression::AbstractExpression> &&right);
+  ExpressionPtr CmpExpr(ExpressionType cmp_type, ExpressionPtr &&left,
+                        ExpressionPtr &&right);
 
-  std::unique_ptr<expression::AbstractExpression> CmpLtExpr(
-      std::unique_ptr<expression::AbstractExpression> &&left,
-      std::unique_ptr<expression::AbstractExpression> &&right);
-
-  std::unique_ptr<expression::AbstractExpression> CmpGtExpr(
-      std::unique_ptr<expression::AbstractExpression> &&left,
-      std::unique_ptr<expression::AbstractExpression> &&right);
-  std::unique_ptr<expression::AbstractExpression> CmpGteExpr(
-      std::unique_ptr<expression::AbstractExpression> &&left,
-      std::unique_ptr<expression::AbstractExpression> &&right);
-
-  std::unique_ptr<expression::AbstractExpression> CmpEqExpr(
-      std::unique_ptr<expression::AbstractExpression> &&left,
-      std::unique_ptr<expression::AbstractExpression> &&right);
+  ExpressionPtr CmpLtExpr(ExpressionPtr &&left, ExpressionPtr &&right);
+  ExpressionPtr CmpGtExpr(ExpressionPtr &&left, ExpressionPtr &&right);
+  ExpressionPtr CmpGteExpr(ExpressionPtr &&left, ExpressionPtr &&right);
+  ExpressionPtr CmpEqExpr(ExpressionPtr &&left, ExpressionPtr &&right);
 
  private:
   storage::Database *test_db;

--- a/test/include/codegen/testing_codegen_util.h
+++ b/test/include/codegen/testing_codegen_util.h
@@ -100,6 +100,7 @@ class PelotonCodeGenTest : public PelotonTest {
   ExpressionPtr ConstDecimalExpr(double val);
 
   ExpressionPtr ColRefExpr(type::TypeId type, uint32_t col_id);
+  ExpressionPtr ColRefExpr(type::TypeId type, bool left, uint32_t col_id);
 
   ExpressionPtr CmpExpr(ExpressionType cmp_type, ExpressionPtr &&left,
                         ExpressionPtr &&right);
@@ -108,6 +109,9 @@ class PelotonCodeGenTest : public PelotonTest {
   ExpressionPtr CmpGtExpr(ExpressionPtr &&left, ExpressionPtr &&right);
   ExpressionPtr CmpGteExpr(ExpressionPtr &&left, ExpressionPtr &&right);
   ExpressionPtr CmpEqExpr(ExpressionPtr &&left, ExpressionPtr &&right);
+
+  ExpressionPtr OpExpr(ExpressionType op_type, type::TypeId type,
+                       ExpressionPtr &&left, ExpressionPtr &&right);
 
  private:
   storage::Database *test_db;

--- a/test/include/codegen/testing_codegen_util.h
+++ b/test/include/codegen/testing_codegen_util.h
@@ -107,6 +107,7 @@ class PelotonCodeGenTest : public PelotonTest {
                         ExpressionPtr &&right);
 
   ExpressionPtr CmpLtExpr(ExpressionPtr &&left, ExpressionPtr &&right);
+  ExpressionPtr CmpLteExpr(ExpressionPtr &&left, ExpressionPtr &&right);
   ExpressionPtr CmpGtExpr(ExpressionPtr &&left, ExpressionPtr &&right);
   ExpressionPtr CmpGteExpr(ExpressionPtr &&left, ExpressionPtr &&right);
   ExpressionPtr CmpEqExpr(ExpressionPtr &&left, ExpressionPtr &&right);

--- a/test/optimizer/operator_test.cpp
+++ b/test/optimizer/operator_test.cpp
@@ -16,33 +16,34 @@ using namespace optimizer;
 class OperatorTests : public PelotonTest {};
 
 // TODO: Test complex expressions
-TEST_F(OperatorTests, OperatorHashAndEqualTest){
+TEST_F(OperatorTests, OperatorHashAndEqualTest) {
   //===--------------------------------------------------------------------===//
   // GroupBy
   //===--------------------------------------------------------------------===//
   const size_t num_exprs = 100;
   std::vector<std::shared_ptr<expression::AbstractExpression>> cols;
-  for (size_t i = 0; i<num_exprs; i++) {
-    auto tv_expr = std::make_shared<expression::TupleValueExpression>(std::to_string(i));
-    auto oids = std::make_tuple<oid_t, oid_t ,oid_t>(0,0,i);
+  for (size_t i = 0; i < num_exprs; i++) {
+    auto tv_expr =
+        std::make_shared<expression::TupleValueExpression>(std::to_string(i));
+    auto oids = std::make_tuple<oid_t, oid_t, oid_t>(0, 0, i);
     tv_expr->SetBoundOid(oids);
     cols.push_back(tv_expr);
   }
 
   // Generate having
-  std::unique_ptr<expression::AbstractExpression> having(
-      new expression::ComparisonExpression(ExpressionType::COMPARE_EQUAL));
   auto col1 = new expression::TupleValueExpression("a");
-  col1->SetBoundOid(0,0,1);
+  col1->SetBoundOid(0, 0, 1);
   auto col2 = new expression::TupleValueExpression("b");
-  col2->SetBoundOid(0,0,2);
-  having->SetChild(0, col1);
-  having->SetChild(1, col2);
+  col2->SetBoundOid(0, 0, 2);
+
+  std::unique_ptr<expression::AbstractExpression> having(
+      new expression::ComparisonExpression(ExpressionType::COMPARE_EQUAL, col1,
+                                           col2));
 
   const size_t num_iter = 1000;
   // HashGroupBy
   Operator l_group_by = PhysicalHashGroupBy::make(cols, having.get());
-  for (size_t i = 0; i<num_iter; i++) {
+  for (size_t i = 0; i < num_iter; i++) {
     std::random_shuffle(cols.begin(), cols.end());
 
     Operator r_group_by = PhysicalHashGroupBy::make(cols, having.get());
@@ -54,11 +55,10 @@ TEST_F(OperatorTests, OperatorHashAndEqualTest){
   // SortGroupBy
   l_group_by = PhysicalSortGroupBy::make(cols, having.get());
 
-  for (size_t i = 0; i<num_iter; i++) {
+  for (size_t i = 0; i < num_iter; i++) {
     std::random_shuffle(cols.begin(), cols.end());
 
-    Operator r_group_by =
-        PhysicalSortGroupBy::make(cols, having.get());
+    Operator r_group_by = PhysicalSortGroupBy::make(cols, having.get());
 
     EXPECT_EQ(l_group_by.Hash(), r_group_by.Hash());
     EXPECT_TRUE(l_group_by == r_group_by);

--- a/test/planner/planner_equality_test.cpp
+++ b/test/planner/planner_equality_test.cpp
@@ -32,7 +32,7 @@ class PlannerEqualityTest : public PelotonTest {
 
   virtual void TearDown() override {
     // Destroy test database
-    auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     auto txn = txn_manager.BeginTransaction();
     catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
     txn_manager.CommitTransaction(txn);
@@ -43,29 +43,26 @@ class PlannerEqualityTest : public PelotonTest {
 
   void CreateAndLoadTable() {
     // Create database
-    auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     auto txn = txn_manager.BeginTransaction();
     catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
     txn_manager.CommitTransaction(txn);
 
     // Create a table 'test'
-    TestingSQLUtil::ExecuteSQLQuery(
-        "CREATE TABLE test(a INT, b INT, c INT);");
+    TestingSQLUtil::ExecuteSQLQuery("CREATE TABLE test(a INT, b INT, c INT);");
 
     // Create a table 'test2'
-    TestingSQLUtil::ExecuteSQLQuery(
-        "CREATE TABLE test2(a INT, b INT, c INT);");
+    TestingSQLUtil::ExecuteSQLQuery("CREATE TABLE test2(a INT, b INT, c INT);");
 
     // Create a table 'test3'
-    TestingSQLUtil::ExecuteSQLQuery(
-        "CREATE TABLE test3(a INT, b INT, c INT);");
+    TestingSQLUtil::ExecuteSQLQuery("CREATE TABLE test3(a INT, b INT, c INT);");
   }
 
   std::shared_ptr<planner::AbstractPlan> GeneratePlanWithOptimizer(
       std::unique_ptr<optimizer::AbstractOptimizer> &optimizer,
       const std::string query, concurrency::TransactionContext *txn) {
     auto &peloton_parser = parser::PostgresParser::GetInstance();
-  
+
     auto parsed_stmt = peloton_parser.BuildParseTree(query);
     auto return_value =
         optimizer->BuildPelotonPlanTree(parsed_stmt, DEFAULT_DB_NAME, txn);
@@ -92,61 +89,59 @@ TEST_F(PlannerEqualityTest, Select) {
   // set up optimizer for every test
   optimizer.reset(new optimizer::Optimizer());
 
-  std::vector<TestItem> items {
-    {"SELECT * from test", "SELECT * from test", true, true},
-    {"SELECT * from test", "SELECT * from test2", false, false},
-    {"SELECT * from test", "SELECT * from test where a = 0", false, false},
-    {"SELECT * from test where a = 1",
-     "SELECT * from test where a = 0", true, true},
-    {"SELECT * from test where b = 1",
-     "SELECT * from test where b > 0", false, false},
-    {"SELECT * from test where a = 1",
-     "SELECT * from test where c = 0", false, false},
-    {"SELECT a from test where b = 1",
-     "SELECT c from test where b = 0", false, false},
-    {"SELECT a,b from test where b = 1",
-     "SELECT b,a from test where b = 0", false, false},
-    {"SELECT a,b from test where b = 1",
-     "SELECT a,b from test where b = $1", true, true},
-    {"SELECT a,b from test where b = $1",
-     "SELECT a,b from test where b = 9", true, true},
-    {"SELECT * from test where b = 1 order by c",
-     "SELECT * from test where b = 0 order by a", false, false},
-    {"SELECT * from test where b = 1 order by c DESC",
-     "SELECT * from test where b = 0 order by c ASC", false, false},
-    {"SELECT * from test where b = 1 order by c+a",
-     "SELECT * from test where b = 0 order by a+c", false, false},
-    {"SELECT avg(*) from test", "SELECT avg(*) from test", true, true},
-    {"SELECT count(*) from test", "SELECT avg(*) from test", false, false},
-    {"SELECT avg(*) from test group by c",
-     "SELECT avg(*) from test group by b", false, false},
-    {"SELECT avg(*) from test group by c",
-     "SELECT avg(*) from test order by c", false, false},
-    {"SELECT avg(*) from test group by a+c",
-     "SELECT avg(*) from test group by b", false, false},
-    {"SELECT a,b from test where b = $1",
-     "SELECT a,b from test where b = $1", true, true},
-    {"SELECT a,b from test where b = $1",
-     "SELECT a,b from test where b = null", false, false},
-    {"SELECT a,b from test where b = $1",
-     "SELECT a,b from test where b = 1", true, true},
-    {"SELECT a,b from test where b = null",
-     "SELECT a,b from test where b = 1", false, false},
-    {"SELECT DISTINCT a from test where b = 1",
-     "SELECT a from test where b = 0", false, false},
-    {"SELECT 1 from test", "SELECT 1 from test", false, false},
-    {"SELECT 1", "SELECT 2", false, false},
-    {"SELECT * FROM test, test2 WHERE test.a = 1 AND test2.b = 0",
-     "SELECT * FROM test, test2 WHERE test.a = 1 AND test2.b = 0",
-     true, true},
-    {"SELECT test.a, test.b, test3.b, test2.c FROM test2, test, test3 "
-         "WHERE test.b = test2.b AND test2.c = test3.c",
-     "SELECT test.a, test.b, test2.c, test3.b FROM test2, test, test3 "
-         "WHERE test.b = test2.b AND test2.c = test3.c", false, false}
+  // clang-format off
+  std::vector<TestItem> items{
+      {"SELECT * from test", "SELECT * from test", true, true},
+      {"SELECT * from test", "SELECT * from test2", false, false},
+      {"SELECT * from test", "SELECT * from test where a = 0", false, false},
+      {"SELECT * from test where a = 1", "SELECT * from test where a = 0", true, true},
+      {"SELECT * from test where b = 1", "SELECT * from test where b > 0", false, false},
+      {"SELECT * from test where a = 1", "SELECT * from test where c = 0", false, false},
+      {"SELECT a from test where b = 1", "SELECT c from test where b = 0", false, false},
+      {"SELECT a,b from test where b = 1", "SELECT b,a from test where b = 0", false, false},
+      {"SELECT a,b from test where b = 1", "SELECT a,b from test where b = $1", true, true},
+      {"SELECT a,b from test where b = $1", "SELECT a,b from test where b = 9", true, true},
+      {"SELECT * from test where b = 1 order by c",
+       "SELECT * from test where b = 0 order by a", false, false},
+      {"SELECT * from test where b = 1 order by c DESC",
+       "SELECT * from test where b = 0 order by c ASC", false, false},
+      {"SELECT * from test where b = 1 order by c+a",
+       "SELECT * from test where b = 0 order by a+c", false, false},
+      {"SELECT avg(*) from test", "SELECT avg(*) from test", true, true},
+      {"SELECT count(*) from test", "SELECT avg(*) from test", false, false},
+      {"SELECT avg(*) from test group by c",
+       "SELECT avg(*) from test group by b", false, false},
+      {"SELECT avg(*) from test group by c",
+       "SELECT avg(*) from test order by c", false, false},
+      {"SELECT avg(*) from test group by a+c",
+       "SELECT avg(*) from test group by b", false, false},
+      {"SELECT a,b from test where b = $1", "SELECT a,b from test where b = $1", true, true},
+      {"SELECT a,b from test where b = $1",
+       "SELECT a,b from test where b = null", false, false},
+      {"SELECT a,b from test where b = $1", "SELECT a,b from test where b = 1", true, true},
+      {"SELECT a,b from test where b = null",
+       "SELECT a,b from test where b = 1", false, false},
+      {"SELECT DISTINCT a from test where b = 1",
+       "SELECT a from test where b = 0", false, false},
+      {"SELECT 1 from test", "SELECT 1 from test", false, false},
+      {"SELECT 1", "SELECT 2", false, false},
+      {"SELECT * FROM test, test2 WHERE test.a = 1 AND test2.b = 0",
+       "SELECT * FROM test, test2 WHERE test.a = 1 AND test2.b = 0", true, true},
+      {"SELECT test.a, test.b, test3.b, test2.c FROM test2, test, test3 "
+       "WHERE test.b = test2.b AND test2.c = test3.c",
+       "SELECT test.a, test.b, test2.c, test3.b FROM test2, test, test3 "
+       "WHERE test.b = test2.b AND test2.c = test3.c", false, false},
+      {"SELECT * from test inner join test2 on test.a < test2.a",
+       "SELECT * from test inner join test2 on test.a < test2.a", true, true},
+      {"SELECT * from test inner join test2 on test.a < test2.a",
+       "SELECT * from test inner join test2 on test.a > test2.a", false, false},
+      {"SELECT * from test inner join test2 on test.a < 1 + test2.a",
+       "SELECT * from test inner join test2 on test.a > 1 - test2.a", false, false},
   };
+  // clang-format on
 
   for (uint32_t i = 0; i < items.size(); i++) {
-    auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     auto txn = txn_manager.BeginTransaction();
 
     TestItem &item = items[i];
@@ -162,7 +157,7 @@ TEST_F(PlannerEqualityTest, Select) {
 
     auto hash_equal = (plan_1->Hash() == plan_2->Hash());
     EXPECT_EQ(item.hash_equal, hash_equal);
-    
+
     auto is_equal = (*plan_1 == *plan_2);
     EXPECT_EQ(item.is_equal, is_equal);
   }
@@ -172,27 +167,27 @@ TEST_F(PlannerEqualityTest, Insert) {
   // set up optimizer for every test
   optimizer.reset(new optimizer::Optimizer());
 
-  std::vector<TestItem> items {
-    {"INSERT into test values(1,1)",
-     "INSERT into test values(1,2)", true, true},
-    {"INSERT into test values(1,1)",
-     "INSERT into test2 values(1,2)", false, false},
-    {"INSERT into test values(1,1)",
-     "INSERT into test values(1,2),(3,4)", false, false},
-    {"INSERT into test values(1,1),(4,5)",
-     "INSERT into test values(1,2),(3,4)", true, true},
-    {"INSERT into test values(1,1,2),(4,5)",
-     "INSERT into test values(1,2),(3,4)", true, true},
-    {"INSERT into test values(1,1,2),(4,5)",
-     "INSERT into test select * from test2", false, false},
-    {"INSERT into test select * from test2",
-     "INSERT into test select * from test3", false, false},
-    {"INSERT into test select * from test3",
-     "INSERT into test select * from test3 where a=1", false, false},
+  std::vector<TestItem> items{
+      {"INSERT into test values(1,1)", "INSERT into test values(1,2)", true,
+       true},
+      {"INSERT into test values(1,1)", "INSERT into test2 values(1,2)", false,
+       false},
+      {"INSERT into test values(1,1)", "INSERT into test values(1,2),(3,4)",
+       false, false},
+      {"INSERT into test values(1,1),(4,5)",
+       "INSERT into test values(1,2),(3,4)", true, true},
+      {"INSERT into test values(1,1,2),(4,5)",
+       "INSERT into test values(1,2),(3,4)", true, true},
+      {"INSERT into test values(1,1,2),(4,5)",
+       "INSERT into test select * from test2", false, false},
+      {"INSERT into test select * from test2",
+       "INSERT into test select * from test3", false, false},
+      {"INSERT into test select * from test3",
+       "INSERT into test select * from test3 where a=1", false, false},
   };
 
   for (uint32_t i = 0; i < items.size(); i++) {
-    auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     auto txn = txn_manager.BeginTransaction();
 
     TestItem &item = items[i];
@@ -208,7 +203,7 @@ TEST_F(PlannerEqualityTest, Insert) {
 
     auto hash_equal = (plan_1->Hash() == plan_2->Hash());
     EXPECT_EQ(item.hash_equal, hash_equal);
-    
+
     auto is_equal = (*plan_1 == *plan_2);
     EXPECT_EQ(item.is_equal, is_equal);
   }
@@ -216,15 +211,16 @@ TEST_F(PlannerEqualityTest, Insert) {
 
 TEST_F(PlannerEqualityTest, Delete) {
   optimizer.reset(new optimizer::Optimizer());
-  std::vector<TestItem> items {
-    {"DELETE from test where a=1", "DELETE from test where a=1", true, true},
-    {"DELETE from test where a=1", "DELETE from test where a=2", true, true},
-    {"DELETE from test where a=1", "DELETE from test2 where a=1", false, false},
-    {"DELETE from test", "DELETE from test", true, true},
+  std::vector<TestItem> items{
+      {"DELETE from test where a=1", "DELETE from test where a=1", true, true},
+      {"DELETE from test where a=1", "DELETE from test where a=2", true, true},
+      {"DELETE from test where a=1", "DELETE from test2 where a=1", false,
+       false},
+      {"DELETE from test", "DELETE from test", true, true},
   };
 
   for (uint32_t i = 0; i < items.size(); i++) {
-    auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     auto txn = txn_manager.BeginTransaction();
 
     TestItem &item = items[i];
@@ -240,7 +236,7 @@ TEST_F(PlannerEqualityTest, Delete) {
 
     auto hash_equal = (plan_1->Hash() == plan_2->Hash());
     EXPECT_EQ(item.hash_equal, hash_equal);
-    
+
     auto is_equal = (*plan_1 == *plan_2);
     EXPECT_EQ(item.is_equal, is_equal);
   }
@@ -250,19 +246,19 @@ TEST_F(PlannerEqualityTest, Update) {
   // set up optimizer for every test
   optimizer.reset(new optimizer::Optimizer());
 
-  std::vector<TestItem> items {
-    {"UPDATE test SET c = b + 1 WHERE a=1",
-     "UPDATE test SET c = b + 2 WHERE a=1", true, true},
-    {"UPDATE test SET c = b + 1 WHERE a=1",
-     "UPDATE test SET c = c + 2 WHERE a=1", false, false},
-    {"UPDATE test SET c = b + 1 WHERE a=1",
-     "UPDATE test2 SET c = b + 2 WHERE a=1", false, false},
-    {"UPDATE test SET c = b + 1 WHERE a=1",
-     "UPDATE test SET c = b + 2 WHERE a=$1", true, true},
+  std::vector<TestItem> items{
+      {"UPDATE test SET c = b + 1 WHERE a=1",
+       "UPDATE test SET c = b + 2 WHERE a=1", true, true},
+      {"UPDATE test SET c = b + 1 WHERE a=1",
+       "UPDATE test SET c = c + 2 WHERE a=1", false, false},
+      {"UPDATE test SET c = b + 1 WHERE a=1",
+       "UPDATE test2 SET c = b + 2 WHERE a=1", false, false},
+      {"UPDATE test SET c = b + 1 WHERE a=1",
+       "UPDATE test SET c = b + 2 WHERE a=$1", true, true},
   };
 
   for (uint32_t i = 0; i < items.size(); i++) {
-    auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     auto txn = txn_manager.BeginTransaction();
 
     TestItem &item = items[i];
@@ -278,7 +274,7 @@ TEST_F(PlannerEqualityTest, Update) {
 
     auto hash_equal = (plan_1->Hash() == plan_2->Hash());
     EXPECT_EQ(item.hash_equal, hash_equal);
-    
+
     auto is_equal = (*plan_1 == *plan_2);
     EXPECT_EQ(item.is_equal, is_equal);
   }


### PR DESCRIPTION
This PR adds block nest-loop joins to the codegen engine. This brings us one step closer to achieving feature parity with the interpreted engine (and one step closer to phasing it out).

Initially this PR had sort-merge joins and union/intersect/extract too, but with all the required infrastructure changes the PR was too complex. I'll submit those once this goes through.

In this PR:
1. The main BNLJ logic.
2. Ability to define auxiliary producer functions aside from the "main" plan function. This will be needed for outer joins later on.
3. Separate a function's declaration from definition so that the function can be used before it is defined (i.e., implemented).
4. Ability to reset parameter cache so that it can be reused across multiple functions.
5. Optimize parameter cache to only generate null checks if parameter is nullable.
6. Optimize zone map scanning logic.
7. Removed all local (i.e., on-stack) from runtime state. Now local variables can be safely defined **anywhere** during code generation. This makes it much easier for beginners since they don't have to worry about whether allocation happens deeply in a loop.
8. Enabled NLJ plans to participate in parameterization and caching.
9. Random formatting.

Tests for all of the above are included.