### PR TITLE
Information about indexes affected by a given query

### DIFF
--- a/src/include/catalog/catalog_cache.h
+++ b/src/include/catalog/catalog_cache.h
@@ -18,6 +18,11 @@
 #include "common/internal_types.h"
 
 namespace peloton {
+
+namespace planner {
+    class PlanUtil;
+}
+
 namespace catalog {
 
 class DatabaseCatalogObject;
@@ -32,6 +37,7 @@ class CatalogCache {
   friend class DatabaseCatalogObject;
   friend class TableCatalogObject;
   friend class IndexCatalogObject;
+  friend class planner::PlanUtil;
 
  public:
   CatalogCache() {}

--- a/src/include/catalog/catalog_cache.h
+++ b/src/include/catalog/catalog_cache.h
@@ -20,8 +20,8 @@
 namespace peloton {
 
 namespace planner {
-    class PlanUtil;
-}
+class PlanUtil;
+}  // namespace planner
 
 namespace catalog {
 

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -24,7 +24,7 @@ namespace parser {
  * @brief Represents "INSERT INTO students VALUES ('Max', 1112233,
  * 'Musterhausen', 2.3)"
  */
-class InsertStatement : SQLStatement {
+class InsertStatement : public SQLStatement {
  public:
   InsertStatement(InsertType type)
       : SQLStatement(StatementType::INSERT), type(type), select(nullptr) {}

--- a/src/include/parser/sql_statement.h
+++ b/src/include/parser/sql_statement.h
@@ -19,10 +19,10 @@
 
 #include <vector>
 
+#include "common/internal_types.h"
 #include "common/macros.h"
 #include "common/printable.h"
 #include "common/sql_node_visitor.h"
-#include "common/internal_types.h"
 
 namespace peloton {
 
@@ -43,7 +43,7 @@ class SQLStatement : public Printable {
 
   virtual ~SQLStatement() {}
 
-  virtual StatementType GetType() { return stmt_type; }
+  virtual StatementType GetType() const { return stmt_type; }
 
   // Get a string representation for debugging
   virtual const std::string GetInfo(int num_indent) const;

--- a/src/include/parser/update_statement.h
+++ b/src/include/parser/update_statement.h
@@ -56,10 +56,6 @@ class UpdateStatement : public SQLStatement {
 
   virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
-  inline void TryBindDatabaseName(std::string default_database_name) {
-    table->TryBindDatabaseName(default_database_name);
-  }
-
   const std::string GetInfo(int num_indent) const override;
 
   const std::string GetInfo() const override;

--- a/src/include/parser/update_statement.h
+++ b/src/include/parser/update_statement.h
@@ -14,8 +14,8 @@
 
 #include <cstring>
 
-#include "expression/abstract_expression.h"
 #include "common/sql_node_visitor.h"
+#include "expression/abstract_expression.h"
 #include "parser/sql_statement.h"
 #include "parser/table_ref.h"
 
@@ -55,6 +55,10 @@ class UpdateStatement : public SQLStatement {
   virtual ~UpdateStatement() {}
 
   virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
+
+  inline void TryBindDatabaseName(std::string default_database_name) {
+    table->TryBindDatabaseName(default_database_name);
+  }
 
   const std::string GetInfo(int num_indent) const override;
 

--- a/src/include/planner/plan_util.h
+++ b/src/include/planner/plan_util.h
@@ -19,8 +19,8 @@
 #include "planner/abstract_scan_plan.h"
 #include "planner/delete_plan.h"
 #include "planner/insert_plan.h"
-#include "planner/update_plan.h"
 #include "planner/populate_index_plan.h"
+#include "planner/update_plan.h"
 #include "storage/data_table.h"
 #include "util/string_util.h"
 
@@ -28,11 +28,11 @@ namespace peloton {
 
 namespace catalog {
 class CatalogCache;
-}
+}  // namespace catalog
 
 namespace parser {
 class SQLStatement;
-}
+}  // namespace parser
 
 namespace planner {
 
@@ -60,7 +60,8 @@ class PlanUtil {
   * @return set of affected index object ids
   */
   static const std::set<oid_t> GetAffectedIndexes(
-      catalog::CatalogCache &catalog_cache, parser::SQLStatement *sql_stmt);
+      catalog::CatalogCache &catalog_cache,
+      const parser::SQLStatement &sql_stmt);
 
  private:
   ///

--- a/src/include/planner/plan_util.h
+++ b/src/include/planner/plan_util.h
@@ -15,6 +15,17 @@
 #include <set>
 #include <string>
 
+#include "catalog/catalog_cache.h"
+#include "catalog/database_catalog.h"
+#include "catalog/table_catalog.h"
+#include "catalog/column_catalog.h"
+#include "catalog/index_catalog.h"
+
+#include "parser/delete_statement.h"
+#include "parser/insert_statement.h"
+#include "parser/sql_statement.h"
+#include "parser/update_statement.h"
+
 #include "planner/abstract_plan.h"
 #include "planner/abstract_scan_plan.h"
 #include "planner/delete_plan.h"
@@ -43,6 +54,15 @@ class PlanUtil {
    */
   static const std::set<oid_t> GetTablesReferenced(
       const planner::AbstractPlan *plan);
+
+  /**
+  * @brief Get the indexes affected by a given query
+  * @param CatalogCache
+  * @param SQLStatement
+  * @return set of affected index object ids
+  */
+  static const std::set<oid_t> GetAffectedIndexes(
+      catalog::CatalogCache& catalog_cache, parser::SQLStatement* sql_stmt);
 
  private:
   ///
@@ -147,6 +167,93 @@ inline void PlanUtil::GetTablesReferenced(const planner::AbstractPlan *plan,
       GetTablesReferenced(child.get(), table_ids);
     }
   }
+}
+
+namespace {
+
+template <typename T>
+bool isDisjoint(const std::set<T> &setA, const std::set<T> &setB) {
+  bool disjoint = true;
+  if (setA.empty() || setB.empty())
+    return disjoint;
+
+  typename std::set<T>::const_iterator setA_it = setA.begin();
+  typename std::set<T>::const_iterator setB_it = setB.begin();
+  while (setA_it != setA.end() && setB_it != setB.end() && disjoint) {
+    if (*setA_it == *setB_it)
+      disjoint = false;
+    else if (*setA_it < *setB_it)
+      setA_it++;
+    else
+      setB_it++;
+  }
+
+  return disjoint;
+}
+
+}  // namespace
+
+inline const std::set<oid_t> PlanUtil::GetAffectedIndexes(
+    catalog::CatalogCache &catalog_cache, parser::SQLStatement *sql_stmt) {
+  std::set<oid_t> index_oids;
+  std::string db_name, table_name;
+  switch (sql_stmt->GetType()) {
+    // For INSERT, DELETE, all indexes are affected
+    case StatementType::INSERT: {
+      auto insert_stmt = static_cast<parser::InsertStatement *>(sql_stmt);
+      db_name = insert_stmt->GetDatabaseName();
+      table_name = insert_stmt->GetTableName();
+    }
+    PELOTON_FALLTHROUGH;
+    case StatementType::DELETE: {
+      if (table_name.empty() || db_name.empty()) {
+        auto delete_stmt = static_cast<parser::DeleteStatement *>(sql_stmt);
+        db_name = delete_stmt->GetDatabaseName();
+        table_name = delete_stmt->GetTableName();
+      }
+      auto indexes_map = catalog_cache.GetDatabaseObject(db_name)
+                             ->GetTableObject(table_name)
+                             ->GetIndexObjects();
+      for (auto &index : indexes_map) {
+        index_oids.insert(index.first);
+      }
+    }
+    break;
+    case StatementType::UPDATE: {
+      auto update_stmt = static_cast<parser::UpdateStatement *>(sql_stmt);
+      db_name = update_stmt->table->GetDatabaseName();
+      table_name = update_stmt->table->GetTableName();
+      auto db_object = catalog_cache.GetDatabaseObject(db_name);
+      auto table_object = db_object->GetTableObject(table_name);
+
+      auto &update_clauses = update_stmt->updates;
+      std::set<oid_t> update_oids;
+      for (const auto &update_clause : update_clauses) {
+        LOG_TRACE("Affected column name for table(%s) in UPDATE query: %s",
+                  table_name.c_str(), update_clause->column.c_str());
+        auto col_object = table_object->GetColumnObject(update_clause->column);
+        update_oids.insert(col_object->GetColumnId());
+      }
+
+      auto indexes_map = table_object->GetIndexObjects();
+      for (auto &index : indexes_map) {
+        LOG_TRACE("Checking if UPDATE query affects index: %s",
+                  index.second->GetIndexName().c_str());
+        const std::vector<oid_t> &key_attrs =
+            index.second->GetKeyAttrs();  // why it's a vector, and not set?
+        const std::set<oid_t> key_attrs_set(key_attrs.begin(), key_attrs.end());
+        if (!isDisjoint(key_attrs_set, update_oids)) {
+          LOG_TRACE("Index (%s) is affected",
+                    index.second->GetIndexName().c_str());
+          index_oids.insert(index.first);
+        }
+      }
+    } break;
+    default:
+      LOG_TRACE("Does not support finding affected indexes for query type: %d",
+                static_cast<int>(sql_stmt->GetType()));
+  }
+  return (index_oids);
 }
 
 }  // namespace planner

--- a/src/include/util/set_util.h
+++ b/src/include/util/set_util.h
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// set_util.h
+//
+// Identification: src/include/util/set_util.h
+//
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <set>
+
+namespace peloton {
+
+class SetUtil {
+ public:
+  template <typename T>
+  static bool isDisjoint(const std::set<T> &setA, const std::set<T> &setB) {
+    bool disjoint = true;
+    if (setA.empty() || setB.empty()) return disjoint;
+
+    typename std::set<T>::const_iterator setA_it = setA.begin();
+    typename std::set<T>::const_iterator setB_it = setB.begin();
+    while (setA_it != setA.end() && setB_it != setB.end() && disjoint) {
+      if (*setA_it == *setB_it) {
+        disjoint = false;
+      } else if (*setA_it < *setB_it) {
+        setA_it++;
+      } else {
+        setB_it++;
+      }
+    }
+
+    return disjoint;
+  }
+};
+
+}  // namespace peloton

--- a/src/include/util/set_util.h
+++ b/src/include/util/set_util.h
@@ -6,7 +6,7 @@
 //
 // Identification: src/include/util/set_util.h
 //
-// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -19,24 +19,28 @@ namespace peloton {
 class SetUtil {
  public:
   template <typename T>
-  static bool isDisjoint(const std::set<T> &setA, const std::set<T> &setB) {
-    bool disjoint = true;
-    if (setA.empty() || setB.empty()) return disjoint;
-
-    typename std::set<T>::const_iterator setA_it = setA.begin();
-    typename std::set<T>::const_iterator setB_it = setB.begin();
-    while (setA_it != setA.end() && setB_it != setB.end() && disjoint) {
-      if (*setA_it == *setB_it) {
-        disjoint = false;
-      } else if (*setA_it < *setB_it) {
-        setA_it++;
-      } else {
-        setB_it++;
-      }
-    }
-
-    return disjoint;
-  }
+  static bool IsDisjoint(const std::set<T> &setA, const std::set<T> &setB);
 };
+
+template <typename T>
+inline bool SetUtil::IsDisjoint(const std::set<T> &setA,
+                                const std::set<T> &setB) {
+  bool disjoint = true;
+  if (setA.empty() || setB.empty()) return disjoint;
+
+  auto setA_it = setA.begin();
+  auto setB_it = setB.begin();
+  while (setA_it != setA.end() && setB_it != setB.end() && disjoint) {
+    if (*setA_it == *setB_it) {
+      disjoint = false;
+    } else if (*setA_it < *setB_it) {
+      setA_it++;
+    } else {
+      setB_it++;
+    }
+  }
+
+  return disjoint;
+}
 
 }  // namespace peloton

--- a/src/planner/plan_util.cpp
+++ b/src/planner/plan_util.cpp
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// plan_util.cpp
+//
+// Identification: src/planner/plan_util.cpp
+//
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <set>
+#include <string>
+
+#include "catalog/catalog_cache.h"
+#include "catalog/column_catalog.h"
+#include "catalog/database_catalog.h"
+#include "catalog/index_catalog.h"
+#include "catalog/table_catalog.h"
+#include "parser/delete_statement.h"
+#include "parser/insert_statement.h"
+#include "parser/sql_statement.h"
+#include "parser/update_statement.h"
+#include "planner/plan_util.h"
+#include "util/set_util.h"
+
+namespace peloton {
+namespace planner {
+
+const std::set<oid_t> PlanUtil::GetAffectedIndexes(
+    catalog::CatalogCache &catalog_cache, parser::SQLStatement *sql_stmt) {
+  std::set<oid_t> index_oids;
+  std::string db_name, table_name;
+  switch (sql_stmt->GetType()) {
+    // For INSERT, DELETE, all indexes are affected
+    case StatementType::INSERT: {
+      auto insert_stmt = static_cast<parser::InsertStatement *>(sql_stmt);
+      db_name = insert_stmt->GetDatabaseName();
+      table_name = insert_stmt->GetTableName();
+    }
+      PELOTON_FALLTHROUGH;
+    case StatementType::DELETE: {
+      if (table_name.empty() || db_name.empty()) {
+        auto delete_stmt = static_cast<parser::DeleteStatement *>(sql_stmt);
+        db_name = delete_stmt->GetDatabaseName();
+        table_name = delete_stmt->GetTableName();
+      }
+      auto indexes_map = catalog_cache.GetDatabaseObject(db_name)
+                             ->GetTableObject(table_name)
+                             ->GetIndexObjects();
+      for (auto &index : indexes_map) {
+        index_oids.insert(index.first);
+      }
+    } break;
+    case StatementType::UPDATE: {
+      auto update_stmt = static_cast<parser::UpdateStatement *>(sql_stmt);
+      db_name = update_stmt->table->GetDatabaseName();
+      table_name = update_stmt->table->GetTableName();
+      auto db_object = catalog_cache.GetDatabaseObject(db_name);
+      auto table_object = db_object->GetTableObject(table_name);
+
+      auto &update_clauses = update_stmt->updates;
+      std::set<oid_t> update_oids;
+      for (const auto &update_clause : update_clauses) {
+        LOG_TRACE("Affected column name for table(%s) in UPDATE query: %s",
+                  table_name.c_str(), update_clause->column.c_str());
+        auto col_object = table_object->GetColumnObject(update_clause->column);
+        update_oids.insert(col_object->GetColumnId());
+      }
+
+      auto indexes_map = table_object->GetIndexObjects();
+      for (auto &index : indexes_map) {
+        LOG_TRACE("Checking if UPDATE query affects index: %s",
+                  index.second->GetIndexName().c_str());
+        const std::vector<oid_t> &key_attrs =
+            index.second->GetKeyAttrs();  // why it's a vector, and not set?
+        const std::set<oid_t> key_attrs_set(key_attrs.begin(), key_attrs.end());
+        if (!SetUtil::isDisjoint(key_attrs_set, update_oids)) {
+          LOG_TRACE("Index (%s) is affected",
+                    index.second->GetIndexName().c_str());
+          index_oids.insert(index.first);
+        }
+      }
+    } break;
+    case StatementType::SELECT:
+      break;
+    default:
+      LOG_TRACE("Does not support finding affected indexes for query type: %d",
+                static_cast<int>(sql_stmt->GetType()));
+  }
+  return (index_oids);
+}
+
+}  // namespace planner
+}  // namespace peloton

--- a/test/planner/plan_util_test.cpp
+++ b/test/planner/plan_util_test.cpp
@@ -154,6 +154,17 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
   EXPECT_EQ(static_cast<int>(affected_indexes.size()), 2);
   expected_oids = std::set<oid_t>({id_idx_oid, fname_idx_oid});
   EXPECT_EQ(expected_oids, affected_indexes);
+
+  // ========= SELECT statement check ==
+  query_string = "SELECT * FROM test_table;";
+  stmt.reset(new Statement("SELECT", query_string));
+  sql_stmt_list = peloton_parser.BuildParseTree(query_string);
+  sql_stmt = sql_stmt_list->GetStatement(0);
+  affected_indexes =
+      planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);
+
+  // no indexes are affected
+  EXPECT_EQ(static_cast<int>(affected_indexes.size()), 0);
 }
 }
 }

--- a/test/planner/plan_util_test.cpp
+++ b/test/planner/plan_util_test.cpp
@@ -100,7 +100,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
   auto &peloton_parser = parser::PostgresParser::GetInstance();
   auto sql_stmt_list = peloton_parser.BuildParseTree(query_string);
   auto sql_stmt = sql_stmt_list->GetStatement(0);
-  static_cast<parser::UpdateStatement *>(sql_stmt)->TryBindDatabaseName(
+  static_cast<parser::UpdateStatement *>(sql_stmt)->table->TryBindDatabaseName(
       TEST_DB_NAME);
   std::set<oid_t> affected_indexes =
       planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);
@@ -115,7 +115,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
   stmt.reset(new Statement("UPDATE", query_string));
   sql_stmt_list = peloton_parser.BuildParseTree(query_string);
   sql_stmt = sql_stmt_list->GetStatement(0);
-  static_cast<parser::UpdateStatement *>(sql_stmt)->TryBindDatabaseName(
+  static_cast<parser::UpdateStatement *>(sql_stmt)->table->TryBindDatabaseName(
       TEST_DB_NAME);
   affected_indexes =
       planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);

--- a/test/planner/plan_util_test.cpp
+++ b/test/planner/plan_util_test.cpp
@@ -1,0 +1,160 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// plan_util_test.cpp
+//
+// Identification: test/planner/plan_util_test.cpp
+//
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/harness.h"
+
+#include "catalog/catalog.h"
+#include "catalog/database_catalog.h"
+#include "catalog/index_catalog.h"
+#include "catalog/table_catalog.h"
+#include "common/statement.h"
+#include "concurrency/transaction_manager_factory.h"
+#include "executor/testing_executor_util.h"
+#include "parser/postgresparser.h"
+#include "storage/data_table.h"
+
+#include "planner/plan_util.h"
+
+namespace peloton {
+namespace test {
+
+#define TEST_DB_NAME "test_db"
+
+class PlanUtilTests : public PelotonTest {};
+
+TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
+  auto catalog = catalog::Catalog::GetInstance();
+  catalog->Bootstrap();
+
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+
+  catalog->CreateDatabase(TEST_DB_NAME, txn);
+  auto db = catalog->GetDatabaseWithName(TEST_DB_NAME, txn);
+  // Insert a table first
+  auto id_column = catalog::Column(
+      type::TypeId::INTEGER, type::Type::GetTypeSize(type::TypeId::INTEGER),
+      "id", true);
+  auto fname_column =
+      catalog::Column(type::TypeId::VARCHAR, 32, "first_name", false);
+  auto lname_column =
+      catalog::Column(type::TypeId::VARCHAR, 32, "last_name", false);
+
+  std::unique_ptr<catalog::Schema> table_schema(
+      new catalog::Schema({id_column, fname_column, lname_column}));
+  txn_manager.CommitTransaction(txn);
+
+  txn = txn_manager.BeginTransaction();
+  catalog->CreateTable(TEST_DB_NAME, "test_table", std::move(table_schema),
+                       txn);
+  txn_manager.CommitTransaction(txn);
+
+  txn = txn_manager.BeginTransaction();
+  auto source_table = db->GetTableWithName("test_table");
+  oid_t col_id = source_table->GetSchema()->GetColumnID(id_column.column_name);
+  LOG_INFO("id: %d", static_cast<int>(col_id));
+  std::vector<oid_t> source_col_ids;
+  source_col_ids.push_back(col_id);
+
+  // create index on 'id'
+  catalog->CreateIndex(TEST_DB_NAME, "test_table", source_col_ids,
+                       "test_id_idx", false, IndexType::BWTREE, txn);
+
+  // create index on 'id' and 'first_name'
+  col_id = source_table->GetSchema()->GetColumnID(fname_column.column_name);
+  LOG_INFO("fname: %d", static_cast<int>(col_id));
+  source_col_ids.push_back(col_id);
+
+  catalog->CreateIndex(TEST_DB_NAME, "test_table", source_col_ids,
+                       "test_fname_idx", false, IndexType::BWTREE, txn);
+  txn_manager.CommitTransaction(txn);
+
+  // dummy txn to get the catalog_cache object
+  txn = txn_manager.BeginTransaction();
+
+  // This is also required so that database objects are cached
+  auto db_object = catalog->GetDatabaseObject(TEST_DB_NAME, txn);
+  EXPECT_EQ(static_cast<int>(db_object->GetTableObjects().size()), 1);
+
+  // Till now, we have a table : id, first_name, last_name
+  // And two indexes on following columns:
+  // 1) id
+  // 2) id and first_name
+  auto table_object = db_object->GetTableObject("test_table");
+  oid_t id_idx_oid = table_object->GetIndexObject("test_id_idx")->GetIndexOid();
+  oid_t fname_idx_oid =
+      table_object->GetIndexObject("test_fname_idx")->GetIndexOid();
+
+  // An update query affecting both indexes
+  std::string query_string = "UPDATE test_table SET id = 0;";
+  std::unique_ptr<Statement> stmt =
+      std::make_unique<Statement>("UPDATE", query_string);
+  auto &peloton_parser = parser::PostgresParser::GetInstance();
+  auto sql_stmt_list = peloton_parser.BuildParseTree(query_string);
+  auto sql_stmt = sql_stmt_list->GetStatement(0);
+  static_cast<parser::UpdateStatement *>(sql_stmt)->TryBindDatabaseName(
+      TEST_DB_NAME);
+  std::set<oid_t> affected_indexes =
+      planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);
+
+  // id and first_name are affected
+  EXPECT_EQ(static_cast<int>(affected_indexes.size()), 2);
+  std::set<oid_t> expected_oids{id_idx_oid, fname_idx_oid};
+  EXPECT_EQ(expected_oids, affected_indexes);
+
+  // Update query affecting only one index
+  query_string = "UPDATE test_table SET first_name = '';";
+  stmt = std::make_unique<Statement>("UPDATE", query_string);
+  sql_stmt_list = peloton_parser.BuildParseTree(query_string);
+  sql_stmt = sql_stmt_list->GetStatement(0);
+  static_cast<parser::UpdateStatement *>(sql_stmt)->TryBindDatabaseName(
+      TEST_DB_NAME);
+  affected_indexes =
+      planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);
+
+  // only first_name is affected
+  EXPECT_EQ(static_cast<int>(affected_indexes.size()), 1);
+  expected_oids = std::set<oid_t>({fname_idx_oid});
+  EXPECT_EQ(expected_oids, affected_indexes);
+
+  // ====== DELETE statements check ===
+  query_string = "DELETE FROM test_table;";
+  stmt = std::make_unique<Statement>("DELETE", query_string);
+  sql_stmt_list = peloton_parser.BuildParseTree(query_string);
+  sql_stmt = sql_stmt_list->GetStatement(0);
+  static_cast<parser::DeleteStatement *>(sql_stmt)->TryBindDatabaseName(
+      TEST_DB_NAME);
+  affected_indexes =
+      planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);
+
+  // all indexes are affected
+  EXPECT_EQ(static_cast<int>(affected_indexes.size()), 2);
+  expected_oids = std::set<oid_t>({id_idx_oid, fname_idx_oid});
+  EXPECT_EQ(expected_oids, affected_indexes);
+
+  // ========= INSERT statements check ==
+  query_string = "INSERT INTO test_table VALUES (1, 'pel', 'ton');";
+  stmt = std::make_unique<Statement>("INSERT", query_string);
+  sql_stmt_list = peloton_parser.BuildParseTree(query_string);
+  sql_stmt = sql_stmt_list->GetStatement(0);
+  static_cast<parser::InsertStatement *>(sql_stmt)->TryBindDatabaseName(
+      TEST_DB_NAME);
+  affected_indexes =
+      planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);
+
+  // all indexes are affected
+  EXPECT_EQ(static_cast<int>(affected_indexes.size()), 2);
+  expected_oids = std::set<oid_t>({id_idx_oid, fname_idx_oid});
+  EXPECT_EQ(expected_oids, affected_indexes);
+}
+}
+}

--- a/test/planner/plan_util_test.cpp
+++ b/test/planner/plan_util_test.cpp
@@ -83,7 +83,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
 
   // This is also required so that database objects are cached
   auto db_object = catalog->GetDatabaseObject(TEST_DB_NAME, txn);
-  EXPECT_EQ(static_cast<int>(db_object->GetTableObjects().size()), 1);
+  EXPECT_EQ(1, static_cast<int>(db_object->GetTableObjects().size()));
 
   // Till now, we have a table : id, first_name, last_name
   // And two indexes on following columns:
@@ -106,7 +106,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
       planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);
 
   // id and first_name are affected
-  EXPECT_EQ(static_cast<int>(affected_indexes.size()), 2);
+  EXPECT_EQ(2, static_cast<int>(affected_indexes.size()));
   std::set<oid_t> expected_oids{id_idx_oid, fname_idx_oid};
   EXPECT_EQ(expected_oids, affected_indexes);
 
@@ -121,7 +121,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
       planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);
 
   // only first_name is affected
-  EXPECT_EQ(static_cast<int>(affected_indexes.size()), 1);
+  EXPECT_EQ(1, static_cast<int>(affected_indexes.size()));
   expected_oids = std::set<oid_t>({fname_idx_oid});
   EXPECT_EQ(expected_oids, affected_indexes);
 
@@ -136,7 +136,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
       planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);
 
   // all indexes are affected
-  EXPECT_EQ(static_cast<int>(affected_indexes.size()), 2);
+  EXPECT_EQ(2, static_cast<int>(affected_indexes.size()));
   expected_oids = std::set<oid_t>({id_idx_oid, fname_idx_oid});
   EXPECT_EQ(expected_oids, affected_indexes);
 
@@ -151,7 +151,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
       planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);
 
   // all indexes are affected
-  EXPECT_EQ(static_cast<int>(affected_indexes.size()), 2);
+  EXPECT_EQ(2, static_cast<int>(affected_indexes.size()));
   expected_oids = std::set<oid_t>({id_idx_oid, fname_idx_oid});
   EXPECT_EQ(expected_oids, affected_indexes);
 
@@ -164,7 +164,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
       planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);
 
   // no indexes are affected
-  EXPECT_EQ(static_cast<int>(affected_indexes.size()), 0);
+  EXPECT_EQ(0, static_cast<int>(affected_indexes.size()));
 }
 }
 }

--- a/test/planner/plan_util_test.cpp
+++ b/test/planner/plan_util_test.cpp
@@ -61,7 +61,6 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
   txn = txn_manager.BeginTransaction();
   auto source_table = db->GetTableWithName("test_table");
   oid_t col_id = source_table->GetSchema()->GetColumnID(id_column.column_name);
-  LOG_INFO("id: %d", static_cast<int>(col_id));
   std::vector<oid_t> source_col_ids;
   source_col_ids.push_back(col_id);
 
@@ -71,7 +70,6 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
 
   // create index on 'id' and 'first_name'
   col_id = source_table->GetSchema()->GetColumnID(fname_column.column_name);
-  LOG_INFO("fname: %d", static_cast<int>(col_id));
   source_col_ids.push_back(col_id);
 
   catalog->CreateIndex(TEST_DB_NAME, "test_table", source_col_ids,
@@ -166,5 +164,6 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
   // no indexes are affected
   EXPECT_EQ(0, static_cast<int>(affected_indexes.size()));
 }
-}
-}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/planner/plan_util_test.cpp
+++ b/test/planner/plan_util_test.cpp
@@ -96,8 +96,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
 
   // An update query affecting both indexes
   std::string query_string = "UPDATE test_table SET id = 0;";
-  std::unique_ptr<Statement> stmt =
-      std::make_unique<Statement>("UPDATE", query_string);
+  std::unique_ptr<Statement> stmt(new Statement("UPDATE", query_string));
   auto &peloton_parser = parser::PostgresParser::GetInstance();
   auto sql_stmt_list = peloton_parser.BuildParseTree(query_string);
   auto sql_stmt = sql_stmt_list->GetStatement(0);
@@ -113,7 +112,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
 
   // Update query affecting only one index
   query_string = "UPDATE test_table SET first_name = '';";
-  stmt = std::make_unique<Statement>("UPDATE", query_string);
+  stmt.reset(new Statement("UPDATE", query_string));
   sql_stmt_list = peloton_parser.BuildParseTree(query_string);
   sql_stmt = sql_stmt_list->GetStatement(0);
   static_cast<parser::UpdateStatement *>(sql_stmt)->TryBindDatabaseName(
@@ -128,7 +127,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
 
   // ====== DELETE statements check ===
   query_string = "DELETE FROM test_table;";
-  stmt = std::make_unique<Statement>("DELETE", query_string);
+  stmt.reset(new Statement("DELETE", query_string));
   sql_stmt_list = peloton_parser.BuildParseTree(query_string);
   sql_stmt = sql_stmt_list->GetStatement(0);
   static_cast<parser::DeleteStatement *>(sql_stmt)->TryBindDatabaseName(
@@ -143,7 +142,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
 
   // ========= INSERT statements check ==
   query_string = "INSERT INTO test_table VALUES (1, 'pel', 'ton');";
-  stmt = std::make_unique<Statement>("INSERT", query_string);
+  stmt.reset(new Statement("INSERT", query_string));
   sql_stmt_list = peloton_parser.BuildParseTree(query_string);
   sql_stmt = sql_stmt_list->GetStatement(0);
   static_cast<parser::InsertStatement *>(sql_stmt)->TryBindDatabaseName(

--- a/test/util/set_util_test.cpp
+++ b/test/util/set_util_test.cpp
@@ -30,16 +30,16 @@ TEST_F(SetUtilTests, DisjointTest) {
   // Check sorted sets
   std::set<int> setA{1, 2, 3, 4};
   std::set<int> setB{4, 5, 6, 7};
-  EXPECT_FALSE(SetUtil::isDisjoint(setA, setB));
+  EXPECT_FALSE(SetUtil::IsDisjoint(setA, setB));
 
   std::set<int> setC{9, 8, 10};
-  EXPECT_TRUE(SetUtil::isDisjoint(setA, setC));
+  EXPECT_TRUE(SetUtil::IsDisjoint(setA, setC));
 
   std::set<int> setD{4, 1, 3, 2};
-  EXPECT_FALSE(SetUtil::isDisjoint(setB, setD));
+  EXPECT_FALSE(SetUtil::IsDisjoint(setB, setD));
 
   std::set<int> setE;
-  EXPECT_TRUE(SetUtil::isDisjoint(setD, setE));
+  EXPECT_TRUE(SetUtil::IsDisjoint(setD, setE));
 }
 
 }  // namespace test

--- a/test/util/set_util_test.cpp
+++ b/test/util/set_util_test.cpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// set_util_test.cpp
+//
+// Identification: test/set_util_test.cpp
+//
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/harness.h"
+#include "common/logger.h"
+
+#include <set>
+
+#include "util/set_util.h"
+
+namespace peloton {
+namespace test {
+
+//===--------------------------------------------------------------------===//
+// SetUtil Test
+//===--------------------------------------------------------------------===//
+
+class SetUtilTests : public PelotonTest {};
+
+TEST_F(SetUtilTests, DisjointTest) {
+  // Check sorted sets
+  std::set<int> setA{1, 2, 3, 4};
+  std::set<int> setB{4, 5, 6, 7};
+  EXPECT_FALSE(SetUtil::isDisjoint(setA, setB));
+
+  std::set<int> setC{9, 8, 10};
+  EXPECT_TRUE(SetUtil::isDisjoint(setA, setC));
+
+  std::set<int> setD{4, 1, 3, 2};
+  EXPECT_FALSE(SetUtil::isDisjoint(setB, setD));
+
+  std::set<int> setE;
+  EXPECT_TRUE(SetUtil::isDisjoint(setD, setE));
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/util/set_util_test.cpp
+++ b/test/util/set_util_test.cpp
@@ -6,7 +6,7 @@
 //
 // Identification: test/set_util_test.cpp
 //
-// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/util/set_util_test.cpp
+++ b/test/util/set_util_test.cpp
@@ -4,7 +4,7 @@
 //
 // set_util_test.cpp
 //
-// Identification: test/set_util_test.cpp
+// Identification: test/util/set_util_test.cpp
 //
 // Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //


### PR DESCRIPTION
This is the first cut for #1097 

I can move the common functions like isDisjoint to some other more common utility class but first I want to get an idea if this is going in the right direction. :)

Also, I didn't create a new class as was described in the issue since there was already this PlanUtil in planner::