### PR TITLE
Minor type related fixes/additions to Floor function

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1064,41 +1064,6 @@ void Catalog::InitializeFunctions() {
                                     function::DecimalFunctions::_Ceil},
           txn);
 
-      AddBuiltinFunction(
-          "ceiling", {type::TypeId::DECIMAL}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
-          txn);
-
-      AddBuiltinFunction(
-          "ceiling", {type::TypeId::TINYINT}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
-          txn);
-
-      AddBuiltinFunction(
-          "ceiling", {type::TypeId::SMALLINT}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
-          txn);
-
-      AddBuiltinFunction(
-          "ceiling", {type::TypeId::INTEGER}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
-          txn);
-
-      AddBuiltinFunction(
-          "ceiling", {type::TypeId::BIGINT}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
-          txn);
-
       /**
        * date functions
        */

--- a/src/codegen/type/bigint_type.cpp
+++ b/src/codegen/type/bigint_type.cpp
@@ -174,6 +174,23 @@ struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   }
 };
 
+// Floor
+struct Floor : public TypeSystem::UnaryOperatorHandleNull {
+  bool SupportsType(const Type &type) const override {
+    return type.GetSqlType() == BigInt::Instance();
+  }
+
+  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+    return Type{BigInt::Instance()};
+  }
+
+  Value Impl(UNUSED_ATTRIBUTE CodeGen &codegen,
+             const Value &val) const override {
+    PL_ASSERT(SupportsType(val.GetType()));
+    return val;
+  }
+};
+
 // Ceiling
 struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
@@ -427,9 +444,11 @@ static std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {
 // Unary operators
 static Negate kNegOp;
 static Ceil kCeilOp;
+static Floor kFloorOp;
 static std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
     {OperatorId::Negation, kNegOp},
-    {OperatorId::Ceil, kCeilOp}};
+    {OperatorId::Ceil, kCeilOp},
+    {OperatorId::Floor, kFloorOp}};
 
 // Binary operations
 static Add kAddOp;

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -16,7 +16,6 @@
 #include "codegen/value.h"
 #include "codegen/proxy/decimal_functions_proxy.h"
 #include "codegen/proxy/values_runtime_proxy.h"
-#include "codegen/proxy/decimal_functions_proxy.h"
 #include "codegen/type/boolean_type.h"
 #include "codegen/type/integer_type.h"
 #include "common/exception.h"

--- a/src/codegen/type/integer_type.cpp
+++ b/src/codegen/type/integer_type.cpp
@@ -172,6 +172,23 @@ struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   }
 };
 
+// Floor
+struct Floor : public TypeSystem::UnaryOperatorHandleNull {
+  bool SupportsType(const Type &type) const override {
+    return type.GetSqlType() == Integer::Instance();
+  }
+
+  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+    return Type{Integer::Instance()};
+  }
+
+  Value Impl(UNUSED_ATTRIBUTE CodeGen &codegen,
+             const Value &val) const override {
+    PL_ASSERT(SupportsType(val.GetType()));
+    return val;
+  }
+};
+
 // Ceiling
 struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
@@ -427,9 +444,11 @@ static std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {
 // Unary operators
 static Negate kNegOp;
 static Ceil kCeilOp;
+static Floor kFloorOp;
 static std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
     {OperatorId::Negation, kNegOp},
-    {OperatorId::Ceil, kCeilOp}};
+    {OperatorId::Ceil, kCeilOp},
+    {OperatorId::Floor, kFloorOp}};
 
 // Binary operations
 static Add kAddOp;

--- a/src/codegen/type/smallint_type.cpp
+++ b/src/codegen/type/smallint_type.cpp
@@ -187,6 +187,23 @@ struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   }
 };
 
+// Floor
+struct Floor : public TypeSystem::UnaryOperatorHandleNull {
+  bool SupportsType(const Type &type) const override {
+    return type.GetSqlType() == SmallInt::Instance();
+  }
+
+  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+    return Type{SmallInt::Instance()};
+  }
+
+  Value Impl(UNUSED_ATTRIBUTE CodeGen &codegen,
+             const Value &val) const override {
+    PL_ASSERT(SupportsType(val.GetType()));
+    return val;
+  }
+};
+
 // Ceiling
 struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
@@ -448,9 +465,11 @@ static std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {
 // Unary operators
 static Negate kNegOp;
 static Ceil kCeilOp;
+static Floor kFloorOp;
 static std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
     {OperatorId::Negation, kNegOp},
-    {OperatorId::Ceil, kCeilOp}};
+    {OperatorId::Ceil, kCeilOp},
+    {OperatorId::Floor, kFloorOp}};
 
 // Binary operations
 static Add kAddOp;

--- a/src/codegen/type/tinyint_type.cpp
+++ b/src/codegen/type/tinyint_type.cpp
@@ -175,6 +175,23 @@ struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   }
 };
 
+// Floor
+struct Floor : public TypeSystem::UnaryOperatorHandleNull {
+  bool SupportsType(const Type &type) const override {
+    return type.GetSqlType() == TinyInt::Instance();
+  }
+
+  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+    return Type{TinyInt::Instance()};
+  }
+
+  Value Impl(UNUSED_ATTRIBUTE CodeGen &codegen,
+             const Value &val) const override {
+    PL_ASSERT(SupportsType(val.GetType()));
+    return val;
+  }
+};
+
 // Ceiling
 struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   bool SupportsType(const Type &type) const override {
@@ -431,9 +448,11 @@ static std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {
 // Unary operators
 static Negate kNegOp;
 static Ceil kCeilOp;
+static Floor kFloorOp;
 static std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
     {OperatorId::Negation, kNegOp},
-    {OperatorId::Ceil, kCeilOp}};
+    {OperatorId::Ceil, kCeilOp},
+    {OperatorId::Floor, kFloorOp}};
 
 // Binary operations
 static Add kAddOp;


### PR DESCRIPTION
Just a few minor additions needed in the Floor function to make it correctly compatible across different numeric types. More or less following the additional suggestions provided in #898.

There was also some duplicate code related to the `ceiling` function - just removed the duplicate part.

Resolves #927 