### PR TITLE
statement_cache_manager_test fix for clang compile error

### DIFF
--- a/test/common/statement_cache_manager_test.cpp
+++ b/test/common/statement_cache_manager_test.cpp
@@ -62,7 +62,7 @@ TEST_F(StatementCacheTests, InvalidateManyTest) {
   std::set<oid_t> ref_table = {0, 1};
 
   for (auto oid : ref_table) {
-    std::string string_name = "foo" + oid;
+    std::string string_name = std::to_string(oid);
     std::string query = "SELECT * FROM TEST";
     auto statement = std::make_shared<Statement>(string_name, query);
     std::set<oid_t> cur_ref_table;
@@ -78,7 +78,7 @@ TEST_F(StatementCacheTests, InvalidateManyTest) {
 
   // Both plans need to replan now
   for (auto oid : ref_table) {
-    std::string string_name = "foo" + oid;
+    std::string string_name = std::to_string(oid);
     auto statement = statement_cache.GetStatement(string_name);
 
     EXPECT_TRUE(statement->GetNeedsReplan());


### PR DESCRIPTION
Someone posted a screenshot showing there would be compiled error in statement_cache_manager_test.cpp. 

I somehow encountered this before in statement_cache.cpp. I fixed that then but some errors remained unfound in the statement_cache_manager_test.cpp.