### PR TITLE
Move old string functions

### DIFF
--- a/src/codegen/expression/comparison_translator.cpp
+++ b/src/codegen/expression/comparison_translator.cpp
@@ -6,7 +6,7 @@
 //
 // Identification: src/codegen/expression/comparison_translator.cpp
 //
-// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -48,8 +48,16 @@ codegen::Value ComparisonTranslator::DeriveValue(CodeGen &codegen,
     case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
       return left.CompareGte(codegen, right);
     case ExpressionType::COMPARE_LIKE: {
-      return left.CallBinaryOp(codegen, OperatorId::Like, right,
-                               OnError::Exception);
+      type::TypeSystem::InvocationContext ctx{
+          .on_error = OnError::Exception,
+          .executor_context = context_.GetExecutorContextPtr()};
+
+      type::Type left_type = left.GetType(), right_type = right.GetType();
+      auto *binary_op = type::TypeSystem::GetBinaryOperator(
+          OperatorId::Like, left_type, left_type, right_type, right_type);
+      PL_ASSERT(binary_op);
+      return binary_op->Eval(codegen, left.CastTo(codegen, left_type),
+                             right.CastTo(codegen, right_type), ctx);
     }
     default: {
       throw Exception{"Invalid expression type for translation " +

--- a/src/codegen/proxy/string_functions_proxy.cpp
+++ b/src/codegen/proxy/string_functions_proxy.cpp
@@ -12,13 +12,12 @@
 
 #include "codegen/proxy/string_functions_proxy.h"
 
-#include "codegen/proxy/type_builder.h"
-#include "function/string_functions.h"
+#include "codegen/proxy/executor_context_proxy.h"
 
 namespace peloton {
 namespace codegen {
 
-// StrWithLen Struct (Used by Substr function)
+// StrWithLen struct
 DEFINE_TYPE(StrWithLen, "peloton::StrWithLen", MEMBER(str), MEMBER(length));
 
 // String Function
@@ -26,6 +25,7 @@ DEFINE_METHOD(peloton::function, StringFunctions, Ascii);
 DEFINE_METHOD(peloton::function, StringFunctions, Like);
 DEFINE_METHOD(peloton::function, StringFunctions, Length);
 DEFINE_METHOD(peloton::function, StringFunctions, Substr);
+DEFINE_METHOD(peloton::function, StringFunctions, Repeat);
 
 // Trim-related functions
 DEFINE_METHOD(peloton::function, StringFunctions, BTrim);

--- a/src/codegen/type/varchar_type.cpp
+++ b/src/codegen/type/varchar_type.cpp
@@ -133,10 +133,11 @@ struct Ascii : public TypeSystem::UnaryOperatorHandleNull {
   }
 
   Value Impl(CodeGen &codegen, const Value &val,
-             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
-      const override {
-    llvm::Value *raw_ret = codegen.Call(StringFunctionsProxy::Ascii,
-                                        {val.GetValue(), val.GetLength()});
+             const TypeSystem::InvocationContext &ctx) const override {
+    llvm::Value *executor_ctx = ctx.executor_context;
+    llvm::Value *raw_ret =
+        codegen.Call(StringFunctionsProxy::Ascii,
+                     {executor_ctx, val.GetValue(), val.GetLength()});
     return Value{Integer::Instance(), raw_ret};
   }
 };
@@ -152,10 +153,11 @@ struct Length : public TypeSystem::UnaryOperatorHandleNull {
   }
 
   Value Impl(CodeGen &codegen, const Value &val,
-             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
-      const override {
-    llvm::Value *raw_ret = codegen.Call(StringFunctionsProxy::Length,
-                                        {val.GetValue(), val.GetLength()});
+             const TypeSystem::InvocationContext &ctx) const override {
+    llvm::Value *executor_ctx = ctx.executor_context;
+    llvm::Value *raw_ret =
+        codegen.Call(StringFunctionsProxy::Length,
+                     {executor_ctx, val.GetValue(), val.GetLength()});
     return Value{Integer::Instance(), raw_ret};
   }
 };
@@ -171,10 +173,11 @@ struct Trim : public TypeSystem::UnaryOperatorHandleNull {
   }
 
   Value Impl(CodeGen &codegen, const Value &val,
-             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
-      const override {
-    llvm::Value *ret = codegen.Call(StringFunctionsProxy::Trim,
-                                    {val.GetValue(), val.GetLength()});
+             const TypeSystem::InvocationContext &ctx) const override {
+    llvm::Value *executor_ctx = ctx.executor_context;
+    llvm::Value *ret =
+        codegen.Call(StringFunctionsProxy::Trim,
+                     {executor_ctx, val.GetValue(), val.GetLength()});
 
     llvm::Value *str_ptr = codegen->CreateExtractValue(ret, 0);
     llvm::Value *str_len = codegen->CreateExtractValue(ret, 1);
@@ -200,24 +203,31 @@ struct Like : public TypeSystem::BinaryOperator {
     return Boolean::Instance();
   }
 
-  Value Impl(CodeGen &codegen, const Value &left, const Value &right) const {
+  Value Impl(CodeGen &codegen, const Value &left, const Value &right,
+             const TypeSystem::InvocationContext &ctx) const {
     // Call StringFunctions::Like(...)
-    llvm::Value *raw_ret = codegen.Call(StringFunctionsProxy::Like,
-                                        {left.GetValue(), left.GetLength(),
-                                         right.GetValue(), right.GetLength()});
+
+    // Setup input arguments
+    llvm::Value *executor_ctx = ctx.executor_context;
+    std::vector<llvm::Value *> args = {executor_ctx, left.GetValue(),
+                                       left.GetLength(), right.GetValue(),
+                                       right.GetLength()};
+
+    // Make call
+    llvm::Value *raw_ret = codegen.Call(StringFunctionsProxy::Like, args);
+
     // Return the result
     return Value{Boolean::Instance(), raw_ret};
   }
 
   Value Eval(CodeGen &codegen, const Value &left, const Value &right,
-             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
-      const override {
+             const TypeSystem::InvocationContext &ctx) const override {
     PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Pre-condition: Left value is the input string; right value is the pattern
 
     if (!left.IsNullable()) {
-      return Impl(codegen, left, right);
+      return Impl(codegen, left, right, ctx);
     }
 
     codegen::Value null_ret, not_null_ret;
@@ -229,7 +239,7 @@ struct Like : public TypeSystem::BinaryOperator {
     input_null.ElseBlock();
     {
       // Input is not null, invoke LIKE
-      not_null_ret = Impl(codegen, left, right);
+      not_null_ret = Impl(codegen, left, right, ctx);
     }
     return input_null.BuildPHI(null_ret, not_null_ret);
   }
@@ -274,11 +284,12 @@ struct BTrim : public TypeSystem::BinaryOperatorHandleNull {
   }
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
-             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
-      const override {
-    llvm::Value *ret = codegen.Call(StringFunctionsProxy::BTrim,
-                                    {left.GetValue(), left.GetLength(),
-                                     right.GetValue(), right.GetLength()});
+             const TypeSystem::InvocationContext &ctx) const override {
+    llvm::Value *executor_ctx = ctx.executor_context;
+    llvm::Value *ret =
+        codegen.Call(StringFunctionsProxy::BTrim,
+                     {executor_ctx, left.GetValue(), left.GetLength(),
+                      right.GetValue(), right.GetLength()});
 
     llvm::Value *str_ptr = codegen->CreateExtractValue(ret, 0);
     llvm::Value *str_len = codegen->CreateExtractValue(ret, 1);
@@ -299,11 +310,12 @@ struct LTrim : public TypeSystem::BinaryOperatorHandleNull {
   }
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
-             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
-      const override {
-    llvm::Value *ret = codegen.Call(StringFunctionsProxy::LTrim,
-                                    {left.GetValue(), left.GetLength(),
-                                     right.GetValue(), right.GetLength()});
+             const TypeSystem::InvocationContext &ctx) const override {
+    llvm::Value *executor_ctx = ctx.executor_context;
+    llvm::Value *ret =
+        codegen.Call(StringFunctionsProxy::LTrim,
+                     {executor_ctx, left.GetValue(), left.GetLength(),
+                      right.GetValue(), right.GetLength()});
 
     llvm::Value *str_ptr = codegen->CreateExtractValue(ret, 0);
     llvm::Value *str_len = codegen->CreateExtractValue(ret, 1);
@@ -324,11 +336,12 @@ struct RTrim : public TypeSystem::BinaryOperatorHandleNull {
   }
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
-             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
-      const override {
-    llvm::Value *ret = codegen.Call(StringFunctionsProxy::RTrim,
-                                    {left.GetValue(), left.GetLength(),
-                                     right.GetValue(), right.GetLength()});
+             const TypeSystem::InvocationContext &ctx) const override {
+    llvm::Value *executor_ctx = ctx.executor_context;
+    llvm::Value *ret =
+        codegen.Call(StringFunctionsProxy::RTrim,
+                     {executor_ctx, left.GetValue(), left.GetLength(),
+                      right.GetValue(), right.GetLength()});
 
     llvm::Value *str_ptr = codegen->CreateExtractValue(ret, 0);
     llvm::Value *str_len = codegen->CreateExtractValue(ret, 1);
@@ -382,14 +395,18 @@ struct Substr : public TypeSystem::NaryOperator {
   }
 
   Value Eval(CodeGen &codegen, const std::vector<Value> &input_args,
-             UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
-      const override {
-    llvm::Value *ret =
-        codegen.Call(StringFunctionsProxy::Substr,
-                     {
-                      input_args[0].GetValue(), input_args[0].GetLength(),
-                      input_args[1].GetValue(), input_args[2].GetValue(),
-                     });
+             const TypeSystem::InvocationContext &ctx) const override {
+    // Setup function arguments
+    llvm::Value *executor_ctx = ctx.executor_context;
+    std::vector<llvm::Value *> args = {
+        executor_ctx, input_args[0].GetValue(), input_args[0].GetLength(),
+        input_args[1].GetValue(), input_args[2].GetValue(),
+    };
+
+    // Call
+    llvm::Value *ret = codegen.Call(StringFunctionsProxy::Substr, args);
+
+    // Pull out what we need and return
     llvm::Value *str_ptr = codegen->CreateExtractValue(ret, 0);
     llvm::Value *str_len = codegen->CreateExtractValue(ret, 1);
     return Value{Varchar::Instance(), str_ptr, str_len};

--- a/src/function/old_engine_string_functions.cpp
+++ b/src/function/old_engine_string_functions.cpp
@@ -1,0 +1,224 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// old_engine_string_functions.cpp
+//
+// Identification: src/function/old_engine_string_functions.cpp
+//
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "function/old_engine_string_functions.h"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+#include "function/string_functions.h"
+#include "type/value_factory.h"
+
+#define NextByte(p, plen) ((p)++, (plen)--)
+
+namespace peloton {
+namespace function {
+
+// ASCII code of the first character of the argument.
+type::Value OldEngineStringFunctions::Ascii(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 1);
+  if (args[0].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
+  }
+
+  uint32_t ret = StringFunctions::Ascii(args[0].GetAs<const char *>(),
+                                        args[0].GetLength());
+  return type::ValueFactory::GetIntegerValue(ret);
+}
+
+type::Value OldEngineStringFunctions::Like(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 2);
+  if (args[0].IsNull() || args[1].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
+  }
+
+  bool ret =
+      StringFunctions::Like(args[0].GetAs<const char *>(), args[0].GetLength(),
+                            args[1].GetAs<const char *>(), args[1].GetLength());
+  return type::ValueFactory::GetBooleanValue(ret);
+}
+
+// Get Character from integer
+type::Value OldEngineStringFunctions::Chr(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 1);
+  if (args[0].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  }
+  int32_t val = args[0].GetAs<int32_t>();
+  std::string str(1, static_cast<char>(val));
+  return type::ValueFactory::GetVarcharValue(str);
+}
+
+// substring
+type::Value OldEngineStringFunctions::Substr(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 3);
+  if (args[0].IsNull() || args[1].IsNull() || args[2].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  }
+  std::string str = args[0].ToString();
+  int32_t from = args[1].GetAs<int32_t>() - 1;
+  int32_t len = args[2].GetAs<int32_t>();
+
+  return type::ValueFactory::GetVarcharValue(str.substr(from, len));
+}
+
+// Number of characters in string
+type::Value OldEngineStringFunctions::CharLength(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 1);
+  if (args[0].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
+  }
+  std::string str = args[0].ToString();
+  int32_t len = str.length();
+  return (type::ValueFactory::GetIntegerValue(len));
+}
+
+// Concatenate two strings
+type::Value OldEngineStringFunctions::Concat(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 2);
+  if (args[0].IsNull() || args[1].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  }
+  std::string str = args[0].ToString() + args[1].ToString();
+  return (type::ValueFactory::GetVarcharValue(str));
+}
+
+// Number of bytes in string
+type::Value OldEngineStringFunctions::OctetLength(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 1);
+  std::string str = args[0].ToString();
+  int32_t len = str.length();
+  return (type::ValueFactory::GetIntegerValue(len));
+}
+
+// Repeat string the specified number of times
+type::Value OldEngineStringFunctions::Repeat(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 2);
+  if (args[0].IsNull() || args[1].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  }
+  std::string str = args[0].ToString();
+  int32_t num = args[1].GetAs<int32_t>();
+
+  std::string ret = "";
+
+  while (num > 0) {
+    if (num % 2) {
+      ret += str;
+    }
+    if (num > 1) {
+      str += str;
+    }
+    num >>= 1;
+  }
+  return (type::ValueFactory::GetVarcharValue(ret));
+}
+
+// Replace all occurrences in string of substring from with substring to
+type::Value OldEngineStringFunctions::Replace(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 3);
+  if (args[0].IsNull() || args[1].IsNull() || args[2].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  }
+  std::string str = args[0].ToString();
+  std::string from = args[1].ToString();
+  std::string to = args[2].ToString();
+  size_t pos = 0;
+  while ((pos = str.find(from, pos)) != std::string::npos) {
+    str.replace(pos, from.length(), to);
+    pos += to.length();
+  }
+  return (type::ValueFactory::GetVarcharValue(str));
+}
+
+// Remove the longest string containing only characters from characters
+// from the start of string
+type::Value OldEngineStringFunctions::LTrim(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 2);
+  if (args[0].IsNull() || args[1].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  }
+
+  auto ret = StringFunctions::LTrim(
+      args.at(0).GetData(), strlen(args.at(0).GetData()) + 1,
+      args.at(1).GetData(), strlen(args.at(1).GetData()) + 1);
+
+  std::string str(ret.str, ret.length - 1);
+  return type::ValueFactory::GetVarcharValue(str);
+}
+
+// Remove the longest string containing only characters from characters
+// from the end of string
+type::Value OldEngineStringFunctions::RTrim(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 2);
+  if (args[0].IsNull() || args[1].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  }
+
+  auto ret = StringFunctions::RTrim(
+      args.at(0).GetData(), strlen(args.at(0).GetData()) + 1,
+      args.at(1).GetData(), strlen(args.at(1).GetData()) + 1);
+
+  std::string str(ret.str, ret.length - 1);
+  return type::ValueFactory::GetVarcharValue(str);
+}
+
+type::Value OldEngineStringFunctions::Trim(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 1);
+  return BTrim({args[0], type::ValueFactory::GetVarcharValue(" ")});
+}
+
+// Remove the longest string consisting only of characters in characters from
+// the start and end of string
+type::Value OldEngineStringFunctions::BTrim(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 2);
+  if (args[0].IsNull() || args[1].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  }
+
+  auto ret = StringFunctions::BTrim(
+      args.at(0).GetData(), strlen(args.at(0).GetData()) + 1,
+      args.at(1).GetData(), strlen(args.at(1).GetData()) + 1);
+
+  std::string str(ret.str, ret.length - 1);
+  return type::ValueFactory::GetVarcharValue(str);
+}
+
+// The length of the string
+type::Value OldEngineStringFunctions::Length(
+    const std::vector<type::Value> &args) {
+  PL_ASSERT(args.size() == 1);
+  if (args[0].IsNull()) {
+    return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
+  }
+
+  uint32_t ret = StringFunctions::Length(args[0].GetAs<const char *>(),
+                                         args[0].GetLength());
+  return type::ValueFactory::GetIntegerValue(ret);
+}
+
+}  // namespace function
+}  // namespace peloton

--- a/src/function/old_engine_string_functions.cpp
+++ b/src/function/old_engine_string_functions.cpp
@@ -16,10 +16,9 @@
 #include <cctype>
 #include <string>
 
+#include "executor/executor_context.h"
 #include "function/string_functions.h"
 #include "type/value_factory.h"
-
-#define NextByte(p, plen) ((p)++, (plen)--)
 
 namespace peloton {
 namespace function {
@@ -32,7 +31,8 @@ type::Value OldEngineStringFunctions::Ascii(
     return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
   }
 
-  uint32_t ret = StringFunctions::Ascii(args[0].GetAs<const char *>(),
+  executor::ExecutorContext ctx{nullptr};
+  uint32_t ret = StringFunctions::Ascii(ctx, args[0].GetAs<const char *>(),
                                         args[0].GetLength());
   return type::ValueFactory::GetIntegerValue(ret);
 }
@@ -44,9 +44,10 @@ type::Value OldEngineStringFunctions::Like(
     return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
   }
 
-  bool ret =
-      StringFunctions::Like(args[0].GetAs<const char *>(), args[0].GetLength(),
-                            args[1].GetAs<const char *>(), args[1].GetLength());
+  executor::ExecutorContext ctx{nullptr};
+  bool ret = StringFunctions::Like(
+      ctx, args[0].GetAs<const char *>(), args[0].GetLength(),
+      args[1].GetAs<const char *>(), args[1].GetLength());
   return type::ValueFactory::GetBooleanValue(ret);
 }
 
@@ -159,8 +160,9 @@ type::Value OldEngineStringFunctions::LTrim(
     return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
   }
 
+  executor::ExecutorContext ctx{nullptr};
   auto ret = StringFunctions::LTrim(
-      args.at(0).GetData(), strlen(args.at(0).GetData()) + 1,
+      ctx, args.at(0).GetData(), strlen(args.at(0).GetData()) + 1,
       args.at(1).GetData(), strlen(args.at(1).GetData()) + 1);
 
   std::string str(ret.str, ret.length - 1);
@@ -176,8 +178,9 @@ type::Value OldEngineStringFunctions::RTrim(
     return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
   }
 
+  executor::ExecutorContext ctx{nullptr};
   auto ret = StringFunctions::RTrim(
-      args.at(0).GetData(), strlen(args.at(0).GetData()) + 1,
+      ctx, args.at(0).GetData(), strlen(args.at(0).GetData()) + 1,
       args.at(1).GetData(), strlen(args.at(1).GetData()) + 1);
 
   std::string str(ret.str, ret.length - 1);
@@ -199,8 +202,9 @@ type::Value OldEngineStringFunctions::BTrim(
     return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
   }
 
+  executor::ExecutorContext ctx{nullptr};
   auto ret = StringFunctions::BTrim(
-      args.at(0).GetData(), strlen(args.at(0).GetData()) + 1,
+      ctx, args.at(0).GetData(), strlen(args.at(0).GetData()) + 1,
       args.at(1).GetData(), strlen(args.at(1).GetData()) + 1);
 
   std::string str(ret.str, ret.length - 1);
@@ -215,7 +219,8 @@ type::Value OldEngineStringFunctions::Length(
     return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
   }
 
-  uint32_t ret = StringFunctions::Length(args[0].GetAs<const char *>(),
+  executor::ExecutorContext ctx{nullptr};
+  uint32_t ret = StringFunctions::Length(ctx, args[0].GetAs<const char *>(),
                                          args[0].GetLength());
   return type::ValueFactory::GetIntegerValue(ret);
 }

--- a/src/function/string_functions.cpp
+++ b/src/function/string_functions.cpp
@@ -6,18 +6,14 @@
 //
 // Identification: src/function/string_functions.cpp
 //
-// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
-#include <algorithm>
-#include <cctype>
-#include <string>
-
 #include "function/string_functions.h"
-#include "type/value_factory.h"
 
-#define NextByte(p, plen) ((p)++, (plen)--)
+#include "common/macros.h"
+#include "executor/executor_context.h"
 
 namespace peloton {
 namespace function {
@@ -27,16 +23,7 @@ uint32_t StringFunctions::Ascii(const char *str, uint32_t length) {
   return length <= 1 ? 0 : static_cast<uint32_t>(str[0]);
 }
 
-// ASCII code of the first character of the argument.
-type::Value StringFunctions::_Ascii(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
-  if (args[0].IsNull()) {
-    return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
-  }
-
-  uint32_t ret = Ascii(args[0].GetAs<const char *>(), args[0].GetLength());
-  return type::ValueFactory::GetIntegerValue(ret);
-}
+#define NextByte(p, plen) ((p)++, (plen)--)
 
 bool StringFunctions::Like(const char *t, uint32_t tlen, const char *p,
                            uint32_t plen) {
@@ -101,120 +88,49 @@ bool StringFunctions::Like(const char *t, uint32_t tlen, const char *p,
   return false;
 }
 
-type::Value StringFunctions::_Like(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 2);
-  if (args[0].IsNull() || args[1].IsNull()) {
-    return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
-  }
-
-  bool ret = Like(args[0].GetAs<const char *>(), args[0].GetLength(),
-                  args[1].GetAs<const char *>(), args[1].GetLength());
-  return type::ValueFactory::GetBooleanValue(ret);
-}
-
-// Get Character from integer
-type::Value StringFunctions::Chr(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
-  if (args[0].IsNull()) {
-    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
-  }
-  int32_t val = args[0].GetAs<int32_t>();
-  std::string str(1, static_cast<char>(val));
-  return type::ValueFactory::GetVarcharValue(str);
-}
+#undef NextByte
 
 StringFunctions::StrWithLen StringFunctions::Substr(const char *str,
                                                     uint32_t str_length,
                                                     int32_t from, int32_t len) {
   int32_t signed_end = from + len - 1;
-  if (signed_end < 0 || str_length == 0)
-    return StringFunctions::StrWithLen(nullptr, 0);
+  if (signed_end < 0 || str_length == 0) {
+    return StringFunctions::StrWithLen{nullptr, 0};
+  }
 
   uint32_t begin = from > 0 ? unsigned(from) - 1 : 0;
   uint32_t end = unsigned(signed_end);
-  if (end > str_length) end = str_length;
-  if (begin > end) return StringFunctions::StrWithLen(nullptr, 0);
-  return StringFunctions::StrWithLen(str + begin, end - begin + 1);
+
+  if (end > str_length) {
+    end = str_length;
+  }
+
+  if (begin > end) {
+    return StringFunctions::StrWithLen{nullptr, 0};
+  }
+
+  return StringFunctions::StrWithLen{str + begin, end - begin + 1};
 }
 
-// substring
-type::Value StringFunctions::_Substr(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 3);
-  if (args[0].IsNull() || args[1].IsNull() || args[2].IsNull()) {
-    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
-  }
-  std::string str = args[0].ToString();
-  int32_t from = args[1].GetAs<int32_t>() - 1;
-  int32_t len = args[2].GetAs<int32_t>();
-  return type::ValueFactory::GetVarcharValue(str.substr(from, len));
-}
+StringFunctions::StrWithLen StringFunctions::Repeat(
+    executor::ExecutorContext &ctx, const char *str, uint32_t length,
+    uint32_t num_repeat) {
+  // Determine the number of bytes we need
+  uint32_t total_len = ((length - 1) * num_repeat) + 1;
 
-// Number of characters in string
-type::Value StringFunctions::CharLength(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
-  if (args[0].IsNull()) {
-    return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
-  }
-  std::string str = args[0].ToString();
-  int32_t len = str.length();
-  return (type::ValueFactory::GetIntegerValue(len));
-}
+  // Allocate new memory
+  auto *pool = ctx.GetPool();
+  auto *new_str = reinterpret_cast<char *>(pool->Allocate(total_len));
 
-// Concatenate two strings
-type::Value StringFunctions::Concat(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 2);
-  if (args[0].IsNull() || args[1].IsNull()) {
-    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  // Perform repeat
+  char *ptr = new_str;
+  for (uint32_t i = 0; i < num_repeat; i++) {
+    PL_MEMCPY(ptr, str, length - 1);
+    ptr += (length - 1);
   }
-  std::string str = args[0].ToString() + args[1].ToString();
-  return (type::ValueFactory::GetVarcharValue(str));
-}
 
-// Number of bytes in string
-type::Value StringFunctions::OctetLength(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
-  std::string str = args[0].ToString();
-  int32_t len = str.length();
-  return (type::ValueFactory::GetIntegerValue(len));
-}
-
-// Repeat string the specified number of times
-type::Value StringFunctions::Repeat(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 2);
-  if (args[0].IsNull() || args[1].IsNull()) {
-    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
-  }
-  std::string str = args[0].ToString();
-  int32_t num = args[1].GetAs<int32_t>();
-  std::string ret = "";
-
-  while (num > 0) {
-    if (num % 2) {
-      ret += str;
-    }
-    if (num > 1) {
-      str += str;
-    }
-    num >>= 1;
-  }
-  return (type::ValueFactory::GetVarcharValue(ret));
-}
-
-// Replace all occurrences in string of substring from with substring to
-type::Value StringFunctions::Replace(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 3);
-  if (args[0].IsNull() || args[1].IsNull() || args[2].IsNull()) {
-    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
-  }
-  std::string str = args[0].ToString();
-  std::string from = args[1].ToString();
-  std::string to = args[2].ToString();
-  size_t pos = 0;
-  while ((pos = str.find(from, pos)) != std::string::npos) {
-    str.replace(pos, from.length(), to);
-    pos += to.length();
-  }
-  return (type::ValueFactory::GetVarcharValue(str));
+  // We done
+  return StringFunctions::StrWithLen{new_str, total_len};
 }
 
 StringFunctions::StrWithLen StringFunctions::LTrim(const char *str,
@@ -223,34 +139,22 @@ StringFunctions::StrWithLen StringFunctions::LTrim(const char *str,
                                                    UNUSED_ATTRIBUTE uint32_t
                                                        from_len) {
   PL_ASSERT(str != nullptr && from != nullptr);
+
   // llvm expects the len to include the terminating '\0'
   if (str_len == 1) {
-    return StringFunctions::StrWithLen(nullptr, 1);
+    return StringFunctions::StrWithLen{nullptr, 1};
   }
 
   str_len -= 1;
   int tail = str_len - 1, head = 0;
 
-  while (head < (int)str_len && strchr(from, str[head]) != NULL) head++;
-
-  return StringFunctions::StrWithLen(str + head,
-                                     std::max(tail - head + 1, 0) + 1);
-}
-
-// Remove the longest string containing only characters from characters
-// from the start of string
-type::Value StringFunctions::_LTrim(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 2);
-  if (args[0].IsNull() || args[1].IsNull()) {
-    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  while (head < (int)str_len && strchr(from, str[head]) != nullptr) {
+    head++;
   }
 
-  StrWithLen ret =
-      LTrim(args.at(0).GetData(), strlen(args.at(0).GetData()) + 1,
-            args.at(1).GetData(), strlen(args.at(1).GetData()) + 1);
-
-  std::string str(ret.str, ret.length - 1);
-  return type::ValueFactory::GetVarcharValue(str);
+  // Determine length and return
+  auto new_len = static_cast<uint32_t>(std::max(tail - head + 1, 0) + 1);
+  return StringFunctions::StrWithLen{str + head, new_len};
 }
 
 StringFunctions::StrWithLen StringFunctions::RTrim(const char *str,
@@ -259,33 +163,20 @@ StringFunctions::StrWithLen StringFunctions::RTrim(const char *str,
                                                    UNUSED_ATTRIBUTE uint32_t
                                                        from_len) {
   PL_ASSERT(str != nullptr && from != nullptr);
+
   // llvm expects the len to include the terminating '\0'
   if (str_len == 1) {
-    return StringFunctions::StrWithLen(nullptr, 1);
+    return StringFunctions::StrWithLen{nullptr, 1};
   }
 
   str_len -= 1;
   int tail = str_len - 1, head = 0;
-  while (tail >= 0 && strchr(from, str[tail]) != NULL) tail--;
-
-  return StringFunctions::StrWithLen(str + head,
-                                     std::max(tail - head + 1, 0) + 1);
-}
-
-// Remove the longest string containing only characters from characters
-// from the end of string
-type::Value StringFunctions::_RTrim(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 2);
-  if (args[0].IsNull() || args[1].IsNull()) {
-    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  while (tail >= 0 && strchr(from, str[tail]) != nullptr) {
+    tail--;
   }
 
-  StrWithLen ret =
-      RTrim(args.at(0).GetData(), strlen(args.at(0).GetData()) + 1,
-            args.at(1).GetData(), strlen(args.at(1).GetData()) + 1);
-
-  std::string str(ret.str, ret.length - 1);
-  return type::ValueFactory::GetVarcharValue(str);
+  auto new_len = static_cast<uint32_t>(std::max(tail - head + 1, 0) + 1);
+  return StringFunctions::StrWithLen{str + head, new_len};
 }
 
 StringFunctions::StrWithLen StringFunctions::Trim(const char *str,
@@ -293,13 +184,6 @@ StringFunctions::StrWithLen StringFunctions::Trim(const char *str,
   return BTrim(str, str_len, " ", 2);
 }
 
-type::Value StringFunctions::_Trim(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
-  return _BTrim({args[0], type::ValueFactory::GetVarcharValue(" ")});
-}
-
-// Remove the longest string consisting only of characters in characters
-// from the start and end of string
 StringFunctions::StrWithLen StringFunctions::BTrim(const char *str,
                                                    uint32_t str_len,
                                                    const char *from,
@@ -307,50 +191,35 @@ StringFunctions::StrWithLen StringFunctions::BTrim(const char *str,
                                                        from_len) {
   PL_ASSERT(str != nullptr && from != nullptr);
 
-  str_len--;  // skip the tailing 0
+  // Skip the tailing 0
+  str_len--;
 
   if (str_len == 0) {
-    return StringFunctions::StrWithLen(str, 1);
+    return StringFunctions::StrWithLen{str, 1};
   }
 
-  int tail = str_len - 1, head = 0;
-  while (tail >= 0 && strchr(from, str[tail]) != NULL) tail--;
+  int head = 0;
+  int tail = str_len - 1;
 
-  while (head < (int)str_len && strchr(from, str[head]) != NULL) head++;
-
-  return StringFunctions::StrWithLen(str + head,
-                                     std::max(tail - head + 1, 0) + 1);
-}
-
-type::Value StringFunctions::_BTrim(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 2);
-  if (args[0].IsNull() || args[1].IsNull()) {
-    return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
+  // Trim tail
+  while (tail >= 0 && strchr(from, str[tail]) != nullptr) {
+    tail--;
   }
 
-  StrWithLen ret =
-      BTrim(args.at(0).GetData(), strlen(args.at(0).GetData()) + 1,
-            args.at(1).GetData(), strlen(args.at(1).GetData()) + 1);
+  // Trim head
+  while (head < (int)str_len && strchr(from, str[head]) != nullptr) {
+    head++;
+  }
 
-  std::string str(ret.str, ret.length - 1);
-  return type::ValueFactory::GetVarcharValue(str);
+  // Done
+  auto new_len = static_cast<uint32_t>(std::max(tail - head + 1, 0) + 1);
+  return StringFunctions::StrWithLen{str + head, new_len};
 }
 
 uint32_t StringFunctions::Length(UNUSED_ATTRIBUTE const char *str,
                                  uint32_t length) {
   PL_ASSERT(str != nullptr);
   return length;
-}
-
-// The length of the string
-type::Value StringFunctions::_Length(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
-  if (args[0].IsNull()) {
-    return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
-  }
-
-  uint32_t ret = Length(args[0].GetAs<const char *>(), args[0].GetLength());
-  return type::ValueFactory::GetIntegerValue(ret);
 }
 
 }  // namespace function

--- a/src/function/string_functions.cpp
+++ b/src/function/string_functions.cpp
@@ -18,14 +18,16 @@
 namespace peloton {
 namespace function {
 
-uint32_t StringFunctions::Ascii(const char *str, uint32_t length) {
+uint32_t StringFunctions::Ascii(UNUSED_ATTRIBUTE executor::ExecutorContext &ctx,
+                                const char *str, uint32_t length) {
   PL_ASSERT(str != nullptr);
   return length <= 1 ? 0 : static_cast<uint32_t>(str[0]);
 }
 
 #define NextByte(p, plen) ((p)++, (plen)--)
 
-bool StringFunctions::Like(const char *t, uint32_t tlen, const char *p,
+bool StringFunctions::Like(UNUSED_ATTRIBUTE executor::ExecutorContext &ctx,
+                           const char *t, uint32_t tlen, const char *p,
                            uint32_t plen) {
   PL_ASSERT(t != nullptr);
   PL_ASSERT(p != nullptr);
@@ -61,7 +63,7 @@ bool StringFunctions::Like(const char *t, uint32_t tlen, const char *p,
 
       while (tlen > 0) {
         if (tolower(*t) == firstpat) {
-          int matched = Like(t, tlen, p, plen);
+          int matched = Like(ctx, t, tlen, p, plen);
 
           if (matched != false) return matched;
         }
@@ -90,9 +92,9 @@ bool StringFunctions::Like(const char *t, uint32_t tlen, const char *p,
 
 #undef NextByte
 
-StringFunctions::StrWithLen StringFunctions::Substr(const char *str,
-                                                    uint32_t str_length,
-                                                    int32_t from, int32_t len) {
+StringFunctions::StrWithLen StringFunctions::Substr(
+    UNUSED_ATTRIBUTE executor::ExecutorContext &ctx, const char *str,
+    uint32_t str_length, int32_t from, int32_t len) {
   int32_t signed_end = from + len - 1;
   if (signed_end < 0 || str_length == 0) {
     return StringFunctions::StrWithLen{nullptr, 0};
@@ -133,11 +135,9 @@ StringFunctions::StrWithLen StringFunctions::Repeat(
   return StringFunctions::StrWithLen{new_str, total_len};
 }
 
-StringFunctions::StrWithLen StringFunctions::LTrim(const char *str,
-                                                   uint32_t str_len,
-                                                   const char *from,
-                                                   UNUSED_ATTRIBUTE uint32_t
-                                                       from_len) {
+StringFunctions::StrWithLen StringFunctions::LTrim(
+    UNUSED_ATTRIBUTE executor::ExecutorContext &ctx, const char *str,
+    uint32_t str_len, const char *from, UNUSED_ATTRIBUTE uint32_t from_len) {
   PL_ASSERT(str != nullptr && from != nullptr);
 
   // llvm expects the len to include the terminating '\0'
@@ -157,11 +157,9 @@ StringFunctions::StrWithLen StringFunctions::LTrim(const char *str,
   return StringFunctions::StrWithLen{str + head, new_len};
 }
 
-StringFunctions::StrWithLen StringFunctions::RTrim(const char *str,
-                                                   uint32_t str_len,
-                                                   const char *from,
-                                                   UNUSED_ATTRIBUTE uint32_t
-                                                       from_len) {
+StringFunctions::StrWithLen StringFunctions::RTrim(
+    UNUSED_ATTRIBUTE executor::ExecutorContext &ctx, const char *str,
+    uint32_t str_len, const char *from, UNUSED_ATTRIBUTE uint32_t from_len) {
   PL_ASSERT(str != nullptr && from != nullptr);
 
   // llvm expects the len to include the terminating '\0'
@@ -179,16 +177,15 @@ StringFunctions::StrWithLen StringFunctions::RTrim(const char *str,
   return StringFunctions::StrWithLen{str + head, new_len};
 }
 
-StringFunctions::StrWithLen StringFunctions::Trim(const char *str,
-                                                  uint32_t str_len) {
-  return BTrim(str, str_len, " ", 2);
+StringFunctions::StrWithLen StringFunctions::Trim(
+    UNUSED_ATTRIBUTE executor::ExecutorContext &ctx, const char *str,
+    uint32_t str_len) {
+  return BTrim(ctx, str, str_len, " ", 2);
 }
 
-StringFunctions::StrWithLen StringFunctions::BTrim(const char *str,
-                                                   uint32_t str_len,
-                                                   const char *from,
-                                                   UNUSED_ATTRIBUTE uint32_t
-                                                       from_len) {
+StringFunctions::StrWithLen StringFunctions::BTrim(
+    UNUSED_ATTRIBUTE executor::ExecutorContext &ctx, const char *str,
+    uint32_t str_len, const char *from, UNUSED_ATTRIBUTE uint32_t from_len) {
   PL_ASSERT(str != nullptr && from != nullptr);
 
   // Skip the tailing 0
@@ -216,8 +213,9 @@ StringFunctions::StrWithLen StringFunctions::BTrim(const char *str,
   return StringFunctions::StrWithLen{str + head, new_len};
 }
 
-uint32_t StringFunctions::Length(UNUSED_ATTRIBUTE const char *str,
-                                 uint32_t length) {
+uint32_t StringFunctions::Length(
+    UNUSED_ATTRIBUTE executor::ExecutorContext &ctx,
+    UNUSED_ATTRIBUTE const char *str, uint32_t length) {
   PL_ASSERT(str != nullptr);
   return length;
 }

--- a/src/include/codegen/proxy/string_functions_proxy.h
+++ b/src/include/codegen/proxy/string_functions_proxy.h
@@ -6,7 +6,7 @@
 //
 // Identification: src/include/codegen/proxy/string_functions_proxy.h
 //
-// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -14,8 +14,6 @@
 
 #include "codegen/proxy/proxy.h"
 #include "codegen/proxy/type_builder.h"
-#include "function/string_functions.h"
-
 #include "codegen/proxy/type_builder.h"
 #include "function/string_functions.h"
 
@@ -32,6 +30,7 @@ PROXY(StringFunctions) {
   DECLARE_METHOD(LTrim);
   DECLARE_METHOD(RTrim);
   DECLARE_METHOD(Substr);
+  DECLARE_METHOD(Repeat);
 };
 
 PROXY(StrWithLen) {

--- a/src/include/function/old_engine_string_functions.h
+++ b/src/include/function/old_engine_string_functions.h
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// old_engine_string_functions.h
+//
+// Identification: src/include/function/old_engine_string_functions.h
+//
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <vector>
+
+#include "type/value.h"
+
+namespace peloton {
+namespace function {
+
+class OldEngineStringFunctions {
+ public:
+  // ASCII code of the first character of the argument.
+  static type::Value Ascii(const std::vector<type::Value> &args);
+
+  // Like
+  static type::Value Like(const std::vector<type::Value> &args);
+
+  // Get Character from integer
+  static type::Value Chr(const std::vector<type::Value> &args);
+
+  // substring
+  static type::Value Substr(const std::vector<type::Value> &args);
+
+  // Number of characters in string
+  static type::Value CharLength(const std::vector<type::Value> &args);
+
+  // Concatenate two strings
+  static type::Value Concat(const std::vector<type::Value> &args);
+
+  // Number of bytes in string
+  static type::Value OctetLength(const std::vector<type::Value> &args);
+
+  // Repeat string the specified number of times
+  static type::Value Repeat(const std::vector<type::Value> &args);
+
+  // Replace all occurrences in string of substring from with substring to
+  static type::Value Replace(const std::vector<type::Value> &args);
+
+  // Remove the longest string containing only characters from characters
+  // from the start of string
+  static type::Value LTrim(const std::vector<type::Value> &args);
+
+  // Remove the longest string containing only characters from characters
+  // from the end of string
+  static type::Value RTrim(const std::vector<type::Value> &args);
+
+  static type::Value Trim(const std::vector<type::Value> &args);
+
+  // Remove the longest string consisting only of characters in characters
+  // from the start and end of string
+  static type::Value BTrim(const std::vector<type::Value> &args);
+
+  // Length will return the number of characters in the given string
+  static type::Value Length(const std::vector<type::Value> &args);
+};
+
+}  // namespace function
+}  // namespace peloton

--- a/src/include/function/string_functions.h
+++ b/src/include/function/string_functions.h
@@ -6,15 +6,13 @@
 //
 // Identification: src/include/function/string_functions.h
 //
-// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
 #pragma once
 
-#include <vector>
-
-#include "type/value.h"
+#include <cstdint>
 
 namespace peloton {
 
@@ -27,67 +25,48 @@ namespace function {
 class StringFunctions {
  public:
   struct StrWithLen {
+    // Constructor
     StrWithLen(const char *str, uint32_t length) : str(str), length(length) {}
+
+    // Member variables
     const char *str;
     uint32_t length;
   };
 
   // ASCII code of the first character of the argument.
   static uint32_t Ascii(const char *str, uint32_t length);
-  static type::Value _Ascii(const std::vector<type::Value> &args);
 
   // Like
   static bool Like(const char *t, uint32_t tlen, const char *p, uint32_t plen);
-  static type::Value _Like(const std::vector<type::Value> &args);
 
-  // Get Character from integer
-  static type::Value Chr(const std::vector<type::Value> &args);
-
-  // substring
+  // Substring
   static StrWithLen Substr(const char *str, uint32_t str_length, int32_t from,
                            int32_t len);
-  static type::Value _Substr(const std::vector<type::Value> &args);
 
-  // Number of characters in string
-  static type::Value CharLength(const std::vector<type::Value> &args);
-
-  // Concatenate two strings
-  static type::Value Concat(const std::vector<type::Value> &args);
-
-  // Number of bytes in string
-  static type::Value OctetLength(const std::vector<type::Value> &args);
-
-  // Repeat string the specified number of times
-  static type::Value Repeat(const std::vector<type::Value> &args);
-
-  // Replace all occurrences in string of substring from with substring to
-  static type::Value Replace(const std::vector<type::Value> &args);
+  // Repeat the given string a given number of times
+  static StrWithLen Repeat(executor::ExecutorContext &ctx, const char *str,
+                           uint32_t length, uint32_t num_repeat);
 
   // Remove the longest string containing only characters from characters
   // from the start of string
   static StrWithLen LTrim(const char *str, uint32_t str_len, const char *from,
                           uint32_t from_len);
-  static type::Value _LTrim(const std::vector<type::Value> &args);
 
   // Remove the longest string containing only characters from characters
   // from the end of string
   static StrWithLen RTrim(const char *str, uint32_t str_len, const char *from,
                           uint32_t from_len);
-  static type::Value _RTrim(const std::vector<type::Value> &args);
 
+  // Trim
   static StrWithLen Trim(const char *str, uint32_t str_len);
-  static type::Value _Trim(const std::vector<type::Value> &args);
 
   // Remove the longest string consisting only of characters in characters
   // from the start and end of string
   static StrWithLen BTrim(const char *str, uint32_t str_len, const char *from,
                           uint32_t from_len);
-  static type::Value _BTrim(const std::vector<type::Value> &args);
 
-  // This function is used by LLVM engine
   // Length will return the number of characters in the given string
   static uint32_t Length(const char *str, uint32_t length);
-  static type::Value _Length(const std::vector<type::Value> &args);
 };
 
 }  // namespace function

--- a/src/include/function/string_functions.h
+++ b/src/include/function/string_functions.h
@@ -34,14 +34,16 @@ class StringFunctions {
   };
 
   // ASCII code of the first character of the argument.
-  static uint32_t Ascii(const char *str, uint32_t length);
+  static uint32_t Ascii(executor::ExecutorContext &ctx, const char *str,
+                        uint32_t length);
 
   // Like
-  static bool Like(const char *t, uint32_t tlen, const char *p, uint32_t plen);
+  static bool Like(executor::ExecutorContext &ctx, const char *t, uint32_t tlen,
+                   const char *p, uint32_t plen);
 
   // Substring
-  static StrWithLen Substr(const char *str, uint32_t str_length, int32_t from,
-                           int32_t len);
+  static StrWithLen Substr(executor::ExecutorContext &ctx, const char *str,
+                           uint32_t str_length, int32_t from, int32_t len);
 
   // Repeat the given string a given number of times
   static StrWithLen Repeat(executor::ExecutorContext &ctx, const char *str,
@@ -49,24 +51,29 @@ class StringFunctions {
 
   // Remove the longest string containing only characters from characters
   // from the start of string
-  static StrWithLen LTrim(const char *str, uint32_t str_len, const char *from,
+  static StrWithLen LTrim(executor::ExecutorContext &ctx, const char *str,
+                          uint32_t str_len, const char *from,
                           uint32_t from_len);
 
   // Remove the longest string containing only characters from characters
   // from the end of string
-  static StrWithLen RTrim(const char *str, uint32_t str_len, const char *from,
+  static StrWithLen RTrim(executor::ExecutorContext &ctx, const char *str,
+                          uint32_t str_len, const char *from,
                           uint32_t from_len);
 
   // Trim
-  static StrWithLen Trim(const char *str, uint32_t str_len);
+  static StrWithLen Trim(executor::ExecutorContext &ctx, const char *str,
+                         uint32_t str_len);
 
   // Remove the longest string consisting only of characters in characters
   // from the start and end of string
-  static StrWithLen BTrim(const char *str, uint32_t str_len, const char *from,
+  static StrWithLen BTrim(executor::ExecutorContext &ctx, const char *str,
+                          uint32_t str_len, const char *from,
                           uint32_t from_len);
 
   // Length will return the number of characters in the given string
-  static uint32_t Length(const char *str, uint32_t length);
+  static uint32_t Length(executor::ExecutorContext &ctx, const char *str,
+                         uint32_t length);
 };
 
 }  // namespace function

--- a/test/function/string_functions_test.cpp
+++ b/test/function/string_functions_test.cpp
@@ -6,7 +6,7 @@
 //
 // Identification: test/expression/string_functions_test.cpp
 //
-// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -17,6 +17,7 @@
 #include "common/harness.h"
 
 #include "function/string_functions.h"
+#include "function/old_engine_string_functions.h"
 #include "common/internal_types.h"
 #include "type/value.h"
 #include "type/value_factory.h"
@@ -69,21 +70,21 @@ TEST_F(StringFunctionsTests, LikeTest) {
 TEST_F(StringFunctionsTests, AsciiTest) {
   const char column_char = 'A';
   for (int i = 0; i < 52; i++) {
-    int expected = (int)column_char + i;
+    auto expected = static_cast<uint32_t>(column_char + i);
 
     std::ostringstream os;
     os << static_cast<char>(expected);
     std::vector<type::Value> args = {
         type::ValueFactory::GetVarcharValue(os.str())};
 
-    auto result = function::StringFunctions::_Ascii(args);
+    auto result = function::OldEngineStringFunctions::Ascii(args);
     EXPECT_FALSE(result.IsNull());
     EXPECT_EQ(expected, result.GetAs<int>());
   }
   // NULL CHECK
   std::vector<type::Value> args = {
       type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR)};
-  auto result = function::StringFunctions::_Ascii(args);
+  auto result = function::OldEngineStringFunctions::Ascii(args);
   EXPECT_TRUE(result.IsNull());
 }
 
@@ -99,14 +100,15 @@ TEST_F(StringFunctionsTests, ChrTest) {
     std::vector<type::Value> args = {
         type::ValueFactory::GetIntegerValue(char_int)};
 
-    auto result = function::StringFunctions::Chr(args);
+    auto result = function::OldEngineStringFunctions::Chr(args);
     EXPECT_FALSE(result.IsNull());
     EXPECT_EQ(expected, result.ToString());
   }
+
   // NULL CHECK
   std::vector<type::Value> args = {
       type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER)};
-  auto result = function::StringFunctions::Chr(args);
+  auto result = function::OldEngineStringFunctions::Chr(args);
   EXPECT_TRUE(result.IsNull());
 }
 
@@ -124,7 +126,7 @@ TEST_F(StringFunctionsTests, SubstrTest) {
       type::ValueFactory::GetIntegerValue(from),
       type::ValueFactory::GetIntegerValue(len),
   };
-  auto result = function::StringFunctions::_Substr(args);
+  auto result = function::OldEngineStringFunctions::Substr(args);
   EXPECT_FALSE(result.IsNull());
   EXPECT_EQ(expected, result.ToString());
 
@@ -136,7 +138,7 @@ TEST_F(StringFunctionsTests, SubstrTest) {
         type::ValueFactory::GetVarcharValue("ccc"),
     };
     nullargs[i] = type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
-    auto result = function::StringFunctions::_Substr(nullargs);
+    auto result = function::OldEngineStringFunctions::Substr(nullargs);
     EXPECT_TRUE(result.IsNull());
   }
 }
@@ -148,14 +150,14 @@ TEST_F(StringFunctionsTests, CharLengthTest) {
     std::vector<type::Value> args = {
         type::ValueFactory::GetVarcharValue(input)};
 
-    auto result = function::StringFunctions::CharLength(args);
+    auto result = function::OldEngineStringFunctions::CharLength(args);
     EXPECT_FALSE(result.IsNull());
     EXPECT_EQ(i, result.GetAs<int>());
   }
   // NULL CHECK
   std::vector<type::Value> args = {
       type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR)};
-  auto result = function::StringFunctions::CharLength(args);
+  auto result = function::OldEngineStringFunctions::CharLength(args);
   EXPECT_TRUE(result.IsNull());
 }
 
@@ -167,7 +169,7 @@ TEST_F(StringFunctionsTests, RepeatTest) {
     std::vector<type::Value> args = {type::ValueFactory::GetVarcharValue(str),
                                      type::ValueFactory::GetIntegerValue(i)};
 
-    auto result = function::StringFunctions::Repeat(args);
+    auto result = function::OldEngineStringFunctions::Repeat(args);
     EXPECT_FALSE(result.IsNull());
     EXPECT_EQ(expected, result.ToString());
   }
@@ -176,7 +178,7 @@ TEST_F(StringFunctionsTests, RepeatTest) {
       type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR),
       type::ValueFactory::GetVarcharValue(str),
   };
-  auto result = function::StringFunctions::Repeat(args);
+  auto result = function::OldEngineStringFunctions::Repeat(args);
   EXPECT_TRUE(result.IsNull());
 }
 
@@ -195,7 +197,7 @@ TEST_F(StringFunctionsTests, ReplaceTest) {
         type::ValueFactory::GetVarcharValue(replaceChar),
         type::ValueFactory::GetVarcharValue(origChar)};
 
-    auto result = function::StringFunctions::Replace(args);
+    auto result = function::OldEngineStringFunctions::Replace(args);
     EXPECT_FALSE(result.IsNull());
     EXPECT_EQ(expected, result.ToString());
   }
@@ -207,7 +209,7 @@ TEST_F(StringFunctionsTests, ReplaceTest) {
         type::ValueFactory::GetVarcharValue("ccc"),
     };
     args[i] = type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
-    auto result = function::StringFunctions::Replace(args);
+    auto result = function::OldEngineStringFunctions::Replace(args);
     EXPECT_TRUE(result.IsNull());
   }
 }
@@ -219,7 +221,7 @@ TEST_F(StringFunctionsTests, LTrimTest) {
   const std::string expected = message + spaces;
   std::vector<type::Value> args = {type::ValueFactory::GetVarcharValue(origStr),
                                    type::ValueFactory::GetVarcharValue(" ")};
-  auto result = function::StringFunctions::_LTrim(args);
+  auto result = function::OldEngineStringFunctions::LTrim(args);
   EXPECT_FALSE(result.IsNull());
   EXPECT_EQ(expected, result.ToString());
 
@@ -230,7 +232,7 @@ TEST_F(StringFunctionsTests, LTrimTest) {
         type::ValueFactory::GetVarcharValue("bbb"),
     };
     nullargs[i] = type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
-    auto result = function::StringFunctions::_LTrim(nullargs);
+    auto result = function::OldEngineStringFunctions::LTrim(nullargs);
     EXPECT_TRUE(result.IsNull());
   }
 }
@@ -242,7 +244,7 @@ TEST_F(StringFunctionsTests, RTrimTest) {
   const std::string expected = spaces + message;
   std::vector<type::Value> args = {type::ValueFactory::GetVarcharValue(origStr),
                                    type::ValueFactory::GetVarcharValue(" ")};
-  auto result = function::StringFunctions::_RTrim(args);
+  auto result = function::OldEngineStringFunctions::RTrim(args);
   EXPECT_FALSE(result.IsNull());
   EXPECT_EQ(expected, result.ToString());
 
@@ -253,7 +255,7 @@ TEST_F(StringFunctionsTests, RTrimTest) {
         type::ValueFactory::GetVarcharValue("bbb"),
     };
     nullargs[i] = type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
-    auto result = function::StringFunctions::_RTrim(nullargs);
+    auto result = function::OldEngineStringFunctions::RTrim(nullargs);
     EXPECT_TRUE(result.IsNull());
   }
 }
@@ -265,11 +267,11 @@ TEST_F(StringFunctionsTests, BTrimTest) {
   const std::string expected = message;
   std::vector<type::Value> args = {type::ValueFactory::GetVarcharValue(origStr),
                                    type::ValueFactory::GetVarcharValue(" ")};
-  auto result = function::StringFunctions::_BTrim(args);
+  auto result = function::OldEngineStringFunctions::BTrim(args);
   EXPECT_FALSE(result.IsNull());
   EXPECT_EQ(expected, result.ToString());
 
-  result = function::StringFunctions::_Trim(
+  result = function::OldEngineStringFunctions::Trim(
       {type::ValueFactory::GetVarcharValue(origStr)});
   EXPECT_FALSE(result.IsNull());
   EXPECT_EQ(expected, result.ToString());
@@ -281,7 +283,7 @@ TEST_F(StringFunctionsTests, BTrimTest) {
         type::ValueFactory::GetVarcharValue("bbb"),
     };
     nullargs[i] = type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
-    auto result = function::StringFunctions::_BTrim(nullargs);
+    auto result = function::OldEngineStringFunctions::BTrim(nullargs);
     EXPECT_TRUE(result.IsNull());
   }
 }
@@ -296,14 +298,14 @@ TEST_F(StringFunctionsTests, LengthTest) {
 
     std::vector<type::Value> args = {type::ValueFactory::GetVarcharValue(str)};
 
-    auto result = function::StringFunctions::_Length(args);
+    auto result = function::OldEngineStringFunctions::Length(args);
     EXPECT_FALSE(result.IsNull());
     EXPECT_EQ(expected, result.GetAs<int>());
   }
   // NULL CHECK
   std::vector<type::Value> args = {
       type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR)};
-  auto result = function::StringFunctions::_Length(args);
+  auto result = function::OldEngineStringFunctions::Length(args);
   EXPECT_TRUE(result.IsNull());
 }
 

--- a/test/function/string_functions_test.cpp
+++ b/test/function/string_functions_test.cpp
@@ -16,12 +16,9 @@
 
 #include "common/harness.h"
 
+#include "executor/executor_context.h"
 #include "function/string_functions.h"
 #include "function/old_engine_string_functions.h"
-#include "common/internal_types.h"
-#include "type/value.h"
-#include "type/value_factory.h"
-#include "util/string_util.h"
 
 using ::testing::NotNull;
 using ::testing::Return;
@@ -29,42 +26,50 @@ using ::testing::Return;
 namespace peloton {
 namespace test {
 
-class StringFunctionsTests : public PelotonTest {};
+class StringFunctionsTests : public PelotonTest {
+ public:
+  StringFunctionsTests() : test_ctx_(nullptr) {}
+
+  executor::ExecutorContext &GetExecutorContext() { return test_ctx_; }
+
+ private:
+  executor::ExecutorContext test_ctx_;
+};
 
 TEST_F(StringFunctionsTests, LikeTest) {
   //-------------- match ---------------- //
   std::string s1 = "forbes \\avenue";  // "forbes \avenue"
   std::string p1 = "%b_s \\\\avenue";  // "%b_s \\avenue"
-  EXPECT_TRUE(function::StringFunctions::Like(s1.c_str(), s1.size(), p1.c_str(),
-                                              p1.size()));
+  EXPECT_TRUE(function::StringFunctions::Like(
+      GetExecutorContext(), s1.c_str(), s1.size(), p1.c_str(), p1.size()));
 
   std::string s2 = "for%bes avenue%";    // "for%bes avenue%"
   std::string p2 = "for%bes a_enue\\%";  // "for%bes a_enue%"
-  EXPECT_TRUE(function::StringFunctions::Like(s2.c_str(), s2.size(), p2.c_str(),
-                                              p2.size()));
+  EXPECT_TRUE(function::StringFunctions::Like(
+      GetExecutorContext(), s2.c_str(), s2.size(), p2.c_str(), p2.size()));
 
   std::string s3 = "Allison";  // "Allison"
   std::string p3 = "%lison";   // "%lison"
-  EXPECT_TRUE(function::StringFunctions::Like(s3.c_str(), s3.size(), p3.c_str(),
-                                              p3.size()));
+  EXPECT_TRUE(function::StringFunctions::Like(
+      GetExecutorContext(), s3.c_str(), s3.size(), p3.c_str(), p3.size()));
 
   //----------Exact Match------------//
   std::string s5 = "Allison";  // "Allison"
   std::string p5 = "Allison";  // "Allison"
-  EXPECT_TRUE(function::StringFunctions::Like(s5.c_str(), s5.size(), p5.c_str(),
-                                              p5.size()));
+  EXPECT_TRUE(function::StringFunctions::Like(
+      GetExecutorContext(), s5.c_str(), s5.size(), p5.c_str(), p5.size()));
 
   //----------Exact Match------------//
   std::string s6 = "Allison";   // "Allison"
   std::string p6 = "A%llison";  // "A%llison"
-  EXPECT_TRUE(function::StringFunctions::Like(s6.c_str(), s6.size(), p6.c_str(),
-                                              p6.size()));
+  EXPECT_TRUE(function::StringFunctions::Like(
+      GetExecutorContext(), s6.c_str(), s6.size(), p6.c_str(), p6.size()));
 
   //-------------- not match ----------------//
   std::string s4 = "forbes avenue";  // "forbes avenue"
   std::string p4 = "f_bes avenue";   // "f_bes avenue"
-  EXPECT_FALSE(function::StringFunctions::Like(s4.c_str(), s4.size(),
-                                               p4.c_str(), p4.size()));
+  EXPECT_FALSE(function::StringFunctions::Like(
+      GetExecutorContext(), s4.c_str(), s4.size(), p4.c_str(), p4.size()));
 }
 
 TEST_F(StringFunctionsTests, AsciiTest) {
@@ -314,32 +319,32 @@ TEST_F(StringFunctionsTests, CodegenSubstrTest) {
   int from = 1;
   int len = 5;
   std::string expected = message.substr(from - 1, len);
-  auto res = function::StringFunctions::Substr(message.c_str(),
-                                               message.length(), from, len);
+  auto res = function::StringFunctions::Substr(
+      GetExecutorContext(), message.c_str(), message.length(), from, len);
   EXPECT_EQ(len + 1, res.length);
   EXPECT_EQ(expected, std::string(res.str, len));
 
   from = 7;
   len = 1;
   expected = message.substr(from - 1, len);
-  res = function::StringFunctions::Substr(message.c_str(), message.length(),
-                                          from, len);
+  res = function::StringFunctions::Substr(GetExecutorContext(), message.c_str(),
+                                          message.length(), from, len);
   EXPECT_EQ(len + 1, res.length);
   EXPECT_EQ(expected, std::string(res.str, len));
 
   from = -2;
   len = 4;
   expected = message.substr(0, 1);
-  res = function::StringFunctions::Substr(message.c_str(), message.length(),
-                                          from, len);
+  res = function::StringFunctions::Substr(GetExecutorContext(), message.c_str(),
+                                          message.length(), from, len);
   EXPECT_EQ(2, res.length);
   EXPECT_EQ(expected, std::string(res.str, 1));
 
   from = -2;
   len = 2;
   expected = "";
-  res = function::StringFunctions::Substr(message.c_str(), message.length(),
-                                          from, len);
+  res = function::StringFunctions::Substr(GetExecutorContext(), message.c_str(),
+                                          message.length(), from, len);
   EXPECT_EQ(0, res.length);
   EXPECT_EQ(nullptr, res.str);
 }


### PR DESCRIPTION
This PR moves the string functions used by the interpreted engine into `OldEngineStringFunctions`. This is in preparation for 15-721. I also added the `Repeat` function to codegen to serve as an example.