### PR TITLE
Fix segfault for query on nonexistent tables

### DIFF
--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -175,6 +175,9 @@ void BindNodeVisitor::Visit(parser::CreateStatement *node) {
 }
 void BindNodeVisitor::Visit(parser::InsertStatement *node) {
   node->TryBindDatabaseName(default_database_name_);
+  context_ = std::make_shared<BinderContext>(nullptr);
+  context_->AddRegularTable(node->GetDatabaseName(), node->GetTableName(),
+                            node->GetTableName(), txn_);
   if (node->select != nullptr) {
     node->select->Accept(this);
   }

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -129,8 +129,6 @@ class Exception : public std::runtime_error {
     }
   }
 
-  ExceptionType GetType() { return type; }
-
   // Based on :: http://panthema.net/2008/0901-stacktrace-demangled/
   static void PrintStackTrace(FILE *out = ::stderr,
                               unsigned int max_frames = 63) {

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -56,7 +56,7 @@ enum class ExceptionType {
   CONNECTION = 21,        // connection related
   SYNTAX = 22,            // syntax related
   SETTINGS = 23,          // settings related
-  BINDER = 24,             // settings related
+  BINDER = 24,            // settings related
   NETWORK = 25
 };
 
@@ -70,8 +70,8 @@ class Exception : public std::runtime_error {
   Exception(ExceptionType exception_type, std::string message)
       : std::runtime_error(message), type(exception_type) {
     exception_message_ = "Exception Type :: " +
-                                    ExceptionTypeToString(exception_type) +
-                                    "\nMessage :: " + message;
+                         ExceptionTypeToString(exception_type) +
+                         "\nMessage :: " + message;
   }
 
   std::string ExceptionTypeToString(ExceptionType type) {
@@ -200,7 +200,7 @@ class Exception : public std::runtime_error {
     }
   }
 
-  friend std::ostream& operator<<(std::ostream& os, const Exception& e);
+  friend std::ostream &operator<<(std::ostream &os, const Exception &e);
 
  private:
   // type
@@ -433,8 +433,9 @@ class ConnectionException : public Exception {
 class NetworkProcessException : public Exception {
   NetworkProcessException() = delete;
 
-  public:
-  NetworkProcessException(std::string msg) : Exception(ExceptionType::NETWORK, msg) {}
+ public:
+  NetworkProcessException(std::string msg)
+      : Exception(ExceptionType::NETWORK, msg) {}
 };
 
 class SettingsException : public Exception {

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -129,6 +129,8 @@ class Exception : public std::runtime_error {
     }
   }
 
+  ExceptionType GetType() { return type; }
+
   // Based on :: http://panthema.net/2008/0901-stacktrace-demangled/
   static void PrintStackTrace(FILE *out = ::stderr,
                               unsigned int max_frames = 63) {

--- a/src/optimizer/query_to_operator_transformer.cpp
+++ b/src/optimizer/query_to_operator_transformer.cpp
@@ -26,7 +26,6 @@
 #include "parser/statements.h"
 
 #include "catalog/manager.h"
-#include "common/exception.h"
 
 using std::vector;
 using std::shared_ptr;

--- a/src/optimizer/query_to_operator_transformer.cpp
+++ b/src/optimizer/query_to_operator_transformer.cpp
@@ -26,6 +26,7 @@
 #include "parser/statements.h"
 
 #include "catalog/manager.h"
+#include "common/exception.h"
 
 using std::vector;
 using std::shared_ptr;
@@ -231,6 +232,10 @@ void QueryToOperatorTransformer::Visit(parser::InsertStatement *op) {
       catalog::Catalog::GetInstance()
           ->GetDatabaseObject(op->GetDatabaseName(), txn_)
           ->GetTableObject(op->GetTableName());
+  
+  if (target_table == nullptr)
+      throw CatalogException("Table " + op->GetTableName() + " is not found");
+
   if (op->type == InsertType::SELECT) {
     auto insert_expr = std::make_shared<OperatorExpression>(
         LogicalInsertSelect::make(target_table));

--- a/src/optimizer/query_to_operator_transformer.cpp
+++ b/src/optimizer/query_to_operator_transformer.cpp
@@ -232,9 +232,6 @@ void QueryToOperatorTransformer::Visit(parser::InsertStatement *op) {
       catalog::Catalog::GetInstance()
           ->GetDatabaseObject(op->GetDatabaseName(), txn_)
           ->GetTableObject(op->GetTableName());
-  
-  if (target_table == nullptr)
-      throw CatalogException("Table " + op->GetTableName() + " is not found");
 
   if (op->type == InsertType::SELECT) {
     auto insert_expr = std::make_shared<OperatorExpression>(

--- a/test/sql/insert_sql_test.cpp
+++ b/test/sql/insert_sql_test.cpp
@@ -63,10 +63,12 @@ void CreateAndLoadTable4() {
       "i CHAR, j VARCHAR, k VARBINARY, l BOOLEAN);");
 
   // Insert tuples into table
-  TestingSQLUtil::ExecuteSQLQuery("INSERT INTO test4 VALUES "
+  TestingSQLUtil::ExecuteSQLQuery(
+      "INSERT INTO test4 VALUES "
       "(1, 2, 3, 4, 5.1, 6.1, '2017-10-10 00:00:00-00', "
       "'A', 'a', '1', 'true');");
-  TestingSQLUtil::ExecuteSQLQuery("INSERT INTO test4 VALUES "
+  TestingSQLUtil::ExecuteSQLQuery(
+      "INSERT INTO test4 VALUES "
       "(11, 12, 13, 14, 15.1, 16.1, '2017-10-11 00:00:00-00', "
       "'B', 'b', '2', 'false');");
 }
@@ -81,8 +83,7 @@ void CreateAndLoadTable5() {
 
 void CreateAndLoadTable6() {
   // Create a table first
-  TestingSQLUtil::ExecuteSQLQuery(
-      "CREATE TABLE test6(a INT, b INT, c INT);");
+  TestingSQLUtil::ExecuteSQLQuery("CREATE TABLE test6(a INT, b INT, c INT);");
 
   // Insert tuples into table
   TestingSQLUtil::ExecuteSQLQuery("INSERT INTO test6 VALUES (1, 22, 333);");
@@ -93,8 +94,7 @@ void CreateAndLoadTable6() {
 
 void CreateAndLoadTable7() {
   // Create a table first
-  TestingSQLUtil::ExecuteSQLQuery(
-      "CREATE TABLE test7(a INT, b INT, c INT);");
+  TestingSQLUtil::ExecuteSQLQuery("CREATE TABLE test7(a INT, b INT, c INT);");
 
   // Insert tuples into table
   TestingSQLUtil::ExecuteSQLQuery("INSERT INTO test7 VALUES (99, 5, 888);");
@@ -102,7 +102,6 @@ void CreateAndLoadTable7() {
   TestingSQLUtil::ExecuteSQLQuery("INSERT INTO test7 VALUES (77, 7, 666);");
   TestingSQLUtil::ExecuteSQLQuery("INSERT INTO test7 VALUES (55, 8, 999);");
 }
-
 
 TEST_F(InsertSQLTests, InsertOneValue) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
@@ -258,12 +257,12 @@ TEST_F(InsertSQLTests, InsertTooLargeVarchar) {
       new optimizer::Optimizer());
 
   std::string query("INSERT INTO test3 VALUES(1, 'abcd', 'abcdefghij');");
-  //std::string query("INSERT INTO test3 VALUES(1, 'abcd', 'abcdefghijk');");
+  // std::string query("INSERT INTO test3 VALUES(1, 'abcd', 'abcdefghijk');");
 
   txn = txn_manager.BeginTransaction();
-  // This should be re-enabled when the check is properly done in catalog 
+  // This should be re-enabled when the check is properly done in catalog
   // It used to be done at the insert query level
-  //EXPECT_THROW(TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query,
+  // EXPECT_THROW(TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query,
   //             txn, peloton::Exception);
   auto plan = TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query, txn);
   EXPECT_EQ(plan->GetPlanNodeType(), PlanNodeType::INSERT);
@@ -402,7 +401,7 @@ TEST_F(InsertSQLTests, InsertIntoSelectSimpleAllType) {
   EXPECT_EQ("5.1", TestingSQLUtil::GetResultValueAsString(result, 4));
   EXPECT_EQ("6.1", TestingSQLUtil::GetResultValueAsString(result, 5));
   EXPECT_EQ("2017-10-10 00:00:00.000000+00",
-             TestingSQLUtil::GetResultValueAsString(result, 6));
+            TestingSQLUtil::GetResultValueAsString(result, 6));
   EXPECT_EQ("A", TestingSQLUtil::GetResultValueAsString(result, 7));
   EXPECT_EQ("a", TestingSQLUtil::GetResultValueAsString(result, 8));
   EXPECT_EQ('1', TestingSQLUtil::GetResultValueAsString(result, 9).at(0));
@@ -419,7 +418,7 @@ TEST_F(InsertSQLTests, InsertIntoSelectSimpleAllType) {
   EXPECT_EQ("5.1", TestingSQLUtil::GetResultValueAsString(result, 4));
   EXPECT_EQ("6.1", TestingSQLUtil::GetResultValueAsString(result, 5));
   EXPECT_EQ("2017-10-10 00:00:00.000000+00",
-             TestingSQLUtil::GetResultValueAsString(result, 6));
+            TestingSQLUtil::GetResultValueAsString(result, 6));
   EXPECT_EQ("A", TestingSQLUtil::GetResultValueAsString(result, 7));
   EXPECT_EQ("a", TestingSQLUtil::GetResultValueAsString(result, 8));
   EXPECT_EQ('1', TestingSQLUtil::GetResultValueAsString(result, 9).at(0));
@@ -436,7 +435,7 @@ TEST_F(InsertSQLTests, InsertIntoSelectSimpleAllType) {
   EXPECT_EQ("15.1", TestingSQLUtil::GetResultValueAsString(result, 4));
   EXPECT_EQ("16.1", TestingSQLUtil::GetResultValueAsString(result, 5));
   EXPECT_EQ("2017-10-11 00:00:00.000000+00",
-             TestingSQLUtil::GetResultValueAsString(result, 6));
+            TestingSQLUtil::GetResultValueAsString(result, 6));
   EXPECT_EQ("B", TestingSQLUtil::GetResultValueAsString(result, 7));
   EXPECT_EQ("b", TestingSQLUtil::GetResultValueAsString(result, 8));
   EXPECT_EQ('2', TestingSQLUtil::GetResultValueAsString(result, 9).at(0));
@@ -529,8 +528,9 @@ TEST_F(InsertSQLTests, UniqueColumn) {
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
 
-  std::string create_table("CREATE TABLE t (id INTEGER NOT NULL PRIMARY KEY,"
-                                        "st VARCHAR(15) NOT NULL UNIQUE);");
+  std::string create_table(
+      "CREATE TABLE t (id INTEGER NOT NULL PRIMARY KEY,"
+      "st VARCHAR(15) NOT NULL UNIQUE);");
   TestingSQLUtil::ExecuteSQLQuery(create_table);
 
   ResultType result;
@@ -542,8 +542,7 @@ TEST_F(InsertSQLTests, UniqueColumn) {
   result = TestingSQLUtil::ExecuteSQLQuery(ins_query_1);
   EXPECT_EQ(result, ResultType::SUCCESS);
   ref_result.push_back("abc");
-  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query,
-                                                ref_result,
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query, ref_result,
                                                 false);
 
   // Second row, distinct from first, should succeed
@@ -551,8 +550,7 @@ TEST_F(InsertSQLTests, UniqueColumn) {
   result = TestingSQLUtil::ExecuteSQLQuery(ins_query_2);
   EXPECT_EQ(result, ResultType::SUCCESS);
   ref_result.push_back("def");
-  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query,
-                                                ref_result,
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query, ref_result,
                                                 false);
 
   // Third row, non-unique value for string, should fail
@@ -560,8 +558,7 @@ TEST_F(InsertSQLTests, UniqueColumn) {
   result = TestingSQLUtil::ExecuteSQLQuery(ins_query_3);
   EXPECT_EQ(result, ResultType::ABORTED);
   // and the results returned should not include failed insert
-  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query,
-                                                ref_result,
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query, ref_result,
                                                 false);
 
   // free the database just created
@@ -570,33 +567,33 @@ TEST_F(InsertSQLTests, UniqueColumn) {
   txn_manager.CommitTransaction(txn);
 }
 
-TEST_F(InsertSQLTests, NonExistentTable){
-    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-    auto txn = txn_manager.BeginTransaction();
-    catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-    txn_manager.CommitTransaction(txn);
-    std::string error_message;
-    int rows_changed;
-    std::unique_ptr<optimizer::AbstractOptimizer> optimizer(
-        new optimizer::Optimizer());
+TEST_F(InsertSQLTests, NonExistentTable) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+  std::string error_message;
+  int rows_changed;
+  std::unique_ptr<optimizer::AbstractOptimizer> optimizer(
+      new optimizer::Optimizer());
 
-    rows_changed = 0;
-    EXPECT_THROW({
-        try {
-        // Insert an int into a non-existent table.
-        std::string query("INSERT INTO NotExistTestTable VALUES(3);");
-        txn = txn_manager.BeginTransaction();
-        auto plan = TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query, txn);
-        EXPECT_EQ(plan->GetPlanNodeType(), PlanNodeType::INSERT);
-        txn_manager.CommitTransaction(txn);
-        } catch (peloton::Exception &ex) {
-        EXPECT_EQ(ExceptionType::CATALOG, ex.GetType());
-        EXPECT_STREQ("Table NotExistTestTable is not found",
-                    ex.what());
-        throw peloton::CatalogException(ex.what());
-        }
-    }, peloton::CatalogException);
-    EXPECT_EQ(0, rows_changed);
+  rows_changed = 0;
+  EXPECT_THROW({
+    try {
+      // Insert an int into a non-existent table.
+      std::string query("INSERT INTO NotExistTestTable VALUES(3);");
+      txn = txn_manager.BeginTransaction();
+      auto plan =
+          TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query, txn);
+      EXPECT_EQ(plan->GetPlanNodeType(), PlanNodeType::INSERT);
+      txn_manager.CommitTransaction(txn);
+    } catch (peloton::Exception &ex) {
+      EXPECT_EQ(ExceptionType::CATALOG, ex.GetType());
+      EXPECT_STREQ("Table NotExistTestTable is not found", ex.what());
+      throw peloton::CatalogException(ex.what());
+    }
+  }, peloton::CatalogException);
+  EXPECT_EQ(0, rows_changed);
 }
 
 }  // namespace test

--- a/test/sql/insert_sql_test.cpp
+++ b/test/sql/insert_sql_test.cpp
@@ -576,15 +576,13 @@ TEST_F(InsertSQLTests, NonExistentTable) {
   int rows_changed;
   std::unique_ptr<optimizer::AbstractOptimizer> optimizer(
       new optimizer::Optimizer());
-
+  // Insert an int into a non-existent table.
+  std::string query("INSERT INTO NonExistentTable VALUES(3);");
+  txn = txn_manager.BeginTransaction();
   rows_changed = 0;
   EXPECT_THROW({
     try {
-      // Insert an int into a non-existent table.
-      std::string query("INSERT INTO NonExistentTable VALUES(3);");
-      txn = txn_manager.BeginTransaction();
-      auto plan =
-          TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query, txn);
+      TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query, txn);
     } catch (peloton::Exception &ex) {
       EXPECT_EQ(ExceptionType::CATALOG, ex.GetType());
       EXPECT_STREQ("Table nonexistenttable is not found", ex.what());

--- a/test/sql/insert_sql_test.cpp
+++ b/test/sql/insert_sql_test.cpp
@@ -585,8 +585,6 @@ TEST_F(InsertSQLTests, NonExistentTable) {
       txn = txn_manager.BeginTransaction();
       auto plan =
           TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query, txn);
-      EXPECT_EQ(plan->GetPlanNodeType(), PlanNodeType::INSERT);
-      txn_manager.CommitTransaction(txn);
     } catch (peloton::Exception &ex) {
       EXPECT_EQ(ExceptionType::CATALOG, ex.GetType());
       EXPECT_STREQ("Table NotExistTestTable is not found", ex.what());

--- a/test/sql/insert_sql_test.cpp
+++ b/test/sql/insert_sql_test.cpp
@@ -578,14 +578,8 @@ TEST_F(InsertSQLTests, NonExistentTable) {
   // Insert an int into a non-existent table.
   std::string query("INSERT INTO NonExistentTable VALUES(3);");
   txn = txn_manager.BeginTransaction();
-  EXPECT_THROW({
-    try {
-      TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query, txn);
-    } catch (peloton::CatalogException &ex) {
-      EXPECT_STREQ("Table nonexistenttable is not found", ex.what());
-      throw peloton::CatalogException(ex.what());
-    }
-  }, peloton::CatalogException);
+  EXPECT_THROW(TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query, txn),
+               peloton::CatalogException);
 }
 
 }  // namespace test

--- a/test/sql/insert_sql_test.cpp
+++ b/test/sql/insert_sql_test.cpp
@@ -573,23 +573,19 @@ TEST_F(InsertSQLTests, NonExistentTable) {
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
   std::string error_message;
-  int rows_changed;
   std::unique_ptr<optimizer::AbstractOptimizer> optimizer(
       new optimizer::Optimizer());
   // Insert an int into a non-existent table.
   std::string query("INSERT INTO NonExistentTable VALUES(3);");
   txn = txn_manager.BeginTransaction();
-  rows_changed = 0;
   EXPECT_THROW({
     try {
       TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query, txn);
-    } catch (peloton::Exception &ex) {
-      EXPECT_EQ(ExceptionType::CATALOG, ex.GetType());
+    } catch (peloton::CatalogException &ex) {
       EXPECT_STREQ("Table nonexistenttable is not found", ex.what());
       throw peloton::CatalogException(ex.what());
     }
   }, peloton::CatalogException);
-  EXPECT_EQ(0, rows_changed);
 }
 
 }  // namespace test

--- a/test/sql/insert_sql_test.cpp
+++ b/test/sql/insert_sql_test.cpp
@@ -581,13 +581,13 @@ TEST_F(InsertSQLTests, NonExistentTable) {
   EXPECT_THROW({
     try {
       // Insert an int into a non-existent table.
-      std::string query("INSERT INTO NotExistTestTable VALUES(3);");
+      std::string query("INSERT INTO NonExistentTable VALUES(3);");
       txn = txn_manager.BeginTransaction();
       auto plan =
           TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query, txn);
     } catch (peloton::Exception &ex) {
       EXPECT_EQ(ExceptionType::CATALOG, ex.GetType());
-      EXPECT_STREQ("Table NotExistTestTable is not found", ex.what());
+      EXPECT_STREQ("Table nonexistenttable is not found", ex.what());
       throw peloton::CatalogException(ex.what());
     }
   }, peloton::CatalogException);


### PR DESCRIPTION
Fixes #1055. I had to dig deep into `lldb` for this! I hope I've added the `throw` at the appropriate place. Using throw here also prevents the segfault from happening on, say `update` queries operating on a table that hasn't been created yet.