### PR TITLE
[Fix] Fix faulty commit of #991 and reset clang-format version

### DIFF
--- a/script/validators/source_validator.py
+++ b/script/validators/source_validator.py
@@ -42,7 +42,7 @@ PELOTON_DIR = os.path.abspath(
     reduce(os.path.join, [CODE_SOURCE_DIR, os.path.pardir, os.path.pardir])
     )
 
-CLANG_FORMAT = "clang-format"
+CLANG_FORMAT = "clang-format-3.6"
 CLANG_FORMAT_FILE = os.path.join(PELOTON_DIR, ".clang-format")
 
 # Other directory paths used are relative to PELOTON_DIR

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -19,11 +19,11 @@
 #include "planner/seq_scan_plan.h"
 #include "planner/abstract_join_plan.h"
 #include "planner/hash_join_plan.h"
+#include "binder/bind_node_visitor.h"
 #include "traffic_cop/traffic_cop.h"
 #include "expression/tuple_value_expression.h"
 #include "optimizer/operators.h"
 #include "optimizer/rule_impls.h"
-#include "binder/bind_node_visitor.h"
 #include "traffic_cop/traffic_cop.h"
 
 namespace peloton {
@@ -35,7 +35,26 @@ namespace test {
 
 using namespace optimizer;
 
-class OptimizerTests : public PelotonTest {};
+class OptimizerTests : public PelotonTest {
+ protected:
+  GroupExpression *GetSingleGroupExpression(Memo &memo, GroupExpression *expr,
+                                            int child_group_idx) {
+    auto group = memo.GetGroupByID(expr->GetChildGroupId(child_group_idx));
+    EXPECT_EQ(1, group->logical_expressions_.size());
+    return group->logical_expressions_[0].get();
+  }
+
+  virtual void TearDown() override {
+    // Destroy test database
+    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+    auto txn = txn_manager.BeginTransaction();
+    catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+    txn_manager.CommitTransaction(txn);
+
+    // Call parent virtual function
+    PelotonTest::TearDown();
+  }
+};
 
 // Test whether update stament will use index scan plan
 // TODO: Split the tests into separate test cases.
@@ -212,9 +231,218 @@ TEST_F(OptimizerTests, HashJoinTest) {
   traffic_cop.CommitQueryHelper();
 
   LOG_INFO("After Join...");
-  // free the database just created
+}
+
+TEST_F(OptimizerTests, PredicatePushDownTest) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE test(a INT PRIMARY KEY, b INT, c INT);");
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE test1(a INT PRIMARY KEY, b INT, c INT);");
+
+  auto &peloton_parser = parser::PostgresParser::GetInstance();
+  auto stmt = peloton_parser.BuildParseTree(
+      "SELECT * FROM test, test1 WHERE test.a = test1.a AND test1.b = 22");
+
+  optimizer::Optimizer optimizer;
   txn = txn_manager.BeginTransaction();
-  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  auto plan = optimizer.BuildPelotonPlanTree(stmt, DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+
+  auto &child_plan = plan->GetChildren();
+  EXPECT_EQ(2, child_plan.size());
+
+  auto l_plan = dynamic_cast<planner::SeqScanPlan *>(child_plan[0].get());
+  auto r_plan = dynamic_cast<planner::SeqScanPlan *>(
+      child_plan[1]->GetChildren()[0].get());
+  planner::SeqScanPlan *test_plan = l_plan;
+  planner::SeqScanPlan *test1_plan = r_plan;
+
+  if (l_plan->GetTable()->GetName() == "test1") {
+    test_plan = r_plan;
+    test1_plan = l_plan;
+  }
+
+  auto test_predicate = test_plan->GetPredicate();
+  EXPECT_EQ(nullptr, test_predicate);
+  auto test1_predicate = test1_plan->GetPredicate();
+  EXPECT_EQ(ExpressionType::COMPARE_EQUAL,
+            test1_predicate->GetExpressionType());
+  auto tv = dynamic_cast<expression::TupleValueExpression *>(
+      test1_predicate->GetModifiableChild(0));
+  EXPECT_TRUE(tv != nullptr);
+  EXPECT_EQ("test1", tv->GetTableName());
+  EXPECT_EQ("b", tv->GetColumnName());
+  auto constant = dynamic_cast<expression::ConstantValueExpression *>(
+      test1_predicate->GetModifiableChild(1));
+  EXPECT_TRUE(constant != nullptr);
+  EXPECT_EQ(22, constant->GetValue().GetAs<int>());
+}
+
+TEST_F(OptimizerTests, PushFilterThroughJoinTest) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE test(a INT PRIMARY KEY, b INT, c INT);");
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE test1(a INT PRIMARY KEY, b INT, c INT);");
+
+  auto &peloton_parser = parser::PostgresParser::GetInstance();
+  auto stmt = peloton_parser.BuildParseTree(
+      "SELECT * FROM test, test1 WHERE test.a = test1.a AND test1.b = 22");
+  auto parse_tree = stmt->GetStatements().at(0).get();
+  auto predicates = std::vector<expression::AbstractExpression *>();
+  optimizer::util::SplitPredicates(reinterpret_cast<parser::SelectStatement *>(
+                                       parse_tree)->where_clause.get(),
+                                   predicates);
+
+  optimizer::Optimizer optimizer;
+  // Only include PushFilterThroughJoin rewrite rule
+  optimizer.metadata_.rule_set.rewrite_rules_map_.clear();
+  optimizer.metadata_.rule_set.AddRewriteRule(
+      RewriteRuleSetName::PREDICATE_PUSH_DOWN, new PushFilterThroughJoin());
+  txn = txn_manager.BeginTransaction();
+
+  auto bind_node_visitor =
+      std::make_shared<binder::BindNodeVisitor>(txn, DEFAULT_DB_NAME);
+  bind_node_visitor->BindNameToNode(parse_tree);
+
+  std::shared_ptr<GroupExpression> gexpr =
+      optimizer.InsertQueryTree(parse_tree, txn);
+  std::vector<GroupID> child_groups = {gexpr->GetGroupID()};
+
+  std::shared_ptr<GroupExpression> head_gexpr =
+      std::make_shared<GroupExpression>(Operator(), child_groups);
+
+  std::shared_ptr<OptimizeContext> root_context =
+      std::make_shared<OptimizeContext>(&(optimizer.metadata_), nullptr);
+  auto task_stack =
+      std::unique_ptr<OptimizerTaskStack>(new OptimizerTaskStack());
+  optimizer.metadata_.SetTaskPool(task_stack.get());
+  task_stack->Push(new TopDownRewrite(gexpr->GetGroupID(), root_context,
+                                      RewriteRuleSetName::PREDICATE_PUSH_DOWN));
+
+  while (!task_stack->Empty()) {
+    auto task = task_stack->Pop();
+    task->execute();
+  }
+
+  auto &memo = optimizer.metadata_.memo;
+
+  // Check join in the root
+  auto group_expr = GetSingleGroupExpression(memo, head_gexpr.get(), 0);
+  EXPECT_EQ(OpType::InnerJoin, group_expr->Op().type());
+  auto join_op = group_expr->Op().As<LogicalInnerJoin>();
+  EXPECT_EQ(1, join_op->join_predicates.size());
+  EXPECT_TRUE(join_op->join_predicates[0].expr->ExactlyEquals(*predicates[0]));
+
+  // Check left get
+  auto l_group_expr = GetSingleGroupExpression(memo, group_expr, 0);
+  EXPECT_EQ(OpType::Get, l_group_expr->Op().type());
+  auto get_op = l_group_expr->Op().As<LogicalGet>();
+  EXPECT_TRUE(get_op->predicates.empty());
+
+  // Check right filter
+  auto r_group_expr = GetSingleGroupExpression(memo, group_expr, 1);
+  EXPECT_EQ(OpType::LogicalFilter, r_group_expr->Op().type());
+  auto filter_op = r_group_expr->Op().As<LogicalFilter>();
+  EXPECT_EQ(1, filter_op->predicates.size());
+  EXPECT_TRUE(filter_op->predicates[0].expr->ExactlyEquals(*predicates[1]));
+
+  // Check get below filter
+  group_expr = GetSingleGroupExpression(memo, r_group_expr, 0);
+  EXPECT_EQ(OpType::Get, l_group_expr->Op().type());
+  get_op = group_expr->Op().As<LogicalGet>();
+  EXPECT_TRUE(get_op->predicates.empty());
+
+  txn_manager.CommitTransaction(txn);
+}
+
+TEST_F(OptimizerTests, PredicatePushDownRewriteTest) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE test(a INT PRIMARY KEY, b INT, c INT);");
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE test1(a INT PRIMARY KEY, b INT, c INT);");
+
+  auto &peloton_parser = parser::PostgresParser::GetInstance();
+  auto stmt = peloton_parser.BuildParseTree(
+      "SELECT * FROM test, test1 WHERE test.a = test1.a AND test1.b = 22");
+  auto parse_tree = stmt->GetStatements().at(0).get();
+  auto predicates = std::vector<expression::AbstractExpression *>();
+  optimizer::util::SplitPredicates(reinterpret_cast<parser::SelectStatement *>(
+                                       parse_tree)->where_clause.get(),
+                                   predicates);
+
+  optimizer::Optimizer optimizer;
+  // Only include PushFilterThroughJoin rewrite rule
+  optimizer.metadata_.rule_set.predicate_push_down_rules_.clear();
+  optimizer.metadata_.rule_set.predicate_push_down_rules_.emplace_back(
+      new PushFilterThroughJoin());
+  optimizer.metadata_.rule_set.predicate_push_down_rules_.emplace_back(
+      new CombineConsecutiveFilter());
+  optimizer.metadata_.rule_set.predicate_push_down_rules_.emplace_back(
+      new EmbedFilterIntoGet());
+
+  txn = txn_manager.BeginTransaction();
+
+  auto bind_node_visitor =
+      std::make_shared<binder::BindNodeVisitor>(txn, DEFAULT_DB_NAME);
+  bind_node_visitor->BindNameToNode(parse_tree);
+
+  std::shared_ptr<GroupExpression> gexpr =
+      optimizer.InsertQueryTree(parse_tree, txn);
+  std::vector<GroupID> child_groups = {gexpr->GetGroupID()};
+
+  std::shared_ptr<GroupExpression> head_gexpr =
+      std::make_shared<GroupExpression>(Operator(), child_groups);
+
+  std::shared_ptr<OptimizeContext> root_context =
+      std::make_shared<OptimizeContext>(&(optimizer.metadata_), nullptr);
+  auto task_stack =
+      std::unique_ptr<OptimizerTaskStack>(new OptimizerTaskStack());
+  optimizer.metadata_.SetTaskPool(task_stack.get());
+  task_stack->Push(new TopDownRewrite(gexpr->GetGroupID(), root_context,
+                                      RewriteRuleSetName::PREDICATE_PUSH_DOWN));
+
+  while (!task_stack->Empty()) {
+    auto task = task_stack->Pop();
+    task->execute();
+  }
+
+  auto &memo = optimizer.metadata_.memo;
+
+  // Check join in the root
+  auto group_expr = GetSingleGroupExpression(memo, head_gexpr.get(), 0);
+  EXPECT_EQ(OpType::InnerJoin, group_expr->Op().type());
+  auto join_op = group_expr->Op().As<LogicalInnerJoin>();
+  EXPECT_EQ(1, join_op->join_predicates.size());
+  EXPECT_TRUE(join_op->join_predicates[0].expr->ExactlyEquals(*predicates[0]));
+
+  // Check left get
+  auto l_group_expr = GetSingleGroupExpression(memo, group_expr, 0);
+  EXPECT_EQ(OpType::Get, l_group_expr->Op().type());
+  auto get_op = l_group_expr->Op().As<LogicalGet>();
+  EXPECT_TRUE(get_op->predicates.empty());
+
+  // Check right filter
+  auto r_group_expr = GetSingleGroupExpression(memo, group_expr, 1);
+  EXPECT_EQ(OpType::Get, r_group_expr->Op().type());
+  get_op = r_group_expr->Op().As<LogicalGet>();
+  EXPECT_EQ(1, get_op->predicates.size());
+  EXPECT_TRUE(get_op->predicates[0].expr->ExactlyEquals(*predicates[1]));
+
   txn_manager.CommitTransaction(txn);
 }
 


### PR DESCRIPTION
* **Fix faulty commit a613847** (https://github.com/cmu-db/peloton/pull/991#issuecomment-356908046)
  I am really sorry, thank you @pmenon for noticing that. 
* **Reset clang-format version in source validator to 3.6, to match the version in the formatter script**
  I just noticed that clang-format of different version produces different output, so source validator and formatter script *must* use the same version. Which version can be discussed in #1015. 