### PR TITLE
Add support for ARRAY type

### DIFF
--- a/src/catalog/column.cpp
+++ b/src/catalog/column.cpp
@@ -34,6 +34,8 @@ void Column::SetInlined() {
   switch (column_type) {
     case type::TypeId::VARCHAR:
     case type::TypeId::VARBINARY:
+    case type::TypeId::INTEGERARRAY:
+    case type::TypeId::DECIMALARRAY:
       break;  // No change of inlined setting
 
     default:

--- a/src/codegen/type/array_type.cpp
+++ b/src/codegen/type/array_type.cpp
@@ -51,8 +51,9 @@ static std::vector<TypeSystem::NoArgOpInfo> kNoArgOperatorTable = {};
 }  // anonymous namespace
 
 // Initialize the ARRAY SQL type with the configured type system
+// TODO:aa_ Support ARRAY for codegen
 Array::Array()
-    : SqlType(peloton::type::TypeId::ARRAY),
+    : SqlType(peloton::type::TypeId::INTEGERARRAY),
       type_system_(kImplicitCastingTable, kExplicitCastingTable,
                    kComparisonTable, kUnaryOperatorTable,
                    kBinaryOperatorTable, kNaryOperatorTable,

--- a/src/common/internal_types.cpp
+++ b/src/common/internal_types.cpp
@@ -236,8 +236,10 @@ std::string TypeIdToString(type::TypeId type) {
       return "VARCHAR";
     case type::TypeId::VARBINARY:
       return "VARBINARY";
-    case type::TypeId::ARRAY:
-      return "ARRAY";
+    case type::TypeId::INTEGERARRAY:
+      return "INTEGERARRAY";
+    case type::TypeId::DECIMALARRAY:
+      return "DECIMALARRAY";
     case type::TypeId::UDT:
       return "UDT";
     default: {
@@ -275,8 +277,10 @@ type::TypeId StringToTypeId(const std::string &str) {
     return type::TypeId::VARCHAR;
   } else if (upper_str == "VARBINARY") {
     return type::TypeId::VARBINARY;
-  } else if (upper_str == "ARRAY") {
-    return type::TypeId::ARRAY;
+  } else if (upper_str == "INTEGERARRAY") {
+    return type::TypeId::INTEGERARRAY;
+  } else if (upper_str == "DECIMALARRAY") {
+    return type::TypeId::DECIMALARRAY;
   } else if (upper_str == "UDT") {
     return type::TypeId::UDT;
   } else {

--- a/src/common/sql_node_visitor.cpp
+++ b/src/common/sql_node_visitor.cpp
@@ -12,6 +12,7 @@
 
 #include "common/sql_node_visitor.h"
 #include "expression/comparison_expression.h"
+#include "expression/array_expression.h"
 #include "expression/aggregate_expression.h"
 #include "expression/conjunction_expression.h"
 #include "expression/function_expression.h"
@@ -58,6 +59,9 @@ void SqlNodeVisitor::Visit(expression::TupleValueExpression *expr) {
   expr->AcceptChildren(this);
 }
 void SqlNodeVisitor::Visit(expression::SubqueryExpression *expr) {
+  expr->AcceptChildren(this);
+}
+void SqlNodeVisitor::Visit(expression::ArrayExpression *expr) {
   expr->AcceptChildren(this);
 }
 

--- a/src/executor/logical_tile.cpp
+++ b/src/executor/logical_tile.cpp
@@ -450,9 +450,14 @@ std::vector<std::vector<std::string>> LogicalTile::GetAllValuesAsStrings(
 
       // LM: I put varchar here because we don't need to do endian conversion
       // for them, and assuming binary and text for a varchar are the same.
+      // array is also the same.
       if (result_format[column_itr] == 0 ||
           cp.base_tile->GetSchema()->GetType(cp.origin_column_id) ==
-              type::TypeId::VARCHAR) {
+          type::TypeId::VARCHAR || 
+          cp.base_tile->GetSchema()->GetType(cp.origin_column_id) == 
+          type::TypeId::INTEGERARRAY || 
+          cp.base_tile->GetSchema()->GetType(cp.origin_column_id) == 
+          type::TypeId::DECIMALARRAY) {
         // don't let to_string function decide what NULL value is
         if (use_to_string_null == false && val.IsNull() == true) {
           // materialize Null values as 0B string

--- a/src/executor/logical_tile.cpp
+++ b/src/executor/logical_tile.cpp
@@ -454,7 +454,6 @@ std::vector<std::vector<std::string>> LogicalTile::GetAllValuesAsStrings(
       if (result_format[column_itr] == 0 ||
           cp.base_tile->GetSchema()->GetType(cp.origin_column_id) ==
           type::TypeId::VARCHAR) {
-        LOG_INFO("if type %d", cp.base_tile->GetSchema()->GetType(cp.origin_column_id));
         // don't let to_string function decide what NULL value is
         if (use_to_string_null == false && val.IsNull() == true) {
           // materialize Null values as 0B string
@@ -464,7 +463,6 @@ std::vector<std::vector<std::string>> LogicalTile::GetAllValuesAsStrings(
           row.push_back(val.ToString());
         }
       } else {
-        LOG_INFO("else type %d", cp.base_tile->GetSchema()->GetType(cp.origin_column_id));
         // TODO:aa_ convert ARRAY into binary
         auto data_length =
             cp.base_tile->GetSchema()->GetLength(cp.origin_column_id);

--- a/src/executor/logical_tile.cpp
+++ b/src/executor/logical_tile.cpp
@@ -453,11 +453,8 @@ std::vector<std::vector<std::string>> LogicalTile::GetAllValuesAsStrings(
       // array is also the same.
       if (result_format[column_itr] == 0 ||
           cp.base_tile->GetSchema()->GetType(cp.origin_column_id) ==
-          type::TypeId::VARCHAR || 
-          cp.base_tile->GetSchema()->GetType(cp.origin_column_id) == 
-          type::TypeId::INTEGERARRAY || 
-          cp.base_tile->GetSchema()->GetType(cp.origin_column_id) == 
-          type::TypeId::DECIMALARRAY) {
+          type::TypeId::VARCHAR) {
+        LOG_INFO("if type %d", cp.base_tile->GetSchema()->GetType(cp.origin_column_id));
         // don't let to_string function decide what NULL value is
         if (use_to_string_null == false && val.IsNull() == true) {
           // materialize Null values as 0B string
@@ -467,6 +464,8 @@ std::vector<std::vector<std::string>> LogicalTile::GetAllValuesAsStrings(
           row.push_back(val.ToString());
         }
       } else {
+        LOG_INFO("else type %d", cp.base_tile->GetSchema()->GetType(cp.origin_column_id));
+        // TODO:aa_ convert ARRAY into binary
         auto data_length =
             cp.base_tile->GetSchema()->GetLength(cp.origin_column_id);
         LOG_TRACE("data length: %ld", data_length);

--- a/src/include/common/internal_types.h
+++ b/src/include/common/internal_types.h
@@ -228,6 +228,7 @@ enum class ExpressionType {
   COLUMN_REF = 502,
   FUNCTION_REF = 503,
   TABLE_REF = 504,
+  ARRAY = 505,
 
   // -----------------------------
   // Miscellaneous

--- a/src/include/common/sql_node_visitor.h
+++ b/src/include/common/sql_node_visitor.h
@@ -49,6 +49,7 @@ class FunctionExpression;
 class OperatorUnaryMinusExpression;
 class CaseExpression;
 class SubqueryExpression;
+class ArrayExpression;
 }
 
 //===--------------------------------------------------------------------===//
@@ -91,6 +92,7 @@ class SqlNodeVisitor {
   virtual void Visit(expression::StarExpression *expr);
   virtual void Visit(expression::TupleValueExpression *expr);
   virtual void Visit(expression::SubqueryExpression *expr);
+  virtual void Visit(expression::ArrayExpression *expr);
 
 };
 

--- a/src/include/expression/array_expression.h
+++ b/src/include/expression/array_expression.h
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// array_expression.h
+//
+// Identification: src/include/expression/array_expression.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "common/sql_node_visitor.h"
+#include "expression/abstract_expression.h"
+#include "parser/postgresparser.h"
+#include "type/value_factory.h"
+
+namespace peloton {
+namespace expression {
+
+//===----------------------------------------------------------------------===//
+// ArrayExpression
+//===----------------------------------------------------------------------===//
+
+class ArrayExpression : public AbstractExpression {
+ public:
+  ArrayExpression(const std::vector<AbstractExpression *> &expr_array, 
+    const type::Value &value)
+      : AbstractExpression(ExpressionType::ARRAY, value.GetTypeId()),
+      value_(value.Copy()) {
+    for (auto &expr : expr_array) {
+      expr_array_.push_back(std::unique_ptr<AbstractExpression>(expr));
+    }
+  }
+
+  type::Value Evaluate(
+      UNUSED_ATTRIBUTE const AbstractTuple *tuple1,
+      UNUSED_ATTRIBUTE const AbstractTuple *tuple2,
+      UNUSED_ATTRIBUTE executor::ExecutorContext *context) const override {
+    return type::ValueFactory::GetBooleanValue(true);
+  }
+
+  AbstractExpression *Copy() const override {
+    return new ArrayExpression(*this);
+  }
+
+  virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
+
+  type::Value GetValue() const { return value_; }
+
+ protected:
+  ArrayExpression(const ArrayExpression &other)
+      : AbstractExpression(other) {}
+
+  std::vector<std::unique_ptr<expression::AbstractExpression>> expr_array_;
+  type::Value value_;
+};
+
+}  // namespace expression
+}  // namespace peloton

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -173,6 +173,9 @@ struct ColumnDefinition {
       case DataType::VARBINARY:
         return type::TypeId::VARBINARY;
 
+      case DataType::DATE:
+        return type::TypeId::DATE;
+
       case DataType::INTEGERARRAY:
         return type::TypeId::INTEGERARRAY;
 

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -50,7 +50,10 @@ struct ColumnDefinition {
     TEXT,
 
     VARCHAR,
-    VARBINARY
+    VARBINARY,
+
+    INTEGERARRAY,
+    DECIMALARRAY
   };
 
   ColumnDefinition(DataType type) : type(type) {
@@ -170,8 +173,11 @@ struct ColumnDefinition {
       case DataType::VARBINARY:
         return type::TypeId::VARBINARY;
 
-      case DataType::DATE:
-        return type::TypeId::DATE;
+      case DataType::INTEGERARRAY:
+        return type::TypeId::INTEGERARRAY;
+
+      case DataType::DECIMALARRAY:
+        return type::TypeId::DECIMALARRAY;
 
       case DataType::INVALID:
       case DataType::PRIMARY:

--- a/src/include/parser/parsenodes.h
+++ b/src/include/parser/parsenodes.h
@@ -147,9 +147,9 @@ typedef struct A_Expr {
 
 typedef struct A_ArrayExpr
 {
-  NodeTag   type;
-  List     *elements;   /* array element expressions */
-  int     location;   /* token location, or -1 if unknown */
+  NodeTag type;
+  List *elements;   /* array element expressions */
+  int location;   /* token location, or -1 if unknown */
 } A_ArrayExpr;
 
 typedef enum NullTestType { IS_NULL, IS_NOT_NULL } NullTestType;

--- a/src/include/parser/parsenodes.h
+++ b/src/include/parser/parsenodes.h
@@ -145,6 +145,13 @@ typedef struct A_Expr {
   int location;     /* token location, or -1 if unknown */
 } A_Expr;
 
+typedef struct A_ArrayExpr
+{
+  NodeTag   type;
+  List     *elements;   /* array element expressions */
+  int     location;   /* token location, or -1 if unknown */
+} A_ArrayExpr;
+
 typedef enum NullTestType { IS_NULL, IS_NOT_NULL } NullTestType;
 
 typedef struct NullTest {

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -134,7 +134,7 @@ class PostgresParser {
   static expression::AbstractExpression *NullTestTransform(NullTest *root);
 
   // transform helper for ArrayExpr nodes
-  static expression::AbstractExpression* ArrayExprTransform(A_ArrayExpr* root);
+  static expression::AbstractExpression *ArrayExprTransform(A_ArrayExpr* root);
 
   // transform helper for where clauses
   static expression::AbstractExpression *WhereTransform(Node *root);

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -133,6 +133,9 @@ class PostgresParser {
   // transform helper for NullTest nodes
   static expression::AbstractExpression *NullTestTransform(NullTest *root);
 
+  // transform helper for ArrayExpr nodes
+  static expression::AbstractExpression* ArrayExprTransform(A_ArrayExpr* root);
+
   // transform helper for where clauses
   static expression::AbstractExpression *WhereTransform(Node *root);
 

--- a/src/include/parser/postgresparser.h
+++ b/src/include/parser/postgresparser.h
@@ -134,7 +134,7 @@ class PostgresParser {
   static expression::AbstractExpression *NullTestTransform(NullTest *root);
 
   // transform helper for ArrayExpr nodes
-  static expression::AbstractExpression *ArrayExprTransform(A_ArrayExpr* root);
+  static expression::AbstractExpression *ArrayExprTransform(A_ArrayExpr *root);
 
   // transform helper for where clauses
   static expression::AbstractExpression *WhereTransform(Node *root);

--- a/src/include/type/array_type.h
+++ b/src/include/type/array_type.h
@@ -26,7 +26,7 @@ class ValueFactory;
 
 class ArrayType : public Type {
  public:
-  ArrayType(): Type(TypeId::ARRAY){}
+  ArrayType(TypeId type);
   ~ArrayType() {}
 
   // Get the element at a given index in this array
@@ -47,21 +47,30 @@ class ArrayType : public Type {
   Value CastAs(const Value& val, const TypeId type_id) const override;
 
   bool IsInlined(const Value& val UNUSED_ATTRIBUTE) const override { return false; }
-  std::string ToString(const Value& val UNUSED_ATTRIBUTE) const override { return ""; }
+  std::string ToString(const Value& val) const override;
   size_t Hash(const Value& val UNUSED_ATTRIBUTE) const override { return 0; }
   void HashCombine(const Value& val UNUSED_ATTRIBUTE, size_t &seed UNUSED_ATTRIBUTE) const override {}
 
   void SerializeTo(const Value& val UNUSED_ATTRIBUTE, SerializeOutput &out UNUSED_ATTRIBUTE) const override {
     throw Exception("Can't serialize array types to storage");
   }
+  // Serialize this value into the given storage space
+  void SerializeTo(const Value& val, SerializeOutput &out) const override;
 
   void SerializeTo(const Value& val UNUSED_ATTRIBUTE, char *storage UNUSED_ATTRIBUTE,
                    bool inlined UNUSED_ATTRIBUTE,
                    AbstractPool *pool UNUSED_ATTRIBUTE) const override {
     throw Exception("Can't serialize array types to storage");
   }
+  // Deserialize a value of the given type from the given storage space.
+  Value DeserializeFrom(const char *storage,
+                                const bool inlined, AbstractPool *pool = nullptr) const override;
 
-  Value Copy(const Value& val UNUSED_ATTRIBUTE) const override { return ValueFactory::GetNullValueByType(type_id_); }
+  // Create a copy of this value
+  Value Copy(const Value &val) const override;
+
+  // Get the number of elements in the array
+  uint32_t GetLength(const Value& val) const override;
 
 };
 

--- a/src/include/type/array_type.h
+++ b/src/include/type/array_type.h
@@ -51,20 +51,16 @@ class ArrayType : public Type {
   size_t Hash(const Value& val UNUSED_ATTRIBUTE) const override { return 0; }
   void HashCombine(const Value& val UNUSED_ATTRIBUTE, size_t &seed UNUSED_ATTRIBUTE) const override {}
 
-  void SerializeTo(const Value& val UNUSED_ATTRIBUTE, SerializeOutput &out UNUSED_ATTRIBUTE) const override {
-    throw Exception("Can't serialize array types to storage");
-  }
   // Serialize this value into the given storage space
   void SerializeTo(const Value& val, SerializeOutput &out) const override;
+  void SerializeTo(const Value& val, char *storage, bool inlined,
+                   AbstractPool *pool) const override;
 
-  void SerializeTo(const Value& val UNUSED_ATTRIBUTE, char *storage UNUSED_ATTRIBUTE,
-                   bool inlined UNUSED_ATTRIBUTE,
-                   AbstractPool *pool UNUSED_ATTRIBUTE) const override {
-    throw Exception("Can't serialize array types to storage");
-  }
   // Deserialize a value of the given type from the given storage space.
   Value DeserializeFrom(const char *storage,
                                 const bool inlined, AbstractPool *pool = nullptr) const override;
+  Value DeserializeFrom(SerializeInput &in,
+                                AbstractPool *pool = nullptr) const override;
 
   // Create a copy of this value
   Value Copy(const Value &val) const override;

--- a/src/include/type/type.h
+++ b/src/include/type/type.h
@@ -55,7 +55,7 @@ class Type {
   static Value GetMinValue(TypeId type_id);
   static Value GetMaxValue(TypeId type_id);
 
-  inline static Type* GetInstance(TypeId type_id) { return kTypes[static_cast<int>(type_id)]; }
+  inline static Type *GetInstance(TypeId type_id) { return kTypes[static_cast<int>(type_id)]; }
 
   inline TypeId GetTypeId() const { return type_id_; }
   
@@ -119,15 +119,15 @@ class Type {
   // space, or whether we must store only a reference to this value. If inlined
   // is false, we may use the provided data pool to allocate space for this
   // value, storing a reference into the allocated pool space in the storage.
-  virtual void SerializeTo(const Value& val, char* storage, bool inlined,
-                           AbstractPool* pool) const;
+  virtual void SerializeTo(const Value& val, char *storage, bool inlined,
+                           AbstractPool *pool) const;
   virtual void SerializeTo(const Value& val, SerializeOutput& out) const;
 
   // Deserialize a value of the given type from the given storage space.
-  virtual Value DeserializeFrom(const char* storage, const bool inlined,
-                                AbstractPool* pool = nullptr) const;
+  virtual Value DeserializeFrom(const char *storage, const bool inlined,
+                                AbstractPool *pool = nullptr) const;
   virtual Value DeserializeFrom(SerializeInput& in,
-                                AbstractPool* pool = nullptr) const;
+                                AbstractPool *pool = nullptr) const;
 
   // Create a copy of this value
   virtual Value Copy(const Value& val) const;
@@ -135,7 +135,7 @@ class Type {
   virtual Value CastAs(const Value& val, const TypeId type_id) const;
 
   // Access the raw variable length data
-  virtual const char* GetData(const Value& val) const;
+  virtual const char *GetData(const Value& val) const;
 
   // Get the length of the variable length data
   virtual uint32_t GetLength(const Value& val) const;
@@ -156,7 +156,7 @@ class Type {
   TypeId type_id_;
 
   // Singleton instances.
-  static Type* kTypes[15];
+  static Type *kTypes[15];
 };
 
 }  // namespace type

--- a/src/include/type/type.h
+++ b/src/include/type/type.h
@@ -58,6 +58,10 @@ class Type {
   inline static Type* GetInstance(TypeId type_id) { return kTypes[static_cast<int>(type_id)]; }
 
   inline TypeId GetTypeId() const { return type_id_; }
+  
+  inline bool IsArrayType() const { 
+    return type_id_ == TypeId::INTEGERARRAY || type_id_ == TypeId::DECIMALARRAY; 
+  }
 
   // Comparison functions
   //
@@ -152,7 +156,7 @@ class Type {
   TypeId type_id_;
 
   // Singleton instances.
-  static Type* kTypes[14];
+  static Type* kTypes[15];
 };
 
 }  // namespace type

--- a/src/include/type/type_id.h
+++ b/src/include/type/type_id.h
@@ -29,7 +29,8 @@ enum class TypeId {
   DATE,
   VARCHAR,
   VARBINARY,
-  ARRAY,
+  INTEGERARRAY,
+  DECIMALARRAY,
   UDT
 };
 

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -104,7 +104,7 @@ class ValueFactory {
 
   template <class T>
   static inline Value GetArrayValue(
-      const std::vector<T> &vals, TypeId type_id) {
+      const std::vector<T> *vals, TypeId type_id) {
     switch (type_id) {
       case TypeId::INTEGER:
         return Value(TypeId::INTEGERARRAY, vals, false);

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -102,6 +102,23 @@ class ValueFactory {
                  manage_data);
   }
 
+  template <class T>
+  static inline Value GetArrayValue(
+      const std::vector<T> &vals, TypeId type_id) {
+    switch (type_id) {
+      case TypeId::INTEGER:
+        return Value(TypeId::INTEGERARRAY, vals, false);
+      case TypeId::DECIMAL:
+        return Value(TypeId::DECIMALARRAY, vals, false);
+      default: {
+        std::string msg =
+            StringUtil::Format("Array Type '%s' does not support GetArrayValue",
+                               TypeIdToString(type_id).c_str());
+        throw Exception(ExceptionType::UNKNOWN_TYPE, msg);
+      }
+    }
+  }
+
   static inline Value GetNullValueByType(TypeId type_id) {
     Value ret_value;
     switch (type_id) {

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -833,7 +833,6 @@ expression::AbstractExpression* PostgresParser::ArrayExprTransform(
 
   auto int32_vec = new std::vector<int32_t>();
   auto double_vec = new std::vector<double>();
-  auto varchar_vec = new std::vector<char *>();
 
   for (auto elem = root->elements->head; elem != nullptr; elem = elem->next) {
     Node* node = reinterpret_cast<Node*>(elem->data.ptr_value);

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -868,12 +868,12 @@ expression::AbstractExpression *PostgresParser::ArrayExprTransform(
   switch (element_type) {
     case type::TypeId::INTEGER: {
       result = new expression::ArrayExpression(expr_array,
-        type::ValueFactory::GetArrayValue<int32_t>(*int32_vec, element_type));
+        type::ValueFactory::GetArrayValue<int32_t>(int32_vec, element_type));
       break;
     }
     case type::TypeId::DECIMAL: {
       result = new expression::ArrayExpression(expr_array,
-        type::ValueFactory::GetArrayValue<double>(*double_vec, element_type));
+        type::ValueFactory::GetArrayValue<double>(double_vec, element_type));
       break;
     }
     default:

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -819,39 +819,38 @@ expression::AbstractExpression *PostgresParser::NullTestTransform(
 
 // This function takes in a Postgres ArrayExpr primnode and transfers
 // it into Peloton AbstractExpression.
-expression::AbstractExpression* PostgresParser::ArrayExprTransform(
-    A_ArrayExpr* root) {
+expression::AbstractExpression *PostgresParser::ArrayExprTransform(
+    A_ArrayExpr *root) {
 
   if (root == nullptr) {
     return nullptr;
   }
 
-  auto expr_array = std::vector<expression::AbstractExpression*>();
-  expression::AbstractExpression* expr = nullptr;
-  expression::AbstractExpression* result = nullptr;
+  auto expr_array = std::vector<expression::AbstractExpression *>();
+  expression::AbstractExpression *expr, *result;
   type::TypeId element_type = type::TypeId::INVALID;
 
   auto int32_vec = new std::vector<int32_t>();
   auto double_vec = new std::vector<double>();
 
   for (auto elem = root->elements->head; elem != nullptr; elem = elem->next) {
-    Node* node = reinterpret_cast<Node*>(elem->data.ptr_value);
+    Node *node = reinterpret_cast<Node *>(elem->data.ptr_value);
     switch (node->type) {
       case T_A_Const: {
-        expr = ConstTransform((A_Const *)node);
-        if(element_type == type::TypeId::INVALID){
+        expr = ConstTransform(reinterpret_cast<A_Const *>(node));
+        if(element_type == type::TypeId::INVALID) {
           element_type = expr->GetValueType();
         }
         expr_array.push_back(expr);
         switch (element_type) {
           case type::TypeId::INTEGER: {
             int32_vec->push_back(
-              ((expression::ConstantValueExpression *)expr)->GetValue().GetInteger());
+              (reinterpret_cast<expression::ConstantValueExpression *>(expr))->GetValue().GetInteger());
             break;
           }
           case type::TypeId::DECIMAL: {
             double_vec->push_back(
-              ((expression::ConstantValueExpression *)expr)->GetValue().GetDecimal());
+              (reinterpret_cast<expression::ConstantValueExpression *>(expr))->GetValue().GetDecimal());
             break;
           }
           default:
@@ -1426,12 +1425,12 @@ parser::AnalyzeStatement *PostgresParser::VacuumTransform(VacuumStmt *root) {
   return result;
 }
 
-parser::VariableSetStatement *PostgresParser::VariableSetTransform(UNUSED_ATTRIBUTE VariableSetStmt* root) {
-  VariableSetStatement* res = new VariableSetStatement();
+parser::VariableSetStatement *PostgresParser::VariableSetTransform(UNUSED_ATTRIBUTE VariableSetStmt *root) {
+  VariableSetStatement *res = new VariableSetStatement();
   return res;
 }
 
-std::vector<std::string>* PostgresParser::ColumnNameTransform(List* root) {
+std::vector<std::string> *PostgresParser::ColumnNameTransform(List *root) {
   auto result = new std::vector<std::string>();
 
   if (root == nullptr) return result;
@@ -1741,7 +1740,7 @@ parser::SQLStatement *PostgresParser::NodeTransform(Node *stmt) {
 // This function transfers a list of Postgres statements into
 // a Peloton SQLStatementList object. It traverses the parse list
 // and call the helper for singles nodes.
-parser::SQLStatementList* PostgresParser::ListTransform(List *root) {
+parser::SQLStatementList *PostgresParser::ListTransform(List *root) {
   if (root == nullptr) {
     return nullptr;
   }

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -17,6 +17,7 @@
 #include <unordered_set>
 
 #include "common/exception.h"
+#include "expression/array_expression.h"
 #include "expression/aggregate_expression.h"
 #include "expression/case_expression.h"
 #include "expression/comparison_expression.h"
@@ -816,6 +817,74 @@ expression::AbstractExpression *PostgresParser::NullTestTransform(
   return result;
 }
 
+// This function takes in a Postgres ArrayExpr primnode and transfers
+// it into Peloton AbstractExpression.
+expression::AbstractExpression* PostgresParser::ArrayExprTransform(
+    A_ArrayExpr* root) {
+
+  if (root == nullptr) {
+    return nullptr;
+  }
+
+  auto expr_array = std::vector<expression::AbstractExpression*>();
+  expression::AbstractExpression* expr = nullptr;
+  expression::AbstractExpression* result = nullptr;
+  type::TypeId element_type = type::TypeId::INVALID;
+
+  auto int32_vec = new std::vector<int32_t>();
+  auto double_vec = new std::vector<double>();
+  auto varchar_vec = new std::vector<char *>();
+
+  for (auto elem = root->elements->head; elem != nullptr; elem = elem->next) {
+    Node* node = reinterpret_cast<Node*>(elem->data.ptr_value);
+    switch (node->type) {
+      case T_A_Const: {
+        expr = ConstTransform((A_Const *)node);
+        if(element_type == type::TypeId::INVALID){
+          element_type = expr->GetValueType();
+        }
+        expr_array.push_back(expr);
+        switch (element_type) {
+          case type::TypeId::INTEGER: {
+            int32_vec->push_back(
+              ((expression::ConstantValueExpression *)expr)->GetValue().GetInteger());
+            break;
+          }
+          case type::TypeId::DECIMAL: {
+            double_vec->push_back(
+              ((expression::ConstantValueExpression *)expr)->GetValue().GetDecimal());
+            break;
+          }
+          default:
+            throw NotImplementedException(StringUtil::Format(
+              "Array element value type %d not supported yet...", element_type));
+        }
+        break;
+      }
+      default:
+        throw NotImplementedException(StringUtil::Format(
+          "Array element of type %d not supported yet...", node->type));
+    }
+  }
+
+  switch (element_type) {
+    case type::TypeId::INTEGER: {
+      result = new expression::ArrayExpression(expr_array,
+        type::ValueFactory::GetArrayValue<int32_t>(*int32_vec, element_type));
+      break;
+    }
+    case type::TypeId::DECIMAL: {
+      result = new expression::ArrayExpression(expr_array,
+        type::ValueFactory::GetArrayValue<double>(*double_vec, element_type));
+      break;
+    }
+    default:
+      throw NotImplementedException(StringUtil::Format(
+        "Array element value type %d not supported yet...", element_type));
+  }
+  return result;
+}
+
 // This function takes in the whereClause part of a Postgres SelectStmt
 // parsenode and transfers it into Peloton AbstractExpression.
 expression::AbstractExpression *PostgresParser::WhereTransform(Node *root) {
@@ -869,8 +938,28 @@ parser::ColumnDefinition *PostgresParser::ColumnDefTransform(ColumnDef *root) {
   parser::ColumnDefinition::DataType data_type =
       parser::ColumnDefinition::StrToDataType(name);
 
+  if (type_name->arrayBounds) {
+    // TODO: Mark corresponding fields in ColumnDefinition class to denote
+    // an array column
+    switch (data_type) {
+      case ColumnDefinition::DataType::INT:
+        result = new ColumnDefinition(root->colname, 
+                                      ColumnDefinition::DataType::INTEGERARRAY);
+        break;
+      case ColumnDefinition::DataType::DECIMAL:
+        result = new ColumnDefinition(root->colname, 
+                                      ColumnDefinition::DataType::DECIMALARRAY);
+        break;
+      default: {
+        throw NotImplementedException(StringUtil::Format(
+            "Column Array DataType %d not supported yet...\n", data_type));
+      }
+    }
+  } else {
+    result = new ColumnDefinition(root->colname, data_type);
+  }
+
   // Transform Varchar len
-  result = new ColumnDefinition(root->colname, data_type);
   if (type_name->typmods) {
     Node *node =
         reinterpret_cast<Node *>(type_name->typmods->head->data.ptr_value);
@@ -1376,23 +1465,12 @@ std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>>
       switch (expr->type) {
         case T_ParamRef: {
           cur_result.push_back(std::unique_ptr<expression::AbstractExpression>(
-              ParamRefTransform((ParamRef *)expr)));
+            ParamRefTransform((ParamRef *)expr)));
           break;
         }
         case T_A_Const: {
           cur_result.push_back(std::unique_ptr<expression::AbstractExpression>(
-              ConstTransform((A_Const *)expr)));
-          break;
-        }
-        case T_TypeCast: {
-          try {
-            cur_result.push_back(
-                std::unique_ptr<expression::AbstractExpression>(
-                    TypeCastTransform((TypeCast *)expr)));
-          } catch (Exception e) {
-            delete result;
-            throw e;
-          }
+            ConstTransform((A_Const *)expr)));
           break;
         }
         case T_SetToDefault: {
@@ -1402,9 +1480,14 @@ std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>>
           cur_result.push_back(nullptr);
           break;
         }
+        case T_A_ArrayExpr: {
+          cur_result.push_back(std::unique_ptr<expression::AbstractExpression>(
+            ArrayExprTransform((A_ArrayExpr *)expr)));
+          break;
+        }
         default:
           throw NotImplementedException(StringUtil::Format(
-              "Value of type %d not supported yet...\n", expr->type));
+            "Value of type %d not supported yet...\n", expr->type));
       }
     }
     result->push_back(std::move(cur_result));

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1472,16 +1472,27 @@ std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>>
             ConstTransform((A_Const *)expr)));
           break;
         }
-        case T_SetToDefault: {
-          // TODO handle default type
-          // add corresponding expression for
-          // default to cur_result
-          cur_result.push_back(nullptr);
+        case T_TypeCast: {
+          try {
+            cur_result.push_back(
+                std::unique_ptr<expression::AbstractExpression>(
+                    TypeCastTransform((TypeCast *)expr)));
+          } catch (Exception e) {
+            delete result;
+            throw e;
+          }
           break;
         }
         case T_A_ArrayExpr: {
           cur_result.push_back(std::unique_ptr<expression::AbstractExpression>(
             ArrayExprTransform((A_ArrayExpr *)expr)));
+          break;
+        }
+        case T_SetToDefault: {
+          // TODO handle default type
+          // add corresponding expression for
+          // default to cur_result
+          cur_result.push_back(nullptr);
           break;
         }
         default:

--- a/src/planner/insert_plan.cpp
+++ b/src/planner/insert_plan.cpp
@@ -14,6 +14,7 @@
 
 #include "catalog/catalog.h"
 #include "expression/constant_value_expression.h"
+#include "expression/array_expression.h"
 #include "storage/data_table.h"
 #include "type/ephemeral_pool.h"
 #include "type/value_factory.h"
@@ -54,6 +55,11 @@ InsertPlan::InsertPlan(storage::DataTable *table,
               std::make_tuple(tuple_idx, column_id, param_idx++);
           parameter_vector_->push_back(pair);
           params_value_type_->push_back(type);
+        } else if (exp->GetExpressionType() ==
+                   ExpressionType::ARRAY) {
+          auto *array_exp =
+              dynamic_cast<expression::ArrayExpression *>(exp.get());
+          values_.push_back(array_exp->GetValue());
         } else {
           PL_ASSERT(exp->GetExpressionType() == ExpressionType::VALUE_CONSTANT);
           auto *const_exp =

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -487,6 +487,16 @@ FieldInfo TrafficCop::GetColumnFieldForValueType(std::string column_name,
       field_size = 255;
       break;
     }
+    case type::TypeId::INTEGERARRAY: {
+      field_type = PostgresValueType::INT4_ARRAY;
+      field_size = 255;
+      break;
+    }
+    case type::TypeId::DECIMALARRAY: {
+      field_type = PostgresValueType::FLOADT4_ARRAY;
+      field_size = 255;
+      break;
+    }
     case type::TypeId::TIMESTAMP: {
       field_type = PostgresValueType::TIMESTAMPS;
       field_size = 64;  // FIXME: Bytes???

--- a/src/type/array_type.cpp
+++ b/src/type/array_type.cpp
@@ -615,6 +615,10 @@ Value ArrayType::CastAs(const Value &val UNUSED_ATTRIBUTE,
 // Create a copy of this value
 Value ArrayType::Copy(const Value& val) const { return Value(val); }
 
+void ArrayType::SerializeTo(const Value& val UNUSED_ATTRIBUTE, SerializeOutput &out UNUSED_ATTRIBUTE) const {
+  throw Exception("Can't serialize array types to storage");
+}
+
 void ArrayType::SerializeTo(const Value& val, char *storage,
                  bool inlined UNUSED_ATTRIBUTE,
                  AbstractPool *pool) const {
@@ -694,6 +698,11 @@ Value ArrayType::DeserializeFrom(const char *storage,
       throw Exception(ExceptionType::INCOMPATIBLE_TYPE, msg);
     }
   }
+}
+
+Value ArrayType::DeserializeFrom(SerializeInput &in UNUSED_ATTRIBUTE,
+                                  AbstractPool *pool UNUSED_ATTRIBUTE) const {
+  throw Exception("Can't deserialize array types from storage");
 }
 
 std::string ArrayType::ToString(const Value &val) const {

--- a/src/type/array_type.cpp
+++ b/src/type/array_type.cpp
@@ -733,6 +733,7 @@ uint32_t ArrayType::GetLength(const Value &val) const {
       std::vector<double> *double_vec = 
           reinterpret_cast<std::vector<double> *>(val.value_.array);
       len = double_vec->size();
+      break;
     }
     default: {
       std::string msg =

--- a/src/type/array_type.cpp
+++ b/src/type/array_type.cpp
@@ -672,23 +672,23 @@ Value ArrayType::DeserializeFrom(const char *storage,
     case TypeId::INTEGERARRAY:
       if(len == 0) {
         auto int32_vec = new std::vector<int32_t>();
-        return Value(type_id_, *int32_vec, false);
+        return Value(type_id_, int32_vec, false);
       } else {
         const int32_t *int32_begin = reinterpret_cast<const int32_t *>(ptr + 
             sizeof(uint32_t));
         auto int32_vec = new std::vector<int32_t>(int32_begin, int32_begin + len);
-        return Value(type_id_, *int32_vec, false);
+        return Value(type_id_, int32_vec, false);
       }
       break;
     case TypeId::DECIMALARRAY:
       if(len == 0) {
         auto double_vec = new std::vector<double>();
-        return Value(type_id_, *double_vec, false);
+        return Value(type_id_, double_vec, false);
       } else {
         const double *double_begin = reinterpret_cast<const double *>(ptr + 
             sizeof(uint32_t));
         auto double_vec = new std::vector<double>(double_begin, double_begin + len);
-        return Value(type_id_, *double_vec, false);
+        return Value(type_id_, double_vec, false);
       }
       break;
     default: {

--- a/src/type/array_type.cpp
+++ b/src/type/array_type.cpp
@@ -12,6 +12,7 @@
 
 #include <include/type/value.h>
 #include "type/array_type.h"
+#include <sstream>
 
 #include "type/boolean_type.h"
 #include "type/decimal_type.h"
@@ -19,9 +20,14 @@
 #include "type/timestamp_type.h"
 #include "type/type.h"
 #include "type/varlen_type.h"
+#include "type/abstract_pool.h"
 
 namespace peloton {
 namespace type {
+
+ArrayType::ArrayType(TypeId type) :
+    Type(type) {
+}
 
 // Get the element at a given index in this array
 Value ArrayType::GetElementAt(const Value &val, uint64_t idx) const {
@@ -161,7 +167,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
 }
 
 CmpBool ArrayType::CompareEquals(const Value &left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::ARRAY);
+  PL_ASSERT(IsArrayType());
   PL_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
@@ -231,7 +237,7 @@ CmpBool ArrayType::CompareEquals(const Value &left, const Value &right) const {
 }
 
 CmpBool ArrayType::CompareNotEquals(const Value &left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::ARRAY);
+  PL_ASSERT(IsArrayType());
   PL_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
@@ -301,7 +307,7 @@ CmpBool ArrayType::CompareNotEquals(const Value &left, const Value &right) const
 }
 
 CmpBool ArrayType::CompareLessThan(const Value &left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::ARRAY);
+  PL_ASSERT(IsArrayType());
   PL_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
@@ -372,7 +378,7 @@ CmpBool ArrayType::CompareLessThan(const Value &left, const Value &right) const 
 
 CmpBool ArrayType::CompareLessThanEquals(const Value &left,
                                        const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::ARRAY);
+  PL_ASSERT(IsArrayType());
   PL_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
@@ -443,7 +449,7 @@ CmpBool ArrayType::CompareLessThanEquals(const Value &left,
 
 CmpBool ArrayType::CompareGreaterThan(const Value &left,
                                     const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::ARRAY);
+  PL_ASSERT(IsArrayType());
   PL_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
@@ -514,7 +520,7 @@ CmpBool ArrayType::CompareGreaterThan(const Value &left,
 
 CmpBool ArrayType::CompareGreaterThanEquals(const Value &left,
                                           const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::ARRAY);
+  PL_ASSERT(IsArrayType());
   PL_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
@@ -583,6 +589,22 @@ CmpBool ArrayType::CompareGreaterThanEquals(const Value &left,
   throw Exception(ExceptionType::UNKNOWN_TYPE, "Element type is invalid.");
 }
 
+TypeId ArrayType::GetElementType(const Value &val) const {
+  TypeId type_id = val.GetTypeId();
+  switch (type_id) {
+    case TypeId::INTEGERARRAY: 
+      return TypeId::INTEGER;
+    case TypeId::DECIMALARRAY: 
+      return TypeId::DECIMAL;
+    default: {
+      std::string msg =
+          StringUtil::Format("Invalid Type '%d' for Array GetElementType method",
+                             static_cast<int>(type_id));
+      throw Exception(ExceptionType::INCOMPATIBLE_TYPE, msg);
+    }
+  }
+}
+
 Value ArrayType::CastAs(const Value &val UNUSED_ATTRIBUTE,
                         UNUSED_ATTRIBUTE const TypeId type_id) const {
   PL_ASSERT(false);
@@ -590,9 +612,127 @@ Value ArrayType::CastAs(const Value &val UNUSED_ATTRIBUTE,
                   "Cannot cast array values.");
 }
 
-TypeId ArrayType::GetElementType(
-    const Value &val UNUSED_ATTRIBUTE) const {
-  return val.size_.elem_type_id;
+// Create a copy of this value
+Value ArrayType::Copy(const Value& val) const { return Value(val); }
+
+void ArrayType::SerializeTo(const Value& val, char *storage,
+                 bool inlined UNUSED_ATTRIBUTE,
+                 AbstractPool *pool) const {
+  TypeId type_id = val.GetTypeId();
+  uint32_t len, size;
+  char* data = nullptr;
+  switch (type_id) {
+    case TypeId::INTEGERARRAY: {
+      std::vector<int32_t> *int32_vec = 
+          reinterpret_cast<std::vector<int32_t> *>(val.value_.array);
+      len = int32_vec->size();
+      size = len * sizeof(int32_t) + sizeof(uint32_t);
+      data = (pool == nullptr) ? new char[size] : (char *)pool->Allocate(size);
+      PL_MEMCPY(data, &len, sizeof(uint32_t));
+      if(len > 0){
+        PL_MEMCPY(data + sizeof(uint32_t), int32_vec->data(),
+                  size - sizeof(uint32_t));
+      }
+      break;
+    }
+    case TypeId::DECIMALARRAY: {
+      std::vector<double> *double_vec = 
+          reinterpret_cast<std::vector<double> *>(val.value_.array);
+      len = double_vec->size();
+      size = len * sizeof(double) + sizeof(uint32_t);
+      data = (pool == nullptr) ? new char[size] : (char *)pool->Allocate(size);
+      PL_MEMCPY(data, &len, sizeof(uint32_t));
+      if(len > 0){
+        PL_MEMCPY(data + sizeof(uint32_t), double_vec->data(),
+                  size - sizeof(uint32_t));
+      }
+      break;
+    }
+    default: {
+      std::string msg =
+          StringUtil::Format("Invalid Type '%d' for Array SerializeTo method",
+                             static_cast<int>(type_id));
+      throw Exception(ExceptionType::INCOMPATIBLE_TYPE, msg);
+    }
+  }
+  *reinterpret_cast<const char **>(storage) = data;
+}
+
+// Deserialize a value of the given type from the given storage space.
+Value ArrayType::DeserializeFrom(const char *storage,
+                                  const bool inlined UNUSED_ATTRIBUTE,
+                                  AbstractPool *pool UNUSED_ATTRIBUTE) const {
+  const char *ptr = *reinterpret_cast<const char *const *>(storage);
+  uint32_t len = *reinterpret_cast<const uint32_t *>(ptr);
+  switch (type_id_) {
+    case TypeId::INTEGERARRAY:
+      if(len == 0) {
+        auto int32_vec = new std::vector<int32_t>();
+        return Value(type_id_, *int32_vec, false);
+      } else {
+        const int32_t *int32_begin = reinterpret_cast<const int32_t *>(ptr + 
+            sizeof(uint32_t));
+        auto int32_vec = new std::vector<int32_t>(int32_begin, int32_begin + len);
+        return Value(type_id_, *int32_vec, false);
+      }
+      break;
+    case TypeId::DECIMALARRAY:
+      if(len == 0) {
+        auto double_vec = new std::vector<double>();
+        return Value(type_id_, *double_vec, false);
+      } else {
+        const double *double_begin = reinterpret_cast<const double *>(ptr + 
+            sizeof(uint32_t));
+        auto double_vec = new std::vector<double>(double_begin, double_begin + len);
+        return Value(type_id_, *double_vec, false);
+      }
+      break;
+    default: {
+      std::string msg =
+          StringUtil::Format("Invalid Type '%d' for Array DeserializeFrom method",
+                             static_cast<int>(type_id_));
+      throw Exception(ExceptionType::INCOMPATIBLE_TYPE, msg);
+    }
+  }
+}
+
+std::string ArrayType::ToString(const Value &val) const {
+  uint32_t len = GetLength(val);
+  std::ostringstream os;
+  os << "{";
+  for (uint32_t idx = 0; idx < len; idx++) {
+    if(idx != 0) {
+      os << ",";
+    }
+    os << GetElementAt(val, idx).ToString();
+  }
+  os << "}";
+  return os.str();
+}
+
+uint32_t ArrayType::GetLength(const Value &val) const {
+  TypeId type_id = val.GetTypeId();
+  uint32_t len;
+  switch (type_id) {
+    case TypeId::INTEGERARRAY: {
+      std::vector<int32_t> *int32_vec = 
+          reinterpret_cast<std::vector<int32_t> *>(val.value_.array);
+      len = int32_vec->size();
+      break;
+    }
+    case TypeId::DECIMALARRAY: {
+      std::vector<double> *double_vec = 
+          reinterpret_cast<std::vector<double> *>(val.value_.array);
+      len = double_vec->size();
+    }
+    default: {
+      std::string msg =
+          StringUtil::Format("Invalid Type '%d' for Array GetLength method",
+                             static_cast<int>(type_id));
+      throw Exception(ExceptionType::INCOMPATIBLE_TYPE, msg);
+    }
+  }
+  return len;
 }
 
 }  // namespace type

--- a/src/type/type.cpp
+++ b/src/type/type.cpp
@@ -43,7 +43,8 @@ Type* Type::kTypes[] = {
     new DateType(),  // not yet implemented
     new VarlenType(TypeId::VARCHAR),
     new VarlenType(TypeId::VARBINARY),
-    new ArrayType(),
+    new ArrayType(TypeId::INTEGERARRAY),
+    new ArrayType(TypeId::DECIMALARRAY),
     new Type(TypeId::UDT),  // not yet implemented
 };
 
@@ -67,7 +68,8 @@ uint64_t Type::GetTypeSize(const TypeId type_id) {
       return 8;
     case TypeId::VARCHAR:
     case TypeId::VARBINARY:
-    case TypeId::ARRAY:
+    case TypeId::INTEGERARRAY:
+    case TypeId::DECIMALARRAY:
       return 0;
     default:
       break;

--- a/src/type/type.cpp
+++ b/src/type/type.cpp
@@ -30,7 +30,7 @@
 namespace peloton {
 namespace type {
 
-Type* Type::kTypes[] = {
+Type *Type::kTypes[] = {
     new Type(TypeId::INVALID),
     new IntegerType(TypeId::PARAMETER_OFFSET),
     new BooleanType(),

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -382,8 +382,10 @@ Value::~Value() {
       }
       break;
     case TypeId::INTEGERARRAY:
+      delete reinterpret_cast<std::vector<int32_t> *>(value_.array);
+      break;
     case TypeId::DECIMALARRAY:
-      delete value_.array;
+      delete reinterpret_cast<std::vector<double> *>(value_.array);
       break;
     default:
       break;

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -28,7 +28,6 @@ Value::Value(const Value &other) {
   type_id_ = other.type_id_;
   size_ = other.size_;
   manage_data_ = other.manage_data_;
-  manage_array_ = other.manage_array_;
   switch (type_id_) {
     case TypeId::VARCHAR:
     case TypeId::VARBINARY:
@@ -45,7 +44,7 @@ Value::Value(const Value &other) {
       break;
     case TypeId::INTEGERARRAY:
     case TypeId::DECIMALARRAY:
-        if (manage_array_) {
+        if (manage_data_) {
           switch (type_id_) {
             case TypeId::INTEGERARRAY: {
               auto vec_ptr = (std::vector<int32_t> *)other.value_.array;
@@ -384,9 +383,7 @@ Value::~Value() {
       break;
     case TypeId::INTEGERARRAY:
     case TypeId::DECIMALARRAY:
-      if (manage_array_) {
-        // TODO:aa_ delete the vector
-      }
+      delete value_.array;
       break;
     default:
       break;

--- a/test/type/array_value_test.cpp
+++ b/test/type/array_value_test.cpp
@@ -100,7 +100,7 @@ TEST_F(ArrayValueTests, GetElementTest) {
   for (size_t i = 0; i < n; i++) {
     vec_integer.push_back(RANDOM32());
   }
-  type::Value array_integer = type::Value(type::TypeId::INTEGERARRAY, vec_integer, false);
+  type::Value array_integer = type::Value(type::TypeId::INTEGERARRAY, &vec_integer, true);
   for (size_t i = 0; i < n; i++) {
     type::Value ele = array_integer.GetElementAt(i);
     EXPECT_EQ(ele.GetAs<int32_t>(), vec_integer[i]);
@@ -122,7 +122,7 @@ TEST_F(ArrayValueTests, GetElementTest) {
   for (size_t i = 0; i < n; i++) {
     vec_decimal.push_back(RANDOM_DECIMAL());
   }
-  type::Value array_decimal = type::Value(type::TypeId::DECIMALARRAY, vec_decimal, false);
+  type::Value array_decimal = type::Value(type::TypeId::DECIMALARRAY, &vec_decimal, true);
   for (size_t i = 0; i < n; i++) {
     type::Value ele = array_decimal.GetElementAt(i);
     EXPECT_EQ(ele.GetAs<double>(), vec_decimal[i]);
@@ -203,7 +203,7 @@ TEST_F(ArrayValueTests, InListTest) {
   for (size_t i = 0; i < n; i++) {
     vec_integer.push_back(RANDOM32());
   }
-  type::Value array_integer = type::Value(type::TypeId::INTEGERARRAY, vec_integer, false);
+  type::Value array_integer = type::Value(type::TypeId::INTEGERARRAY, &vec_integer, true);
   for (size_t i = 0; i < n; i++) {
     type::Value in_list =
         array_integer.InList(type::ValueFactory::GetIntegerValue(vec_integer[i]));
@@ -245,7 +245,7 @@ TEST_F(ArrayValueTests, InListTest) {
   for (size_t i = 0; i < n; i++) {
     vec_decimal.push_back(RANDOM64());
   }
-  type::Value array_decimal = type::Value(type::TypeId::DECIMALARRAY, vec_decimal, false);
+  type::Value array_decimal = type::Value(type::TypeId::DECIMALARRAY, &vec_decimal, true);
   for (size_t i = 0; i < n; i++) {
     type::Value in_list =
         array_decimal.InList(type::ValueFactory::GetDecimalValue(vec_decimal[i]));

--- a/test/type/array_value_test.cpp
+++ b/test/type/array_value_test.cpp
@@ -63,6 +63,8 @@ TEST_F(ArrayValueTests, GetElementTest) {
   // Create vectors of different types
   // Insert n elements into each vector
   size_t n = 10;
+
+/*
   std::vector<bool> vec_bool;
   for (size_t i = 0; i < n; i++) {
     vec_bool.push_back(RANDOM(2));
@@ -92,17 +94,19 @@ TEST_F(ArrayValueTests, GetElementTest) {
     type::Value ele = array_smallint.GetElementAt(i);
     EXPECT_EQ(ele.GetAs<int16_t>(), vec_smallint[i]);
   }
+  */
 
   std::vector<int32_t> vec_integer;
   for (size_t i = 0; i < n; i++) {
     vec_integer.push_back(RANDOM32());
   }
-  type::Value array_integer = type::Value(type::TypeId::ARRAY, vec_integer, type::TypeId::INTEGER);
+  type::Value array_integer = type::Value(type::TypeId::INTEGERARRAY, vec_integer, false);
   for (size_t i = 0; i < n; i++) {
     type::Value ele = array_integer.GetElementAt(i);
     EXPECT_EQ(ele.GetAs<int32_t>(), vec_integer[i]);
   }
 
+/*
   std::vector<int64_t> vec_bigint;
   for (size_t i = 0; i < n; i++) {
     vec_bigint.push_back(RANDOM64());
@@ -112,17 +116,19 @@ TEST_F(ArrayValueTests, GetElementTest) {
     type::Value ele = array_bigint.GetElementAt(i);
     EXPECT_EQ(ele.GetAs<int64_t>(), vec_bigint[i]);
   }
+  */
 
   std::vector<double> vec_decimal;
   for (size_t i = 0; i < n; i++) {
     vec_decimal.push_back(RANDOM_DECIMAL());
   }
-  type::Value array_decimal = type::Value(type::TypeId::ARRAY, vec_decimal, type::TypeId::DECIMAL);
+  type::Value array_decimal = type::Value(type::TypeId::DECIMALARRAY, vec_decimal, false);
   for (size_t i = 0; i < n; i++) {
     type::Value ele = array_decimal.GetElementAt(i);
     EXPECT_EQ(ele.GetAs<double>(), vec_decimal[i]);
   }
 
+/*
   std::vector<std::string> vec_varchar;
   for (size_t i = 0; i < n; i++) {
     vec_varchar.push_back(RANDOM_STRING(RANDOM(100) + 1));
@@ -132,12 +138,14 @@ TEST_F(ArrayValueTests, GetElementTest) {
     type::Value ele = array_varchar.GetElementAt(i);
     EXPECT_EQ((ele).GetData(), vec_varchar[i]);
   }
+  */
 }
 
 TEST_F(ArrayValueTests, InListTest) {
   // Create vectors of different types
   // Insert n elements into each vector
   size_t n = 10;
+/*
   std::vector<bool> vec_bool;
   for (size_t i = 0; i < n; i++) {
     vec_bool.push_back(RANDOM(2));
@@ -189,12 +197,13 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
+  */
 
   std::vector<int32_t> vec_integer;
   for (size_t i = 0; i < n; i++) {
     vec_integer.push_back(RANDOM32());
   }
-  type::Value array_integer = type::Value(type::TypeId::ARRAY, vec_integer, type::TypeId::INTEGER);
+  type::Value array_integer = type::Value(type::TypeId::INTEGERARRAY, vec_integer, false);
   for (size_t i = 0; i < n; i++) {
     type::Value in_list =
         array_integer.InList(type::ValueFactory::GetIntegerValue(vec_integer[i]));
@@ -210,6 +219,7 @@ TEST_F(ArrayValueTests, InListTest) {
     }
   }
 
+/*
   std::vector<int64_t> vec_bigint;
   for (size_t i = 0; i < n; i++) {
     vec_bigint.push_back(RANDOM64());
@@ -229,12 +239,13 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
+  */
 
   std::vector<double> vec_decimal;
   for (size_t i = 0; i < n; i++) {
     vec_decimal.push_back(RANDOM64());
   }
-  type::Value array_decimal = type::Value(type::TypeId::ARRAY, vec_decimal, type::TypeId::DECIMAL);
+  type::Value array_decimal = type::Value(type::TypeId::DECIMALARRAY, vec_decimal, false);
   for (size_t i = 0; i < n; i++) {
     type::Value in_list =
         array_decimal.InList(type::ValueFactory::GetDecimalValue(vec_decimal[i]));
@@ -250,6 +261,7 @@ TEST_F(ArrayValueTests, InListTest) {
     }
   }
 
+/*
   std::vector<std::string> vec_varchar;
   for (size_t i = 0; i < n; i++) {
     vec_varchar.push_back(RANDOM_STRING(RANDOM(100) + 1));
@@ -269,8 +281,10 @@ TEST_F(ArrayValueTests, InListTest) {
       EXPECT_TRUE((in_list).IsFalse());
     }
   }
+  */
 }
 
+/*
 void CheckEqual(type::Value v1, type::Value v2) {
   CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
@@ -342,5 +356,6 @@ TEST_F(ArrayValueTests, CompareTest) {
   // Test null varchar
   EXPECT_TRUE(v.CompareEquals(type::ValueFactory::GetVarcharValue(nullptr, 0)) == CmpBool::NULL_);
 }
+*/
 }
 }

--- a/test/type/types_test.cpp
+++ b/test/type/types_test.cpp
@@ -104,13 +104,14 @@ TEST_F(TypesTests, BackendTypeTest) {
 
 TEST_F(TypesTests, TypeIdTest) {
   std::vector<type::TypeId> list = {
-      type::TypeId::INVALID,   type::TypeId::PARAMETER_OFFSET,
-      type::TypeId::BOOLEAN,   type::TypeId::TINYINT,
-      type::TypeId::SMALLINT,  type::TypeId::INTEGER,
-      type::TypeId::BIGINT,    type::TypeId::DECIMAL,
-      type::TypeId::TIMESTAMP, type::TypeId::DATE,
-      type::TypeId::VARCHAR,   type::TypeId::VARBINARY,
-      type::TypeId::ARRAY,     type::TypeId::UDT};
+      type::TypeId::INVALID,      type::TypeId::PARAMETER_OFFSET,
+      type::TypeId::BOOLEAN,      type::TypeId::TINYINT,
+      type::TypeId::SMALLINT,     type::TypeId::INTEGER,
+      type::TypeId::BIGINT,       type::TypeId::DECIMAL,
+      type::TypeId::TIMESTAMP,    type::TypeId::DATE,
+      type::TypeId::VARCHAR,      type::TypeId::VARBINARY,
+      type::TypeId::INTEGERARRAY, type::TypeId::DECIMALARRAY,
+      type::TypeId::UDT};
 
   // Make sure that ToString and FromString work
   for (auto val : list) {


### PR DESCRIPTION
This PR fully supports array type internally. For queries from clients, however, this is only for the traditional interpreter and additional work is needed for codegen. We can make the latter one a task for new students.
 
And for supporting optimizers for client queries. the following functions need to be overloaded:
```
virtual bool operator==(const AbstractExpression &rhs) const;
virtual bool operator!=(const AbstractExpression &rhs) const {
       return !(*this == rhs);
}
virtual hash_t Hash() const;

virtual bool ExactlyEquals(const AbstractExpression &other) const;
virtual hash_t HashForExactMatch() const;
```