### PR TITLE
Remove C++14 usage 

### DIFF
--- a/src/network/postgres_protocol_handler.cpp
+++ b/src/network/postgres_protocol_handler.cpp
@@ -347,7 +347,7 @@ ProcessResult PostgresProtocolHandler::ExecQueryMessage(InputPacket *pkt, const 
     };
     default: {
       std::string stmt_name = "unamed";
-      std::unique_ptr<parser::SQLStatementList> unnamed_sql_stmt_list = std::make_unique<parser::SQLStatementList>();
+      std::unique_ptr<parser::SQLStatementList> unnamed_sql_stmt_list(new parser::SQLStatementList());
       unnamed_sql_stmt_list->PassInStatement(std::move(sql_stmt));
       traffic_cop_->SetStatement(traffic_cop_->PrepareStatement(stmt_name, query, std::move(unnamed_sql_stmt_list), error_message));
       if (traffic_cop_->GetStatement().get() == nullptr) {

--- a/test/network/exception_test.cpp
+++ b/test/network/exception_test.cpp
@@ -72,7 +72,7 @@ void *ParserExceptionTest(int port) {
     } catch (const pqxx::pqxx_exception &e) {
       const pqxx::sql_error *s = dynamic_cast<const pqxx::sql_error*>(&e.base());
       if (s) {
-        LOG_INFO("Invalid Drop Query: %s", e.base().what());
+        LOG_TRACE("Invalid Drop Query: %s", e.base().what());
         exception_count += 1;
       }
     }
@@ -85,7 +85,7 @@ void *ParserExceptionTest(int port) {
     } catch (const pqxx::pqxx_exception &e) {
       const pqxx::sql_error *s = dynamic_cast<const pqxx::sql_error*>(&e.base());
       if (s) {
-        LOG_INFO("Invalid Create Query: %s", e.base().what());
+        LOG_TRACE("Invalid Create Query: %s", e.base().what());
         exception_count += 1;
       }
     }
@@ -102,7 +102,7 @@ void *ParserExceptionTest(int port) {
     } catch (const pqxx::pqxx_exception &e) {
       const pqxx::sql_error *s = dynamic_cast<const pqxx::sql_error*>(&e.base());
       if (s) {
-        LOG_INFO("Invalid Select Query: %s", e.base().what());
+        LOG_TRACE("Invalid Select Query: %s", e.base().what());
         exception_count += 1;
       }
     }
@@ -115,7 +115,7 @@ void *ParserExceptionTest(int port) {
     } catch (const pqxx::pqxx_exception &e) {
       const pqxx::sql_error *s = dynamic_cast<const pqxx::sql_error*>(&e.base());
       if (s) {
-        LOG_INFO("Invalid Select Query: %s", e.base().what());
+        LOG_TRACE("Invalid Select Query: %s", e.base().what());
         exception_count += 1;
       }
     }
@@ -128,7 +128,7 @@ void *ParserExceptionTest(int port) {
     } catch (const pqxx::pqxx_exception &e) {
       const pqxx::sql_error *s = dynamic_cast<const pqxx::sql_error*>(&e.base());
       if (s) {
-        LOG_INFO("Invalid Prepare Query: %s", e.base().what());
+        LOG_TRACE("Invalid Prepare Query: %s", e.base().what());
         exception_count += 1;
       }
     }
@@ -142,7 +142,7 @@ void *ParserExceptionTest(int port) {
     } catch (const pqxx::pqxx_exception &e) {
       const pqxx::sql_error *s = dynamic_cast<const pqxx::sql_error*>(&e.base());
       if (s) {
-        LOG_INFO("Invalid Execute Query: %s", e.base().what());
+        LOG_TRACE("Invalid Execute Query: %s", e.base().what());
         exception_count += 1;
       }
     }
@@ -155,7 +155,7 @@ void *ParserExceptionTest(int port) {
     } catch (const pqxx::pqxx_exception &e) {
       const pqxx::sql_error *s = dynamic_cast<const pqxx::sql_error*>(&e.base());
       if (s) {
-        LOG_INFO("Empty Query: %s", e.base().what());
+        LOG_TRACE("Empty Query: %s", e.base().what());
         EXPECT_TRUE(false);
       }
     }
@@ -164,7 +164,7 @@ void *ParserExceptionTest(int port) {
     EXPECT_EQ(exception_count, total);
 
   } catch (const std::exception &e) {
-    LOG_INFO("[ExceptionTest] Exception occurred: %s", e.what());
+    LOG_ERROR("[ExceptionTest] Exception occurred: %s", e.what());
     EXPECT_TRUE(false);
   }
 


### PR DESCRIPTION
This PR removes the `make_unique` introduced in #785 
@aaron-tian Could you check if it's good now? Thanks!