### PR TITLE
 [Cleanup] Add clang builds in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
                     - g++-4.8
           env:
             # NAME has no actual use, just to make the travis jobs overview more clear
-            - NAME="gcc4.8 Debug (Coveralls)"
+            - NAME="gcc4.8 Debug+Tests+Coveralls"
             - CXX=g++-4.8
             - CC=gcc-4.8
             - PELOTON_BUILD_TYPE=Debug
@@ -62,7 +62,7 @@ matrix:
                     - g++-4.8
           env:
             # NAME has no actual use, just to make the travis jobs overview more clear
-            - NAME="gcc4.8 Release"
+            - NAME="gcc4.8 Release+Tests"
             - CXX=g++-4.8
             - CC=gcc-4.8
             - PELOTON_BUILD_TYPE=Release
@@ -80,6 +80,45 @@ matrix:
             - bash ../script/testing/psql/psql_test.sh
             # run jdbc tests
             - python ../script/validators/jdbc_validator.py
+
+        # Linux builds for gcc 5
+                - os: linux
+                  sudo: required
+                  dist: trusty
+                  compiler: gcc
+                  addons:
+                      apt:
+                          sources:
+                              - llvm-toolchain-precise-3.7
+                              - ubuntu-toolchain-r-test
+                          packages:
+                            - g++-5
+                  env:
+                    # NAME has no actual use, just to make the travis jobs overview more clear
+                    - NAME="gcc5 Debug"
+                    - CXX=g++-5
+                    - CC=gcc-5
+                    - PELOTON_BUILD_TYPE=Debug
+                    - COVERALLS=Off
+
+                - os: linux
+                  sudo: required
+                  dist: trusty
+                  compiler: gcc
+                  addons:
+                      apt:
+                          sources:
+                              - llvm-toolchain-precise-3.7
+                              - ubuntu-toolchain-r-test
+                          packages:
+                            - g++-5
+                  env:
+                    # NAME has no actual use, just to make the travis jobs overview more clear
+                    - NAME="gcc5 Release"
+                    - CXX=g++-5
+                    - CC=gcc-5
+                    - PELOTON_BUILD_TYPE=Release
+                    - COVERALLS=Off
 
         # Linux builds for clang 3.7
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,45 +82,45 @@ matrix:
             - python ../script/validators/jdbc_validator.py
 
         # Linux builds for gcc 5
-                - os: linux
-                  sudo: required
-                  dist: trusty
-                  compiler: gcc
-                  addons:
-                      apt:
-                          sources:
-                              - llvm-toolchain-precise-3.7
-                              - ubuntu-toolchain-r-test
-                          packages:
-                            - g++-5
-                  env:
-                    # NAME has no actual use, just to make the travis jobs overview more clear
-                    - NAME="gcc5 Debug"
-                    - CXX=g++-5
-                    - CC=gcc-5
-                    - PELOTON_BUILD_TYPE=Debug
-                    - COVERALLS=Off
+        - os: linux
+          sudo: required
+          dist: trusty
+          compiler: gcc
+          addons:
+              apt:
+                  sources:
+                      - llvm-toolchain-precise-3.7
+                      - ubuntu-toolchain-r-test
+                  packages:
+                    - g++-5
+          env:
+            # NAME has no actual use, just to make the travis jobs overview more clear
+            - NAME="gcc5 Debug"
+            - CXX=g++-5
+            - CC=gcc-5
+            - PELOTON_BUILD_TYPE=Debug
+            - COVERALLS=Off
 
-                - os: linux
-                  sudo: required
-                  dist: trusty
-                  compiler: gcc
-                  addons:
-                      apt:
-                          sources:
-                              - llvm-toolchain-precise-3.7
-                              - ubuntu-toolchain-r-test
-                          packages:
-                            - g++-5
-                  env:
-                    # NAME has no actual use, just to make the travis jobs overview more clear
-                    - NAME="gcc5 Release"
-                    - CXX=g++-5
-                    - CC=gcc-5
-                    - PELOTON_BUILD_TYPE=Release
-                    - COVERALLS=Off
+        - os: linux
+          sudo: required
+          dist: trusty
+          compiler: gcc
+          addons:
+              apt:
+                  sources:
+                      - llvm-toolchain-precise-3.7
+                      - ubuntu-toolchain-r-test
+                  packages:
+                    - g++-5
+          env:
+            # NAME has no actual use, just to make the travis jobs overview more clear
+            - NAME="gcc5 Release"
+            - CXX=g++-5
+            - CC=gcc-5
+            - PELOTON_BUILD_TYPE=Release
+            - COVERALLS=Off
 
-        # Linux builds for clang 3.7
+        # Linux builds for clang 3.9
         - os: linux
           sudo: required
           dist: trusty
@@ -131,12 +131,12 @@ matrix:
                       - llvm-toolchain-precise-3.7
                       - ubuntu-toolchain-r-test
                   packages:
-                    - clang-3.7
+                    - clang-3.9
           env:
             # NAME has no actual use, just to make the travis jobs overview more clear
-            - NAME="clang3.7 Debug"
-            - CXX=clang-3.7
-            - CC=clang-3.7
+            - NAME="clang3.9 Debug"
+            - CXX=clang-3.9
+            - CC=clang-3.9
             - PELOTON_BUILD_TYPE=Debug
             - COVERALLS=Off
 
@@ -150,12 +150,12 @@ matrix:
                       - llvm-toolchain-precise-3.7
                       - ubuntu-toolchain-r-test
                   packages:
-                    - clang-3.7
+                    - clang-3.9
           env:
             # NAME has no actual use, just to make the travis jobs overview more clear
-            - NAME="clang3.7 Release"
-            - CXX=clang-3.7
-            - CC=clang-3.7
+            - NAME="clang3.9 Release"
+            - CXX=clang-3.9
+            - CC=clang-3.9
             - PELOTON_BUILD_TYPE=Release
             - COVERALLS=Off
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 #language: c++
 matrix:
+    fast_finish: true
+
     include:
         # Mac build
         - os: osx
           osx_image: xcode8.3
           compiler: clang
           env:
+            # NAME has no actual use, just to make the travis jobs overview more clear
+            - NAME="clang Debug"
             - PELOTON_BUILD_TYPE=Debug
             - COVERALLS=Off
 
-        # Linux builds
+        # Linux builds for gcc 4.8
         - os: linux
           sudo: required
           dist: trusty
@@ -20,44 +24,30 @@ matrix:
                       - llvm-toolchain-precise-3.7
                       - ubuntu-toolchain-r-test
                   packages:
-                    - g++-4.9
-          env: 
-            - CXX=g++-4.9
+                    - g++-4.8
+          env:
+            # NAME has no actual use, just to make the travis jobs overview more clear
+            - NAME="gcc4.8 Debug (Coveralls)"
+            - CXX=g++-4.8
+            - CC=gcc-4.8
             - PELOTON_BUILD_TYPE=Debug
-            - COVERALLS=Off
-
-        - os: linux
-          sudo: required
-          dist: trusty
-          compiler: gcc
-          addons:
-              apt:
-                  sources:
-                      - llvm-toolchain-precise-3.7
-                      - ubuntu-toolchain-r-test
-                  packages:
-                    - g++-4.9
-          env: 
-            - CXX=g++-4.9
-            - PELOTON_BUILD_TYPE=Release
-            - COVERALLS=Off
-        
-        #Job where coveralls is executed
-        - os: linux
-          sudo: required
-          dist: trusty
-          compiler: gcc
-          addons:
-              apt:
-                  sources:
-                      - llvm-toolchain-precise-3.7
-                      - ubuntu-toolchain-r-test
-                  packages:
-                    - g++-5
-          env: 
-            - CXX=g++-5
-            - PELOTON_BUILD_TYPE=Debug
+            # COVERALLS: we run coveralls only for one compiler
             - COVERALLS=On
+          # only run tests if the build itself succeeded
+          after_success:
+            # run tests
+            - if [[ $TRAVIS_OS_NAME != 'osx' ]]; then make check -j4; fi
+            - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then ASAN_OPTIONS=detect_container_overflow=0 make check -j4; fi
+            # build benchmarks
+            - make benchmark -j4
+            # install peloton
+            - make install
+            # run psql tests
+            - bash ../script/testing/psql/psql_test.sh
+            # run jdbc tests
+            - python ../script/validators/jdbc_validator.py
+            # upload coverage info
+            - make coveralls
 
         - os: linux
           sudo: required
@@ -69,20 +59,77 @@ matrix:
                       - llvm-toolchain-precise-3.7
                       - ubuntu-toolchain-r-test
                   packages:
-                    - g++-5
-          env: 
-            - CXX=g++-5
+                    - g++-4.8
+          env:
+            # NAME has no actual use, just to make the travis jobs overview more clear
+            - NAME="gcc4.8 Release"
+            - CXX=g++-4.8
+            - CC=gcc-4.8
+            - PELOTON_BUILD_TYPE=Release
+            - COVERALLS=Off
+          # only run tests if the build itself succeeded
+          after_success:
+            # run tests
+            - if [[ $TRAVIS_OS_NAME != 'osx' ]]; then make check -j4; fi
+            - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then ASAN_OPTIONS=detect_container_overflow=0 make check -j4; fi
+            # build benchmarks
+            - make benchmark -j4
+            # install peloton
+            - make install
+            # run psql tests
+            - bash ../script/testing/psql/psql_test.sh
+            # run jdbc tests
+            - python ../script/validators/jdbc_validator.py
+
+        # Linux builds for clang 3.7
+        - os: linux
+          sudo: required
+          dist: trusty
+          compiler: clang
+          addons:
+              apt:
+                  sources:
+                      - llvm-toolchain-precise-3.7
+                      - ubuntu-toolchain-r-test
+                  packages:
+                    - clang-3.7
+          env:
+            # NAME has no actual use, just to make the travis jobs overview more clear
+            - NAME="clang3.7 Debug"
+            - CXX=clang-3.7
+            - CC=clang-3.7
+            - PELOTON_BUILD_TYPE=Debug
+            - COVERALLS=Off
+
+        - os: linux
+          sudo: required
+          dist: trusty
+          compiler: clang
+          addons:
+              apt:
+                  sources:
+                      - llvm-toolchain-precise-3.7
+                      - ubuntu-toolchain-r-test
+                  packages:
+                    - clang-3.7
+          env:
+            # NAME has no actual use, just to make the travis jobs overview more clear
+            - NAME="clang3.7 Release"
+            - CXX=clang-3.7
+            - CC=clang-3.7
             - PELOTON_BUILD_TYPE=Release
             - COVERALLS=Off
 
-before_script:
+install:
     # setup environment
     - ./script/installation/packages.sh
     - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then pip install --user cpp-coveralls; fi
 
-script:
+before_script:
     # first, run source_validator
     - python ./script/validators/source_validator.py
+
+script:
     # create build directory
     - mkdir build
     - cd build
@@ -90,16 +137,3 @@ script:
     - PATH=/usr/lib/llvm-3.7/bin:/usr/bin:$PATH cmake -DCOVERALLS=$COVERALLS -DCMAKE_PREFIX_PATH=`llvm-config-3.7 --prefix` -DCMAKE_BUILD_TYPE=$PELOTON_BUILD_TYPE -DUSE_SANITIZER=Address ..
     # build
     - make -j4
-    # run tests
-    - if [[ $TRAVIS_OS_NAME != 'osx' ]]; then make check -j4; fi
-    - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then ASAN_OPTIONS=detect_container_overflow=0 make check -j4; fi
-    # build benchmarks
-    - make benchmark -j4
-    # install peloton
-    - make install
-    # run psql tests
-    - bash ../script/testing/psql/psql_test.sh
-    # run jdbc tests
-    - python ../script/validators/jdbc_validator.py
-    # upload coverage info
-    - bash -c "if [ $(echo $COVERALLS | tr "[:lower:]" "[:upper:]") = 'ON' ] ; then make coveralls; fi"

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -71,6 +71,10 @@ llvm_map_components_to_libnames(LLVM_LIBRARIES core mcjit nativecodegen native)
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 list(APPEND Peloton_LINKER_LIBS ${LLVM_LIBRARIES})
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS")
+endif()
+
 # --[ IWYU
 
 # Generate clang compilation database


### PR DESCRIPTION
This PR 
  * adds clang builds in travis and 
  * adapts the sources not to rise any warnings/errors in clang *(in progress)*

---

Following files have classes with unused private members. I thought adding `UNUSED_ATTRIBUTE` could temporary help to get rid of the clang warnings, but apparently gcc doesn't support this for class members. So we should take a look at all of these and remove them if possible. 
```
/src/include/codegen/operator/update_translator.h
/src/include/codegen/type/type_system.h
/src/include/common/exception.h
/src/include/concurrency/local_epoch.h
/src/include/executor/hash_join_executor.h
/src/include/index/bloom_filter.h
/src/include/logging/logical_checkpoint_manager.h
/src/include/logging/logical_log_manager.h
/src/include/network/postgres_protocol_handler.h
/src/include/optimizer/child_property_generator.h
/src/include/optimizer/cost_and_stats_calculator.h
/src/include/optimizer/property_enforcer.h
/src/include/optimizer/query_property_extractor.h
/src/include/optimizer/query_to_operator_transformer.h
/src/include/optimizer/stats.h
/src/include/optimizer/stats/hyperloglog.h
/src/include/optimizer/tuple_sample.h
/src/include/storage/tile_group_header.h
```

In addition the linker fails because of missing symbols in protobuf, I haven't yet figured out why. The linker doesn't get any paths for protobuf, but with gcc it works somehow. 
```
../lib/libpeloton-d.so.0.0.5: undefined reference to `google::protobuf::Message::InitializationErrorString() const'
../lib/libpeloton-d.so.0.0.5: undefined reference to `google::protobuf::Message::GetTypeName() const'
../lib/libpeloton-d.so.0.0.5: undefined reference to `google::protobuf::internal::empty_string_'
../lib/libpeloton-d.so.0.0.5: undefined reference to `__atomic_compare_exchange'
../lib/libpeloton-d.so.0.0.5: undefined reference to `__atomic_load'
../lib/libpeloton-d.so.0.0.5: undefined reference to `google::protobuf::internal::StringTypeHandlerBase::New()'
```

Cmake can be configured to use clang as follows:
```
cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-3.7 -DCMAKE_CXX_COMPILER=clang++-3.7 ..
```