### PR TITLE
Fix typo introduced by commit eccc8b47468

### DIFF
--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -34,7 +34,7 @@ if [ "$DISTRO" = "UBUNTU" ]; then
     # Fix for cmake3 name change in Ubuntu 15.x and 16.x plus --force-yes deprecation 
     CMAKE_NAME="cmake3"
     FORCE_Y="--force-yes"
-    MAJOR_VERSION=$(echo "$DISTRO_VER" | cut -d '.' -f 1)
+    MAJOR_VER=$(echo "$DISTRO_VER" | cut -d '.' -f 1)
     for version in "15" "16"
     do
        if [ "$MAJOR_VER" = "$version" ]


### PR DESCRIPTION
Oops, sorry about that but the fix eccc8b47468 I sent yesterday had a small typo introduced at the last minute. 😞  It didn't break the installation for Ubuntu 14.x, but didn't  work as intended for Ubuntu 15.x and 16.x. Now it works as expected for both versions as I just tested. Will keep my eyes really peeled next time. Again, sorry about that.