### PR TITLE
Enable codegen for all functions

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -981,6 +981,26 @@ void Catalog::InitializeFunctions() {
        * decimal functions
        */
       AddBuiltinFunction(
+          "sqrt", {type::TypeId::TINYINT}, type::TypeId::DECIMAL, internal_lang,
+          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
+                                            function::DecimalFunctions::Sqrt},
+          txn);
+      AddBuiltinFunction(
+          "sqrt", {type::TypeId::SMALLINT}, type::TypeId::DECIMAL, internal_lang,
+          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
+                                            function::DecimalFunctions::Sqrt},
+          txn);
+      AddBuiltinFunction(
+          "sqrt", {type::TypeId::INTEGER}, type::TypeId::DECIMAL, internal_lang,
+          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
+                                            function::DecimalFunctions::Sqrt},
+          txn);
+      AddBuiltinFunction(
+          "sqrt", {type::TypeId::BIGINT}, type::TypeId::DECIMAL, internal_lang,
+          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
+                                            function::DecimalFunctions::Sqrt},
+          txn);
+      AddBuiltinFunction(
           "sqrt", {type::TypeId::DECIMAL}, type::TypeId::DECIMAL, internal_lang,
           "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
                                             function::DecimalFunctions::Sqrt},
@@ -1088,7 +1108,7 @@ void Catalog::InitializeFunctions() {
 
     } catch (CatalogException &e) {
       txn_manager.AbortTransaction(txn);
-      throw & e;
+      throw e;
     }
     txn_manager.CommitTransaction(txn);
     initialized = true;

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -147,6 +147,12 @@ llvm::Value *CodeGen::CallPrintf(const std::string &format,
   return CallFunc(printf_fn, printf_args);
 }
 
+llvm::Value *CodeGen::Sqrt(llvm::Value *val) {
+  llvm::Function *sqrt_func = llvm::Intrinsic::getDeclaration(
+      &GetModule(), llvm::Intrinsic::sqrt, val->getType());
+  return CallFunc(sqrt_func, {val});
+}
+
 llvm::Value *CodeGen::CallAddWithOverflow(llvm::Value *left, llvm::Value *right,
                                           llvm::Value *&overflow_bit) {
   PL_ASSERT(left->getType() == right->getType());

--- a/src/codegen/query_compiler.cpp
+++ b/src/codegen/query_compiler.cpp
@@ -121,7 +121,6 @@ bool QueryCompiler::IsExpressionSupported(
     const expression::AbstractExpression &expr) {
   switch (expr.GetExpressionType()) {
     case ExpressionType::STAR:
-    case ExpressionType::FUNCTION:
     case ExpressionType::VALUE_PARAMETER:
       return false;
     default:

--- a/src/codegen/type/bigint_type.cpp
+++ b/src/codegen/type/bigint_type.cpp
@@ -231,6 +231,28 @@ struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   }
 };
 
+// Sqrt
+struct Sqrt : public TypeSystem::UnaryOperatorHandleNull {
+  CastBigInt cast;
+
+  bool SupportsType(const Type &type) const override {
+    return type.GetSqlType() == BigInt::Instance();
+  }
+
+  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+    return Decimal::Instance();
+  }
+
+ protected:
+  Value Impl(CodeGen &codegen, const Value &val,
+             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
+  const override {
+    auto casted = cast.Impl(codegen, val, Decimal::Instance());
+    auto *raw_ret = codegen.Sqrt(casted.GetValue());
+    return Value{Decimal::Instance(), raw_ret};
+  }
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// Binary operations
@@ -475,10 +497,12 @@ std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {{kCompareBigInt}};
 Negate kNegOp;
 Ceil kCeilOp;
 Floor kFloorOp;
+Sqrt kSqrt;
 std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
     {OperatorId::Negation, kNegOp},
     {OperatorId::Ceil, kCeilOp},
-    {OperatorId::Floor, kFloorOp}};
+    {OperatorId::Floor, kFloorOp},
+    {OperatorId::Sqrt, kSqrt}};
 
 // Binary operations
 Add kAddOp;

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -239,6 +239,25 @@ struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   }
 };
 
+// Sqrt
+struct Sqrt : public TypeSystem::UnaryOperatorHandleNull {
+  bool SupportsType(const Type &type) const override {
+    return type.GetSqlType() == Decimal::Instance();
+  }
+
+  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+    return Decimal::Instance();
+  }
+
+ protected:
+  Value Impl(CodeGen &codegen, const Value &val,
+             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
+      const override {
+    auto *raw_ret = codegen.Sqrt(val.GetValue());
+    return Value{Decimal::Instance(), raw_ret};
+  }
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// Binary operations
@@ -460,11 +479,13 @@ Negate kNegOp;
 Floor kFloorOp;
 Round kRound;
 Ceil kCeilOp;
+Sqrt kSqrt;
 std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
     {OperatorId::Negation, kNegOp},
     {OperatorId::Floor, kFloorOp},
     {OperatorId::Round, kRound},
-    {OperatorId::Ceil, kCeilOp}};
+    {OperatorId::Ceil, kCeilOp},
+    {OperatorId::Sqrt, kSqrt}};
 
 // Binary operations
 Add kAddOp;

--- a/src/codegen/type/integer_type.cpp
+++ b/src/codegen/type/integer_type.cpp
@@ -228,6 +228,28 @@ struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   }
 };
 
+// Sqrt
+struct Sqrt : public TypeSystem::UnaryOperatorHandleNull {
+  CastInteger cast;
+
+  bool SupportsType(const Type &type) const override {
+    return type.GetSqlType() == Integer::Instance();
+  }
+
+  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+    return Decimal::Instance();
+  }
+
+ protected:
+  Value Impl(CodeGen &codegen, const Value &val,
+             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
+  const override {
+    auto casted = cast.Impl(codegen, val, Decimal::Instance());
+    auto *raw_ret = codegen.Sqrt(casted.GetValue());
+    return Value{Decimal::Instance(), raw_ret};
+  }
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// Binary operations
@@ -475,10 +497,12 @@ std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {
 Negate kNegOp;
 Ceil kCeilOp;
 Floor kFloorOp;
+Sqrt kSqrt;
 std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
     {OperatorId::Negation, kNegOp},
     {OperatorId::Ceil, kCeilOp},
-    {OperatorId::Floor, kFloorOp}};
+    {OperatorId::Floor, kFloorOp},
+    {OperatorId::Sqrt, kSqrt}};
 
 // Binary operations
 Add kAddOp;

--- a/src/codegen/type/smallint_type.cpp
+++ b/src/codegen/type/smallint_type.cpp
@@ -235,6 +235,28 @@ struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   }
 };
 
+// Sqrt
+struct Sqrt : public TypeSystem::UnaryOperatorHandleNull {
+  CastSmallInt cast;
+
+  bool SupportsType(const Type &type) const override {
+    return type.GetSqlType() == SmallInt::Instance();
+  }
+
+  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+    return Decimal::Instance();
+  }
+
+ protected:
+  Value Impl(CodeGen &codegen, const Value &val,
+             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
+      const override {
+    auto casted = cast.Impl(codegen, val, Decimal::Instance());
+    auto *raw_ret = codegen.Sqrt(casted.GetValue());
+    return Value{Decimal::Instance(), raw_ret};
+  }
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// Binary operations
@@ -483,10 +505,12 @@ std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {{kCompareSmallInt}};
 Negate kNegOp;
 Ceil kCeilOp;
 Floor kFloorOp;
+Sqrt kSqrtOp;
 std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
     {OperatorId::Negation, kNegOp},
     {OperatorId::Ceil, kCeilOp},
-    {OperatorId::Floor, kFloorOp}};
+    {OperatorId::Floor, kFloorOp},
+    {OperatorId::Sqrt, kSqrtOp}};
 
 // Binary operations
 Add kAddOp;

--- a/src/codegen/type/tinyint_type.cpp
+++ b/src/codegen/type/tinyint_type.cpp
@@ -232,6 +232,28 @@ struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   }
 };
 
+// Sqrt
+struct Sqrt : public TypeSystem::UnaryOperatorHandleNull {
+  CastTinyInt cast;
+
+  bool SupportsType(const Type &type) const override {
+    return type.GetSqlType() == TinyInt::Instance();
+  }
+
+  Type ResultType(UNUSED_ATTRIBUTE const Type &val_type) const override {
+    return Decimal::Instance();
+  }
+
+ protected:
+  Value Impl(CodeGen &codegen, const Value &val,
+             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
+  const override {
+    auto casted = cast.Impl(codegen, val, Decimal::Instance());
+    auto *raw_ret = codegen.Sqrt(casted.GetValue());
+    return Value{Decimal::Instance(), raw_ret};
+  }
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// Binary operations
@@ -479,10 +501,12 @@ std::vector<TypeSystem::ComparisonInfo> kComparisonTable = {{kCompareTinyInt}};
 Negate kNegOp;
 Ceil kCeilOp;
 Floor kFloorOp;
+Sqrt kSqrtOp;
 std::vector<TypeSystem::UnaryOpInfo> kUnaryOperatorTable = {
     {OperatorId::Negation, kNegOp},
     {OperatorId::Ceil, kCeilOp},
-    {OperatorId::Floor, kFloorOp}};
+    {OperatorId::Floor, kFloorOp},
+    {OperatorId::Sqrt, kSqrtOp}};
 
 // Binary operations
 Add kAddOp;

--- a/src/include/codegen/codegen.h
+++ b/src/include/codegen/codegen.h
@@ -101,6 +101,7 @@ class CodeGen {
   //===--------------------------------------------------------------------===//
   llvm::Value *CallPrintf(const std::string &format,
                           const std::vector<llvm::Value *> &args);
+  llvm::Value *Sqrt(llvm::Value *val);
 
   //===--------------------------------------------------------------------===//
   // Arithmetic with overflow logic - These methods perform the desired math op,

--- a/test/function/functions_test.cpp
+++ b/test/function/functions_test.cpp
@@ -96,29 +96,20 @@ TEST_F(FunctionsTests, FuncCallTest) {
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
 
-  TestingSQLUtil::ExecuteSQLQuery("CREATE TABLE test(a DECIMAL, s VARCHAR);");
-  TestingSQLUtil::ExecuteSQLQuery("INSERT INTO test VALUES (4.0, 'abc');");
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE test(a TINYINT, b SMALLINT, c INTEGER, d BIGINT, e "
+      "DECIMAL, s VARCHAR);");
+  TestingSQLUtil::ExecuteSQLQuery(
+      "INSERT INTO test VALUES (1.0, 4.0, 9.0, 16.0, 25.0, ' abc ');");
 
-  std::vector<ResultValue> result;
-  std::vector<FieldInfo> tuple_descriptor;
-  std::string error_message;
-  int rows_affected;
+  std::vector<std::string> result = {"1|2|3|4|5"};
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
+      "SELECT SQRT(a), SQRT(b), SQRT(c), SQRT(d), SQRT(e) FROM test;", result,
+      false);
 
-  TestingSQLUtil::ExecuteSQLQuery("SELECT SQRT(a), SUBSTR(s,1,2) FROM test;",
-                                  result, tuple_descriptor, rows_affected,
-                                  error_message);
-  EXPECT_EQ(1, result[0].size());
-  EXPECT_EQ('2', result[0][0]);
-  EXPECT_EQ(2, result[1].size());
-  EXPECT_EQ(result[1][0], 'a');
-  EXPECT_EQ(result[1][1], 'b');
-
-  TestingSQLUtil::ExecuteSQLQuery("SELECT ASCII(s) FROM test;", result,
-                                  tuple_descriptor, rows_affected,
-                                  error_message);
-  EXPECT_EQ(2, result[0].size());
-  EXPECT_EQ('9', result[0][0]);
-  EXPECT_EQ('7', result[0][1]);
+  result = {"32"};
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult("SELECT ASCII(s) FROM test;",
+                                                result, false);
 
   // free the database just created
   txn = txn_manager.BeginTransaction();
@@ -135,19 +126,13 @@ TEST_F(FunctionsTests, SubstrFuncCallTest) {
   TestingSQLUtil::ExecuteSQLQuery("CREATE TABLE test(a DECIMAL, s VARCHAR);");
   TestingSQLUtil::ExecuteSQLQuery("INSERT INTO test VALUES (4.0, '1234567');");
 
-  std::vector<ResultValue> result;
-  std::vector<FieldInfo> tuple_descriptor;
-  std::string error_message;
-  int rows_affected;
+  std::vector<std::string> result = {"12345"};
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
+      "SELECT SUBSTR(s,1,5) FROM test;", result, false);
 
-  TestingSQLUtil::ExecuteSQLQuery("SELECT SUBSTR(s,1,5) FROM test;", result,
-                                  tuple_descriptor, rows_affected,
-                                  error_message);
-  EXPECT_EQ(1, result.size());
-  EXPECT_EQ("12345", std::string(result[0].begin(), result[0].begin() + 5));
-  TestingSQLUtil::ExecuteSQLQuery("SELECT SUBSTR(s,7,1) FROM test;", result,
-                                  tuple_descriptor, rows_affected,
-                                  error_message);
+  result = {"7"};
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
+      "SELECT SUBSTR(s,7,1) FROM test;", result, false);
   EXPECT_EQ(1, result.size());
   EXPECT_EQ("7", std::string(result[0].begin(), result[0].begin() + 1));
 


### PR DESCRIPTION
This PR enables codegen for all functions. Some functions are not supported, but will be implemented incrementally. This PR implements only `sqrt()`, the only extra function needed to pass the tests.