### PR TITLE
Parser support for a range of types of queries

### DIFF
--- a/src/common/internal_types.cpp
+++ b/src/common/internal_types.cpp
@@ -2370,9 +2370,9 @@ std::string LayoutTypeToString(LayoutType type) {
       return "HYBRID";
     }
     default: {
-      throw ConversionException(StringUtil::Format(
-          "No string conversion for LayoutType value '%d'",
-          static_cast<int>(type)));
+      throw ConversionException(
+          StringUtil::Format("No string conversion for LayoutType value '%d'",
+                             static_cast<int>(type)));
     }
   }
   return "INVALID";
@@ -2382,9 +2382,6 @@ std::ostream &operator<<(std::ostream &os, const LayoutType &type) {
   os << LayoutTypeToString(type);
   return os;
 }
-
-
-
 
 type::TypeId PostgresValueTypeToPelotonValueType(PostgresValueType type) {
   switch (type) {

--- a/src/common/internal_types.cpp
+++ b/src/common/internal_types.cpp
@@ -841,6 +841,8 @@ IndexType StringToIndexType(const std::string &str) {
   std::string upper_str = StringUtil::Upper(str);
   if (upper_str == "INVALID") {
     return IndexType::INVALID;
+  } else if (upper_str == "BTREE") {
+    return IndexType::BWTREE;
   } else if (upper_str == "BWTREE") {
     return IndexType::BWTREE;
   } else if (upper_str == "HASH") {

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -16,6 +16,7 @@
 #include "common/sql_node_visitor.h"
 #include "expression/abstract_expression.h"
 #include "parser/sql_statement.h"
+#include "parser/select_statement.h"
 #include "common/internal_types.h"
 
 namespace peloton {
@@ -213,7 +214,7 @@ struct ColumnDefinition {
  */
 class CreateStatement : public TableRefStatement {
  public:
-  enum CreateType { kTable, kDatabase, kIndex, kTrigger };
+  enum CreateType { kTable, kDatabase, kIndex, kTrigger, kSchema, kView };
 
   CreateStatement(CreateType type)
       : TableRefStatement(StatementType::CREATE),
@@ -228,12 +229,17 @@ class CreateStatement : public TableRefStatement {
   bool if_not_exists;
 
   std::vector<std::unique_ptr<ColumnDefinition>> columns;
+
   std::vector<std::string> index_attrs;
-
   IndexType index_type;
-
   std::string index_name;
+
   std::string trigger_name;
+
+  std::string schema_name;
+
+  std::string view_name;
+  std::unique_ptr<SelectStatement> view_query;
 
   bool unique = false;
 

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -234,8 +234,6 @@ class CreateStatement : public TableRefStatement {
   IndexType index_type;
   std::string index_name;
 
-  std::string trigger_name;
-
   std::string schema_name;
 
   std::string view_name;
@@ -243,6 +241,7 @@ class CreateStatement : public TableRefStatement {
 
   bool unique = false;
 
+  std::string trigger_name;
   std::vector<std::string> trigger_funcname;
   std::vector<std::string> trigger_args;
   std::vector<std::string> trigger_columns;

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -35,28 +35,53 @@ class DropStatement : public TableRefStatement {
   };
 
   DropStatement(EntityType type)
-      : TableRefStatement(StatementType::DROP), type(type), missing(false) {}
+      : TableRefStatement(StatementType::DROP),
+        type(type),
+        missing(false),
+        cascade(false) {}
 
-  DropStatement(EntityType type, std::string table_name_of_trigger, std::string trigger_name)
+  DropStatement(EntityType type, std::string table_name_of_trigger,
+                std::string trigger_name)
       : TableRefStatement(StatementType::DROP),
         type(type),
         table_name_of_trigger(table_name_of_trigger),
         trigger_name(trigger_name) {}
 
+  EntityType GetDropType() { return this->type; }
+
+  bool GetMissing() { return this->missing; }
+
+  std::string GetIndexName() { return this->index_name; }
+
+  std::string GetPrepStmt() { return this->prep_stmt; }
+
+  std::string GetSchemaName() { return this->schema_name; }
+
+  std::string GetTriggerName() { return this->trigger_name; }
+
+  std::string GetTriggerTableName() { return this->table_name_of_trigger; }
+
   virtual ~DropStatement() {}
 
-  virtual void Accept(SqlNodeVisitor* v) override {
-    v->Visit(this);
-  }
+  virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
+  // Type of DROP
   EntityType type;
+  // CASCADE or RESTRICT
+  bool cascade;
+  // IF EXISTS
+  bool missing;
+
+  // drop index
   std::string index_name;
   std::string prep_stmt;
-  bool missing;
 
   // drop trigger
   std::string table_name_of_trigger;
   std::string trigger_name;
+
+  // drop schema
+  std::string schema_name;
 };
 
 }  // namespace parser

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -36,52 +36,87 @@ class DropStatement : public TableRefStatement {
 
   DropStatement(EntityType type)
       : TableRefStatement(StatementType::DROP),
-        type(type),
-        missing(false),
-        cascade(false) {}
+        type_(type),
+        missing_(false),
+        cascade_(false) {}
 
   DropStatement(EntityType type, std::string table_name_of_trigger,
                 std::string trigger_name)
       : TableRefStatement(StatementType::DROP),
-        type(type),
-        table_name_of_trigger(table_name_of_trigger),
-        trigger_name(trigger_name) {}
+        type_(type),
+        table_name_of_trigger_(table_name_of_trigger),
+        trigger_name_(trigger_name) {}
 
-  EntityType GetDropType() { return this->type; }
+  EntityType GetDropType() { return type_; }
 
-  bool GetMissing() { return this->missing; }
+  bool GetMissing() { return missing_; }
 
-  std::string GetIndexName() { return this->index_name; }
+  void SetMissing(bool missing) { missing_ = missing; }
 
-  std::string GetPrepStmt() { return this->prep_stmt; }
+  bool GetCascade() { return cascade_; }
 
-  std::string GetSchemaName() { return this->schema_name; }
+  void SetCascade(bool cascade) { cascade_ = cascade; }
 
-  std::string GetTriggerName() { return this->trigger_name; }
+  std::string& GetIndexName() { return index_name_; }
 
-  std::string GetTriggerTableName() { return this->table_name_of_trigger; }
+  void SetIndexName(std::string& index_name) { index_name_ = index_name; }
+
+  void SetIndexName(char *index_name) { index_name_ = index_name; }
+
+  std::string& GetPrepStmt() { return prep_stmt_; }
+
+  void SetPrepStmt(std::string& prep_stmt) { prep_stmt_ = prep_stmt; }
+
+  void SetPrepStmt(char *prep_stmt) { prep_stmt_ = prep_stmt; }
+
+  std::string& GetSchemaName() { return schema_name_; }
+
+  void SetSchemaName(std::string& schema_name) { schema_name_ = schema_name; }
+
+  void SetSchemaName(char *schema_name) { schema_name_ = schema_name; }
+
+  std::string& GetTriggerName() { return trigger_name_; }
+
+  void SetTriggerName(std::string& trigger_name) {
+    trigger_name_ = trigger_name;
+  }
+
+  void SetTriggerName(char* trigger_name) {
+    trigger_name_ = trigger_name;
+  }
+
+  std::string& GetTriggerTableName() { return table_name_of_trigger_; }
+
+  void SetTriggerTableName(std::string& table_name_of_trigger) {
+    table_name_of_trigger_ = table_name_of_trigger;
+  }
+
+  void SetTriggerTableName(char* table_name_of_trigger) {
+    table_name_of_trigger_ = table_name_of_trigger;
+  }
 
   virtual ~DropStatement() {}
 
   virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
+private:
   // Type of DROP
-  EntityType type;
+  EntityType type_;
   // IF EXISTS
-  bool missing;
-    // CASCADE or RESTRICT
-  bool cascade;
+  bool missing_;
+  // CASCADE or RESTRICT
+  bool cascade_;
 
   // drop index
-  std::string index_name;
-  std::string prep_stmt;
+  std::string index_name_;
+  std::string prep_stmt_;
 
   // drop trigger
-  std::string table_name_of_trigger;
-  std::string trigger_name;
+  std::string table_name_of_trigger_;
+  std::string trigger_name_;
 
   // drop schema
-  std::string schema_name;
+  std::string schema_name_;
 };
 
 }  // namespace parser

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -67,10 +67,10 @@ class DropStatement : public TableRefStatement {
 
   // Type of DROP
   EntityType type;
-  // CASCADE or RESTRICT
-  bool cascade;
   // IF EXISTS
   bool missing;
+    // CASCADE or RESTRICT
+  bool cascade;
 
   // drop index
   std::string index_name;

--- a/src/include/parser/parsenodes.h
+++ b/src/include/parser/parsenodes.h
@@ -631,6 +631,49 @@ typedef struct CreateDatabaseStmt {
   List *options; /* List of DefElem nodes */
 } CreateDatabaseStmt;
 
+typedef struct CreateSchemaStmt
+{
+  NodeTag   type;
+  char     *schemaname;   /* the name of the schema to create */
+  Node     *authrole;   /* the owner of the created schema */
+  List     *schemaElts;   /* schema components (list of parsenodes) */
+  bool    if_not_exists;  /* just do nothing if schema already exists? */
+} CreateSchemaStmt;
+
+typedef enum RoleSpecType
+{
+  ROLESPEC_CSTRING,     /* role name is stored as a C string */
+  ROLESPEC_CURRENT_USER,    /* role spec is CURRENT_USER */
+  ROLESPEC_SESSION_USER,    /* role spec is SESSION_USER */
+  ROLESPEC_PUBLIC       /* role name is "public" */
+} RoleSpecType;
+
+typedef struct RoleSpec
+{
+  NodeTag   type;
+  RoleSpecType roletype;    /* Type of this rolespec */
+  char     *rolename;   /* filled only for ROLESPEC_CSTRING */
+  int     location;   /* token location, or -1 if unknown */
+} RoleSpec;
+
+typedef enum ViewCheckOption
+{
+  NO_CHECK_OPTION,
+  LOCAL_CHECK_OPTION,
+  CASCADED_CHECK_OPTION
+} ViewCheckOption;
+
+typedef struct ViewStmt
+{
+  NodeTag   type;
+  RangeVar   *view;     /* the view to be created */
+  List     *aliases;    /* target column names */
+  Node     *query;      /* the SELECT query */
+  bool    replace;    /* replace an existing view? */
+  List     *options;    /* options from WITH clause */
+  ViewCheckOption withCheckOption;  /* WITH CHECK OPTION */
+} ViewStmt;
+
 typedef struct ParamRef {
   NodeTag type;
   int number;   /* the number of the parameter */

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -187,6 +187,12 @@ class PostgresParser {
   static parser::SQLStatement *CreateDatabaseTransform(
       CreateDatabaseStmt *root);
 
+  // transform helper for create schema statements
+  static parser::SQLStatement *CreateSchemaTransform(CreateSchemaStmt *root);
+
+  // transform helper for create view statements
+  static parser::SQLStatement *CreateViewTransform(ViewStmt *root);
+
   // transform helper for column name (for insert statement)
   static std::vector<std::string> *ColumnNameTransform(List *root);
 
@@ -199,7 +205,7 @@ class PostgresParser {
   static parser::SQLStatement *InsertTransform(InsertStmt *root);
 
   // transform helper for select statements
-  static parser::SQLStatement *SelectTransform(SelectStmt *root);
+  static parser::SelectStatement *SelectTransform(SelectStmt *root);
 
   // transform helper for delete statements
   static parser::SQLStatement *DeleteTransform(DeleteStmt *root);

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -180,11 +180,12 @@ class PostgresParser {
 
   /**
    * @brief transform helper for create database statement
-   * 
+   *
    * @param Postgres CreateDatabaseStmt parsenode
    * @return a peloton CreateStatement node
    */
-  static parser::SQLStatement *CreateDatabaseTransform(CreateDatabaseStmt *root);
+  static parser::SQLStatement *CreateDatabaseTransform(
+      CreateDatabaseStmt *root);
 
   // transform helper for column name (for insert statement)
   static std::vector<std::string> *ColumnNameTransform(List *root);
@@ -221,17 +222,20 @@ class PostgresParser {
 
   /**
    * @brief transform helper for drop database statement
-   * 
+   *
    * @param Postgres DropDatabaseStmt parsenode
    * @return a peloton DropStatement node
    */
-  static parser::DropStatement* DropDatabaseTransform(DropDatabaseStmt* root);
-  
+  static parser::DropStatement *DropDatabaseTransform(DropDatabaseStmt *root);
+
   // transform helper for drop table statement
   static parser::DropStatement *DropTableTransform(DropStmt *root);
 
   // transform helper for drop trigger statement
   static parser::DropStatement *DropTriggerTransform(DropStmt *root);
+
+  // transform helper for drop schema statement
+  static parser::DropStatement *DropSchemaTransform(DropStmt *root);
 
   // transform helper for truncate statement
   static parser::DeleteStatement *TruncateTransform(TruncateStmt *root);

--- a/src/parser/parser_utils.cpp
+++ b/src/parser/parser_utils.cpp
@@ -224,6 +224,8 @@ std::string ParserUtils::GetCreateStatementInfo(CreateStatement *stmt,
     }
     case CreateStatement::CreateType::kTrigger: {
       os << "Create type: Trigger" << "\n";
+      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("Trigger table name: %s", stmt->trigger_name.c_str()) << "\n";
+      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("Trigger name: %s", stmt->GetTableName().c_str()) << "\n";
       break;
     }
     case CreateStatement::CreateType::kSchema: {
@@ -233,6 +235,7 @@ std::string ParserUtils::GetCreateStatementInfo(CreateStatement *stmt,
     }
     case CreateStatement::CreateType::kView: {
       os << "Create type: View" << "\n";
+      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("View name: %s", stmt->view_name.c_str()) << "\n";
       break;
     }
   }

--- a/src/parser/parser_utils.cpp
+++ b/src/parser/parser_utils.cpp
@@ -199,18 +199,28 @@ std::string ParserUtils::GetCreateStatementInfo(CreateStatement *stmt,
 
   switch (stmt->type) {
     case CreateStatement::CreateType::kTable: {
-      os << "Create type: Table" << "\n";
-      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("IF NOT EXISTS: %s", (stmt->if_not_exists)? "True":"False") << "\n";
-      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("Table name: %s", stmt->GetTableName().c_str()) << "\n";
+      os << "Create type: Table"
+         << "\n";
+      os << StringUtil::Indent(num_indent + 1)
+         << StringUtil::Format("IF NOT EXISTS: %s",
+                               (stmt->if_not_exists) ? "True" : "False")
+         << "\n";
+      os << StringUtil::Indent(num_indent + 1)
+         << StringUtil::Format("Table name: %s", stmt->GetTableName().c_str())
+         << "\n";
       break;
     }
     case CreateStatement::CreateType::kDatabase: {
-      os << "Create type: Database" << "\n";
-      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("Database name: %s", stmt->GetDatabaseName().c_str()) << "\n";
+      os << "Create type: Database"
+         << "\n";
+      os << StringUtil::Indent(num_indent + 1)
+         << StringUtil::Format("Database name: %s",
+                               stmt->GetDatabaseName().c_str()) << "\n";
       break;
     }
     case CreateStatement::CreateType::kIndex: {
-      os << "Create type: Index" << "\n";
+      os << "Create type: Index"
+         << "\n";
       os << StringUtil::Indent(num_indent + 1) << stmt->index_name << "\n";
       os << StringUtil::Indent(num_indent + 1)
          << "INDEX : table : " << stmt->GetTableName()
@@ -223,19 +233,30 @@ std::string ParserUtils::GetCreateStatementInfo(CreateStatement *stmt,
       break;
     }
     case CreateStatement::CreateType::kTrigger: {
-      os << "Create type: Trigger" << "\n";
-      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("Trigger table name: %s", stmt->trigger_name.c_str()) << "\n";
-      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("Trigger name: %s", stmt->GetTableName().c_str()) << "\n";
+      os << "Create type: Trigger"
+         << "\n";
+      os << StringUtil::Indent(num_indent + 1)
+         << StringUtil::Format("Trigger table name: %s",
+                               stmt->trigger_name.c_str()) << "\n";
+      os << StringUtil::Indent(num_indent + 1)
+         << StringUtil::Format("Trigger name: %s", stmt->GetTableName().c_str())
+         << "\n";
       break;
     }
     case CreateStatement::CreateType::kSchema: {
-      os << "Create type: Schema" << "\n";
-      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("Schema name: %s", stmt->schema_name.c_str()) << "\n";
+      os << "Create type: Schema"
+         << "\n";
+      os << StringUtil::Indent(num_indent + 1)
+         << StringUtil::Format("Schema name: %s", stmt->schema_name.c_str())
+         << "\n";
       break;
     }
     case CreateStatement::CreateType::kView: {
-      os << "Create type: View" << "\n";
-      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("View name: %s", stmt->view_name.c_str()) << "\n";
+      os << "Create type: View"
+         << "\n";
+      os << StringUtil::Indent(num_indent + 1)
+         << StringUtil::Format("View name: %s", stmt->view_name.c_str())
+         << "\n";
       break;
     }
   }

--- a/src/parser/parser_utils.cpp
+++ b/src/parser/parser_utils.cpp
@@ -195,20 +195,46 @@ std::string ParserUtils::GetCreateStatementInfo(CreateStatement *stmt,
                                                 uint num_indent) {
   std::ostringstream os;
   os << StringUtil::Indent(num_indent) << "CreateStatment\n";
-  os << StringUtil::Indent(num_indent + 1) << stmt->type << "\n";
+  os << StringUtil::Indent(num_indent + 1);
 
-  if (stmt->type == CreateStatement::CreateType::kIndex) {
-    os << StringUtil::Indent(num_indent + 1) << stmt->index_name << "\n";
-    os << StringUtil::Indent(num_indent + 1)
-       << "INDEX : table : " << stmt->GetTableName()
-       << " unique : " << stmt->unique << " attrs : ";
-    for (auto &key : stmt->index_attrs) os << key << " ";
-    os << "\n";
-    os << StringUtil::Indent(num_indent + 1)
-       << "Type : " << IndexTypeToString(stmt->index_type) << "\n";
-    os << "\n";
-  } else if (stmt->type == CreateStatement::CreateType::kTable) {
-    os << StringUtil::Indent(num_indent + 1) << stmt->GetTableName() << "\n";
+  switch (stmt->type) {
+    case CreateStatement::CreateType::kTable: {
+      os << "Create type: Table" << "\n";
+      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("IF NOT EXISTS: %s", (stmt->if_not_exists)? "True":"False") << "\n";
+      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("Table name: %s", stmt->GetTableName().c_str()) << "\n";
+      break;
+    }
+    case CreateStatement::CreateType::kDatabase: {
+      os << "Create type: Database" << "\n";
+      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("Database name: %s", stmt->GetDatabaseName().c_str()) << "\n";
+      break;
+    }
+    case CreateStatement::CreateType::kIndex: {
+      os << "Create type: Index" << "\n";
+      os << StringUtil::Indent(num_indent + 1) << stmt->index_name << "\n";
+      os << StringUtil::Indent(num_indent + 1)
+         << "INDEX : table : " << stmt->GetTableName()
+         << " unique : " << stmt->unique << " attrs : ";
+      for (auto &key : stmt->index_attrs) os << key << " ";
+      os << "\n";
+      os << StringUtil::Indent(num_indent + 1)
+         << "Type : " << IndexTypeToString(stmt->index_type) << "\n";
+      os << "\n";
+      break;
+    }
+    case CreateStatement::CreateType::kTrigger: {
+      os << "Create type: Trigger" << "\n";
+      break;
+    }
+    case CreateStatement::CreateType::kSchema: {
+      os << "Create type: Schema" << "\n";
+      os << StringUtil::Indent(num_indent + 1) << StringUtil::Format("Schema name: %s", stmt->schema_name.c_str()) << "\n";
+      break;
+    }
+    case CreateStatement::CreateType::kView: {
+      os << "Create type: View" << "\n";
+      break;
+    }
   }
 
   if (!stmt->columns.empty()) {

--- a/src/parser/parser_utils.cpp
+++ b/src/parser/parser_utils.cpp
@@ -24,7 +24,7 @@
 namespace peloton {
 namespace parser {
 
-std::string ParserUtils::GetTableRefInfo(const TableRef* table,
+std::string ParserUtils::GetTableRefInfo(const TableRef *table,
                                          uint num_indent) {
   std::ostringstream os;
   switch (table->type) {
@@ -43,7 +43,8 @@ std::string ParserUtils::GetTableRefInfo(const TableRef* table,
       os << StringUtil::Indent(num_indent + 1) << "-> Right\n";
       os << GetTableRefInfo(table->join->right.get(), num_indent + 2) << "\n";
       os << StringUtil::Indent(num_indent + 1) << "-> Join Condition\n";
-      os << GetExpressionInfo(table->join->condition.get(), num_indent + 2) << "\n";
+      os << GetExpressionInfo(table->join->condition.get(), num_indent + 2)
+         << "\n";
       break;
 
     case TableReferenceType::CROSS_PRODUCT:
@@ -67,7 +68,7 @@ std::string ParserUtils::GetTableRefInfo(const TableRef* table,
 }
 
 std::string ParserUtils::GetOperatorExpression(
-    const expression::AbstractExpression* expr, uint num_indent) {
+    const expression::AbstractExpression *expr, uint num_indent) {
   if (expr == NULL) {
     return StringUtil::Indent(num_indent) + "null";
   }
@@ -80,14 +81,15 @@ std::string ParserUtils::GetOperatorExpression(
 }
 
 std::string ParserUtils::GetExpressionInfo(
-    const expression::AbstractExpression* expr, uint num_indent) {
+    const expression::AbstractExpression *expr, uint num_indent) {
   if (expr == NULL) {
     return StringUtil::Indent(num_indent) + "null";
   }
 
   std::ostringstream os;
-  os << StringUtil::Indent(num_indent) << "-> Expr Type :: "
-     << ExpressionTypeToString(expr->GetExpressionType()) << "\n";
+  os << StringUtil::Indent(num_indent)
+     << "-> Expr Type :: " << ExpressionTypeToString(expr->GetExpressionType())
+     << "\n";
 
   switch (expr->GetExpressionType()) {
     case ExpressionType::STAR:
@@ -96,13 +98,15 @@ std::string ParserUtils::GetExpressionInfo(
     case ExpressionType::VALUE_TUPLE:
       os << StringUtil::Indent(num_indent + 1) << expr->GetInfo() << "\n";
       os << StringUtil::Indent(num_indent + 1)
-         << ((expression::TupleValueExpression*)expr)->GetTableName() << "<";
-      os << ((expression::TupleValueExpression*)expr)->GetColumnName() << ">\n";
+         << ((expression::TupleValueExpression *)expr)->GetTableName() << "<";
+      os << ((expression::TupleValueExpression *)expr)->GetColumnName()
+         << ">\n";
       break;
     case ExpressionType::COMPARE_GREATERTHAN:
       os << StringUtil::Indent(num_indent + 1) << expr->GetInfo() << "\n";
       for (size_t i = 0; i < (expr)->GetChildrenSize(); ++i) {
-        os << StringUtil::Indent(num_indent + 1) << ((expr)->GetChild(i))->GetInfo() << "\n";
+        os << StringUtil::Indent(num_indent + 1)
+           << ((expr)->GetChild(i))->GetInfo() << "\n";
       }
       break;
     case ExpressionType::VALUE_CONSTANT:
@@ -125,7 +129,7 @@ std::string ParserUtils::GetExpressionInfo(
   return info;
 }
 
-std::string ParserUtils::GetSelectStatementInfo(SelectStatement* stmt,
+std::string ParserUtils::GetSelectStatementInfo(SelectStatement *stmt,
                                                 uint num_indent) {
   std::ostringstream os;
   os << StringUtil::Indent(num_indent) << "SelectStatement\n";
@@ -140,12 +144,14 @@ std::string ParserUtils::GetSelectStatementInfo(SelectStatement* stmt,
 
   if (stmt->where_clause != NULL) {
     os << StringUtil::Indent(num_indent + 1) << "-> Search Conditions:\n";
-    os << GetExpressionInfo(stmt->where_clause.get(), num_indent + 2) << std::endl;
+    os << GetExpressionInfo(stmt->where_clause.get(), num_indent + 2)
+       << std::endl;
   }
 
   if (stmt->union_select != NULL) {
     os << StringUtil::Indent(num_indent + 1) << "-> Union:\n";
-    os << GetSelectStatementInfo(stmt->union_select.get(), num_indent + 2) << std::endl;
+    os << GetSelectStatementInfo(stmt->union_select.get(), num_indent + 2)
+       << std::endl;
   }
 
   if (stmt->order != NULL) {
@@ -164,24 +170,28 @@ std::string ParserUtils::GetSelectStatementInfo(SelectStatement* stmt,
   if (stmt->group_by != NULL) {
     os << StringUtil::Indent(num_indent + 1) << "-> GroupBy:\n";
     for (auto &column : stmt->group_by->columns) {
-      os << StringUtil::Indent(num_indent + 2) << column->GetInfo() << std::endl;
+      os << StringUtil::Indent(num_indent + 2) << column->GetInfo()
+         << std::endl;
     }
     if (stmt->group_by->having) {
-      os << StringUtil::Indent(num_indent + 2) << stmt->group_by->having->GetInfo() << std::endl;
+      os << StringUtil::Indent(num_indent + 2)
+         << stmt->group_by->having->GetInfo() << std::endl;
     }
   }
 
   if (stmt->limit != NULL) {
     os << StringUtil::Indent(num_indent + 1) << "-> Limit:\n";
-    os << StringUtil::Indent(num_indent + 2) << std::to_string(stmt->limit->limit) << "\n";
-    os << StringUtil::Indent(num_indent + 2) << std::to_string(stmt->limit->offset) << "\n";
+    os << StringUtil::Indent(num_indent + 2)
+       << std::to_string(stmt->limit->limit) << "\n";
+    os << StringUtil::Indent(num_indent + 2)
+       << std::to_string(stmt->limit->offset) << "\n";
   }
   std::string info = os.str();
   StringUtil::RTrim(info);
   return info;
 }
 
-std::string ParserUtils::GetCreateStatementInfo(CreateStatement* stmt,
+std::string ParserUtils::GetCreateStatementInfo(CreateStatement *stmt,
                                                 uint num_indent) {
   std::ostringstream os;
   os << StringUtil::Indent(num_indent) << "CreateStatment\n";
@@ -189,12 +199,13 @@ std::string ParserUtils::GetCreateStatementInfo(CreateStatement* stmt,
 
   if (stmt->type == CreateStatement::CreateType::kIndex) {
     os << StringUtil::Indent(num_indent + 1) << stmt->index_name << "\n";
-    os << StringUtil::Indent(num_indent + 1) << "INDEX : table : " << stmt->GetTableName()
+    os << StringUtil::Indent(num_indent + 1)
+       << "INDEX : table : " << stmt->GetTableName()
        << " unique : " << stmt->unique << " attrs : ";
     for (auto &key : stmt->index_attrs) os << key << " ";
     os << "\n";
-    os << StringUtil::Indent(num_indent + 1) << "Type : "
-       << IndexTypeToString(stmt->index_type) << "\n";
+    os << StringUtil::Indent(num_indent + 1)
+       << "Type : " << IndexTypeToString(stmt->index_type) << "\n";
     os << "\n";
   } else if (stmt->type == CreateStatement::CreateType::kTable) {
     os << StringUtil::Indent(num_indent + 1) << stmt->GetTableName() << "\n";
@@ -202,13 +213,16 @@ std::string ParserUtils::GetCreateStatementInfo(CreateStatement* stmt,
 
   if (!stmt->columns.empty()) {
     for (auto &col : stmt->columns) {
-      if (col->name.empty()) {continue;}
+      if (col->name.empty()) {
+        continue;
+      }
       if (col->type == ColumnDefinition::DataType::PRIMARY) {
         os << StringUtil::Indent(num_indent + 1) << "-> PRIMARY KEY : ";
         for (auto &key : col->primary_key) os << key << " ";
         os << "\n";
       } else if (col->type == ColumnDefinition::DataType::FOREIGN) {
-        os << StringUtil::Indent(num_indent + 1) << "-> FOREIGN KEY : References " << col->name << " Source : ";
+        os << StringUtil::Indent(num_indent + 1)
+           << "-> FOREIGN KEY : References " << col->name << " Source : ";
         for (auto &key : col->foreign_key_source) {
           os << key << " ";
         }
@@ -218,11 +232,11 @@ std::string ParserUtils::GetCreateStatementInfo(CreateStatement* stmt,
         }
         os << "\n";
       } else {
-        os << StringUtil::Indent(num_indent + 1) << "-> COLUMN REF : " << col->name << " "
+        os << StringUtil::Indent(num_indent + 1)
+           << "-> COLUMN REF : " << col->name << " "
            // << col->type << " not null : "
-           << col->not_null << " primary : "
-           << col->primary << " unique " << col->unique << " varlen "
-           << col->varlen << "\n";
+           << col->not_null << " primary : " << col->primary << " unique "
+           << col->unique << " varlen " << col->varlen << "\n";
       }
     }
   }
@@ -231,7 +245,7 @@ std::string ParserUtils::GetCreateStatementInfo(CreateStatement* stmt,
   return info;
 }
 
-std::string ParserUtils::GetInsertStatementInfo(InsertStatement* stmt,
+std::string ParserUtils::GetInsertStatementInfo(InsertStatement *stmt,
                                                 uint num_indent) {
   std::ostringstream os;
   os << StringUtil::Indent(num_indent) << "InsertStatment\n";
@@ -263,7 +277,7 @@ std::string ParserUtils::GetInsertStatementInfo(InsertStatement* stmt,
   return info;
 }
 
-std::string ParserUtils::GetDeleteStatementInfo(DeleteStatement* stmt,
+std::string ParserUtils::GetDeleteStatementInfo(DeleteStatement *stmt,
                                                 uint num_indent) {
   std::ostringstream os;
   os << StringUtil::Indent(num_indent) << "DeleteStatment\n";
@@ -271,14 +285,15 @@ std::string ParserUtils::GetDeleteStatementInfo(DeleteStatement* stmt,
   return os.str();
 }
 
-std::string ParserUtils::GetUpdateStatementInfo(UpdateStatement* stmt,
+std::string ParserUtils::GetUpdateStatementInfo(UpdateStatement *stmt,
                                                 uint num_indent) {
   std::ostringstream os;
   os << StringUtil::Indent(num_indent) << "UpdateStatment\n";
   os << GetTableRefInfo(stmt->table.get(), num_indent + 1) << std::endl;
   os << StringUtil::Indent(num_indent + 1) << "-> Updates :: \n";
   for (auto &update : stmt->updates) {
-    os << StringUtil::Indent(num_indent + 2) << "Column: " << update->column << std::endl;
+    os << StringUtil::Indent(num_indent + 2) << "Column: " << update->column
+       << std::endl;
     os << GetExpressionInfo(update->value.get(), num_indent + 3) << std::endl;
   }
   os << StringUtil::Indent(num_indent + 1) << "-> Where :: \n"
@@ -286,16 +301,18 @@ std::string ParserUtils::GetUpdateStatementInfo(UpdateStatement* stmt,
   return os.str();
 }
 
-std::string ParserUtils::GetCopyStatementInfo(CopyStatement* stmt,
+std::string ParserUtils::GetCopyStatementInfo(CopyStatement *stmt,
                                               uint num_indent) {
   std::ostringstream os;
   os << StringUtil::Indent(num_indent) << "CopyStatment\n";
-  os << StringUtil::Indent(num_indent + 1) << "-> Type :: " << CopyTypeToString(stmt->type)
-     << "\n";
+  os << StringUtil::Indent(num_indent + 1)
+     << "-> Type :: " << CopyTypeToString(stmt->type) << "\n";
   os << GetTableRefInfo(stmt->cpy_table.get(), num_indent + 1) << std::endl;
 
-  os << StringUtil::Indent(num_indent + 1) << "-> File Path :: " << stmt->file_path << std::endl;
-  os << StringUtil::Indent(num_indent + 1) << "-> Delimiter :: " << stmt->delimiter;
+  os << StringUtil::Indent(num_indent + 1)
+     << "-> File Path :: " << stmt->file_path << std::endl;
+  os << StringUtil::Indent(num_indent + 1)
+     << "-> Delimiter :: " << stmt->delimiter;
   return os.str();
 }
 

--- a/src/parser/parser_utils.cpp
+++ b/src/parser/parser_utils.cpp
@@ -193,6 +193,9 @@ std::string ParserUtils::GetCreateStatementInfo(CreateStatement* stmt,
        << " unique : " << stmt->unique << " attrs : ";
     for (auto &key : stmt->index_attrs) os << key << " ";
     os << "\n";
+    os << StringUtil::Indent(num_indent + 1) << "Type : "
+       << IndexTypeToString(stmt->index_type) << "\n";
+    os << "\n";
   } else if (stmt->type == CreateStatement::CreateType::kTable) {
     os << StringUtil::Indent(num_indent + 1) << stmt->GetTableName() << "\n";
   }

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1013,7 +1013,12 @@ parser::SQLStatement *PostgresParser::CreateIndexTransform(IndexStmt *root) {
         reinterpret_cast<IndexElem *>(cell->data.ptr_value)->name;
     result->index_attrs.push_back(std::string(index_attr));
   }
-  result->index_type = IndexType::BWTREE;
+  try {
+    result->index_type = StringToIndexType(std::string(root->accessMethod));
+  } catch (ConversionException e) {
+    delete result;
+    throw e;
+  }
   result->table_info_.reset(new TableInfo());
   result->table_info_->table_name = root->relation->relname;
   result->index_name = root->idxname;
@@ -1514,6 +1519,9 @@ parser::SQLStatementList *PostgresParser::ListTransform(List *root) {
     delete result;
     throw e;
   } catch (NotImplementedException e) {
+    delete result;
+    throw e;
+  } catch (ConversionException e) {
     delete result;
     throw e;
   } catch (Exception e) {

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1143,7 +1143,7 @@ parser::SQLStatement *PostgresParser::CreateViewTransform(
     ViewStmt *root) {
   parser::CreateStatement *result =
       new parser::CreateStatement(CreateStatement::kView);
-  // result->table_info_.reset(RangeVarTransform(reinterpret_cast<RangeVar *>(root->view)));
+  result->view_name = root->view->relname;
   if (root->query->type != T_SelectStmt) {
     delete result;
     throw NotImplementedException("CREATE VIEW as query only supports SELECT query...\n");

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1174,13 +1174,13 @@ parser::DropStatement *PostgresParser::DropDatabaseTransform(
 
   result->table_info_.reset(new parser::TableInfo());
   result->table_info_->database_name = root->dbname;
-  result->missing = root->missing_ok;
+  result->SetMissing(root->missing_ok);
   return result;
 }
 
 parser::DropStatement *PostgresParser::DropTableTransform(DropStmt *root) {
   auto result = new DropStatement(DropStatement::EntityType::kTable);
-  result->missing = root->missing_ok;
+  result->SetMissing(root->missing_ok);
   for (auto cell = root->objects->head; cell != nullptr; cell = cell->next) {
     auto table_info = new TableInfo{};
     auto table_list = reinterpret_cast<List *>(cell->data.ptr_value);
@@ -1197,21 +1197,21 @@ parser::DropStatement *PostgresParser::DropTriggerTransform(DropStmt *root) {
   auto result = new DropStatement(DropStatement::EntityType::kTrigger);
   auto cell = root->objects->head;
   auto list = reinterpret_cast<List *>(cell->data.ptr_value);
-  result->table_name_of_trigger =
-      reinterpret_cast<value *>(list->head->data.ptr_value)->val.str;
-  result->trigger_name =
-      reinterpret_cast<value *>(list->head->next->data.ptr_value)->val.str;
+  result->SetTriggerTableName(
+      reinterpret_cast<value *>(list->head->data.ptr_value)->val.str);
+  result->SetTriggerName(
+      reinterpret_cast<value *>(list->head->next->data.ptr_value)->val.str);
   return result;
 }
 
 parser::DropStatement *PostgresParser::DropSchemaTransform(DropStmt *root) {
   auto result = new DropStatement(DropStatement::EntityType::kSchema);
-  result->cascade = (root->behavior == DropBehavior::DROP_CASCADE);
-  result->missing = root->missing_ok;
+  result->SetCascade(root->behavior == DropBehavior::DROP_CASCADE);
+  result->SetMissing(root->missing_ok);
   for (auto cell = root->objects->head; cell != nullptr; cell = cell->next) {
     auto table_list = reinterpret_cast<List *>(cell->data.ptr_value);
-    result->schema_name =
-        reinterpret_cast<value *>(table_list->head->data.ptr_value)->val.str;
+    result->SetSchemaName(
+        reinterpret_cast<value *>(table_list->head->data.ptr_value)->val.str);
     break;
   }
   return result;

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1104,7 +1104,8 @@ parser::SQLStatement *PostgresParser::CreateSchemaTransform(
     Node *authrole = reinterpret_cast<Node *>(root->authrole);
     if (authrole->type == T_RoleSpec) {
       RoleSpec *role = reinterpret_cast<RoleSpec *>(authrole);
-      // Peloton do not need the authrole, the only usage is when no schema name is specified
+      // Peloton do not need the authrole, the only usage is when no schema name
+      // is specified
       if (root->schemaname == nullptr) {
         result->schema_name = role->rolename;
       }
@@ -1121,7 +1122,7 @@ parser::SQLStatement *PostgresParser::CreateSchemaTransform(
         "CREATE SCHEMA does not support schema_element yet...\n");
   }
   for (auto cell = root->schemaElts->head; cell != nullptr; cell = cell->next) {
-    Node *node = reinterpret_cast<Node*>(cell->data.ptr_value);
+    Node *node = reinterpret_cast<Node *>(cell->data.ptr_value);
     switch (node->type) {
       case T_CreateStmt:
         // CreateTransform((CreateStmt *)node);
@@ -1139,16 +1140,17 @@ parser::SQLStatement *PostgresParser::CreateSchemaTransform(
   return result;
 }
 
-parser::SQLStatement *PostgresParser::CreateViewTransform(
-    ViewStmt *root) {
+parser::SQLStatement *PostgresParser::CreateViewTransform(ViewStmt *root) {
   parser::CreateStatement *result =
       new parser::CreateStatement(CreateStatement::kView);
   result->view_name = root->view->relname;
   if (root->query->type != T_SelectStmt) {
     delete result;
-    throw NotImplementedException("CREATE VIEW as query only supports SELECT query...\n");
+    throw NotImplementedException(
+        "CREATE VIEW as query only supports SELECT query...\n");
   }
-  result->view_query.reset(SelectTransform(reinterpret_cast<SelectStmt *>(root->query)));
+  result->view_query.reset(
+      SelectTransform(reinterpret_cast<SelectStmt *>(root->query)));
   return result;
 }
 
@@ -1538,7 +1540,8 @@ parser::SQLStatement *PostgresParser::NodeTransform(Node *stmt) {
       result = CreateTriggerTransform(reinterpret_cast<CreateTrigStmt *>(stmt));
       break;
     case T_CreateSchemaStmt:
-      result = CreateSchemaTransform(reinterpret_cast<CreateSchemaStmt *>(stmt));
+      result =
+          CreateSchemaTransform(reinterpret_cast<CreateSchemaStmt *>(stmt));
       break;
     case T_ViewStmt:
       result = CreateViewTransform(reinterpret_cast<ViewStmt *>(stmt));

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -813,8 +813,8 @@ expression::AbstractExpression *PostgresParser::WhenTransform(Node *root) {
       break;
     }
     default: {
-      throw NotImplementedException(
-        StringUtil::Format("WHEN of type %d not supported yet...", root->type));
+      throw NotImplementedException(StringUtil::Format(
+          "WHEN of type %d not supported yet...", root->type));
     }
   }
   return result;
@@ -1152,8 +1152,7 @@ parser::DeleteStatement *PostgresParser::TruncateTransform(TruncateStmt *root) {
 parser::ExecuteStatement *PostgresParser::ExecuteTransform(ExecuteStmt *root) {
   auto result = new ExecuteStatement();
   result->name = root->name;
-  if (root->params != nullptr)
-    try {
+  if (root->params != nullptr) try {
       result->parameters = ParamListTransform(root->params);
     } catch (NotImplementedException e) {
       delete result;
@@ -1242,18 +1241,19 @@ PostgresParser::ValueListsTransform(List *root) {
       switch (expr->type) {
         case T_ParamRef: {
           cur_result.push_back(std::unique_ptr<expression::AbstractExpression>(
-            ParamRefTransform((ParamRef *)expr)));
+              ParamRefTransform((ParamRef *)expr)));
           break;
         }
         case T_A_Const: {
           cur_result.push_back(std::unique_ptr<expression::AbstractExpression>(
-            ConstTransform((A_Const *)expr)));
+              ConstTransform((A_Const *)expr)));
           break;
         }
         case T_TypeCast: {
           try {
-            cur_result.push_back(std::unique_ptr<expression::AbstractExpression>(
-                TypeCastTransform((TypeCast *)expr)));
+            cur_result.push_back(
+                std::unique_ptr<expression::AbstractExpression>(
+                    TypeCastTransform((TypeCast *)expr)));
           } catch (Exception e) {
             delete result;
             throw e;
@@ -1269,7 +1269,7 @@ PostgresParser::ValueListsTransform(List *root) {
         }
         default:
           throw NotImplementedException(StringUtil::Format(
-            "Value of type %d not supported yet...\n", expr->type));
+              "Value of type %d not supported yet...\n", expr->type));
       }
     }
     result->push_back(std::move(cur_result));
@@ -1290,7 +1290,7 @@ PostgresParser::ParamListTransform(List *root) {
     switch (param->type) {
       case T_A_Const: {
         result.push_back(std::unique_ptr<expression::AbstractExpression>(
-          ConstTransform((A_Const *)(cell->data.ptr_value))));
+            ConstTransform((A_Const *)(cell->data.ptr_value))));
         break;
       }
       case T_A_Expr: {
@@ -1304,12 +1304,10 @@ PostgresParser::ParamListTransform(List *root) {
         break;
       }
       default:
-        throw NotImplementedException(
-          StringUtil::Format(
+        throw NotImplementedException(StringUtil::Format(
             "Expression type %d not supported in ParamListTransform yet...",
             param->type));
     }
-
   }
 
   return result;

--- a/src/planner/drop_plan.cpp
+++ b/src/planner/drop_plan.cpp
@@ -25,25 +25,25 @@ DropPlan::DropPlan(const std::string &name) {
 }
 
 DropPlan::DropPlan(parser::DropStatement *parse_tree) {
-  switch (parse_tree->type) {
+  switch (parse_tree->GetDropType()) {
     case parser::DropStatement::EntityType::kDatabase: {
       database_name = parse_tree->GetDatabaseName();
-      missing = parse_tree->missing;
+      missing = parse_tree->GetMissing();
       drop_type = DropType::DB;
       break;
     }
     case parser::DropStatement::EntityType::kTable: {
       database_name = parse_tree->GetDatabaseName();
       table_name = parse_tree->GetTableName();
-      missing = parse_tree->missing;
+      missing = parse_tree->GetMissing();
       drop_type = DropType::TABLE;
       break;
     }
     case parser::DropStatement::EntityType::kTrigger: {
       // note parse_tree->table_name is different from parse_tree->GetTableName()
       database_name = parse_tree->GetDatabaseName();
-      table_name = std::string(parse_tree->table_name_of_trigger);
-      trigger_name = std::string(parse_tree->trigger_name);
+      table_name = std::string(parse_tree->GetTriggerTableName());
+      trigger_name = std::string(parse_tree->GetTriggerName());
       drop_type = DropType::TRIGGER;
       break;
     }

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -291,7 +291,7 @@ TEST_F(ParserTests, DropTest) {
   EXPECT_TRUE(stmt_list->is_valid);
   auto stmt = stmt_list->GetStatement(0);
   EXPECT_EQ(StatementType::DROP, stmt->GetType());
-  auto d_stmt = (parser::DropStatement*)stmt;
+  auto d_stmt = (parser::DropStatement *)stmt;
   EXPECT_STREQ("test_db", d_stmt->GetDatabaseName().c_str());
   EXPECT_EQ(parser::DropStatement::EntityType::kDatabase, d_stmt->type);
   EXPECT_FALSE(d_stmt->missing);
@@ -303,11 +303,33 @@ TEST_F(ParserTests, DropTest) {
   EXPECT_TRUE(exist_stmt_list->is_valid);
   stmt = exist_stmt_list->GetStatement(0);
   EXPECT_EQ(StatementType::DROP, stmt->GetType());
-  d_stmt = (parser::DropStatement*)stmt;
+  d_stmt = (parser::DropStatement *)stmt;
   EXPECT_STREQ("test_db", d_stmt->GetDatabaseName().c_str());
   EXPECT_EQ(parser::DropStatement::EntityType::kDatabase, d_stmt->type);
   EXPECT_TRUE(d_stmt->missing);
 
+  // Drop schema
+  query = "DROP SCHEMA sche;";
+  stmt_list.reset(parser.BuildParseTree(query).release());
+  EXPECT_TRUE(stmt_list->is_valid);
+  stmt = stmt_list->GetStatement(0);
+  EXPECT_EQ(StatementType::DROP, stmt->GetType());
+  d_stmt = (parser::DropStatement *)stmt;
+  EXPECT_STREQ("sche", d_stmt->GetSchemaName().c_str());
+  EXPECT_EQ(parser::DropStatement::EntityType::kSchema, d_stmt->type);
+  EXPECT_FALSE(d_stmt->missing);
+
+  // Test with CASCADE clause
+  query = "DROP SCHEMA sche CASCADE;";
+  stmt_list.reset(parser.BuildParseTree(query).release());
+  EXPECT_TRUE(stmt_list->is_valid);
+  stmt = stmt_list->GetStatement(0);
+  EXPECT_EQ(StatementType::DROP, stmt->GetType());
+  d_stmt = (parser::DropStatement *)stmt;
+  EXPECT_STREQ("sche", d_stmt->GetSchemaName().c_str());
+  EXPECT_EQ(parser::DropStatement::EntityType::kSchema, d_stmt->type);
+  EXPECT_FALSE(d_stmt->missing);
+  EXPECT_TRUE(d_stmt->cascade);
 }
 
 TEST_F(ParserTests, TM1Test) {

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -293,8 +293,8 @@ TEST_F(ParserTests, DropTest) {
   EXPECT_EQ(StatementType::DROP, stmt->GetType());
   auto d_stmt = (parser::DropStatement *)stmt;
   EXPECT_STREQ("test_db", d_stmt->GetDatabaseName().c_str());
-  EXPECT_EQ(parser::DropStatement::EntityType::kDatabase, d_stmt->type);
-  EXPECT_FALSE(d_stmt->missing);
+  EXPECT_EQ(parser::DropStatement::EntityType::kDatabase, d_stmt->GetDropType());
+  EXPECT_FALSE(d_stmt->GetMissing());
 
   // Test with IF EXISTS clause
   query = "DROP DATABASE IF EXISTS test_db;";
@@ -305,8 +305,8 @@ TEST_F(ParserTests, DropTest) {
   EXPECT_EQ(StatementType::DROP, stmt->GetType());
   d_stmt = (parser::DropStatement *)stmt;
   EXPECT_STREQ("test_db", d_stmt->GetDatabaseName().c_str());
-  EXPECT_EQ(parser::DropStatement::EntityType::kDatabase, d_stmt->type);
-  EXPECT_TRUE(d_stmt->missing);
+  EXPECT_EQ(parser::DropStatement::EntityType::kDatabase, d_stmt->GetDropType());
+  EXPECT_TRUE(d_stmt->GetMissing());
 
   // Drop schema
   query = "DROP SCHEMA sche;";
@@ -316,8 +316,8 @@ TEST_F(ParserTests, DropTest) {
   EXPECT_EQ(StatementType::DROP, stmt->GetType());
   d_stmt = (parser::DropStatement *)stmt;
   EXPECT_STREQ("sche", d_stmt->GetSchemaName().c_str());
-  EXPECT_EQ(parser::DropStatement::EntityType::kSchema, d_stmt->type);
-  EXPECT_FALSE(d_stmt->missing);
+  EXPECT_EQ(parser::DropStatement::EntityType::kSchema, d_stmt->GetDropType());
+  EXPECT_FALSE(d_stmt->GetMissing());
 
   // Test with CASCADE clause
   query = "DROP SCHEMA sche CASCADE;";
@@ -327,9 +327,9 @@ TEST_F(ParserTests, DropTest) {
   EXPECT_EQ(StatementType::DROP, stmt->GetType());
   d_stmt = (parser::DropStatement *)stmt;
   EXPECT_STREQ("sche", d_stmt->GetSchemaName().c_str());
-  EXPECT_EQ(parser::DropStatement::EntityType::kSchema, d_stmt->type);
-  EXPECT_FALSE(d_stmt->missing);
-  EXPECT_TRUE(d_stmt->cascade);
+  EXPECT_EQ(parser::DropStatement::EntityType::kSchema, d_stmt->GetDropType());
+  EXPECT_FALSE(d_stmt->GetMissing());
+  EXPECT_TRUE(d_stmt->GetCascade());
 }
 
 TEST_F(ParserTests, TM1Test) {

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -748,7 +748,7 @@ TEST_F(PostgresParserTests, CreateDbTest) {
   std::unique_ptr<parser::SQLStatementList> stmt_list(
       parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
-  auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
+  auto create_stmt = (parser::CreateStatement *)stmt_list->GetStatement(0);
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
   // TODO: Check attributes
   EXPECT_EQ("tt", create_stmt->GetDatabaseName());
@@ -761,7 +761,7 @@ TEST_F(PostgresParserTests, CreateSchemaTest) {
   std::unique_ptr<parser::SQLStatementList> stmt_list(
       parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
-  auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
+  auto create_stmt = (parser::CreateStatement *)stmt_list->GetStatement(0);
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
   // Check attributes
   EXPECT_EQ("tt", create_stmt->schema_name);
@@ -771,21 +771,23 @@ TEST_F(PostgresParserTests, CreateSchemaTest) {
 
   stmt_list.reset(parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
-  create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
+  create_stmt = (parser::CreateStatement *)stmt_list->GetStatement(0);
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
   // Check attributes
   EXPECT_EQ("joe", create_stmt->schema_name);
 }
 
 TEST_F(PostgresParserTests, CreateViewTest) {
-  std::string query = "CREATE VIEW comedies AS SELECT * FROM films "
-                      "WHERE kind = 'Comedy';";
+  std::string query =
+      "CREATE VIEW comedies AS SELECT * FROM films "
+      "WHERE kind = 'Comedy';";
 
   auto parser = parser::PostgresParser::GetInstance();
   std::unique_ptr<parser::SQLStatementList> stmt_list(
       parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
-  UNUSED_ATTRIBUTE auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
+  UNUSED_ATTRIBUTE auto create_stmt =
+      (parser::CreateStatement *)stmt_list->GetStatement(0);
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
   // Check attributes
   EXPECT_EQ("comedies", create_stmt->view_name);
@@ -794,11 +796,13 @@ TEST_F(PostgresParserTests, CreateViewTest) {
   EXPECT_EQ("films", view_query->from_table.get()->GetTableName());
   EXPECT_EQ(1, view_query->select_list.size());
   EXPECT_TRUE(view_query->where_clause.get() != nullptr);
-  EXPECT_EQ(ExpressionType::COMPARE_EQUAL, view_query->where_clause.get()->GetExpressionType());
+  EXPECT_EQ(ExpressionType::COMPARE_EQUAL,
+            view_query->where_clause.get()->GetExpressionType());
   EXPECT_EQ(2, view_query->where_clause.get()->GetChildrenSize());
   auto left_child = view_query->where_clause.get()->GetChild(0);
   EXPECT_EQ(ExpressionType::VALUE_TUPLE, left_child->GetExpressionType());
-  EXPECT_EQ("kind", ((expression::TupleValueExpression *)left_child)->GetColumnName());
+  EXPECT_EQ("kind",
+            ((expression::TupleValueExpression *)left_child)->GetColumnName());
   auto right_child = view_query->where_clause.get()->GetChild(1);
   EXPECT_EQ(ExpressionType::VALUE_CONSTANT, right_child->GetExpressionType());
 }

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -748,8 +748,47 @@ TEST_F(PostgresParserTests, CreateDbTest) {
   std::unique_ptr<parser::SQLStatementList> stmt_list(
       parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);
-  //  auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
-  //  LOG_INFO("%s", stmt_list->GetInfo().c_str());
+  auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
+  LOG_INFO("%s", stmt_list->GetInfo().c_str());
+  // TODO: Check attributes
+  EXPECT_EQ("tt", create_stmt->GetDatabaseName());
+}
+
+TEST_F(PostgresParserTests, CreateSchemaTest) {
+  std::string query = "CREATE SCHEMA tt";
+
+  auto parser = parser::PostgresParser::GetInstance();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
+  EXPECT_TRUE(stmt_list->is_valid);
+  auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
+  LOG_INFO("%s", stmt_list->GetInfo().c_str());
+  // Check attributes
+  EXPECT_EQ("tt", create_stmt->schema_name);
+
+  // Test default schema name
+  query = "CREATE SCHEMA AUTHORIZATION joe";
+
+  stmt_list.reset(parser.BuildParseTree(query).release());
+  EXPECT_TRUE(stmt_list->is_valid);
+  create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
+  LOG_INFO("%s", stmt_list->GetInfo().c_str());
+  // Check attributes
+  EXPECT_EQ("joe", create_stmt->schema_name);
+}
+
+TEST_F(PostgresParserTests, CreateViewTest) {
+  std::string query = "CREATE VIEW comedies AS SELECT * FROM films "
+                      "WHERE kind = 'Comedy';";
+
+  auto parser = parser::PostgresParser::GetInstance();
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      parser.BuildParseTree(query).release());
+  EXPECT_TRUE(stmt_list->is_valid);
+  UNUSED_ATTRIBUTE auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
+  LOG_INFO("%s", stmt_list->GetInfo().c_str());
+  // Check attributes
+  // EXPECT_EQ("comedies", create_stmt->view_name);
 }
 
 TEST_F(PostgresParserTests, DistinctFromTest) {

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -788,7 +788,19 @@ TEST_F(PostgresParserTests, CreateViewTest) {
   UNUSED_ATTRIBUTE auto create_stmt = (parser::CreateStatement*)stmt_list->GetStatement(0);
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
   // Check attributes
-  // EXPECT_EQ("comedies", create_stmt->view_name);
+  EXPECT_EQ("comedies", create_stmt->view_name);
+  EXPECT_TRUE(create_stmt->view_query.get() != nullptr);
+  auto view_query = create_stmt->view_query.get();
+  EXPECT_EQ("films", view_query->from_table.get()->GetTableName());
+  EXPECT_EQ(1, view_query->select_list.size());
+  EXPECT_TRUE(view_query->where_clause.get() != nullptr);
+  EXPECT_EQ(ExpressionType::COMPARE_EQUAL, view_query->where_clause.get()->GetExpressionType());
+  EXPECT_EQ(2, view_query->where_clause.get()->GetChildrenSize());
+  auto left_child = view_query->where_clause.get()->GetChild(0);
+  EXPECT_EQ(ExpressionType::VALUE_TUPLE, left_child->GetExpressionType());
+  EXPECT_EQ("kind", ((expression::TupleValueExpression *)left_child)->GetColumnName());
+  auto right_child = view_query->where_clause.get()->GetChild(1);
+  EXPECT_EQ(ExpressionType::VALUE_CONSTANT, right_child->GetExpressionType());
 }
 
 TEST_F(PostgresParserTests, DistinctFromTest) {

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -393,8 +393,8 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   auto constant =
       (expression::ConstantValueExpression *)update_stmt->updates.at(0)
           ->value.get();
-  EXPECT_EQ(type::CmpBool::TRUE, constant->GetValue().CompareEquals(
-                                     type::ValueFactory::GetDecimalValue(48)));
+  EXPECT_EQ(CmpBool::TRUE, constant->GetValue().CompareEquals(
+                               type::ValueFactory::GetDecimalValue(48)));
 
   // Test Second Set Condition
   EXPECT_EQ(update_stmt->updates.at(1)->column, "s_ytd");
@@ -403,8 +403,8 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   auto child1 = (expression::TupleValueExpression *)op_expr->GetChild(0);
   EXPECT_EQ(child1->GetColumnName(), "s_ytd");
   auto child2 = (expression::ConstantValueExpression *)op_expr->GetChild(1);
-  EXPECT_EQ(type::CmpBool::TRUE, child2->GetValue().CompareEquals(
-                                     type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(CmpBool::TRUE, child2->GetValue().CompareEquals(
+                               type::ValueFactory::GetIntegerValue(1)));
 
   // Test Where clause
   auto where = (expression::OperatorExpression *)update_stmt->where.get();
@@ -414,16 +414,15 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   auto column = (expression::TupleValueExpression *)cond1->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_i_id");
   constant = (expression::ConstantValueExpression *)cond1->GetChild(1);
-  EXPECT_EQ(type::CmpBool::TRUE,
-            constant->GetValue().CompareEquals(
-                type::ValueFactory::GetIntegerValue(68999)));
+  EXPECT_EQ(CmpBool::TRUE, constant->GetValue().CompareEquals(
+                               type::ValueFactory::GetIntegerValue(68999)));
   auto cond2 = (expression::OperatorExpression *)where->GetChild(1);
   EXPECT_EQ(cond2->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
   column = (expression::TupleValueExpression *)cond2->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_w_id");
   constant = (expression::ConstantValueExpression *)cond2->GetChild(1);
-  EXPECT_EQ(type::CmpBool::TRUE, constant->GetValue().CompareEquals(
-                                     type::ValueFactory::GetIntegerValue(4)));
+  EXPECT_EQ(CmpBool::TRUE, constant->GetValue().CompareEquals(
+                               type::ValueFactory::GetIntegerValue(4)));
 }
 
 TEST_F(PostgresParserTests, StringUpdateTest) {
@@ -587,8 +586,9 @@ TEST_F(PostgresParserTests, InsertTest) {
     // Test normal value
     type::Value five = type::ValueFactory::GetIntegerValue(5);
     CmpBool res = five.CompareEquals(
-        ((expression::ConstantValueExpression *)
-             insert_stmt->insert_values.at(1).at(1).get())->GetValue());
+        ((expression::ConstantValueExpression *)insert_stmt->insert_values.at(1)
+             .at(1)
+             .get())->GetValue());
     EXPECT_EQ(CmpBool::TRUE, res);
 
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
@@ -772,10 +772,10 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   auto child2 =
       (expression::ConstantValueExpression *)default_expr->GetChild(1);
   EXPECT_TRUE(child2 != nullptr);
-  EXPECT_EQ(CmpBool::TRUE,
-            child1->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(CmpBool::TRUE,
-            child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
+  EXPECT_EQ(CmpBool::TRUE, child1->GetValue().CompareEquals(
+                               type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(CmpBool::TRUE, child2->GetValue().CompareEquals(
+                               type::ValueFactory::GetIntegerValue(2)));
 
   // Check Second column
   column = create_stmt->columns.at(1).get();
@@ -819,12 +819,14 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   auto plus_child2 =
       (expression::ConstantValueExpression *)check_child1->GetChild(1);
   EXPECT_TRUE(plus_child2 != nullptr);
-  EXPECT_EQ(CmpBool::TRUE,
-            plus_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
-  auto check_child2 = (expression::ConstantValueExpression*)column->check_expression->GetChild(1);
+  EXPECT_EQ(CmpBool::TRUE, plus_child2->GetValue().CompareEquals(
+                               type::ValueFactory::GetIntegerValue(1)));
+  auto check_child2 =
+      (expression::ConstantValueExpression *)column->check_expression->GetChild(
+          1);
   EXPECT_TRUE(check_child2 != nullptr);
-  EXPECT_EQ(CmpBool::TRUE,
-            check_child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(0)));
+  EXPECT_EQ(CmpBool::TRUE, check_child2->GetValue().CompareEquals(
+                               type::ValueFactory::GetIntegerValue(0)));
 
   // Check Fifth column
   column = create_stmt->columns.at(4).get();
@@ -998,9 +1000,9 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   auto const_expr =
       (expression::ConstantValueExpression *)fun_expr->GetChild(0);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_EQ(CmpBool::TRUE,
-            const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
-  auto tv_expr = (expression::TupleValueExpression*) fun_expr->GetChild(1);
+  EXPECT_EQ(CmpBool::TRUE, const_expr->GetValue().CompareEquals(
+                               type::ValueFactory::GetIntegerValue(1)));
+  auto tv_expr = (expression::TupleValueExpression *)fun_expr->GetChild(1);
   EXPECT_TRUE(tv_expr != nullptr);
   EXPECT_EQ("a", tv_expr->GetColumnName());
 
@@ -1012,8 +1014,8 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ(1, fun_expr->GetChildrenSize());
   const_expr = (expression::ConstantValueExpression *)fun_expr->GetChild(0);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_EQ(CmpBool::TRUE,
-            const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(99)));
+  EXPECT_EQ(CmpBool::TRUE, const_expr->GetValue().CompareEquals(
+                               type::ValueFactory::GetIntegerValue(99)));
 
   // Check FUN(b) > 2
   auto op_expr =
@@ -1028,8 +1030,8 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ("b", tv_expr->GetColumnName());
   const_expr = (expression::ConstantValueExpression *)op_expr->GetChild(1);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_EQ(CmpBool::TRUE, 
-            const_expr->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(2)));
+  EXPECT_EQ(CmpBool::TRUE, const_expr->GetValue().CompareEquals(
+                               type::ValueFactory::GetIntegerValue(2)));
 }
 
 TEST_F(PostgresParserTests, CaseTest) {

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -391,9 +391,10 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   // Test First Set Condition
   EXPECT_EQ(update_stmt->updates.at(0)->column, "s_quantity");
   auto constant =
-      (expression::ConstantValueExpression *)update_stmt->updates.at(0)->value.get();
-  EXPECT_EQ(CmpBool::TRUE, constant->GetValue().CompareEquals(
-      type::ValueFactory::GetDecimalValue(48)));
+      (expression::ConstantValueExpression *)update_stmt->updates.at(0)
+          ->value.get();
+  EXPECT_EQ(type::CmpBool::TRUE, constant->GetValue().CompareEquals(
+                                     type::ValueFactory::GetDecimalValue(48)));
 
   // Test Second Set Condition
   EXPECT_EQ(update_stmt->updates.at(1)->column, "s_ytd");
@@ -402,8 +403,8 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   auto child1 = (expression::TupleValueExpression *)op_expr->GetChild(0);
   EXPECT_EQ(child1->GetColumnName(), "s_ytd");
   auto child2 = (expression::ConstantValueExpression *)op_expr->GetChild(1);
-  EXPECT_EQ(CmpBool::TRUE, 
-      child2->GetValue().CompareEquals(type::ValueFactory::GetIntegerValue(1)));
+  EXPECT_EQ(type::CmpBool::TRUE, child2->GetValue().CompareEquals(
+                                     type::ValueFactory::GetIntegerValue(1)));
 
   // Test Where clause
   auto where = (expression::OperatorExpression *)update_stmt->where.get();
@@ -413,15 +414,16 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   auto column = (expression::TupleValueExpression *)cond1->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_i_id");
   constant = (expression::ConstantValueExpression *)cond1->GetChild(1);
-  EXPECT_EQ(CmpBool::TRUE, constant->GetValue().CompareEquals(
-      type::ValueFactory::GetIntegerValue(68999)));
+  EXPECT_EQ(type::CmpBool::TRUE,
+            constant->GetValue().CompareEquals(
+                type::ValueFactory::GetIntegerValue(68999)));
   auto cond2 = (expression::OperatorExpression *)where->GetChild(1);
   EXPECT_EQ(cond2->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
   column = (expression::TupleValueExpression *)cond2->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_w_id");
   constant = (expression::ConstantValueExpression *)cond2->GetChild(1);
-  EXPECT_EQ(CmpBool::TRUE, constant->GetValue().CompareEquals(
-      type::ValueFactory::GetIntegerValue(4)));
+  EXPECT_EQ(type::CmpBool::TRUE, constant->GetValue().CompareEquals(
+                                     type::ValueFactory::GetIntegerValue(4)));
 }
 
 TEST_F(PostgresParserTests, StringUpdateTest) {

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -1051,11 +1051,11 @@ TEST_F(PostgresParserTests, DropTriggerTest) {
       static_cast<parser::DropStatement *>(stmt_list->GetStatement(0));
   // drop type
   EXPECT_EQ(parser::DropStatement::EntityType::kTrigger,
-            drop_trigger_stmt->type);
+            drop_trigger_stmt->GetDropType());
   // trigger name
-  EXPECT_EQ("if_dist_exists", drop_trigger_stmt->trigger_name);
+  EXPECT_EQ("if_dist_exists", drop_trigger_stmt->GetTriggerName());
   // table name
-  EXPECT_EQ("films", drop_trigger_stmt->table_name_of_trigger);
+  EXPECT_EQ("films", drop_trigger_stmt->GetTriggerTableName());
 }
 
 TEST_F(PostgresParserTests, FuncCallTest) {

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -1123,13 +1123,14 @@ TEST_F(PostgresParserTests, IndexTypeTest) {
 
     LOG_TRACE("%d : %s", ++ii, result->GetInfo().c_str());
   }
+
+  // Following queries are using index types that we do no currently support.
   std::vector<std::string> invalid_queries;
   invalid_queries.push_back("CREATE INDEX ii ON t USING GIN (col);");
   invalid_queries.push_back("CREATE INDEX ii ON t USING BRIN (col);");
   for (auto query : invalid_queries) {
     EXPECT_THROW(parser::PostgresParser::ParseSQLString(query.c_str()),
                  peloton::Exception);
-    // parser::PostgresParser::ParseSQLString(query.c_str());
   }
 }
 


### PR DESCRIPTION
This PR adds support for a few types of queries in parser with corresponding tests
- With this PR the parser will be able to support queries like "CREATE INDEX ind ON t USING SKIPLIST (col);"
- With this PR the parser will be able to support queries like "CREATE SCHEMA schema_name;"
- With this PR the parser will be able to support queries like "CREATE VIEW view_name AS query;"
- Corresponding tests
Note: Postgres' default index type is "BTREE", while Peloton's is "BWTREE", as we do not currently support BTREE index type, the default index type is now set to BWTREE if no type is specified in the query.
  