### PR TITLE
Standardize macro names

### DIFF
--- a/script/coding_style.md
+++ b/script/coding_style.md
@@ -21,7 +21,7 @@ Another measure of the function is the number of local variables.  They shouldn'
 
 **PRINTF** Refrain from using `printf` and `std::cout`. Instead use the logging macros, such as LOG_LEVEL_INFO, in `common/logger.h`.
 
-**DON'T REINVENT THE MACROS** Use `PL_ASSERT` in `common/macros.h` instead of regular `assert`. This header file icontains a number of macros that you should use, rather than explicitly coding some variant of them yourself.
+**DON'T REINVENT THE MACROS** Use `PELOTON_ASSERT` in `common/macros.h` instead of regular `assert`. This header file icontains a number of macros that you should use, rather than explicitly coding some variant of them yourself.
 
 **PLAFORM-SPECIFIC CODE** Add platform-specific code only to `common/platform.h`.
 
@@ -53,7 +53,7 @@ The example above illustrates a valid use of the `inline` keyword for the defini
 
 **EDITOR MODELINES** Some editors can interpret configuration information embedded in source files, indicated with special markers.  For example, emacs interprets lines marked like this:	-*- mode: c -*-. Do NOT include any of these in source files. People have their own personal editor configurations, and your source files should not override them.
 
-**ALLOCATING MEMORY** Use `PL_MEMCPY` macro in `common/macros.h`. Always use smart pointers, such as `std::unique_ptr`, to simplify memory management.
+**ALLOCATING MEMORY** Use `PELOTON_MEMCPY` macro in `common/macros.h`. Always use smart pointers, such as `std::unique_ptr`, to simplify memory management.
 
 **PRINTING PELOTON MESSAGES** Peloton developers like to be seen as literate. Do mind the spelling of messages to make a good impression. Do not use crippled words like "dont"; use "do not" or "don't" instead.  Make the messages concise, clear, and unambiguous. Use appropriate log levels, such as LOG_LEVEL_TRACE, in `common/logger.h`. Coming up with good debugging messages can be quite a challenge; and once you have them, they can be a huge help for troubleshooting.
 

--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -232,7 +232,7 @@ void BindNodeVisitor::Visit(expression::TupleValueExpression *expr) {
                    context_, table_name, col_name, value_type, depth))
         throw Exception("Invalid table reference " + expr->GetTableName());
     }
-    PL_ASSERT(!expr->GetIsBound());
+    PELOTON_ASSERT(!expr->GetIsBound());
     expr->SetDepth(depth);
     expr->SetColName(col_name);
     expr->SetValueType(value_type);

--- a/src/binder/binder_context.cpp
+++ b/src/binder/binder_context.cpp
@@ -37,7 +37,7 @@ void BinderContext::AddRegularTable(const std::string db_name,
                                     const std::string table_alias,
                                     concurrency::TransactionContext *txn) {
   // using catalog object to retrieve meta-data
-  // PL_ASSERT(txn->catalog_cache.GetDatabaseObject(db_name) != nullptr);
+  // PELOTON_ASSERT(txn->catalog_cache.GetDatabaseObject(db_name) != nullptr);
   auto table_object =
     catalog::Catalog::GetInstance()->GetTableObject(db_name, table_name, txn);
     // txn->catalog_cache.GetDatabaseObject(db_name)->GetTableObject(table_name, true);

--- a/src/brain/clusterer.cpp
+++ b/src/brain/clusterer.cpp
@@ -66,8 +66,8 @@ double Clusterer::GetFraction(oid_t cluster_offset) const {
 }
 
 column_map_type Clusterer::GetPartitioning(oid_t tile_count) const {
-  PL_ASSERT(tile_count >= 1);
-  PL_ASSERT(tile_count <= sample_column_count_);
+  PELOTON_ASSERT(tile_count >= 1);
+  PELOTON_ASSERT(tile_count <= sample_column_count_);
 
   std::map<double, oid_t> frequencies;
   oid_t cluster_itr = START_OID;
@@ -116,7 +116,7 @@ column_map_type Clusterer::GetPartitioning(oid_t tile_count) const {
   }
 
   // check if all columns are present in partitioning
-  PL_ASSERT(column_to_tile_map.size() == sample_column_count_);
+  PELOTON_ASSERT(column_to_tile_map.size() == sample_column_count_);
 
   // build partitioning
   column_map_type partitioning;

--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -173,7 +173,7 @@ double IndexTuner::ComputeWorkloadWriteRatio(
 
   // Compute write ratio
   auto total_duration = total_read_duration + total_write_duration;
-  PL_ASSERT(total_duration > 0);
+  PELOTON_ASSERT(total_duration > 0);
   write_ratio = total_write_duration / (total_duration);
 
   // Compute exponential moving average
@@ -218,7 +218,7 @@ std::vector<sample_frequency_map_entry> GetFrequentSamples(
     }
   }
 
-  PL_ASSERT(total_weight > 0);
+  PELOTON_ASSERT(total_weight > 0);
 
   // Normalize
   std::unordered_map<brain::Sample, double>::iterator sample_frequency_map_itr;
@@ -599,7 +599,7 @@ void IndexTuner::BootstrapTPCC(const std::string& path) {
     auto txn = txn_manager.BeginTransaction();
     auto table = catalog->GetTableWithName(database_name, table_name, txn);
     txn_manager.CommitTransaction(txn);
-    PL_ASSERT(table != nullptr);
+    PELOTON_ASSERT(table != nullptr);
     for (auto& sample : samples) {
       table->RecordIndexSample(sample);
     }

--- a/src/brain/layout_tuner.cpp
+++ b/src/brain/layout_tuner.cpp
@@ -106,7 +106,7 @@ Sample GetClustererSample(const Sample& sample, oid_t column_count) {
     }
   }
 
-  PL_ASSERT(columns_accessed_bitmap.size() == column_count);
+  PELOTON_ASSERT(columns_accessed_bitmap.size() == column_count);
   clusterer_sample.SetColumnsAccessed(columns_accessed_bitmap);
 
   return clusterer_sample;

--- a/src/brain/sample.cpp
+++ b/src/brain/sample.cpp
@@ -64,7 +64,7 @@ Sample &Sample::operator+(const Sample &rhs) {
   size_t column_itr;
   size_t column_count = columns_accessed_.size();
 
-  PL_ASSERT(rhs.columns_accessed_.size() == column_count);
+  PELOTON_ASSERT(rhs.columns_accessed_.size() == column_count);
 
   for (column_itr = 0; column_itr < column_count; column_itr++) {
     auto other_val = rhs.columns_accessed_[column_itr];

--- a/src/catalog/abstract_catalog.cpp
+++ b/src/catalog/abstract_catalog.cpp
@@ -125,10 +125,10 @@ bool AbstractCatalog::DeleteWithIndexScan(
   // Index scan as child node
   std::vector<oid_t> column_offsets;  // No projection
   auto index = catalog_table_->GetIndex(index_offset);
-  PL_ASSERT(index != nullptr);
+  PELOTON_ASSERT(index != nullptr);
   std::vector<oid_t> key_column_offsets =
       index->GetMetadata()->GetKeySchema()->GetIndexedColumns();
-  PL_ASSERT(values.size() == key_column_offsets.size());
+  PELOTON_ASSERT(values.size() == key_column_offsets.size());
   std::vector<ExpressionType> expr_types(values.size(),
                                          ExpressionType::COMPARE_EQUAL);
   std::vector<expression::AbstractExpression *> runtime_keys;
@@ -173,7 +173,7 @@ AbstractCatalog::GetResultWithIndexScan(
   auto index = catalog_table_->GetIndex(index_offset);
   std::vector<oid_t> key_column_offsets =
       index->GetMetadata()->GetKeySchema()->GetIndexedColumns();
-  PL_ASSERT(values.size() == key_column_offsets.size());
+  PELOTON_ASSERT(values.size() == key_column_offsets.size());
   std::vector<ExpressionType> expr_types(values.size(),
                                          ExpressionType::COMPARE_EQUAL);
   std::vector<expression::AbstractExpression *> runtime_keys;

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -623,7 +623,7 @@ ResultType Catalog::DropIndex(oid_t index_oid,
 storage::Database *Catalog::GetDatabaseWithName(
     const std::string &database_name,
     concurrency::TransactionContext *txn) const {
-  PL_ASSERT(txn != nullptr);
+  PELOTON_ASSERT(txn != nullptr);
 
   // Check in pg_database using txn
   auto database_object =
@@ -644,7 +644,7 @@ storage::Database *Catalog::GetDatabaseWithName(
 storage::DataTable *Catalog::GetTableWithName(
     const std::string &database_name, const std::string &table_name,
     concurrency::TransactionContext *txn) {
-  PL_ASSERT(txn != nullptr);
+  PELOTON_ASSERT(txn != nullptr);
 
   LOG_TRACE("Looking for table %s in database %s", table_name.c_str(),
             database_name.c_str());

--- a/src/catalog/catalog_cache.cpp
+++ b/src/catalog/catalog_cache.cpp
@@ -62,7 +62,7 @@ bool CatalogCache::EvictDatabaseObject(oid_t database_oid) {
   }
 
   auto database_object = it->second;
-  PL_ASSERT(database_object);
+  PELOTON_ASSERT(database_object);
   database_objects_cache.erase(it);
   database_name_cache.erase(database_object->GetDatabaseName());
   return true;
@@ -79,7 +79,7 @@ bool CatalogCache::EvictDatabaseObject(const std::string &database_name) {
   }
 
   auto database_object = it->second;
-  PL_ASSERT(database_object);
+  PELOTON_ASSERT(database_object);
   database_name_cache.erase(it);
   database_objects_cache.erase(database_object->GetDatabaseOid());
   return true;

--- a/src/catalog/column_catalog.cpp
+++ b/src/catalog/column_catalog.cpp
@@ -226,7 +226,7 @@ ColumnCatalog::GetColumnObjects(oid_t table_oid,
   // try get from cache
   auto table_object =
       TableCatalog::GetInstance()->GetTableObject(table_oid, txn);
-  PL_ASSERT(table_object && table_object->GetTableOid() == table_oid);
+  PELOTON_ASSERT(table_object && table_object->GetTableOid() == table_oid);
   auto column_objects = table_object->GetColumnObjects(true);
   if (column_objects.size() != 0) return column_objects;
 

--- a/src/catalog/column_stats_catalog.cpp
+++ b/src/catalog/column_stats_catalog.cpp
@@ -140,13 +140,13 @@ std::unique_ptr<std::vector<type::Value>> ColumnStatsCatalog::GetColumnStats(
   auto result_tiles =
       GetResultWithIndexScan(column_ids, index_offset, values, txn);
 
-  PL_ASSERT(result_tiles->size() <= 1);  // unique
+  PELOTON_ASSERT(result_tiles->size() <= 1);  // unique
   if (result_tiles->size() == 0) {
     return nullptr;
   }
 
   auto tile = (*result_tiles)[0].get();
-  PL_ASSERT(tile->GetTupleCount() <= 1);
+  PELOTON_ASSERT(tile->GetTupleCount() <= 1);
   if (tile->GetTupleCount() == 0) {
     return nullptr;
   }
@@ -190,7 +190,7 @@ size_t ColumnStatsCatalog::GetTableStats(
   auto result_tiles =
       GetResultWithIndexScan(column_ids, index_offset, values, txn);
 
-  PL_ASSERT(result_tiles->size() <= 1);  // unique
+  PELOTON_ASSERT(result_tiles->size() <= 1);  // unique
   if (result_tiles->size() == 0) {
     return 0;
   }

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -79,7 +79,7 @@ bool DatabaseCatalogObject::EvictTableObject(oid_t table_oid) {
   }
 
   auto table_object = it->second;
-  PL_ASSERT(table_object);
+  PELOTON_ASSERT(table_object);
   table_objects_cache.erase(it);
   table_name_cache.erase(table_object->GetTableName());
   return true;
@@ -97,7 +97,7 @@ bool DatabaseCatalogObject::EvictTableObject(const std::string &table_name) {
   }
 
   auto table_object = it->second;
-  PL_ASSERT(table_object);
+  PELOTON_ASSERT(table_object);
   table_name_cache.erase(it);
   table_objects_cache.erase(table_object->GetTableOid());
   return true;
@@ -162,7 +162,7 @@ DatabaseCatalogObject::GetTableObjects(bool cached_only) {
     return TableCatalog::GetInstance()->GetTableObjects(database_oid, txn);
   }
   // make sure to check IsValidTableObjects() before getting table objects
-  PL_ASSERT(valid_table_objects);
+  PELOTON_ASSERT(valid_table_objects);
   return table_objects_cache;
 }
 
@@ -301,7 +301,7 @@ std::shared_ptr<DatabaseCatalogObject> DatabaseCatalog::GetDatabaseObject(
         std::make_shared<DatabaseCatalogObject>((*result_tiles)[0].get(), txn);
     // insert into cache
     bool success = txn->catalog_cache.InsertDatabaseObject(database_object);
-    PL_ASSERT(success == true);
+    PELOTON_ASSERT(success == true);
     (void)success;
     return database_object;
   } else {
@@ -342,7 +342,7 @@ std::shared_ptr<DatabaseCatalogObject> DatabaseCatalog::GetDatabaseObject(
     if (database_object) {
       // insert into cache
       bool success = txn->catalog_cache.InsertDatabaseObject(database_object);
-      PL_ASSERT(success == true);
+      PELOTON_ASSERT(success == true);
       (void)success;
     }
     return database_object;

--- a/src/catalog/index_catalog.cpp
+++ b/src/catalog/index_catalog.cpp
@@ -216,7 +216,7 @@ std::shared_ptr<IndexCatalogObject> IndexCatalog::GetIndexObject(
     // fetch all indexes into table object (cannot use the above index object)
     auto table_object = TableCatalog::GetInstance()->GetTableObject(
         index_object->GetTableOid(), txn);
-    PL_ASSERT(table_object &&
+    PELOTON_ASSERT(table_object &&
               table_object->GetTableOid() == index_object->GetTableOid());
     return table_object->GetIndexObject(index_oid);
   } else {
@@ -254,7 +254,7 @@ std::shared_ptr<IndexCatalogObject> IndexCatalog::GetIndexObject(
     // fetch all indexes into table object (cannot use the above index object)
     auto table_object = TableCatalog::GetInstance()->GetTableObject(
         index_object->GetTableOid(), txn);
-    PL_ASSERT(table_object &&
+    PELOTON_ASSERT(table_object &&
               table_object->GetTableOid() == index_object->GetTableOid());
     return table_object->GetIndexObject(index_name);
   } else {
@@ -280,7 +280,7 @@ IndexCatalog::GetIndexObjects(oid_t table_oid, concurrency::TransactionContext *
   // try get from cache
   auto table_object =
       TableCatalog::GetInstance()->GetTableObject(table_oid, txn);
-  PL_ASSERT(table_object && table_object->GetTableOid() == table_oid);
+  PELOTON_ASSERT(table_object && table_object->GetTableOid() == table_oid);
   auto index_objects = table_object->GetIndexObjects(true);
   if (index_objects.empty() == false) return index_objects;
 

--- a/src/catalog/language_catalog.cpp
+++ b/src/catalog/language_catalog.cpp
@@ -82,11 +82,11 @@ std::unique_ptr<LanguageCatalogObject> LanguageCatalog::GetLanguageByOid(
 
   auto result_tiles =
       GetResultWithIndexScan(column_ids, index_offset, values, txn);
-  PL_ASSERT(result_tiles->size() <= 1);
+  PELOTON_ASSERT(result_tiles->size() <= 1);
 
   std::unique_ptr<LanguageCatalogObject> ret;
   if (result_tiles->size() == 1) {
-    PL_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
+    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
     ret.reset(new LanguageCatalogObject((*result_tiles)[0].get()));
   }
 
@@ -102,11 +102,11 @@ std::unique_ptr<LanguageCatalogObject> LanguageCatalog::GetLanguageByName(
 
   auto result_tiles =
       GetResultWithIndexScan(column_ids, index_offset, values, txn);
-  PL_ASSERT(result_tiles->size() <= 1);
+  PELOTON_ASSERT(result_tiles->size() <= 1);
 
   std::unique_ptr<LanguageCatalogObject> ret;
   if (result_tiles->size() == 1) {
-    PL_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
+    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
     ret.reset(new LanguageCatalogObject((*result_tiles)[0].get()));
   }
 

--- a/src/catalog/proc_catalog.cpp
+++ b/src/catalog/proc_catalog.cpp
@@ -98,11 +98,11 @@ std::unique_ptr<ProcCatalogObject> ProcCatalog::GetProcByOid(
 
   auto result_tiles =
       GetResultWithIndexScan(column_ids, index_offset, values, txn);
-  PL_ASSERT(result_tiles->size() <= 1);
+  PELOTON_ASSERT(result_tiles->size() <= 1);
 
   std::unique_ptr<ProcCatalogObject> ret;
   if (result_tiles->size() == 1) {
-    PL_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
+    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
     ret.reset(new ProcCatalogObject((*result_tiles)[0].get(), txn));
   }
 
@@ -122,11 +122,11 @@ std::unique_ptr<ProcCatalogObject> ProcCatalog::GetProcByName(
 
   auto result_tiles =
       GetResultWithIndexScan(column_ids, index_offset, values, txn);
-  PL_ASSERT(result_tiles->size() <= 1);
+  PELOTON_ASSERT(result_tiles->size() <= 1);
 
   std::unique_ptr<ProcCatalogObject> ret;
   if (result_tiles->size() == 1) {
-    PL_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
+    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
     ret.reset(new ProcCatalogObject((*result_tiles)[0].get(), txn));
   }
 

--- a/src/catalog/query_metrics_catalog.cpp
+++ b/src/catalog/query_metrics_catalog.cpp
@@ -131,9 +131,9 @@ stats::QueryMetric::QueryParamBuf QueryMetricsCatalog::GetParamTypes(
       GetResultWithIndexScan(column_ids, index_offset, values, txn);
 
   stats::QueryMetric::QueryParamBuf param_types;
-  PL_ASSERT(result_tiles->size() <= 1);  // unique
+  PELOTON_ASSERT(result_tiles->size() <= 1);  // unique
   if (result_tiles->size() != 0) {
-    PL_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
+    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
     if ((*result_tiles)[0]->GetTupleCount() != 0) {
       auto param_types_value = (*result_tiles)[0]->GetValue(0, 0);
       param_types.buf = const_cast<uchar *>(
@@ -158,9 +158,9 @@ int64_t QueryMetricsCatalog::GetNumParams(const std::string &name,
       GetResultWithIndexScan(column_ids, index_offset, values, txn);
 
   int64_t num_params = 0;
-  PL_ASSERT(result_tiles->size() <= 1);  // unique
+  PELOTON_ASSERT(result_tiles->size() <= 1);  // unique
   if (result_tiles->size() != 0) {
-    PL_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
+    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
     if ((*result_tiles)[0]->GetTupleCount() != 0) {
       num_params = (*result_tiles)[0]
                        ->GetValue(0, 0)

--- a/src/catalog/schema.cpp
+++ b/src/catalog/schema.cpp
@@ -153,7 +153,7 @@ Schema *Schema::CopySchema(const Schema *schema,
   // For each column index, push the column
   for (oid_t column_index : index_list) {
     // Make sure the index does not refer to invalid element
-    PL_ASSERT(column_index < schema->columns.size());
+    PELOTON_ASSERT(column_index < schema->columns.size());
 
     column_list.push_back(schema->columns[column_index]);
   }
@@ -248,7 +248,7 @@ Schema *Schema::AppendSchemaPtrList(const std::vector<Schema *> &schema_list) {
 Schema *Schema::AppendSchemaPtrList(
     const std::vector<Schema *> &schema_list,
     const std::vector<std::vector<oid_t>> &subsets) {
-  PL_ASSERT(schema_list.size() == subsets.size());
+  PELOTON_ASSERT(schema_list.size() == subsets.size());
 
   std::vector<Column> columns;
   for (unsigned int i = 0; i < schema_list.size(); i++) {

--- a/src/catalog/settings_catalog.cpp
+++ b/src/catalog/settings_catalog.cpp
@@ -103,9 +103,9 @@ std::string SettingsCatalog::GetSettingValue(const std::string &name,
       GetResultWithIndexScan(column_ids, index_offset, values, txn);
 
   std::string config_value = "";
-  PL_ASSERT(result_tiles->size() <= 1);
+  PELOTON_ASSERT(result_tiles->size() <= 1);
   if (result_tiles->size() != 0) {
-    PL_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
+    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
     if ((*result_tiles)[0]->GetTupleCount() != 0) {
       config_value = (*result_tiles)[0]->GetValue(0, 0).ToString();
     }
@@ -124,9 +124,9 @@ std::string SettingsCatalog::GetDefaultValue(const std::string &name,
       GetResultWithIndexScan(column_ids, index_offset, values, txn);
 
   std::string config_value = "";
-  PL_ASSERT(result_tiles->size() <= 1);
+  PELOTON_ASSERT(result_tiles->size() <= 1);
   if (result_tiles->size() != 0) {
-    PL_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
+    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
     if ((*result_tiles)[0]->GetTupleCount() != 0) {
       config_value = (*result_tiles)[0]->GetValue(0, 0).ToString();
     }

--- a/src/catalog/table_catalog.cpp
+++ b/src/catalog/table_catalog.cpp
@@ -85,7 +85,7 @@ bool TableCatalogObject::EvictIndexObject(oid_t index_oid) {
   }
 
   auto index_object = it->second;
-  PL_ASSERT(index_object);
+  PELOTON_ASSERT(index_object);
   index_objects.erase(it);
   index_names.erase(index_object->GetIndexName());
   return true;
@@ -105,7 +105,7 @@ bool TableCatalogObject::EvictIndexObject(const std::string &index_name) {
   }
 
   auto index_object = it->second;
-  PL_ASSERT(index_object);
+  PELOTON_ASSERT(index_object);
   index_names.erase(it);
   index_objects.erase(index_object->GetIndexOid());
   return true;
@@ -209,7 +209,7 @@ bool TableCatalogObject::EvictColumnObject(oid_t column_id) {
   }
 
   auto column_object = it->second;
-  PL_ASSERT(column_object);
+  PELOTON_ASSERT(column_object);
   column_objects.erase(it);
   column_names.erase(column_object->GetColumnName());
   return true;
@@ -229,7 +229,7 @@ bool TableCatalogObject::EvictColumnObject(const std::string &column_name) {
   }
 
   auto column_object = it->second;
-  PL_ASSERT(column_object);
+  PELOTON_ASSERT(column_object);
   column_names.erase(it);
   column_objects.erase(column_object->GetColumnId());
   return true;
@@ -423,9 +423,9 @@ std::shared_ptr<TableCatalogObject> TableCatalog::GetTableObject(
     // insert into cache
     auto database_object = DatabaseCatalog::GetInstance()->GetDatabaseObject(
         table_object->GetDatabaseOid(), txn);
-    PL_ASSERT(database_object);
+    PELOTON_ASSERT(database_object);
     bool success = database_object->InsertTableObject(table_object);
-    PL_ASSERT(success == true);
+    PELOTON_ASSERT(success == true);
     (void)success;
     return table_object;
   } else {
@@ -474,9 +474,9 @@ std::shared_ptr<TableCatalogObject> TableCatalog::GetTableObject(
     // insert into cache
     auto database_object = DatabaseCatalog::GetInstance()->GetDatabaseObject(
         table_object->GetDatabaseOid(), txn);
-    PL_ASSERT(database_object);
+    PELOTON_ASSERT(database_object);
     bool success = database_object->InsertTableObject(table_object);
-    PL_ASSERT(success == true);
+    PELOTON_ASSERT(success == true);
     (void)success;
     return table_object;
   }
@@ -499,7 +499,7 @@ TableCatalog::GetTableObjects(oid_t database_oid,
   // try get from cache
   auto database_object =
       DatabaseCatalog::GetInstance()->GetDatabaseObject(database_oid, txn);
-  PL_ASSERT(database_object != nullptr);
+  PELOTON_ASSERT(database_object != nullptr);
   if (database_object->IsValidTableObjects()) {
     return database_object->GetTableObjects(true);
   }

--- a/src/catalog/trigger_catalog.cpp
+++ b/src/catalog/trigger_catalog.cpp
@@ -145,7 +145,7 @@ oid_t TriggerCatalog::GetTriggerOid(std::string trigger_name, oid_t table_oid,
     LOG_INFO("trigger %s doesn't exist", trigger_name.c_str());
   } else {
     LOG_INFO("size of the result tiles = %lu", result_tiles->size());
-    PL_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
+    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
     if ((*result_tiles)[0]->GetTupleCount() != 0) {
       trigger_oid = (*result_tiles)[0]->GetValue(0, 0).GetAs<oid_t>();
     }

--- a/src/catalog/zone_map_catalog.cpp
+++ b/src/catalog/zone_map_catalog.cpp
@@ -112,14 +112,14 @@ std::unique_ptr<std::vector<type::Value>> ZoneMapCatalog::GetColumnStatistics(
   auto result_tiles =
       GetResultWithIndexScan(column_ids, index_offset, values, txn);
 
-  PL_ASSERT(result_tiles->size() <= 1);  // unique
+  PELOTON_ASSERT(result_tiles->size() <= 1);  // unique
   if (result_tiles->size() == 0) {
     LOG_DEBUG("Result Tiles = 0");
     return nullptr;
   }
 
   auto tile = (*result_tiles)[0].get();
-  PL_ASSERT(tile->GetTupleCount() <= 1);
+  PELOTON_ASSERT(tile->GetTupleCount() <= 1);
   if (tile->GetTupleCount() == 0) {
     return nullptr;
   }

--- a/src/codegen/aggregation.cpp
+++ b/src/codegen/aggregation.cpp
@@ -90,7 +90,7 @@ void Aggregation::Setup(
         // We decompose averages into separate SUM() and COUNT() components
 
         // SUM() - the type must match the type of the expression
-        PL_ASSERT(agg_term.expression != nullptr);
+        PELOTON_ASSERT(agg_term.expression != nullptr);
         auto sum_type = agg_term.expression->ResultType();
         if (IsGlobal()) {
           sum_type = sum_type.AsNullable();
@@ -169,7 +169,7 @@ void Aggregation::Setup(
     CodeGen &codegen,
     const std::vector<planner::AggregatePlan::AggTerm> &agg_terms,
     bool is_global) {
-  PL_ASSERT(is_global);
+  PELOTON_ASSERT(is_global);
   // Create empty vector and hand the reference to the actual implementation
   // makes it easier to call this function without providing grouping keys
   std::vector<type::Type> empty;
@@ -198,7 +198,7 @@ void Aggregation::TearDownState(CodeGen &codegen) {
 
 void Aggregation::CreateInitialGlobalValues(CodeGen &codegen,
                                             llvm::Value *space) const {
-  PL_ASSERT(IsGlobal());
+  PELOTON_ASSERT(IsGlobal());
   auto null_bitmap =
       UpdateableStorage::NullBitmap{codegen, GetAggregateStorage(), space};
   null_bitmap.InitAllNull(codegen);
@@ -211,7 +211,7 @@ void Aggregation::CreateInitialValues(
     const std::vector<codegen::Value> &initial,
     const std::vector<codegen::Value> &grouping_keys) const {
   // Global aggregations should be calling CreateInitialGlobalValues(...)
-  PL_ASSERT(!IsGlobal());
+  PELOTON_ASSERT(!IsGlobal());
 
   // The null bitmap tracker
   UpdateableStorage::NullBitmap null_bitmap{codegen, storage_, space};
@@ -378,7 +378,7 @@ void Aggregation::DoAdvanceValue(CodeGen &codegen, llvm::Value *space,
   }
 
   // Store the updated value in the appropriate slot
-  PL_ASSERT(next.GetType().type_id != peloton::type::TypeId::INVALID);
+  PELOTON_ASSERT(next.GetType().type_id != peloton::type::TypeId::INVALID);
   storage_.SetValueSkipNull(codegen, space, storage_index, next);
 }
 

--- a/src/codegen/buffering_consumer.cpp
+++ b/src/codegen/buffering_consumer.cpp
@@ -94,7 +94,7 @@ void BufferingConsumer::ConsumeResult(ConsumerContext &ctx,
     // Derive the column's final value
     Value val = row.DeriveValue(codegen, output_ais_[i]);
 
-    PL_ASSERT(output_ais_[i]->type == val.GetType());
+    PELOTON_ASSERT(output_ais_[i]->type == val.GetType());
     const auto &sql_type = val.GetType().GetSqlType();
 
     // Check if it's NULL

--- a/src/codegen/code_context.cpp
+++ b/src/codegen/code_context.cpp
@@ -123,7 +123,7 @@ CodeContext::CodeContext()
                     .setMCPU(llvm::sys::getHostCPUName())
                     .setErrorStr(&err_str_)
                     .create());
-  PL_ASSERT(engine_ != nullptr);
+  PELOTON_ASSERT(engine_ != nullptr);
 
   // The set of optimization passes we include
   pass_manager_.reset(new llvm::legacy::FunctionPassManager(module_));
@@ -153,7 +153,7 @@ CodeContext::~CodeContext() {
 }
 
 void CodeContext::RegisterFunction(llvm::Function *func) {
-  PL_ASSERT(func->getParent() == &GetModule() &&
+  PELOTON_ASSERT(func->getParent() == &GetModule() &&
             "The provided function is part of a different context and module");
   // Insert the function without an implementation
   functions_.emplace_back(func, nullptr);
@@ -161,9 +161,9 @@ void CodeContext::RegisterFunction(llvm::Function *func) {
 
 void CodeContext::RegisterExternalFunction(llvm::Function *func_decl,
                                            CodeContext::FuncPtr func_impl) {
-  PL_ASSERT(func_decl->isDeclaration() &&
+  PELOTON_ASSERT(func_decl->isDeclaration() &&
             "The first argument must be a function declaration");
-  PL_ASSERT(func_impl != nullptr && "The function pointer cannot be NULL");
+  PELOTON_ASSERT(func_impl != nullptr && "The function pointer cannot be NULL");
   functions_.emplace_back(func_decl, func_impl);
 
   // Register the builtin symbol by name
@@ -179,7 +179,7 @@ void CodeContext::RegisterBuiltin(llvm::Function *func_decl,
   }
 
   // Sanity check
-  PL_ASSERT(func_decl->isDeclaration() &&
+  PELOTON_ASSERT(func_decl->isDeclaration() &&
             "You cannot provide a function definition for a builtin function");
 
   // Register the builtin function

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -83,7 +83,7 @@ llvm::Value *CodeGen::ConstStringPtr(const std::string &s) const {
 llvm::Value *CodeGen::AllocateVariable(llvm::Type *type,
                                        const std::string &name) {
   // To allocate a variable, a function must be under construction
-  PL_ASSERT(code_context_.GetCurrentFunction() != nullptr);
+  PELOTON_ASSERT(code_context_.GetCurrentFunction() != nullptr);
 
   // All variable allocations go into the current function's "entry" block. By
   // convention, we insert the allocation instruction before the first
@@ -155,7 +155,7 @@ llvm::Value *CodeGen::Sqrt(llvm::Value *val) {
 
 llvm::Value *CodeGen::CallAddWithOverflow(llvm::Value *left, llvm::Value *right,
                                           llvm::Value *&overflow_bit) {
-  PL_ASSERT(left->getType() == right->getType());
+  PELOTON_ASSERT(left->getType() == right->getType());
 
   // Get the intrinsic that does the addition with overflow checking
   llvm::Function *add_func = llvm::Intrinsic::getDeclaration(
@@ -173,7 +173,7 @@ llvm::Value *CodeGen::CallAddWithOverflow(llvm::Value *left, llvm::Value *right,
 
 llvm::Value *CodeGen::CallSubWithOverflow(llvm::Value *left, llvm::Value *right,
                                           llvm::Value *&overflow_bit) {
-  PL_ASSERT(left->getType() == right->getType());
+  PELOTON_ASSERT(left->getType() == right->getType());
 
   // Get the intrinsic that does the addition with overflow checking
   llvm::Function *sub_func = llvm::Intrinsic::getDeclaration(
@@ -191,7 +191,7 @@ llvm::Value *CodeGen::CallSubWithOverflow(llvm::Value *left, llvm::Value *right,
 
 llvm::Value *CodeGen::CallMulWithOverflow(llvm::Value *left, llvm::Value *right,
                                           llvm::Value *&overflow_bit) {
-  PL_ASSERT(left->getType() == right->getType());
+  PELOTON_ASSERT(left->getType() == right->getType());
   llvm::Function *mul_func = llvm::Intrinsic::getDeclaration(
       &GetModule(), llvm::Intrinsic::smul_with_overflow, left->getType());
 
@@ -206,7 +206,7 @@ llvm::Value *CodeGen::CallMulWithOverflow(llvm::Value *left, llvm::Value *right,
 }
 
 void CodeGen::ThrowIfOverflow(llvm::Value *overflow) const {
-  PL_ASSERT(overflow->getType() == BoolType());
+  PELOTON_ASSERT(overflow->getType() == BoolType());
 
   // Get the overflow basic block for the currently generating function
   auto *func = code_context_.GetCurrentFunction();
@@ -225,7 +225,7 @@ void CodeGen::ThrowIfOverflow(llvm::Value *overflow) const {
 }
 
 void CodeGen::ThrowIfDivideByZero(llvm::Value *divide_by_zero) const {
-  PL_ASSERT(divide_by_zero->getType() == BoolType());
+  PELOTON_ASSERT(divide_by_zero->getType() == BoolType());
 
   // Get the divide-by-zero basic block for the currently generating function
   auto *func = code_context_.GetCurrentFunction();
@@ -271,7 +271,7 @@ llvm::Type *CodeGen::LookupType(const std::string &name) const {
 
 llvm::Value *CodeGen::GetState() const {
   auto *func_builder = code_context_.GetCurrentFunction();
-  PL_ASSERT(func_builder != nullptr);
+  PELOTON_ASSERT(func_builder != nullptr);
 
   // The first argument of the function is always the runtime state
   return func_builder->GetArgumentByPosition(0);

--- a/src/codegen/compact_storage.cpp
+++ b/src/codegen/compact_storage.cpp
@@ -33,7 +33,7 @@ class BitmapWriter {
   }
 
   void SetBit(CodeGen &codegen, uint32_t bit_idx, llvm::Value *bit_val) {
-    PL_ASSERT(bit_val->getType() == codegen.BoolType());
+    PELOTON_ASSERT(bit_val->getType() == codegen.BoolType());
     // Cast to byte, left shift into position
     auto *byte_val = codegen->CreateZExt(bit_val, codegen.ByteType());
     byte_val = codegen->CreateShl(byte_val, bit_idx & 7);
@@ -172,8 +172,8 @@ llvm::Type *CompactStorage::Setup(CodeGen &codegen,
 llvm::Value *CompactStorage::StoreValues(
     CodeGen &codegen, llvm::Value *area_start,
     const std::vector<codegen::Value> &to_store) const {
-  PL_ASSERT(storage_type_ != nullptr);
-  PL_ASSERT(to_store.size() == schema_.size());
+  PELOTON_ASSERT(storage_type_ != nullptr);
+  PELOTON_ASSERT(to_store.size() == schema_.size());
 
   // Decompose the values we're storing into their raw value, length and
   // null-bit components

--- a/src/codegen/compilation_context.cpp
+++ b/src/codegen/compilation_context.cpp
@@ -80,7 +80,7 @@ void CompilationContext::Prepare(const expression::AbstractExpression &exp) {
 // Produce tuples for the given operator
 void CompilationContext::Produce(const planner::AbstractPlan &op) {
   auto *translator = GetTranslator(op);
-  PL_ASSERT(translator != nullptr);
+  PELOTON_ASSERT(translator != nullptr);
   translator->Produce();
 }
 

--- a/src/codegen/deleter.cpp
+++ b/src/codegen/deleter.cpp
@@ -20,13 +20,13 @@ namespace codegen {
 
 void Deleter::Init(storage::DataTable *table,
                    executor::ExecutorContext *executor_context) {
-  PL_ASSERT(table != nullptr && executor_context != nullptr);
+  PELOTON_ASSERT(table != nullptr && executor_context != nullptr);
   table_ = table;
   executor_context_ = executor_context;
 }
 
 void Deleter::Delete(uint32_t tile_group_id, uint32_t tuple_offset) {
-  PL_ASSERT(table_ != nullptr && executor_context_ != nullptr);
+  PELOTON_ASSERT(table_ != nullptr && executor_context_ != nullptr);
   LOG_TRACE("Deleting tuple <%u, %u> from table '%s' (db ID: %u, table ID: %u)",
             tile_group_id, tuple_offset, table_->GetName().c_str(),
             table_->GetDatabaseOid(), table_->GetOid());

--- a/src/codegen/expression/arithmetic_translator.cpp
+++ b/src/codegen/expression/arithmetic_translator.cpp
@@ -22,7 +22,7 @@ ArithmeticTranslator::ArithmeticTranslator(
     const expression::OperatorExpression &arithmetic,
     CompilationContext &context)
     : ExpressionTranslator(arithmetic, context) {
-  PL_ASSERT(arithmetic.GetChildrenSize() == 2);
+  PELOTON_ASSERT(arithmetic.GetChildrenSize() == 2);
 }
 
 // Produce the value that is the result of codegening the expression

--- a/src/codegen/expression/comparison_translator.cpp
+++ b/src/codegen/expression/comparison_translator.cpp
@@ -23,7 +23,7 @@ ComparisonTranslator::ComparisonTranslator(
     const expression::ComparisonExpression &comparison,
     CompilationContext &context)
     : ExpressionTranslator(comparison, context) {
-  PL_ASSERT(comparison.GetChildrenSize() == 2);
+  PELOTON_ASSERT(comparison.GetChildrenSize() == 2);
 }
 
 // Produce the result of performing the comparison of left and right values
@@ -55,7 +55,7 @@ codegen::Value ComparisonTranslator::DeriveValue(CodeGen &codegen,
       type::Type left_type = left.GetType(), right_type = right.GetType();
       auto *binary_op = type::TypeSystem::GetBinaryOperator(
           OperatorId::Like, left_type, left_type, right_type, right_type);
-      PL_ASSERT(binary_op);
+      PELOTON_ASSERT(binary_op);
       return binary_op->Eval(codegen, left.CastTo(codegen, left_type),
                              right.CastTo(codegen, right_type), ctx);
     }

--- a/src/codegen/expression/conjunction_translator.cpp
+++ b/src/codegen/expression/conjunction_translator.cpp
@@ -22,7 +22,7 @@ ConjunctionTranslator::ConjunctionTranslator(
     const expression::ConjunctionExpression &conjunction,
     CompilationContext &context)
     : ExpressionTranslator(conjunction, context) {
-  PL_ASSERT(conjunction.GetChildrenSize() == 2);
+  PELOTON_ASSERT(conjunction.GetChildrenSize() == 2);
 }
 
 // Produce the value that is the result of codegening the expression

--- a/src/codegen/expression/function_translator.cpp
+++ b/src/codegen/expression/function_translator.cpp
@@ -26,8 +26,8 @@ FunctionTranslator::FunctionTranslator(
     CompilationContext &context)
     : ExpressionTranslator(func_expr, context) {
   if (!func_expr.IsUDF()) {
-    PL_ASSERT(func_expr.GetFunc().op_id != OperatorId::Invalid);
-    PL_ASSERT(func_expr.GetFunc().impl != nullptr);
+    PELOTON_ASSERT(func_expr.GetFunc().op_id != OperatorId::Invalid);
+    PELOTON_ASSERT(func_expr.GetFunc().impl != nullptr);
 
     // Prepare each of the child expressions
     for (uint32_t i = 0; i < func_expr.GetChildrenSize(); i++) {
@@ -60,7 +60,7 @@ codegen::Value FunctionTranslator::DeriveValue(CodeGen &codegen,
       // Lookup unary operation
       auto *unary_op =
           type::TypeSystem::GetUnaryOperator(operator_id, args[0].GetType());
-      PL_ASSERT(unary_op != nullptr);
+      PELOTON_ASSERT(unary_op != nullptr);
 
       // Invoke
       return unary_op->Eval(codegen, args[0], ctx);
@@ -69,7 +69,7 @@ codegen::Value FunctionTranslator::DeriveValue(CodeGen &codegen,
       type::Type left_type = args[0].GetType(), right_type = args[1].GetType();
       auto *binary_op = type::TypeSystem::GetBinaryOperator(
           operator_id, left_type, left_type, right_type, right_type);
-      PL_ASSERT(binary_op);
+      PELOTON_ASSERT(binary_op);
 
       // Invoke
       return binary_op->Eval(codegen, args[0].CastTo(codegen, left_type),
@@ -84,7 +84,7 @@ codegen::Value FunctionTranslator::DeriveValue(CodeGen &codegen,
 
       // Lookup the function
       auto *nary_op = type::TypeSystem::GetNaryOperator(operator_id, arg_types);
-      PL_ASSERT(nary_op != nullptr);
+      PELOTON_ASSERT(nary_op != nullptr);
 
       // Invoke
       return nary_op->Eval(codegen, args, ctx);

--- a/src/codegen/expression/negation_translator.cpp
+++ b/src/codegen/expression/negation_translator.cpp
@@ -23,7 +23,7 @@ NegationTranslator::NegationTranslator(
     const expression::OperatorUnaryMinusExpression &unary_minus_expression,
     CompilationContext &ctx)
     : ExpressionTranslator(unary_minus_expression, ctx) {
-  PL_ASSERT(unary_minus_expression.GetChildrenSize() == 1);
+  PELOTON_ASSERT(unary_minus_expression.GetChildrenSize() == 1);
 }
 
 Value NegationTranslator::DeriveValue(CodeGen &codegen,

--- a/src/codegen/expression/null_check_translator.cpp
+++ b/src/codegen/expression/null_check_translator.cpp
@@ -23,7 +23,7 @@ namespace codegen {
 NullCheckTranslator::NullCheckTranslator(
     const expression::OperatorExpression &null_check, CompilationContext &ctx)
     : ExpressionTranslator(null_check, ctx) {
-  PL_ASSERT(null_check.GetChildrenSize() == 1);
+  PELOTON_ASSERT(null_check.GetChildrenSize() == 1);
 }
 
 Value NullCheckTranslator::DeriveValue(CodeGen &codegen,

--- a/src/codegen/expression/tuple_value_translator.cpp
+++ b/src/codegen/expression/tuple_value_translator.cpp
@@ -22,7 +22,7 @@ TupleValueTranslator::TupleValueTranslator(
     const expression::TupleValueExpression &tve_expr,
     CompilationContext &context)
     : ExpressionTranslator(tve_expr, context) {
-  PL_ASSERT(tve_expr.GetAttributeRef() != nullptr);
+  PELOTON_ASSERT(tve_expr.GetAttributeRef() != nullptr);
 }
 
 // Produce the value that is the result of codegening the expression

--- a/src/codegen/function_builder.cpp
+++ b/src/codegen/function_builder.cpp
@@ -135,7 +135,7 @@ FunctionBuilder::FunctionBuilder(
 // When we destructing the FunctionBuilder, we just do a sanity check to ensure
 // that the user actually finished constructing the function. This is because we
 // do cleanup in Finish().
-FunctionBuilder::~FunctionBuilder() { PL_ASSERT(finished_); }
+FunctionBuilder::~FunctionBuilder() { PELOTON_ASSERT(finished_); }
 
 // Here, we just need to iterate over the arguments in the function to find a
 // match. The names of the arguments were provided and set at construction time.
@@ -149,7 +149,7 @@ llvm::Value *FunctionBuilder::GetArgumentByName(std::string name) {
 }
 
 llvm::Value *FunctionBuilder::GetArgumentByPosition(uint32_t index) {
-  PL_ASSERT(index < func_->arg_size());
+  PELOTON_ASSERT(index < func_->arg_size());
   uint32_t pos = 0;
   for (auto arg_iter = func_->arg_begin(), end = func_->arg_end();
        arg_iter != end; ++arg_iter, ++pos) {
@@ -245,7 +245,7 @@ void FunctionBuilder::ReturnAndFinish(llvm::Value *ret) {
 
   // Restore previous function construction state in the code context
   if (previous_insert_point_ != nullptr) {
-    PL_ASSERT(previous_function_ != nullptr);
+    PELOTON_ASSERT(previous_function_ != nullptr);
     code_context_.GetBuilder().SetInsertPoint(previous_insert_point_);
     code_context_.SetCurrentFunction(previous_function_);
   }

--- a/src/codegen/hash.cpp
+++ b/src/codegen/hash.cpp
@@ -40,7 +40,7 @@ llvm::Value *Hash::HashValues(CodeGen &codegen,
     llvm::Value *val = nullptr;
     llvm::Value *len = nullptr;
     value.ValuesForHash(val, len);
-    PL_ASSERT(val != nullptr);
+    PELOTON_ASSERT(val != nullptr);
 
     llvm::Type *val_type = val->getType();
 
@@ -156,7 +156,7 @@ llvm::Value *Hash::ComputeCRC32Hash(CodeGen &codegen,
   // Hash the numerics
   llvm::Function *crc32_func = llvm::Intrinsic::getDeclaration(
       &codegen.GetModule(), llvm::Intrinsic::x86_sse42_crc32_64_64);
-  PL_ASSERT(crc32_func != nullptr);
+  PELOTON_ASSERT(crc32_func != nullptr);
   for (auto *val : numerics) {
     crc_low = codegen.CallFunc(crc32_func, {crc_low, val});
     crc_high = codegen.CallFunc(crc32_func, {crc_high, val});

--- a/src/codegen/inserter.cpp
+++ b/src/codegen/inserter.cpp
@@ -26,7 +26,7 @@ namespace codegen {
 
 void Inserter::Init(storage::DataTable *table,
                     executor::ExecutorContext *executor_context) {
-  PL_ASSERT(table && executor_context);
+  PELOTON_ASSERT(table && executor_context);
   table_ = table;
   executor_context_ = executor_context;
 }
@@ -44,12 +44,12 @@ char *Inserter::AllocateTupleStorage() {
 
 peloton::type::AbstractPool *Inserter::GetPool() {
   // This should be called after AllocateTupleStorage()
-  PL_ASSERT(tile_);
+  PELOTON_ASSERT(tile_);
   return tile_->GetPool();
 }
 
 void Inserter::Insert() {
-  PL_ASSERT(table_ && executor_context_ && tile_);
+  PELOTON_ASSERT(table_ && executor_context_ && tile_);
   auto *txn = executor_context_->GetTransaction();
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
 

--- a/src/codegen/lang/if.cpp
+++ b/src/codegen/lang/if.cpp
@@ -90,7 +90,7 @@ Value If::BuildPHI(const codegen::Value &v1, const codegen::Value &v2) {
     // The if hasn't been ended, end it now
     EndIf();
   }
-  PL_ASSERT(v1.GetType() == v2.GetType());
+  PELOTON_ASSERT(v1.GetType() == v2.GetType());
   std::vector<std::pair<Value, llvm::BasicBlock *>> vals = {
       {v1, last_bb_in_then_},
       {v2,
@@ -99,7 +99,7 @@ Value If::BuildPHI(const codegen::Value &v1, const codegen::Value &v2) {
 }
 
 llvm::Value *If::BuildPHI(llvm::Value *v1, llvm::Value *v2) {
-  PL_ASSERT(v1->getType() == v2->getType());
+  PELOTON_ASSERT(v1->getType() == v2->getType());
   llvm::PHINode *phi = cg_->CreatePHI(v1->getType(), 2);
   phi->addIncoming(v1, last_bb_in_then_);
   phi->addIncoming(v2, last_bb_in_else_ != nullptr ? last_bb_in_else_

--- a/src/codegen/lang/loop.cpp
+++ b/src/codegen/lang/loop.cpp
@@ -79,7 +79,7 @@ void Loop::LoopEnd(llvm::Value *end_condition,
 // Collect all the final values of the loop variables after the loop is
 // complete
 void Loop::CollectFinalLoopVariables(std::vector<llvm::Value *> &loop_vals) {
-  PL_ASSERT(last_loop_bb_ != nullptr);
+  PELOTON_ASSERT(last_loop_bb_ != nullptr);
   for (auto *phi_node : phi_nodes_) {
     llvm::PHINode *end_phi =
         cg_->CreatePHI(phi_node->getType(), 2 + break_bbs_.size(),

--- a/src/codegen/lang/vectorized_loop.cpp
+++ b/src/codegen/lang/vectorized_loop.cpp
@@ -33,7 +33,7 @@ VectorizedLoop::VectorizedLoop(CodeGen &codegen, llvm::Value *num_elements,
 }
 
 VectorizedLoop::~VectorizedLoop() {
-  PL_ASSERT(ended_ && "You didn't call lang::VectorizedLoop::LoopEnd()!");
+  PELOTON_ASSERT(ended_ && "You didn't call lang::VectorizedLoop::LoopEnd()!");
 }
 
 VectorizedLoop::Range VectorizedLoop::GetCurrentRange() const {

--- a/src/codegen/oa_hash_table.cpp
+++ b/src/codegen/oa_hash_table.cpp
@@ -627,7 +627,7 @@ void OAHashTable::VectorizedIterate(
   // 2. In the next-pass, only the valid buckets are read, invoking the callback
 
   uint32_t size = selection_vector.GetCapacity();
-  PL_ASSERT((size & (size - 1)) == 0);
+  PELOTON_ASSERT((size & (size - 1)) == 0);
 
   // The start of the buckets array
   llvm::Value *entry_ptr = LoadHashTableField(codegen, hash_table, 0);

--- a/src/codegen/operator/block_nested_loop_join_translator.cpp
+++ b/src/codegen/operator/block_nested_loop_join_translator.cpp
@@ -59,7 +59,7 @@ BlockNestedLoopJoinTranslator::BlockNestedLoopJoinTranslator(
     : OperatorTranslator(context, pipeline),
       nlj_plan_(nlj_plan),
       left_pipeline_(this) {
-  PL_ASSERT(nlj_plan.GetChildrenSize() == 2 &&
+  PELOTON_ASSERT(nlj_plan.GetChildrenSize() == 2 &&
             "NLJ must have exactly two children");
 
   // Prepare children
@@ -247,7 +247,7 @@ BufferedTupleCallback::BufferedTupleCallback(
 // This function is called for each tuple in the BNLJ buffer.
 void BufferedTupleCallback::ProcessEntry(
     CodeGen &codegen, const std::vector<codegen::Value> &left_row) const {
-  PL_ASSERT(left_row.size() == left_attributes_.size());
+  PELOTON_ASSERT(left_row.size() == left_attributes_.size());
 
   // Add all the attributes from left tuple (from the sorter) into the row
   // coming from the right input side. We need to do this in order to evaluate

--- a/src/codegen/operator/global_group_by_translator.cpp
+++ b/src/codegen/operator/global_group_by_translator.cpp
@@ -49,7 +49,7 @@ GlobalGroupByTranslator::GlobalGroupByTranslator(
 
   // Create the materialization buffer where we aggregate things
   auto *aggregate_storage = aggregation_.GetAggregateStorage().GetStorageType();
-  PL_ASSERT(aggregate_storage->isStructTy());
+  PELOTON_ASSERT(aggregate_storage->isStructTy());
 
   auto *mat_buffer_type = llvm::StructType::create(
       codegen.GetContext(),
@@ -85,7 +85,7 @@ void GlobalGroupByTranslator::Produce() const {
   std::vector<BufferAttributeAccess> buffer_accessors;
 
   const auto &agg_terms = plan_.GetUniqueAggTerms();
-  PL_ASSERT(agg_terms.size() == aggregate_vals.size());
+  PELOTON_ASSERT(agg_terms.size() == aggregate_vals.size());
   for (size_t i = 0; i < agg_terms.size(); i++) {
     buffer_accessors.emplace_back(aggregate_vals, i);
   }

--- a/src/codegen/operator/hash_join_translator.cpp
+++ b/src/codegen/operator/hash_join_translator.cpp
@@ -89,8 +89,8 @@ HashJoinTranslator::HashJoinTranslator(const planner::HashJoinPlan &join,
   }
 
   // Make sure the key types are equal
-  PL_ASSERT(left_key_type.size() == right_key_type.size());
-  PL_ASSERT(std::equal(left_key_type.begin(), left_key_type.end(),
+  PELOTON_ASSERT(left_key_type.size() == right_key_type.size());
+  PELOTON_ASSERT(std::equal(left_key_type.begin(), left_key_type.end(),
                        right_key_type.begin()));
 
   // Collect (unique) attributes that are stored in hash-table

--- a/src/codegen/operator/order_by_translator.cpp
+++ b/src/codegen/operator/order_by_translator.cpp
@@ -68,7 +68,7 @@ OrderByTranslator::OrderByTranslator(const planner::OrderByPlan &plan,
   // Now consider the sort columns
   const auto &sort_col_ais = plan_.GetSortKeyAIs();
   const auto &sort_col_ids = plan_.GetSortKeys();
-  PL_ASSERT(!sort_col_ids.empty());
+  PELOTON_ASSERT(!sort_col_ids.empty());
 
   for (uint32_t i = 0; i < sort_col_ais.size(); i++) {
     const auto *ai = sort_col_ais[i];

--- a/src/codegen/operator/projection_translator.cpp
+++ b/src/codegen/operator/projection_translator.cpp
@@ -24,7 +24,7 @@ ProjectionTranslator::ProjectionTranslator(const planner::ProjectionPlan &plan,
                                            Pipeline &pipeline)
     : OperatorTranslator(context, pipeline), plan_(plan) {
   // Prepare translator for our child
-  PL_ASSERT(plan.GetChildrenSize() < 2);
+  PELOTON_ASSERT(plan.GetChildrenSize() < 2);
   context.Prepare(*plan_.GetChild(0), pipeline);
 
   // Prepare translators for the projection
@@ -60,7 +60,7 @@ void ProjectionTranslator::PrepareProjection(
   if (projection_info.IsNonTrivial()) {
     for (const auto &target : projection_info.GetTargetList()) {
       const auto &derived_attribute = target.second;
-      PL_ASSERT(derived_attribute.expr != nullptr);
+      PELOTON_ASSERT(derived_attribute.expr != nullptr);
       context.Prepare(*derived_attribute.expr);
     }
   }

--- a/src/codegen/operator/table_scan_translator.cpp
+++ b/src/codegen/operator/table_scan_translator.cpp
@@ -227,7 +227,7 @@ void TableScanTranslator::ScanConsumer::FilterRowsByPredicate(
     codegen::Value valid_row = row.DeriveValue(codegen, *predicate);
 
     // Reify the boolean value since it may be NULL
-    PL_ASSERT(valid_row.GetType().GetSqlType() == type::Boolean::Instance());
+    PELOTON_ASSERT(valid_row.GetType().GetSqlType() == type::Boolean::Instance());
     llvm::Value *bool_val = type::Boolean::Instance().Reify(codegen, valid_row);
 
     // Set the validity of the row

--- a/src/codegen/pipeline.cpp
+++ b/src/codegen/pipeline.cpp
@@ -33,7 +33,7 @@ void Pipeline::Add(const OperatorTranslator *translator) {
 void Pipeline::InstallBoundaryAtInput(const OperatorTranslator *translator) {
   // Validate the assumption
   (void)translator;
-  PL_ASSERT(pipeline_[pipeline_index_] == translator);
+  PELOTON_ASSERT(pipeline_[pipeline_index_] == translator);
   stage_boundaries_.push_back(pipeline_index_ + 1);
 }
 
@@ -41,7 +41,7 @@ void Pipeline::InstallBoundaryAtInput(const OperatorTranslator *translator) {
 void Pipeline::InstallBoundaryAtOutput(const OperatorTranslator *translator) {
   // Validate the assumption
   (void)translator;
-  PL_ASSERT(pipeline_[pipeline_index_] == translator);
+  PELOTON_ASSERT(pipeline_[pipeline_index_] == translator);
   if (!stage_boundaries_.empty() &&
       stage_boundaries_.back() != pipeline_index_) {
     stage_boundaries_.push_back(pipeline_index_);

--- a/src/codegen/query.cpp
+++ b/src/codegen/query.cpp
@@ -31,12 +31,12 @@ void Query::Execute(std::unique_ptr<executor::ExecutorContext> executor_context,
 
   llvm::Type *runtime_state_type = runtime_state_.FinalizeType(codegen);
   size_t parameter_size = codegen.SizeOf(runtime_state_type);
-  PL_ASSERT((parameter_size % 8 == 0) && "parameter size not multiple of 8");
+  PELOTON_ASSERT((parameter_size % 8 == 0) && "parameter size not multiple of 8");
 
   // Allocate some space for the function arguments
   std::unique_ptr<char[]> param_data{new char[parameter_size]};
   char *param = param_data.get();
-  PL_MEMSET(param, 0, parameter_size);
+  PELOTON_MEMSET(param, 0, parameter_size);
 
   // We use this handy class to avoid complex casting and pointer manipulation
   struct FunctionArguments {
@@ -123,15 +123,15 @@ bool Query::Prepare(const QueryFunctions &query_funcs) {
   // Get pointers to the JITed functions
   init_func_ = (compiled_function_t)code_context_.GetRawFunctionPointer(
       query_funcs.init_func);
-  PL_ASSERT(init_func_ != nullptr);
+  PELOTON_ASSERT(init_func_ != nullptr);
 
   plan_func_ = (compiled_function_t)code_context_.GetRawFunctionPointer(
       query_funcs.plan_func);
-  PL_ASSERT(plan_func_ != nullptr);
+  PELOTON_ASSERT(plan_func_ != nullptr);
 
   tear_down_func_ = (compiled_function_t)code_context_.GetRawFunctionPointer(
       query_funcs.tear_down_func);
-  PL_ASSERT(tear_down_func_ != nullptr);
+  PELOTON_ASSERT(tear_down_func_ != nullptr);
 
   LOG_TRACE("Query has been setup ...");
 

--- a/src/codegen/row_batch.cpp
+++ b/src/codegen/row_batch.cpp
@@ -123,7 +123,7 @@ codegen::Value RowBatch::Row::DeriveValue(
 
   // Not in cache, derive using expression translator
   auto *translator = batch_.context_.GetTranslator(expr);
-  PL_ASSERT(translator != nullptr);
+  PELOTON_ASSERT(translator != nullptr);
   auto ret = translator->DeriveValue(codegen, *this);
   cache_.insert(std::make_pair(&expr, ret));
   return ret;
@@ -167,7 +167,7 @@ llvm::Value *RowBatch::Row::GetTID(CodeGen &codegen) {
   if (tid_ == nullptr) {
     tid_ = batch_.GetPhysicalPosition(codegen, *this);
   }
-  PL_ASSERT(tid_ != nullptr);
+  PELOTON_ASSERT(tid_ != nullptr);
   return tid_;
 }
 

--- a/src/codegen/runtime_state.cpp
+++ b/src/codegen/runtime_state.cpp
@@ -24,7 +24,7 @@ RuntimeState::RuntimeState() : constructed_type_(nullptr) {}
 // whether the requesting operator wants to manage the memory.
 RuntimeState::StateID RuntimeState::RegisterState(std::string name,
                                                   llvm::Type *type) {
-  PL_ASSERT(constructed_type_ == nullptr);
+  PELOTON_ASSERT(constructed_type_ == nullptr);
   RuntimeState::StateID state_id = state_slots_.size();
   RuntimeState::StateInfo state_info;
   state_info.name = name;
@@ -38,8 +38,8 @@ llvm::Value *RuntimeState::LoadStatePtr(CodeGen &codegen,
   // At this point, the runtime state type must have been finalized. Otherwise,
   // it'd be impossible for us to index into it because the type would be
   // incomplete.
-  PL_ASSERT(constructed_type_ != nullptr);
-  PL_ASSERT(state_id < state_slots_.size());
+  PELOTON_ASSERT(constructed_type_ != nullptr);
+  PELOTON_ASSERT(state_id < state_slots_.size());
 
   auto &state_info = state_slots_[state_id];
 
@@ -57,12 +57,12 @@ llvm::Value *RuntimeState::LoadStateValue(
   llvm::Value *state = codegen->CreateLoad(state_ptr);
 #ifndef NDEBUG
   auto &state_info = state_slots_[state_id];
-  PL_ASSERT(state->getType() == state_info.type);
+  PELOTON_ASSERT(state->getType() == state_info.type);
   if (state->getType()->isStructTy()) {
-    PL_ASSERT(state_info.type->isStructTy());
+    PELOTON_ASSERT(state_info.type->isStructTy());
     auto *our_type = llvm::cast<llvm::StructType>(state_info.type);
     auto *ret_type = llvm::cast<llvm::StructType>(state->getType());
-    PL_ASSERT(ret_type->isLayoutIdentical(our_type));
+    PELOTON_ASSERT(ret_type->isLayoutIdentical(our_type));
   }
 #endif
   return state;

--- a/src/codegen/table_storage.cpp
+++ b/src/codegen/table_storage.cpp
@@ -38,7 +38,7 @@ void TableStorage::StoreValues(CodeGen &codegen, llvm::Value *tuple_ptr,
     auto *ptr = codegen->CreateConstInBoundsGEP1_32(codegen.ByteType(),
                                                     tuple_ptr, offset);
     if (sql_type.IsVariableLength()) {
-      PL_ASSERT(value.GetLength() != nullptr);
+      PELOTON_ASSERT(value.GetLength() != nullptr);
       auto val_ptr = codegen->CreateBitCast(ptr, val_type);
       lang::If value_is_null{codegen, value.IsNull(codegen)};
       {

--- a/src/codegen/tile_group.cpp
+++ b/src/codegen/tile_group.cpp
@@ -138,12 +138,12 @@ codegen::Value TileGroup::LoadColumn(
       codegen::Varlen::SafeGetPtrAndLength(
           codegen, codegen->CreateLoad(varlen_ptr_ptr), val, length);
     }
-    PL_ASSERT(val != nullptr && length != nullptr);
+    PELOTON_ASSERT(val != nullptr && length != nullptr);
   } else {
     // Get the LLVM type of the column
     llvm::Type *col_type = nullptr, *col_len_type = nullptr;
     sql_type.GetTypeForMaterialization(codegen, col_type, col_len_type);
-    PL_ASSERT(col_type != nullptr && col_len_type == nullptr);
+    PELOTON_ASSERT(col_type != nullptr && col_len_type == nullptr);
 
     // val = *(col_type*)col_address;
     val = codegen->CreateLoad(
@@ -162,7 +162,7 @@ codegen::Value TileGroup::LoadColumn(
         auto null_val =
             codegen::Value{sql_type, sql_type.GetNullValue(codegen).GetValue()};
         auto val_is_null = val_tmp.CompareEq(codegen, null_val);
-        PL_ASSERT(!val_is_null.IsNullable());
+        PELOTON_ASSERT(!val_is_null.IsNullable());
         is_null = val_is_null.GetValue();
       }
     }
@@ -189,7 +189,7 @@ TileGroup::TileGroupAccess::Row::Row(const TileGroup &tile_group,
 
 codegen::Value TileGroup::TileGroupAccess::Row::LoadColumn(
     CodeGen &codegen, uint32_t col_idx) const {
-  PL_ASSERT(col_idx < layout_.size());
+  PELOTON_ASSERT(col_idx < layout_.size());
   return tile_group_.LoadColumn(codegen, GetTID(), layout_[col_idx]);
 }
 

--- a/src/codegen/transaction_runtime.cpp
+++ b/src/codegen/transaction_runtime.cpp
@@ -73,7 +73,7 @@ bool TransactionRuntime::IsOwner(concurrency::TransactionContext &txn,
   bool is_owner = txn_manager.IsOwner(&txn, tile_group_header, tuple_offset);
   bool is_written = txn_manager.IsWritten(&txn, tile_group_header,
                                           tuple_offset);
-  PL_ASSERT((is_owner == false && is_written == true) == false);
+  PELOTON_ASSERT((is_owner == false && is_written == true) == false);
   if (is_owner == true && is_written == true)
     return true;
   return false;

--- a/src/codegen/translator_factory.cpp
+++ b/src/codegen/translator_factory.cpp
@@ -128,7 +128,7 @@ std::unique_ptr<OperatorTranslator> TranslatorFactory::CreateTranslator(
                       PlanNodeTypeToString(plan_node.GetPlanNodeType())};
     }
   }
-  PL_ASSERT(translator != nullptr);
+  PELOTON_ASSERT(translator != nullptr);
   return std::unique_ptr<OperatorTranslator>{translator};
 }
 
@@ -215,7 +215,7 @@ std::unique_ptr<ExpressionTranslator> TranslatorFactory::CreateTranslator(
                       ExpressionTypeToString(exp.GetExpressionType())};
     }
   }
-  PL_ASSERT(translator != nullptr);
+  PELOTON_ASSERT(translator != nullptr);
   return std::unique_ptr<ExpressionTranslator>{translator};
 }
 

--- a/src/codegen/tuple_runtime.cpp
+++ b/src/codegen/tuple_runtime.cpp
@@ -26,7 +26,7 @@ void TupleRuntime::CreateVarlen(char *data, uint32_t len, char *buf,
   auto *area =
       reinterpret_cast<varlen_t *>(pool->Allocate(sizeof(uint32_t) + len));
   area->len = len;
-  PL_MEMCPY(area->data, data, len);
+  PELOTON_MEMCPY(area->data, data, len);
 
   *reinterpret_cast<varlen_t **>(buf) = area;
 }

--- a/src/codegen/type/bigint_type.cpp
+++ b/src/codegen/type/bigint_type.cpp
@@ -192,7 +192,7 @@ struct Abs : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              const TypeSystem::InvocationContext &ctx)
     const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
     // The BigInt subtraction implementation
     Sub sub;
     // Zero place-holder
@@ -219,7 +219,7 @@ struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
 
     llvm::Value *overflow_bit = nullptr;
     llvm::Value *result = codegen.CallSubWithOverflow(
@@ -247,7 +247,7 @@ struct Floor : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
     return cast.Impl(codegen, val, Decimal::Instance());
   }
 };
@@ -267,7 +267,7 @@ struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
     return cast.Impl(codegen, val, Decimal::Instance());
   }
 };
@@ -315,7 +315,7 @@ struct Add : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do addition
     llvm::Value *overflow_bit = nullptr;
@@ -345,7 +345,7 @@ Type Sub::ResultType(UNUSED_ATTRIBUTE const Type &left_type,
 
 Value Sub::Impl(CodeGen &codegen, const Value &left, const Value &right,
                 const TypeSystem::InvocationContext &ctx) const {
-  PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+  PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
   // Do subtraction
   llvm::Value *overflow_bit = nullptr;
@@ -375,7 +375,7 @@ struct Mul : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do multiplication
     llvm::Value *overflow_bit = nullptr;
@@ -406,7 +406,7 @@ struct Div : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
     auto *div0 = codegen->CreateICmpEQ(right.GetValue(), codegen.Const64(0));
@@ -462,7 +462,7 @@ struct Modulo : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
     auto *div0 = codegen->CreateICmpEQ(right.GetValue(), codegen.Const64(0));
@@ -579,17 +579,17 @@ BigInt::BigInt()
                    kNaryOperatorTable, kNoArgOperatorTable) {}
 
 Value BigInt::GetMinValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const64(peloton::type::PELOTON_INT64_MIN);
+  auto *raw_val = codegen.Const64(peloton::type::PELOTON_VALUE_INT64_MIN);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value BigInt::GetMaxValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const64(peloton::type::PELOTON_INT64_MAX);
+  auto *raw_val = codegen.Const64(peloton::type::PELOTON_VALUE_INT64_MAX);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value BigInt::GetNullValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const64(peloton::type::PELOTON_INT64_NULL);
+  auto *raw_val = codegen.Const64(peloton::type::PELOTON_VALUE_INT64_NULL);
   return Value{Type{TypeId(), true}, raw_val, nullptr, codegen.ConstBool(true)};
 }
 

--- a/src/codegen/type/boolean_type.cpp
+++ b/src/codegen/type/boolean_type.cpp
@@ -40,7 +40,7 @@ struct CastBooleanToInteger : public TypeSystem::CastHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &value,
              const Type &to_type) const override {
-    PL_ASSERT(SupportsTypes(value.GetType(), to_type));
+    PELOTON_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // Any integral value requires a zero-extension
     auto *raw_val = codegen->CreateZExt(value.GetValue(), codegen.Int32Type());
@@ -62,7 +62,7 @@ struct CastBooleanToDecimal : public TypeSystem::CastHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &value,
              const Type &to_type) const override {
-    PL_ASSERT(SupportsTypes(value.GetType(), to_type));
+    PELOTON_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // Converts True to 1.0 and False to 0.0
     auto *raw_val =
@@ -80,7 +80,7 @@ struct CastBooleanToVarchar : public TypeSystem::CastHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &value,
              const Type &to_type) const override {
-    PL_ASSERT(SupportsTypes(value.GetType(), to_type));
+    PELOTON_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // Convert this boolean (unsigned int) into a string
     llvm::Value *str_val = codegen->CreateSelect(
@@ -109,7 +109,7 @@ struct CompareBoolean : public TypeSystem::SimpleComparisonHandleNull {
 
   Value CompareLtImpl(CodeGen &codegen, const Value &left,
                       const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do the comparison
     llvm::Value *result =
@@ -121,7 +121,7 @@ struct CompareBoolean : public TypeSystem::SimpleComparisonHandleNull {
 
   Value CompareLteImpl(CodeGen &codegen, const Value &left,
                        const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do the comparison
     llvm::Value *result =
@@ -133,7 +133,7 @@ struct CompareBoolean : public TypeSystem::SimpleComparisonHandleNull {
 
   Value CompareEqImpl(CodeGen &codegen, const Value &left,
                       const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do the comparison
     llvm::Value *result =
@@ -145,7 +145,7 @@ struct CompareBoolean : public TypeSystem::SimpleComparisonHandleNull {
 
   Value CompareNeImpl(CodeGen &codegen, const Value &left,
                       const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do the comparison
     llvm::Value *result =
@@ -157,7 +157,7 @@ struct CompareBoolean : public TypeSystem::SimpleComparisonHandleNull {
 
   Value CompareGtImpl(CodeGen &codegen, const Value &left,
                       const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do the comparison
     llvm::Value *result =
@@ -169,7 +169,7 @@ struct CompareBoolean : public TypeSystem::SimpleComparisonHandleNull {
 
   Value CompareGteImpl(CodeGen &codegen, const Value &left,
                        const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do the comparison
     llvm::Value *result =
@@ -181,7 +181,7 @@ struct CompareBoolean : public TypeSystem::SimpleComparisonHandleNull {
 
   Value CompareForSortImpl(CodeGen &codegen, const Value &left,
                            const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // For boolean sorting, we convert 1-bit boolean values into a 32-bit number
     const auto int_type = type::Type{Integer::Instance()};
@@ -297,17 +297,17 @@ Boolean::Boolean()
                    kNaryOperatorTable, kNoArgOperatorTable) {}
 
 Value Boolean::GetMinValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.ConstBool(peloton::type::PELOTON_BOOLEAN_MIN);
+  auto *raw_val = codegen.ConstBool(peloton::type::PELOTON_VALUE_BOOLEAN_MIN);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value Boolean::GetMaxValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.ConstBool(peloton::type::PELOTON_BOOLEAN_MAX);
+  auto *raw_val = codegen.ConstBool(peloton::type::PELOTON_VALUE_BOOLEAN_MAX);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value Boolean::GetNullValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.ConstBool(peloton::type::PELOTON_BOOLEAN_NULL);
+  auto *raw_val = codegen.ConstBool(peloton::type::PELOTON_VALUE_BOOLEAN_NULL);
   return Value{Type{TypeId(), true}, raw_val, nullptr, codegen.ConstBool(true)};
 }
 
@@ -316,7 +316,7 @@ llvm::Value *Boolean::CheckNull(CodeGen &codegen, llvm::Value *bool_ptr) const {
       codegen.Int8Type(),
       codegen->CreateBitCast(bool_ptr, codegen.Int8Type()->getPointerTo()));
   return codegen->CreateICmpEQ(
-      b, codegen.Const8(peloton::type::PELOTON_BOOLEAN_NULL));
+      b, codegen.Const8(peloton::type::PELOTON_VALUE_BOOLEAN_NULL));
 }
 
 void Boolean::GetTypeForMaterialization(CodeGen &codegen, llvm::Type *&val_type,

--- a/src/codegen/type/date_type.cpp
+++ b/src/codegen/type/date_type.cpp
@@ -45,7 +45,7 @@ struct CastDateToTimestamp : public TypeSystem::CastHandleNull {
   // Cast the given decimal value into the provided type
   Value Impl(CodeGen &codegen, const Value &value,
              const type::Type &to_type) const override {
-    PL_ASSERT(SupportsTypes(value.GetType(), to_type));
+    PELOTON_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // Date is number of days since 2000, timestamp is micros since same
     auto *date = codegen->CreateZExt(value.GetValue(), codegen.Int64Type());
@@ -167,17 +167,17 @@ Date::Date()
                    kNaryOperatorTable, kNoArgOperatorTable) {}
 
 Value Date::GetMinValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const32(peloton::type::PELOTON_DATE_MIN);
+  auto *raw_val = codegen.Const32(peloton::type::PELOTON_VALUE_DATE_MIN);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value Date::GetMaxValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const32(peloton::type::PELOTON_DATE_MAX);
+  auto *raw_val = codegen.Const32(peloton::type::PELOTON_VALUE_DATE_MAX);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value Date::GetNullValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const32(peloton::type::PELOTON_DATE_NULL);
+  auto *raw_val = codegen.Const32(peloton::type::PELOTON_VALUE_DATE_NULL);
   return Value{Type{TypeId(), true}, raw_val, nullptr, codegen.ConstBool(true)};
 }
 

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -57,8 +57,8 @@ struct CastDecimal : public TypeSystem::CastHandleNull {
   // Cast the given decimal value into the provided type
   Value Impl(CodeGen &codegen, const Value &value,
              const type::Type &to_type) const override {
-    PL_ASSERT(SupportsTypes(value.GetType(), to_type));
-    PL_ASSERT(!to_type.nullable);
+    PELOTON_ASSERT(SupportsTypes(value.GetType(), to_type));
+    PELOTON_ASSERT(!to_type.nullable);
 
     llvm::Type *val_type = nullptr, *len_type = nullptr;
     to_type.GetSqlType().GetTypeForMaterialization(codegen, val_type, len_type);
@@ -167,7 +167,7 @@ struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
 
     llvm::Value *overflow_bit = nullptr;
     llvm::Value *result = codegen.CallSubWithOverflow(
@@ -250,7 +250,7 @@ struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
 
     auto *result = codegen.Call(DecimalFunctionsProxy::Ceil, {val.GetValue()});
 
@@ -299,7 +299,7 @@ struct Add : public TypeSystem::BinaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     auto *raw_val = codegen->CreateFAdd(left.GetValue(), right.GetValue());
     return Value{Decimal::Instance(), raw_val, nullptr, nullptr};
   }
@@ -321,7 +321,7 @@ struct Sub : public TypeSystem::BinaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     auto *raw_val = codegen->CreateFSub(left.GetValue(), right.GetValue());
     return Value{Decimal::Instance(), raw_val, nullptr, nullptr};
   }
@@ -343,7 +343,7 @@ struct Mul : public TypeSystem::BinaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     auto *raw_val = codegen->CreateFMul(left.GetValue(), right.GetValue());
     return Value{Decimal::Instance(), raw_val, nullptr, nullptr};
   }
@@ -364,7 +364,7 @@ struct Div : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
     llvm::Value *div0 =
@@ -421,7 +421,7 @@ struct Modulo : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
     llvm::Value *div0 =
@@ -542,17 +542,17 @@ Decimal::Decimal()
                    kNaryOperatorTable, kNoArgOperatorTable) {}
 
 Value Decimal::GetMinValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.ConstDouble(peloton::type::PELOTON_DECIMAL_MIN);
+  auto *raw_val = codegen.ConstDouble(peloton::type::PELOTON_VALUE_DECIMAL_MIN);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value Decimal::GetMaxValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.ConstDouble(peloton::type::PELOTON_DECIMAL_MAX);
+  auto *raw_val = codegen.ConstDouble(peloton::type::PELOTON_VALUE_DECIMAL_MAX);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value Decimal::GetNullValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.ConstDouble(peloton::type::PELOTON_DECIMAL_NULL);
+  auto *raw_val = codegen.ConstDouble(peloton::type::PELOTON_VALUE_DECIMAL_NULL);
   return Value{Type{TypeId(), true}, raw_val, nullptr, codegen.ConstBool(true)};
 }
 

--- a/src/codegen/type/integer_type.cpp
+++ b/src/codegen/type/integer_type.cpp
@@ -215,7 +215,7 @@ struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
 
     llvm::Value *overflow_bit = nullptr;
     llvm::Value *result = codegen.CallSubWithOverflow(
@@ -243,7 +243,7 @@ struct Floor : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
     return cast.Impl(codegen, val, Decimal::Instance());
   }
 };
@@ -263,7 +263,7 @@ struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
     return cast.Impl(codegen, val, Decimal::Instance());
   }
 };
@@ -311,7 +311,7 @@ struct Add : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do addition
     llvm::Value *overflow_bit = nullptr;
@@ -341,7 +341,7 @@ Type Sub::ResultType(UNUSED_ATTRIBUTE const Type &left_type,
 
 Value Sub::Impl(CodeGen &codegen, const Value &left, const Value &right,
                 const TypeSystem::InvocationContext &ctx) const {
-  PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+  PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
   // Do subtraction
   llvm::Value *overflow_bit = nullptr;
@@ -371,7 +371,7 @@ struct Mul : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do multiplication
     llvm::Value *overflow_bit = nullptr;
@@ -402,7 +402,7 @@ struct Div : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
     auto *div0 = codegen->CreateICmpEQ(right.GetValue(), codegen.Const32(0));
@@ -458,7 +458,7 @@ struct Modulo : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
     auto *div0 = codegen->CreateICmpEQ(right.GetValue(), codegen.Const32(0));
@@ -579,17 +579,17 @@ Integer::Integer()
                    kNaryOperatorTable, kNoArgOperatorTable) {}
 
 Value Integer::GetMinValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const32(peloton::type::PELOTON_INT32_MIN);
+  auto *raw_val = codegen.Const32(peloton::type::PELOTON_VALUE_INT32_MIN);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value Integer::GetMaxValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const32(peloton::type::PELOTON_INT32_MAX);
+  auto *raw_val = codegen.Const32(peloton::type::PELOTON_VALUE_INT32_MAX);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value Integer::GetNullValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const32(peloton::type::PELOTON_INT32_NULL);
+  auto *raw_val = codegen.Const32(peloton::type::PELOTON_VALUE_INT32_NULL);
   return Value{Type{TypeId(), true}, raw_val, nullptr, codegen.ConstBool(true)};
 }
 

--- a/src/codegen/type/smallint_type.cpp
+++ b/src/codegen/type/smallint_type.cpp
@@ -199,7 +199,7 @@ struct Abs : public TypeSystem::UnaryOperatorHandleNull {
 
     // The smallint subtraction implementation
     Sub sub;
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
     // Zero place-holder
     auto zero = codegen::Value{type::SmallInt::Instance(), codegen.Const16(0)};
 
@@ -224,7 +224,7 @@ struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
 
     llvm::Value *overflow_bit = nullptr;
     llvm::Value *result = codegen.CallSubWithOverflow(
@@ -252,7 +252,7 @@ struct Floor : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
     return cast.Impl(codegen, val, Decimal::Instance());
   }
 };
@@ -272,7 +272,7 @@ struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
     return cast.Impl(codegen, val, Decimal::Instance());
   }
 };
@@ -320,7 +320,7 @@ struct Add : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do addition
     llvm::Value *overflow_bit = nullptr;
@@ -351,7 +351,7 @@ Type Sub::ResultType(UNUSED_ATTRIBUTE const Type &left_type,
 
 Value Sub::Impl(CodeGen &codegen, const Value &left, const Value &right,
                 const TypeSystem::InvocationContext &ctx) const {
-  PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+  PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
   // Do subtraction
   llvm::Value *overflow_bit = nullptr;
@@ -381,7 +381,7 @@ struct Mul : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do multiplication
     llvm::Value *overflow_bit = nullptr;
@@ -412,7 +412,7 @@ struct Div : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
     auto *div0 = codegen->CreateICmpEQ(right.GetValue(), codegen.Const16(0));
@@ -469,7 +469,7 @@ struct Modulo : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
     auto *div0 = codegen->CreateICmpEQ(right.GetValue(), codegen.Const16(0));
@@ -589,17 +589,17 @@ SmallInt::SmallInt()
                    kNaryOperatorTable, kNoArgOperatorTable) {}
 
 Value SmallInt::GetMinValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const16(peloton::type::PELOTON_INT16_MIN);
+  auto *raw_val = codegen.Const16(peloton::type::PELOTON_VALUE_INT16_MIN);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value SmallInt::GetMaxValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const16(peloton::type::PELOTON_INT16_MAX);
+  auto *raw_val = codegen.Const16(peloton::type::PELOTON_VALUE_INT16_MAX);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value SmallInt::GetNullValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const16(peloton::type::PELOTON_INT16_NULL);
+  auto *raw_val = codegen.Const16(peloton::type::PELOTON_VALUE_INT16_NULL);
   return Value{Type{TypeId(), true}, raw_val, nullptr, codegen.ConstBool(true)};
 }
 

--- a/src/codegen/type/timestamp_type.cpp
+++ b/src/codegen/type/timestamp_type.cpp
@@ -44,7 +44,7 @@ struct CastTimestampToDate : public TypeSystem::CastHandleNull {
   // Cast the given decimal value into the provided type
   Value Impl(CodeGen &codegen, const Value &value,
              const type::Type &to_type) const override {
-    PL_ASSERT(SupportsTypes(value.GetType(), to_type));
+    PELOTON_ASSERT(SupportsTypes(value.GetType(), to_type));
 
     // TODO: Fix me
     auto *usecs_per_date =
@@ -188,17 +188,17 @@ Timestamp::Timestamp()
                    kNaryOperatorTable, kNoArgOperatorTable) {}
 
 Value Timestamp::GetMinValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const64(peloton::type::PELOTON_TIMESTAMP_MIN);
+  auto *raw_val = codegen.Const64(peloton::type::PELOTON_VALUE_TIMESTAMP_MIN);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value Timestamp::GetMaxValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const64(peloton::type::PELOTON_TIMESTAMP_MAX);
+  auto *raw_val = codegen.Const64(peloton::type::PELOTON_VALUE_TIMESTAMP_MAX);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value Timestamp::GetNullValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const64(peloton::type::PELOTON_TIMESTAMP_NULL);
+  auto *raw_val = codegen.Const64(peloton::type::PELOTON_VALUE_TIMESTAMP_NULL);
   return Value{Type{TypeId(), true}, raw_val, nullptr, codegen.ConstBool(true)};
 }
 

--- a/src/codegen/type/tinyint_type.cpp
+++ b/src/codegen/type/tinyint_type.cpp
@@ -193,7 +193,7 @@ struct Abs : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              const TypeSystem::InvocationContext &ctx)
     const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
     // The tinyint subtraction implementation
     Sub sub;
     // Zero place-holder
@@ -220,7 +220,7 @@ struct Negate : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
 
     llvm::Value *overflow_bit = nullptr;
     llvm::Value *result = codegen.CallSubWithOverflow(
@@ -248,7 +248,7 @@ struct Floor : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
     return cast.Impl(codegen, val, Decimal::Instance());
   }
 };
@@ -268,7 +268,7 @@ struct Ceil : public TypeSystem::UnaryOperatorHandleNull {
   Value Impl(UNUSED_ATTRIBUTE CodeGen &codegen, const Value &val,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsType(val.GetType()));
+    PELOTON_ASSERT(SupportsType(val.GetType()));
     return cast.Impl(codegen, val, Decimal::Instance());
   }
 };
@@ -316,7 +316,7 @@ struct Add : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do addition
     llvm::Value *overflow_bit = nullptr;
@@ -346,7 +346,7 @@ Type Sub::ResultType(UNUSED_ATTRIBUTE const Type &left_type,
 
 Value Sub::Impl(CodeGen &codegen, const Value &left, const Value &right,
            const TypeSystem::InvocationContext &ctx) const {
-  PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+  PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
   // Do subtraction
   llvm::Value *overflow_bit = nullptr;
@@ -376,7 +376,7 @@ struct Mul : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Do multiplication
     llvm::Value *overflow_bit = nullptr;
@@ -407,7 +407,7 @@ struct Div : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
     auto *div0 = codegen->CreateICmpEQ(right.GetValue(), codegen.Const8(0));
@@ -463,7 +463,7 @@ struct Modulo : public TypeSystem::BinaryOperatorHandleNull {
 
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // First, check if the divisor is zero
     auto *div0 = codegen->CreateICmpEQ(right.GetValue(), codegen.Const8(0));
@@ -583,17 +583,17 @@ TinyInt::TinyInt()
                    kNaryOperatorTable, kNoArgOperatorTable) {}
 
 Value TinyInt::GetMinValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const8(peloton::type::PELOTON_INT8_MIN);
+  auto *raw_val = codegen.Const8(peloton::type::PELOTON_VALUE_INT8_MIN);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value TinyInt::GetMaxValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const8(peloton::type::PELOTON_INT8_MAX);
+  auto *raw_val = codegen.Const8(peloton::type::PELOTON_VALUE_INT8_MAX);
   return Value{*this, raw_val, nullptr, nullptr};
 }
 
 Value TinyInt::GetNullValue(CodeGen &codegen) const {
-  auto *raw_val = codegen.Const8(peloton::type::PELOTON_INT8_NULL);
+  auto *raw_val = codegen.Const8(peloton::type::PELOTON_VALUE_INT8_NULL);
   return Value{Type{TypeId(), true}, raw_val, nullptr, codegen.ConstBool(true)};
 }
 

--- a/src/codegen/type/varbinary_type.cpp
+++ b/src/codegen/type/varbinary_type.cpp
@@ -57,7 +57,7 @@ struct CompareVarbinary : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareLtImpl(CodeGen &codegen, const Value &left,
                       const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, check is result is < 0
     llvm::Value *result = CompareStrings(codegen, left, right);
     llvm::Value *is_lt_0 = codegen->CreateICmpSLT(result, codegen.Const32(0));
@@ -66,7 +66,7 @@ struct CompareVarbinary : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareLteImpl(CodeGen &codegen, const Value &left,
                        const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, check is result is <= 0
     llvm::Value *result = CompareStrings(codegen, left, right);
     llvm::Value *is_lte_0 = codegen->CreateICmpSLE(result, codegen.Const32(0));
@@ -75,7 +75,7 @@ struct CompareVarbinary : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareEqImpl(CodeGen &codegen, const Value &left,
                       const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, check is result is == 0
     llvm::Value *result = CompareStrings(codegen, left, right);
     llvm::Value *is_eq_0 = codegen->CreateICmpEQ(result, codegen.Const32(0));
@@ -84,7 +84,7 @@ struct CompareVarbinary : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareNeImpl(CodeGen &codegen, const Value &left,
                       const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, check is result is != 0
     llvm::Value *result = CompareStrings(codegen, left, right);
     llvm::Value *is_ne_0 = codegen->CreateICmpNE(result, codegen.Const32(0));
@@ -93,7 +93,7 @@ struct CompareVarbinary : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareGtImpl(CodeGen &codegen, const Value &left,
                       const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, check is result is <= 0
     llvm::Value *result = CompareStrings(codegen, left, right);
     llvm::Value *is_gt_0 = codegen->CreateICmpSGT(result, codegen.Const32(0));
@@ -102,7 +102,7 @@ struct CompareVarbinary : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareGteImpl(CodeGen &codegen, const Value &left,
                        const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, check is result is >= 0
     llvm::Value *result = CompareStrings(codegen, left, right);
     llvm::Value *is_gte_0 = codegen->CreateICmpSGE(result, codegen.Const32(0));
@@ -111,7 +111,7 @@ struct CompareVarbinary : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareForSortImpl(CodeGen &codegen, const Value &left,
                            const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, return result directly
     llvm::Value *result = CompareStrings(codegen, left, right);
     return Value{Integer::Instance(), result};

--- a/src/codegen/type/varchar_type.cpp
+++ b/src/codegen/type/varchar_type.cpp
@@ -57,7 +57,7 @@ struct CompareVarchar : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareLtImpl(CodeGen &codegen, const Value &left,
                       const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, check is result is < 0
     llvm::Value *result = CompareStrings(codegen, left, right);
     llvm::Value *is_lt_0 = codegen->CreateICmpSLT(result, codegen.Const32(0));
@@ -66,7 +66,7 @@ struct CompareVarchar : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareLteImpl(CodeGen &codegen, const Value &left,
                        const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, check is result is <= 0
     llvm::Value *result = CompareStrings(codegen, left, right);
     llvm::Value *is_lte_0 = codegen->CreateICmpSLE(result, codegen.Const32(0));
@@ -75,7 +75,7 @@ struct CompareVarchar : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareEqImpl(CodeGen &codegen, const Value &left,
                       const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, check is result is == 0
     llvm::Value *result = CompareStrings(codegen, left, right);
     llvm::Value *is_eq_0 = codegen->CreateICmpEQ(result, codegen.Const32(0));
@@ -84,7 +84,7 @@ struct CompareVarchar : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareNeImpl(CodeGen &codegen, const Value &left,
                       const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, check is result is != 0
     llvm::Value *result = CompareStrings(codegen, left, right);
     llvm::Value *is_ne_0 = codegen->CreateICmpNE(result, codegen.Const32(0));
@@ -93,7 +93,7 @@ struct CompareVarchar : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareGtImpl(CodeGen &codegen, const Value &left,
                       const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, check is result is <= 0
     llvm::Value *result = CompareStrings(codegen, left, right);
     llvm::Value *is_gt_0 = codegen->CreateICmpSGT(result, codegen.Const32(0));
@@ -102,7 +102,7 @@ struct CompareVarchar : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareGteImpl(CodeGen &codegen, const Value &left,
                        const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, check is result is >= 0
     llvm::Value *result = CompareStrings(codegen, left, right);
     llvm::Value *is_gte_0 = codegen->CreateICmpSGE(result, codegen.Const32(0));
@@ -111,7 +111,7 @@ struct CompareVarchar : public TypeSystem::ExpensiveComparisonHandleNull {
 
   Value CompareForSortImpl(CodeGen &codegen, const Value &left,
                            const Value &right) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
     // Call CompareStrings, return result directly
     llvm::Value *result = CompareStrings(codegen, left, right);
     return Value{Integer::Instance(), result};
@@ -224,7 +224,7 @@ struct Like : public TypeSystem::BinaryOperator {
 
   Value Eval(CodeGen &codegen, const Value &left, const Value &right,
              const TypeSystem::InvocationContext &ctx) const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     // Pre-condition: Left value is the input string; right value is the pattern
 
@@ -265,7 +265,7 @@ struct DateTrunc : public TypeSystem::BinaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     llvm::Value *raw_ret = codegen.Call(TimestampFunctionsProxy::DateTrunc,
                                         {left.GetValue(), right.GetValue()});
@@ -288,7 +288,7 @@ struct DatePart : public TypeSystem::BinaryOperatorHandleNull {
   Value Impl(CodeGen &codegen, const Value &left, const Value &right,
              UNUSED_ATTRIBUTE const TypeSystem::InvocationContext &ctx)
       const override {
-    PL_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
+    PELOTON_ASSERT(SupportsTypes(left.GetType(), right.GetType()));
 
     llvm::Value *raw_ret = codegen.Call(TimestampFunctionsProxy::DatePart,
                                         {left.GetValue(), right.GetValue()});

--- a/src/codegen/updateable_storage.cpp
+++ b/src/codegen/updateable_storage.cpp
@@ -23,7 +23,7 @@ namespace codegen {
 // can be found it (i.e., which index to pass into Get() to get the value)
 //===----------------------------------------------------------------------===//
 uint32_t UpdateableStorage::AddType(const type::Type &type) {
-  PL_ASSERT(storage_type_ == nullptr);
+  PELOTON_ASSERT(storage_type_ == nullptr);
   schema_.push_back(type);
   return static_cast<uint32_t>(schema_.size() - 1);
 }
@@ -96,23 +96,23 @@ void UpdateableStorage::FindStoragePositionFor(uint32_t item_index,
   for (const auto &entry_info : storage_format_) {
     if (entry_info.logical_index == item_index) {
       if (entry_info.is_length) {
-        PL_ASSERT(len_idx == -1);
+        PELOTON_ASSERT(len_idx == -1);
         len_idx = entry_info.physical_index;
       } else {
-        PL_ASSERT(val_idx == -1);
+        PELOTON_ASSERT(val_idx == -1);
         val_idx = entry_info.physical_index;
       }
     }
   }
-  PL_ASSERT(val_idx >= 0);
+  PELOTON_ASSERT(val_idx >= 0);
 }
 
 // Get the value at a specific index into the storage area
 codegen::Value UpdateableStorage::GetValueSkipNull(CodeGen &codegen,
                                                    llvm::Value *space,
                                                    uint64_t index) const {
-  PL_ASSERT(storage_type_ != nullptr);
-  PL_ASSERT(index < schema_.size());
+  PELOTON_ASSERT(storage_type_ != nullptr);
+  PELOTON_ASSERT(index < schema_.size());
 
   // Get the physical position in the storage space where the data is located
   int32_t val_idx, len_idx;
@@ -192,7 +192,7 @@ void UpdateableStorage::SetValue(
     CodeGen &codegen, llvm::Value *space, uint64_t index,
     const codegen::Value &value,
     UpdateableStorage::NullBitmap &null_bitmap) const {
-  PL_ASSERT(null_bitmap.IsNullable(index));
+  PELOTON_ASSERT(null_bitmap.IsNullable(index));
 
   // Set the NULL bit
   llvm::Value *null = value.IsNull(codegen);
@@ -258,7 +258,7 @@ llvm::Value *UpdateableStorage::NullBitmap::IsNull(CodeGen &codegen,
 
 void UpdateableStorage::NullBitmap::SetNull(CodeGen &codegen, uint32_t index,
                                             llvm::Value *null_bit) {
-  PL_ASSERT(null_bit->getType() == codegen.BoolType());
+  PELOTON_ASSERT(null_bit->getType() == codegen.BoolType());
 
   uint32_t byte_pos = index >> 3;
 
@@ -293,7 +293,7 @@ void UpdateableStorage::NullBitmap::SetNull(CodeGen &codegen, uint32_t index,
 
 void UpdateableStorage::NullBitmap::MergeValues(lang::If &if_clause,
                                                 llvm::Value *before_if_value) {
-  PL_ASSERT(bytes_[active_byte_pos_] != nullptr);
+  PELOTON_ASSERT(bytes_[active_byte_pos_] != nullptr);
   bytes_[active_byte_pos_] =
       if_clause.BuildPHI(bytes_[active_byte_pos_], before_if_value);
 }

--- a/src/codegen/updater.cpp
+++ b/src/codegen/updater.cpp
@@ -30,7 +30,7 @@ namespace codegen {
 void Updater::Init(storage::DataTable *table,
                    executor::ExecutorContext *executor_context,
                    Target *target_vector, uint32_t target_vector_size) {
-  PL_ASSERT(table != nullptr && executor_context != nullptr&&
+  PELOTON_ASSERT(table != nullptr && executor_context != nullptr&&
             target_vector != nullptr);
   table_ = table;
   executor_context_ = executor_context;
@@ -50,7 +50,7 @@ char *Updater::GetDataPtr(uint32_t tile_group_id, uint32_t tuple_offset) {
 }
 
 char *Updater::Prepare(uint32_t tile_group_id, uint32_t tuple_offset) {
-  PL_ASSERT(table_ != nullptr && executor_context_ != nullptr);
+  PELOTON_ASSERT(table_ != nullptr && executor_context_ != nullptr);
   auto *txn = executor_context_->GetTransaction();
   auto tile_group = table_->GetTileGroupById(tile_group_id).get();
   auto *tile_group_header = tile_group->GetHeader();
@@ -74,7 +74,7 @@ char *Updater::Prepare(uint32_t tile_group_id, uint32_t tuple_offset) {
 }
 
 char *Updater::PreparePK(uint32_t tile_group_id, uint32_t tuple_offset) {
-  PL_ASSERT(table_ != nullptr && executor_context_ != nullptr);
+  PELOTON_ASSERT(table_ != nullptr && executor_context_ != nullptr);
   auto *txn = executor_context_->GetTransaction();
   auto tile_group = table_->GetTileGroupById(tile_group_id).get();
   auto *tile_group_header = tile_group->GetHeader();
@@ -108,12 +108,12 @@ char *Updater::PreparePK(uint32_t tile_group_id, uint32_t tuple_offset) {
 
 peloton::type::AbstractPool *Updater::GetPool() {
   // This should be called after Prepare() or PreparePK()
-  PL_ASSERT(tile_);
+  PELOTON_ASSERT(tile_);
   return tile_->GetPool();
 }
 
 void Updater::Update() {
-  PL_ASSERT(table_ != nullptr && executor_context_ != nullptr);
+  PELOTON_ASSERT(table_ != nullptr && executor_context_ != nullptr);
   LOG_TRACE("Updating tuple <%u, %u> from table '%s' (db ID: %u, table ID: %u)",
             old_location_.block, old_location_.offset,
             table_->GetName().c_str(), table_->GetDatabaseOid(),
@@ -147,7 +147,7 @@ void Updater::Update() {
 }
 
 void Updater::UpdatePK() {
-  PL_ASSERT(table_ != nullptr && executor_context_ != nullptr);
+  PELOTON_ASSERT(table_ != nullptr && executor_context_ != nullptr);
   LOG_TRACE("Updating tuple <%u, %u> from table '%s' (db ID: %u, table ID: %u)",
             old_location_.block, old_location_.offset,
             table_->GetName().c_str(), table_->GetDatabaseOid(),

--- a/src/codegen/util/bloom_filter.cpp
+++ b/src/codegen/util/bloom_filter.cpp
@@ -61,7 +61,7 @@ void BloomFilter::Init(uint64_t estimated_num_tuples) {
   // Allocate memory for the underlying bytes array
   uint64_t num_bytes = (num_bits_ + 7) / 8;
   bytes_ = new char[num_bytes];
-  PL_MEMSET(bytes_, 0, num_bytes);
+  PELOTON_MEMSET(bytes_, 0, num_bytes);
 
   // Initialize Statistics
   num_misses_ = 0;

--- a/src/codegen/util/oa_hash_table.cpp
+++ b/src/codegen/util/oa_hash_table.cpp
@@ -51,7 +51,7 @@ void OAHashTable::Init(uint64_t key_size, uint64_t value_size,
   bucket_mask_ = num_buckets_ - 1;
 
   // Sanity check
-  PL_ASSERT((num_buckets_ & bucket_mask_) == 0);
+  PELOTON_ASSERT((num_buckets_ & bucket_mask_) == 0);
 
   // No elements in the table right now
   num_entries_ = num_valid_buckets_ = 0;
@@ -84,7 +84,7 @@ char *OAHashTable::StoreToKeyValueList(KeyValueList **kv_list_p_p) {
   KeyValueList *kv_list_p = *kv_list_p_p;
 
   // Size always <= capacity
-  PL_ASSERT(kv_list_p->capacity >= kv_list_p->size);
+  PELOTON_ASSERT(kv_list_p->capacity >= kv_list_p->size);
 
   // We always need this to compute something
   uint32_t size = kv_list_p->size;
@@ -110,10 +110,10 @@ char *OAHashTable::StoreToKeyValueList(KeyValueList **kv_list_p_p) {
     uint64_t new_kv_list_length = GetCurrentKeyValueListSize(new_capacity);
 
     kv_list_p = static_cast<KeyValueList *>(malloc(new_kv_list_length));
-    PL_ASSERT(kv_list_p != nullptr);
+    PELOTON_ASSERT(kv_list_p != nullptr);
 
     // Copy from the old memory chunk to the new chunk
-    PL_MEMCPY(kv_list_p, *kv_list_p_p, current_length);
+    PELOTON_MEMCPY(kv_list_p, *kv_list_p_p, current_length);
 
     // Update capacity field after copying
     kv_list_p->capacity = new_capacity;
@@ -158,7 +158,7 @@ OAHashTable::HashEntry *OAHashTable::FindNextFreeEntry(uint64_t hash_value) {
     }
   }
 
-  PL_ASSERT(false);
+  PELOTON_ASSERT(false);
   return nullptr;
 }
 
@@ -217,8 +217,8 @@ char *OAHashTable::StoreTuple(HashEntry *entry, uint64_t hash) {
     entry->kv_list = static_cast<KeyValueList *>(malloc(
         GetCurrentKeyValueListSize(OAHashTable::kInitialKVListCapacity)));
 
-    PL_ASSERT(entry->kv_list != nullptr);
-    PL_ASSERT(entry->HasKeyValueList());
+    PELOTON_ASSERT(entry->kv_list != nullptr);
+    PELOTON_ASSERT(entry->HasKeyValueList());
 
     // Initialize members - also copy the current data into the kv list
     // to simplify iterating over the hash table
@@ -229,7 +229,7 @@ char *OAHashTable::StoreTuple(HashEntry *entry, uint64_t hash) {
     // in the HashEntry to provide a fast path for key comparison during probing
     // because no matter whether there is a KeyValueList, the key is always at
     // the same location.
-    PL_MEMCPY(entry->kv_list->data, entry->data + key_size_, value_size_);
+    PELOTON_MEMCPY(entry->kv_list->data, entry->data + key_size_, value_size_);
 
     // Return the second element's payload. The first element has been copied
     // from the HashEntry. This pointer is for dumping value.
@@ -272,7 +272,7 @@ void OAHashTable::InitializeArray(HashEntry *entries) {
 //===----------------------------------------------------------------------===//
 void OAHashTable::Resize(HashEntry **entry_p_p) {
   // Make it an assertion to prevent potential bugs
-  PL_ASSERT(NeedsResize());
+  PELOTON_ASSERT(NeedsResize());
 
   LOG_DEBUG("Resizing hash-table from %llu buckets to %llu",
             (unsigned long long)num_buckets_,
@@ -346,7 +346,7 @@ void OAHashTable::Resize(HashEntry **entry_p_p) {
 
       // Copy everything, including is_free flag, hash value and key-value
       // to the new free entry we just found
-      PL_MEMCPY(new_entry_char_p, current_entry_char_p, entry_size_);
+      PELOTON_MEMCPY(new_entry_char_p, current_entry_char_p, entry_size_);
     }
 
     // No matter we ignore an entry or not this has to be done

--- a/src/codegen/util/sorter.cpp
+++ b/src/codegen/util/sorter.cpp
@@ -115,7 +115,7 @@ void Sorter::Resize() {
   uint64_t curr_used_size = GetUsedSpace();
 
   // Ensure the current size is a power of two
-  PL_ASSERT(curr_alloc_size % 2 == 0);
+  PELOTON_ASSERT(curr_alloc_size % 2 == 0);
 
   // Allocate double the buffer room
   uint64_t next_alloc_size = curr_alloc_size << 1;
@@ -130,7 +130,7 @@ void Sorter::Resize() {
 
   // Now copy the previous buffer into the new area. Note that we only need
   // to copy over the USED space into the new space.
-  PL_MEMCPY(new_buffer_start, buffer_start_, buffer_pos_ - buffer_start_);
+  PELOTON_MEMCPY(new_buffer_start, buffer_start_, buffer_pos_ - buffer_start_);
 
   // Set pointers
   char *old_buffer_start = buffer_start_;

--- a/src/codegen/value.cpp
+++ b/src/codegen/value.cpp
@@ -27,13 +27,13 @@ Value::Value(const type::Type &type, llvm::Value *val, llvm::Value *length,
              llvm::Value *null)
     : type_(type), value_(val), length_(length), null_(null) {
   // If the value is NULL-able, it better have an accompanying NULL bit
-  PL_ASSERT(!type_.nullable || null_ != nullptr);
+  PELOTON_ASSERT(!type_.nullable || null_ != nullptr);
 }
 
 // Return a boolean value indicating whether this value is NULL
 llvm::Value *Value::IsNull(CodeGen &codegen) const {
   if (IsNullable()) {
-    PL_ASSERT(null_ != nullptr && null_->getType() == codegen.BoolType());
+    PELOTON_ASSERT(null_ != nullptr && null_->getType() == codegen.BoolType());
     return null_;
   } else {
     return codegen.ConstBool(false);
@@ -57,7 +57,7 @@ Value Value::CastTo(CodeGen &codegen, const type::Type &to_type) const {
 
   // Lookup the cast operation and execute it
   const auto *cast_op = type::TypeSystem::GetCast(GetType(), to_type);
-  PL_ASSERT(cast_op != nullptr);
+  PELOTON_ASSERT(cast_op != nullptr);
   return cast_op->Eval(codegen, *this, to_type);
 }
 
@@ -68,7 +68,7 @@ Value Value::CastTo(CodeGen &codegen, const type::Type &to_type) const {
   const auto *comparison = type::TypeSystem::GetComparison( \
       GetType(), left_cast, other.GetType(), right_cast);   \
                                                             \
-  PL_ASSERT(comparison != nullptr);                         \
+  PELOTON_ASSERT(comparison != nullptr);                         \
   Value left = CastTo(codegen, left_cast);                  \
   Value right = other.CastTo(codegen, right_cast);          \
                                                             \
@@ -203,7 +203,7 @@ Value Value::Max(CodeGen &codegen, const Value &other) const {
 // Generate a hash for the given value
 //===----------------------------------------------------------------------===//
 void Value::ValuesForHash(llvm::Value *&val, llvm::Value *&len) const {
-  PL_ASSERT(GetType().type_id != peloton::type::TypeId::INVALID);
+  PELOTON_ASSERT(GetType().type_id != peloton::type::TypeId::INVALID);
   val = GetValue();
   len = GetType().GetSqlType().IsVariableLength() ? GetLength() : nullptr;
 }
@@ -214,7 +214,7 @@ void Value::ValuesForHash(llvm::Value *&val, llvm::Value *&len) const {
 void Value::ValuesForMaterialization(CodeGen &codegen, llvm::Value *&val,
                                      llvm::Value *&len,
                                      llvm::Value *&null) const {
-  PL_ASSERT(GetType().type_id != peloton::type::TypeId::INVALID);
+  PELOTON_ASSERT(GetType().type_id != peloton::type::TypeId::INVALID);
   val = GetValue();
   len = GetType().GetSqlType().IsVariableLength() ? GetLength() : nullptr;
   null = IsNull(codegen);
@@ -223,7 +223,7 @@ void Value::ValuesForMaterialization(CodeGen &codegen, llvm::Value *&val,
 // Return the value that can be
 Value Value::ValueFromMaterialization(const type::Type &type, llvm::Value *val,
                                       llvm::Value *len, llvm::Value *null) {
-  PL_ASSERT(type.type_id != peloton::type::TypeId::INVALID);
+  PELOTON_ASSERT(type.type_id != peloton::type::TypeId::INVALID);
   return Value{type, val,
                (type.GetSqlType().IsVariableLength() ? len : nullptr),
                (type.nullable ? null : nullptr)};
@@ -245,11 +245,11 @@ Value Value::BuildPHI(
   llvm::Type *null_type = codegen.BoolType();
   llvm::Type *val_type = nullptr, *len_type = nullptr;
   sql_type.GetTypeForMaterialization(codegen, val_type, len_type);
-  PL_ASSERT(val_type != nullptr);
+  PELOTON_ASSERT(val_type != nullptr);
 
   // Do the merge depending on the type
   if (sql_type.IsVariableLength()) {
-    PL_ASSERT(len_type != nullptr);
+    PELOTON_ASSERT(len_type != nullptr);
     auto *val_phi = codegen->CreatePHI(val_type, num_entries);
     auto *len_phi = codegen->CreatePHI(len_type, num_entries);
     auto *null_phi = codegen->CreatePHI(null_type, num_entries);
@@ -260,7 +260,7 @@ Value Value::BuildPHI(
     }
     return Value{type, val_phi, len_phi, null_phi};
   } else {
-    PL_ASSERT(len_type == nullptr);
+    PELOTON_ASSERT(len_type == nullptr);
     auto *val_phi = codegen->CreatePHI(val_type, num_entries);
     auto *null_phi = codegen->CreatePHI(null_type, num_entries);
     for (const auto &val_pair : vals) {
@@ -274,7 +274,7 @@ Value Value::BuildPHI(
 Value Value::CallUnaryOp(CodeGen &codegen, OperatorId op_id) const {
   // Lookup the operation in the value's type system
   auto *unary_op = type::TypeSystem::GetUnaryOperator(op_id, GetType());
-  PL_ASSERT(unary_op != nullptr);
+  PELOTON_ASSERT(unary_op != nullptr);
 
   // Setup the invocation context
   type::TypeSystem::InvocationContext ctx{.on_error = OnError::Exception,
@@ -292,7 +292,7 @@ Value Value::CallBinaryOp(CodeGen &codegen, OperatorId op_id,
   // Lookup the operation in the type system
   auto *binary_op = type::TypeSystem::GetBinaryOperator(
       op_id, GetType(), left_target_type, other.GetType(), right_target_type);
-  PL_ASSERT(binary_op != nullptr);
+  PELOTON_ASSERT(binary_op != nullptr);
 
   // Cast input types as need be
   Value casted_left = CastTo(codegen, left_target_type);

--- a/src/common/cache.cpp
+++ b/src/common/cache.cpp
@@ -63,8 +63,8 @@ typename Cache<Key, Value>::iterator Cache<Key, Value>::find(const Key &key) {
 template <class Key, class Value>
 typename Cache<Key, Value>::iterator Cache<Key, Value>::insert(
     const Entry &entry) {
-  PL_ASSERT(list_.size() == map_.size());
-  PL_ASSERT(list_.size() <= this->capacity_);
+  PELOTON_ASSERT(list_.size() == map_.size());
+  PELOTON_ASSERT(list_.size() <= this->capacity_);
   auto map_itr = map_.find(entry.first);
   auto cache_itr = iterator(map_itr);
 
@@ -73,7 +73,7 @@ typename Cache<Key, Value>::iterator Cache<Key, Value>::insert(
     list_.push_front(entry.first);
     auto ret =
         map_.emplace(entry.first, std::make_pair(entry.second, list_.begin()));
-    PL_ASSERT(ret.second); /* should not fail */
+    PELOTON_ASSERT(ret.second); /* should not fail */
     cache_itr = iterator(ret.first);
     while (map_.size() > this->capacity_) {
       auto deleted = list_.back();
@@ -84,8 +84,8 @@ typename Cache<Key, Value>::iterator Cache<Key, Value>::insert(
     list_.splice(list_.begin(), list_, map_itr->second.second);
     map_itr->second = std::make_pair(entry.second, list_.begin());
   }
-  PL_ASSERT(list_.size() == map_.size());
-  PL_ASSERT(list_.size() <= capacity_);
+  PELOTON_ASSERT(list_.size() == map_.size());
+  PELOTON_ASSERT(list_.size() <= capacity_);
   return cache_itr;
 }
 
@@ -111,7 +111,7 @@ void Cache<Key, Value>::delete_key(const Key &key) {
  */
 template <class Key, class Value>
 typename Cache<Key, Value>::size_type Cache<Key, Value>::size() const {
-  PL_ASSERT(map_.size() == list_.size());
+  PELOTON_ASSERT(map_.size() == list_.size());
   return map_.size();
 }
 

--- a/src/common/container/lock_free_array.cpp
+++ b/src/common/container/lock_free_array.cpp
@@ -40,7 +40,7 @@ LOCK_FREE_ARRAY_TYPE::~LockFreeArray(){
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 bool LOCK_FREE_ARRAY_TYPE::Update(const std::size_t &offset, ValueType value){
-  PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
+  PELOTON_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
   LOG_TRACE("Update at %lu", lock_free_array_offset.load());
   lock_free_array->at(offset) =  value;
   return true;
@@ -55,7 +55,7 @@ bool LOCK_FREE_ARRAY_TYPE::Append(ValueType value){
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 bool LOCK_FREE_ARRAY_TYPE::Erase(const std::size_t &offset, const ValueType& invalid_value){
-  PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
+  PELOTON_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
   LOG_TRACE("Erase at %lu", offset);
   lock_free_array->at(offset) =  invalid_value;
   return true;
@@ -63,7 +63,7 @@ bool LOCK_FREE_ARRAY_TYPE::Erase(const std::size_t &offset, const ValueType& inv
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 ValueType LOCK_FREE_ARRAY_TYPE::Find(const std::size_t &offset) const{
-  PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
+  PELOTON_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
   LOG_TRACE("Find at %lu", offset);
   auto value = lock_free_array->at(offset);
   return value;
@@ -72,7 +72,7 @@ ValueType LOCK_FREE_ARRAY_TYPE::Find(const std::size_t &offset) const{
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 ValueType LOCK_FREE_ARRAY_TYPE::FindValid(const std::size_t &offset,
                                           const ValueType& invalid_value) const {
-  PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
+  PELOTON_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
   LOG_TRACE("Find Valid at %lu", offset);
 
   std::size_t valid_array_itr = 0;

--- a/src/common/item_pointer.cpp
+++ b/src/common/item_pointer.cpp
@@ -20,7 +20,7 @@ namespace peloton {
 ItemPointer INVALID_ITEMPOINTER;
 
 bool AtomicUpdateItemPointer(ItemPointer* src_ptr, const ItemPointer& value) {
-  PL_ASSERT(sizeof(ItemPointer) == sizeof(int64_t));
+  PELOTON_ASSERT(sizeof(ItemPointer) == sizeof(int64_t));
   int64_t* cast_src_ptr = reinterpret_cast<int64_t*>((void*)src_ptr);
   int64_t* cast_value_ptr = reinterpret_cast<int64_t*>((void*)&value);
   return __sync_bool_compare_and_swap(cast_src_ptr, *cast_src_ptr,

--- a/src/concurrency/decentralized_epoch_manager.cpp
+++ b/src/concurrency/decentralized_epoch_manager.cpp
@@ -20,7 +20,7 @@ namespace concurrency {
   // enter epoch with thread id
   cid_t DecentralizedEpochManager::EnterEpoch(const size_t thread_id, const TimestampType ts_type) {
 
-    PL_ASSERT(local_epochs_.find(thread_id) != local_epochs_.end());
+    PELOTON_ASSERT(local_epochs_.find(thread_id) != local_epochs_.end());
 
     if (ts_type == TimestampType::SNAPSHOT_READ) {
 
@@ -50,7 +50,7 @@ namespace concurrency {
 
   void DecentralizedEpochManager::ExitEpoch(const size_t thread_id, const eid_t epoch_id) {
 
-    PL_ASSERT(local_epochs_.find(thread_id) != local_epochs_.end());
+    PELOTON_ASSERT(local_epochs_.find(thread_id) != local_epochs_.end());
 
     // exit from the corresponding local epoch.
     local_epochs_.at(thread_id)->ExitEpoch(epoch_id);

--- a/src/concurrency/local_epoch.cpp
+++ b/src/concurrency/local_epoch.cpp
@@ -66,7 +66,7 @@ namespace concurrency {
   void LocalEpoch::ExitEpoch(const eid_t epoch_id) {
     epoch_lock_.Lock();
 
-    PL_ASSERT(epoch_map_.find(epoch_id) != epoch_map_.end());
+    PELOTON_ASSERT(epoch_map_.find(epoch_id) != epoch_map_.end());
     epoch_map_.at(epoch_id)->txn_count_--;
 
     while (epoch_queue_.size() != 0) {
@@ -75,7 +75,7 @@ namespace concurrency {
         epoch_map_.erase(epoch_ptr->epoch_id_);
         epoch_queue_.pop();
       } else {
-        PL_ASSERT(epoch_ptr->epoch_id_ > epoch_id_lower_bound_);
+        PELOTON_ASSERT(epoch_ptr->epoch_id_ > epoch_id_lower_bound_);
         epoch_id_lower_bound_ = epoch_ptr->epoch_id_ - 1;
         break;
       }
@@ -99,7 +99,7 @@ namespace concurrency {
           epoch_map_.erase(epoch_ptr->epoch_id_);
           epoch_queue_.pop();
         } else {
-          PL_ASSERT(epoch_ptr->epoch_id_ > epoch_id_lower_bound_);
+          PELOTON_ASSERT(epoch_ptr->epoch_id_ > epoch_id_lower_bound_);
           epoch_id_lower_bound_ = epoch_ptr->epoch_id_ - 1;
           break;
         }

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -193,7 +193,7 @@ void TimestampOrderingTransactionManager::YieldOwnership(
     UNUSED_ATTRIBUTE TransactionContext *const current_txn,
     const storage::TileGroupHeader *const tile_group_header,
     const oid_t &tuple_id) {
-  PL_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id));
+  PELOTON_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id));
   tile_group_header->SetTransactionId(tuple_id, INITIAL_TXN_ID);
 }
 
@@ -251,7 +251,7 @@ bool TimestampOrderingTransactionManager::PerformRead(
       }
 
       // if we have already owned the version.
-      PL_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id) == true);
+      PELOTON_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id) == true);
 
       // Increment table read op stats
       if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
@@ -309,7 +309,7 @@ bool TimestampOrderingTransactionManager::PerformRead(
         current_txn->RecordReadOwn(location);
       }
       // if we have already owned the version.
-      PL_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id) == true);
+      PELOTON_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id) == true);
       // Increment table read op stats
       if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
           StatsType::INVALID) {
@@ -360,7 +360,7 @@ bool TimestampOrderingTransactionManager::PerformRead(
   //// handle SERIALIZABLE and REPEATABLE_READS
   //////////////////////////////////////////////////////////
   else {
-    PL_ASSERT(current_txn->GetIsolationLevel() ==
+    PELOTON_ASSERT(current_txn->GetIsolationLevel() ==
                   IsolationLevelType::SERIALIZABLE ||
               current_txn->GetIsolationLevel() ==
                   IsolationLevelType::REPEATABLE_READS);
@@ -396,14 +396,14 @@ bool TimestampOrderingTransactionManager::PerformRead(
         UNUSED_ATTRIBUTE bool ret = SetLastReaderCommitId(
             tile_group_header, tuple_id, current_txn->GetCommitId(), true);
 
-        PL_ASSERT(ret == true);
+        PELOTON_ASSERT(ret == true);
         // there's no need to maintain read set for timestamp ordering protocol.
         // T/O does not check the read set during commit phase.
       }
 
       // if we have already owned the version.
-      PL_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id) == true);
-      PL_ASSERT(GetLastReaderCommitId(tile_group_header, tuple_id) ==
+      PELOTON_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id) == true);
+      PELOTON_ASSERT(GetLastReaderCommitId(tile_group_header, tuple_id) ==
                     current_txn->GetCommitId() ||
                 GetLastReaderCommitId(tile_group_header, tuple_id) == 0);
       // Increment table read op stats
@@ -440,7 +440,7 @@ bool TimestampOrderingTransactionManager::PerformRead(
       } else {
         // if the current transaction has already owned this tuple,
         // then perform read directly.
-        PL_ASSERT(GetLastReaderCommitId(tile_group_header, tuple_id) ==
+        PELOTON_ASSERT(GetLastReaderCommitId(tile_group_header, tuple_id) ==
                       current_txn->GetCommitId() ||
                   GetLastReaderCommitId(tile_group_header, tuple_id) == 0);
 
@@ -464,7 +464,7 @@ bool TimestampOrderingTransactionManager::PerformRead(
 void TimestampOrderingTransactionManager::PerformInsert(
     TransactionContext *const current_txn, const ItemPointer &location,
     ItemPointer *index_entry_ptr) {
-  PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
@@ -475,9 +475,9 @@ void TimestampOrderingTransactionManager::PerformInsert(
 
   // check MVCC info
   // the tuple slot must be empty.
-  PL_ASSERT(tile_group_header->GetTransactionId(tuple_id) == INVALID_TXN_ID);
-  PL_ASSERT(tile_group_header->GetBeginCommitId(tuple_id) == MAX_CID);
-  PL_ASSERT(tile_group_header->GetEndCommitId(tuple_id) == MAX_CID);
+  PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_id) == INVALID_TXN_ID);
+  PELOTON_ASSERT(tile_group_header->GetBeginCommitId(tuple_id) == MAX_CID);
+  PELOTON_ASSERT(tile_group_header->GetEndCommitId(tuple_id) == MAX_CID);
 
   tile_group_header->SetTransactionId(tuple_id, transaction_id);
 
@@ -502,7 +502,7 @@ void TimestampOrderingTransactionManager::PerformInsert(
 void TimestampOrderingTransactionManager::PerformUpdate(
     TransactionContext *const current_txn, const ItemPointer &location,
     const ItemPointer &new_location) {
-  PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 
   ItemPointer old_location = location;
 
@@ -521,17 +521,17 @@ void TimestampOrderingTransactionManager::PerformUpdate(
   auto transaction_id = current_txn->GetTransactionId();
   // if we can perform update, then we must have already locked the older
   // version.
-  PL_ASSERT(tile_group_header->GetTransactionId(old_location.offset) ==
+  PELOTON_ASSERT(tile_group_header->GetTransactionId(old_location.offset) ==
             transaction_id);
-  PL_ASSERT(tile_group_header->GetPrevItemPointer(old_location.offset)
+  PELOTON_ASSERT(tile_group_header->GetPrevItemPointer(old_location.offset)
                 .IsNull() == true);
 
   // check whether the new version is empty.
-  PL_ASSERT(new_tile_group_header->GetTransactionId(new_location.offset) ==
+  PELOTON_ASSERT(new_tile_group_header->GetTransactionId(new_location.offset) ==
             INVALID_TXN_ID);
-  PL_ASSERT(new_tile_group_header->GetBeginCommitId(new_location.offset) ==
+  PELOTON_ASSERT(new_tile_group_header->GetBeginCommitId(new_location.offset) ==
             MAX_CID);
-  PL_ASSERT(new_tile_group_header->GetEndCommitId(new_location.offset) ==
+  PELOTON_ASSERT(new_tile_group_header->GetEndCommitId(new_location.offset) ==
             MAX_CID);
 
   // if the executor doesn't call PerformUpdate after AcquireOwnership,
@@ -568,7 +568,7 @@ void TimestampOrderingTransactionManager::PerformUpdate(
     // its first trial.
     UNUSED_ATTRIBUTE auto res =
         AtomicUpdateItemPointer(index_entry_ptr, new_location);
-    PL_ASSERT(res == true);
+    PELOTON_ASSERT(res == true);
   }
 
   // Add the old tuple into the update set
@@ -586,7 +586,7 @@ void TimestampOrderingTransactionManager::PerformUpdate(
 void TimestampOrderingTransactionManager::PerformUpdate(
     TransactionContext *const current_txn UNUSED_ATTRIBUTE,
     const ItemPointer &location) {
-  PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 
   oid_t tile_group_id = location.block;
   UNUSED_ATTRIBUTE oid_t tuple_id = location.offset;
@@ -595,10 +595,10 @@ void TimestampOrderingTransactionManager::PerformUpdate(
   UNUSED_ATTRIBUTE auto tile_group_header =
       manager.GetTileGroup(tile_group_id)->GetHeader();
 
-  PL_ASSERT(tile_group_header->GetTransactionId(tuple_id) ==
+  PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_id) ==
             current_txn->GetTransactionId());
-  PL_ASSERT(tile_group_header->GetBeginCommitId(tuple_id) == MAX_CID);
-  PL_ASSERT(tile_group_header->GetEndCommitId(tuple_id) == MAX_CID);
+  PELOTON_ASSERT(tile_group_header->GetBeginCommitId(tuple_id) == MAX_CID);
+  PELOTON_ASSERT(tile_group_header->GetEndCommitId(tuple_id) == MAX_CID);
 
   // no need to add the older version into the update set.
   // if there exists older version, then the older version must already
@@ -619,7 +619,7 @@ void TimestampOrderingTransactionManager::PerformUpdate(
 void TimestampOrderingTransactionManager::PerformDelete(
     TransactionContext *const current_txn, const ItemPointer &location,
     const ItemPointer &new_location) {
-  PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 
   ItemPointer old_location = location;
 
@@ -637,23 +637,23 @@ void TimestampOrderingTransactionManager::PerformDelete(
 
   auto transaction_id = current_txn->GetTransactionId();
 
-  PL_ASSERT(GetLastReaderCommitId(tile_group_header, old_location.offset) ==
+  PELOTON_ASSERT(GetLastReaderCommitId(tile_group_header, old_location.offset) ==
             current_txn->GetCommitId());
 
   // if we can perform delete, then we must have already locked the older
   // version.
-  PL_ASSERT(tile_group_header->GetTransactionId(old_location.offset) ==
+  PELOTON_ASSERT(tile_group_header->GetTransactionId(old_location.offset) ==
             transaction_id);
   // we must be deleting the latest version.
-  PL_ASSERT(tile_group_header->GetPrevItemPointer(old_location.offset)
+  PELOTON_ASSERT(tile_group_header->GetPrevItemPointer(old_location.offset)
                 .IsNull() == true);
 
   // check whether the new version is empty.
-  PL_ASSERT(new_tile_group_header->GetTransactionId(new_location.offset) ==
+  PELOTON_ASSERT(new_tile_group_header->GetTransactionId(new_location.offset) ==
             INVALID_TXN_ID);
-  PL_ASSERT(new_tile_group_header->GetBeginCommitId(new_location.offset) ==
+  PELOTON_ASSERT(new_tile_group_header->GetBeginCommitId(new_location.offset) ==
             MAX_CID);
-  PL_ASSERT(new_tile_group_header->GetEndCommitId(new_location.offset) ==
+  PELOTON_ASSERT(new_tile_group_header->GetEndCommitId(new_location.offset) ==
             MAX_CID);
 
   // Set up double linked list
@@ -689,7 +689,7 @@ void TimestampOrderingTransactionManager::PerformDelete(
     // its first trial.
     UNUSED_ATTRIBUTE auto res =
         AtomicUpdateItemPointer(index_entry_ptr, new_location);
-    PL_ASSERT(res == true);
+    PELOTON_ASSERT(res == true);
   }
 
   current_txn->RecordDelete(old_location);
@@ -704,7 +704,7 @@ void TimestampOrderingTransactionManager::PerformDelete(
 
 void TimestampOrderingTransactionManager::PerformDelete(
     TransactionContext *const current_txn, const ItemPointer &location) {
-  PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
@@ -712,9 +712,9 @@ void TimestampOrderingTransactionManager::PerformDelete(
   auto &manager = catalog::Manager::GetInstance();
   auto tile_group_header = manager.GetTileGroup(tile_group_id)->GetHeader();
 
-  PL_ASSERT(tile_group_header->GetTransactionId(tuple_id) ==
+  PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_id) ==
             current_txn->GetTransactionId());
-  PL_ASSERT(tile_group_header->GetBeginCommitId(tuple_id) == MAX_CID);
+  PELOTON_ASSERT(tile_group_header->GetBeginCommitId(tuple_id) == MAX_CID);
 
   tile_group_header->SetEndCommitId(tuple_id, INVALID_CID);
 
@@ -806,10 +806,10 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
         ItemPointer new_version =
             tile_group_header->GetPrevItemPointer(tuple_slot);
 
-        PL_ASSERT(new_version.IsNull() == false);
+        PELOTON_ASSERT(new_version.IsNull() == false);
 
         auto cid = tile_group_header->GetEndCommitId(tuple_slot);
-        PL_ASSERT(cid > end_commit_id);
+        PELOTON_ASSERT(cid > end_commit_id);
         auto new_tile_group_header =
             manager.GetTileGroup(new_version.block)->GetHeader();
         new_tile_group_header->SetBeginCommitId(new_version.offset,
@@ -839,7 +839,7 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
             tile_group_header->GetPrevItemPointer(tuple_slot);
 
         auto cid = tile_group_header->GetEndCommitId(tuple_slot);
-        PL_ASSERT(cid > end_commit_id);
+        PELOTON_ASSERT(cid > end_commit_id);
         auto new_tile_group_header =
             manager.GetTileGroup(new_version.block)->GetHeader();
         new_tile_group_header->SetBeginCommitId(new_version.offset,
@@ -868,7 +868,7 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
         log_manager.LogDelete(ItemPointer(tile_group_id, tuple_slot));
 
       } else if (tuple_entry.second == RWType::INSERT) {
-        PL_ASSERT(tile_group_header->GetTransactionId(tuple_slot) ==
+        PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_slot) ==
                   current_txn->GetTransactionId());
         // set the begin commit id to persist insert
         tile_group_header->SetBeginCommitId(tuple_slot, end_commit_id);
@@ -884,7 +884,7 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
         log_manager.LogInsert(ItemPointer(tile_group_id, tuple_slot));
 
       } else if (tuple_entry.second == RWType::INS_DEL) {
-        PL_ASSERT(tile_group_header->GetTransactionId(tuple_slot) ==
+        PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_slot) ==
                   current_txn->GetTransactionId());
 
         tile_group_header->SetBeginCommitId(tuple_slot, MAX_CID);
@@ -924,7 +924,7 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
 ResultType TimestampOrderingTransactionManager::AbortTransaction(
     TransactionContext *const current_txn) {
   // a pre-declared read-only transaction will never abort.
-  PL_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
 
   LOG_TRACE("Aborting peloton txn : %" PRId64, current_txn->GetTransactionId());
   auto &manager = catalog::Manager::GetInstance();
@@ -982,10 +982,10 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
         // we need to unlink it by resetting the item pointers.
 
         // this must be the latest version of a version chain.
-        PL_ASSERT(new_tile_group_header->GetPrevItemPointer(new_version.offset)
+        PELOTON_ASSERT(new_tile_group_header->GetPrevItemPointer(new_version.offset)
                       .IsNull() == true);
 
-        PL_ASSERT(tile_group_header->GetEndCommitId(tuple_slot) == MAX_CID);
+        PELOTON_ASSERT(tile_group_header->GetEndCommitId(tuple_slot) == MAX_CID);
         // if we updated the latest version.
         // We must first adjust the head pointer
         // before we unlink the aborted version from version list
@@ -993,7 +993,7 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
             tile_group_header->GetIndirection(tuple_slot);
         UNUSED_ATTRIBUTE auto res = AtomicUpdateItemPointer(
             index_entry_ptr, ItemPointer(tile_group_id, tuple_slot));
-        PL_ASSERT(res == true);
+        PELOTON_ASSERT(res == true);
         //////////////////////////////////////////////////
 
         // we should set the version before releasing the lock.
@@ -1031,7 +1031,7 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
         // we need to unlink it by resetting the item pointers.
 
         // this must be the latest version of a version chain.
-        PL_ASSERT(new_tile_group_header->GetPrevItemPointer(new_version.offset)
+        PELOTON_ASSERT(new_tile_group_header->GetPrevItemPointer(new_version.offset)
                       .IsNull() == true);
 
         // if we updated the latest version.
@@ -1041,7 +1041,7 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
             tile_group_header->GetIndirection(tuple_slot);
         UNUSED_ATTRIBUTE auto res = AtomicUpdateItemPointer(
             index_entry_ptr, ItemPointer(tile_group_id, tuple_slot));
-        PL_ASSERT(res == true);
+        PELOTON_ASSERT(res == true);
         //////////////////////////////////////////////////
 
         // we should set the version before releasing the lock.

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -110,7 +110,7 @@ void TransactionContext::RecordRead(const ItemPointer &location) {
   oid_t tuple_id = location.offset;
 
   if (IsInRWSet(location)) {
-    PL_ASSERT(rw_set_.at(tile_group_id).at(tuple_id) != RWType::DELETE &&
+    PELOTON_ASSERT(rw_set_.at(tile_group_id).at(tuple_id) != RWType::DELETE &&
               rw_set_.at(tile_group_id).at(tuple_id) != RWType::INS_DEL);
     return;
   } else {
@@ -129,7 +129,7 @@ void TransactionContext::RecordReadOwn(const ItemPointer &location) {
       // record write.
       return;
     }
-    PL_ASSERT(type != RWType::DELETE && type != RWType::INS_DEL);
+    PELOTON_ASSERT(type != RWType::DELETE && type != RWType::INS_DEL);
   } else {
     rw_set_[tile_group_id][tuple_id] = RWType::READ_OWN;
   }
@@ -155,10 +155,10 @@ void TransactionContext::RecordUpdate(const ItemPointer &location) {
       return;
     }
     if (type == RWType::DELETE) {
-      PL_ASSERT(false);
+      PELOTON_ASSERT(false);
       return;
     }
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
   } else {
     // consider select_for_udpate case.
     rw_set_[tile_group_id][tuple_id] = RWType::UPDATE;
@@ -170,7 +170,7 @@ void TransactionContext::RecordInsert(const ItemPointer &location) {
   oid_t tuple_id = location.offset;
 
   if (IsInRWSet(location)) {
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
   } else {
     rw_set_[tile_group_id][tuple_id] = RWType::INSERT;
     ++insert_count_;
@@ -202,10 +202,10 @@ bool TransactionContext::RecordDelete(const ItemPointer &location) {
       return true;
     }
     if (type == RWType::DELETE) {
-      PL_ASSERT(false);
+      PELOTON_ASSERT(false);
       return false;
     }
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
   } else {
     rw_set_[tile_group_id][tuple_id] = RWType::DELETE;
   }

--- a/src/concurrency/transaction_manager.cpp
+++ b/src/concurrency/transaction_manager.cpp
@@ -132,7 +132,7 @@ bool TransactionManager::IsOccupied(TransactionContext *const current_txn,
   // unless it is an insertion/select for update.
   if (own == true) {
     if (tuple_begin_cid == MAX_CID && tuple_end_cid != INVALID_CID) {
-      PL_ASSERT(tuple_end_cid == MAX_CID);
+      PELOTON_ASSERT(tuple_end_cid == MAX_CID);
       // the only version that is visible is the newly inserted one.
       return true;
     } else if (current_txn->GetRWType(position) == RWType::READ_OWN) {
@@ -191,7 +191,7 @@ VisibilityType TransactionManager::IsVisible(
   if (type == VisibilityIdType::READ_ID) {
     txn_vis_id = current_txn->GetReadId();
   } else {
-    PL_ASSERT(type == VisibilityIdType::COMMIT_ID);
+    PELOTON_ASSERT(type == VisibilityIdType::COMMIT_ID);
     txn_vis_id = current_txn->GetCommitId();
   }
 
@@ -215,7 +215,7 @@ VisibilityType TransactionManager::IsVisible(
   // unless it is an insertion/select-for-update
   if (own == true) {
     if (tuple_begin_cid == MAX_CID && tuple_end_cid != INVALID_CID) {
-      PL_ASSERT(tuple_end_cid == MAX_CID);
+      PELOTON_ASSERT(tuple_end_cid == MAX_CID);
       // the only version that is visible is the newly inserted/updated one.
       return VisibilityType::OK;
     } else if (current_txn->GetRWType(ItemPointer(tile_group_id, tuple_id)) ==

--- a/src/executor/abstract_join_executor.cpp
+++ b/src/executor/abstract_join_executor.cpp
@@ -41,7 +41,7 @@ AbstractJoinExecutor::AbstractJoinExecutor(const planner::AbstractPlan *node,
  * @return true on success, false otherwise.
  */
 bool AbstractJoinExecutor::DInit() {
-  PL_ASSERT(children_.size() == 2);
+  PELOTON_ASSERT(children_.size() == 2);
 
   // Grab data from plan node.
   const planner::AbstractJoinPlan &node =
@@ -68,7 +68,7 @@ std::vector<LogicalTile::ColumnInfo> AbstractJoinExecutor::BuildSchema(
     schema.assign(left.begin(), left.end());
     schema.insert(schema.end(), right.begin(), right.end());
   } else {
-    PL_ASSERT(!proj_info_->IsNonTrivial());
+    PELOTON_ASSERT(!proj_info_->IsNonTrivial());
     auto &direct_map_list = proj_info_->GetDirectMapList();
     schema.resize(direct_map_list.size());
 
@@ -76,10 +76,10 @@ std::vector<LogicalTile::ColumnInfo> AbstractJoinExecutor::BuildSchema(
     LOG_TRACE("Projection: %s", proj_info_->Debug().c_str());
     for (auto &entry : direct_map_list) {
       if (entry.second.first == 0) {
-        PL_ASSERT(entry.second.second < left.size());
+        PELOTON_ASSERT(entry.second.second < left.size());
         schema[entry.first] = left[entry.second.second];
       } else {
-        PL_ASSERT(entry.second.second < right.size());
+        PELOTON_ASSERT(entry.second.second < right.size());
         schema[entry.first] = right[entry.second.second];
       }
     }
@@ -90,7 +90,7 @@ std::vector<LogicalTile::ColumnInfo>
 AbstractJoinExecutor::BuildSchemaFromLeftTile(
     const std::vector<LogicalTile::ColumnInfo> *left_schema,
     const catalog::Schema *output_schema, oid_t left_pos_list_count) {
-  PL_ASSERT(left_schema != nullptr);
+  PELOTON_ASSERT(left_schema != nullptr);
 
   // dummy physical tile for the empty child
   std::shared_ptr<storage::Tile> ptile(storage::TileFactory::GetTile(
@@ -113,7 +113,7 @@ AbstractJoinExecutor::BuildSchemaFromLeftTile(
     }
   } else {
     // non trivial projection. construct from direct map list
-    PL_ASSERT(!proj_info_->IsNonTrivial());
+    PELOTON_ASSERT(!proj_info_->IsNonTrivial());
     auto &direct_map_list = proj_info_->GetDirectMapList();
     schema.resize(direct_map_list.size());
 
@@ -128,12 +128,12 @@ AbstractJoinExecutor::BuildSchemaFromLeftTile(
         schema[schema_col_idx] = col;
       } else {
         // map left column to output tile column
-        PL_ASSERT(entry.second.second < left_schema->size());
+        PELOTON_ASSERT(entry.second.second < left_schema->size());
         schema[schema_col_idx] = (*left_schema)[entry.second.second];
       }
     }
   }
-  PL_ASSERT(schema.size() == total_size);
+  PELOTON_ASSERT(schema.size() == total_size);
   return schema;
 }
 
@@ -141,7 +141,7 @@ std::vector<LogicalTile::ColumnInfo>
 AbstractJoinExecutor::BuildSchemaFromRightTile(
     const std::vector<LogicalTile::ColumnInfo> *right_schema,
     const catalog::Schema *output_schema) {
-  PL_ASSERT(right_schema != nullptr);
+  PELOTON_ASSERT(right_schema != nullptr);
   // dummy physical tile for the empty child tile
   std::shared_ptr<storage::Tile> ptile(storage::TileFactory::GetTile(
       BackendType::MM, INVALID_OID, INVALID_OID, INVALID_OID, INVALID_OID,
@@ -163,7 +163,7 @@ AbstractJoinExecutor::BuildSchemaFromRightTile(
     schema.insert(schema.end(), right_schema->begin(), right_schema->end());
   } else {
     // non trivial projection. construct from direct map list
-    PL_ASSERT(!proj_info_->IsNonTrivial());
+    PELOTON_ASSERT(!proj_info_->IsNonTrivial());
     auto &direct_map_list = proj_info_->GetDirectMapList();
     schema.resize(direct_map_list.size());
 
@@ -178,14 +178,14 @@ AbstractJoinExecutor::BuildSchemaFromRightTile(
         schema[schema_col_idx] = col;
       } else {
         // map right column to output tile column
-        PL_ASSERT(entry.second.second < right_schema->size());
+        PELOTON_ASSERT(entry.second.second < right_schema->size());
         schema[schema_col_idx] = (*right_schema)[entry.second.second];
         // reserve the left-most position list for left tile
         schema[schema_col_idx].position_list_idx += 1;
       }
     }
   }
-  PL_ASSERT(schema.size() == total_size);
+  PELOTON_ASSERT(schema.size() == total_size);
   return schema;
 }
 
@@ -195,8 +195,8 @@ AbstractJoinExecutor::BuildSchemaFromRightTile(
 std::unique_ptr<LogicalTile> AbstractJoinExecutor::BuildOutputLogicalTile(
     LogicalTile *left_tile, LogicalTile *right_tile) {
   // Check the input logical tiles.
-  PL_ASSERT(left_tile != nullptr);
-  PL_ASSERT(right_tile != nullptr);
+  PELOTON_ASSERT(left_tile != nullptr);
+  PELOTON_ASSERT(right_tile != nullptr);
 
   // Construct output logical tile.
   std::unique_ptr<LogicalTile> output_tile(LogicalTileFactory::GetTile());
@@ -221,7 +221,7 @@ std::unique_ptr<LogicalTile> AbstractJoinExecutor::BuildOutputLogicalTile(
 std::unique_ptr<LogicalTile> AbstractJoinExecutor::BuildOutputLogicalTile(
     LogicalTile *left_tile, LogicalTile *right_tile,
     const catalog::Schema *output_schema) {
-  PL_ASSERT(output_schema != nullptr);
+  PELOTON_ASSERT(output_schema != nullptr);
 
   std::unique_ptr<LogicalTile> output_tile(LogicalTileFactory::GetTile());
 
@@ -256,8 +256,8 @@ std::vector<std::vector<oid_t>> AbstractJoinExecutor::BuildPostitionLists(
   size_t output_tile_column_count =
       left_tile_column_count + right_tile_column_count;
 
-  PL_ASSERT(left_tile_column_count > 0);
-  PL_ASSERT(right_tile_column_count > 0);
+  PELOTON_ASSERT(left_tile_column_count > 0);
+  PELOTON_ASSERT(right_tile_column_count > 0);
 
   // Construct position lists for output tile
   std::vector<std::vector<oid_t>> position_lists;
@@ -274,7 +274,7 @@ std::vector<std::vector<oid_t>> AbstractJoinExecutor::BuildPostitionLists(
  * to the new result tile
  */
 void AbstractJoinExecutor::BufferLeftTile(LogicalTile *left_tile) {
-  PL_ASSERT(join_type_ != JoinType::INVALID);
+  PELOTON_ASSERT(join_type_ != JoinType::INVALID);
   left_result_tiles_.emplace_back(left_tile);
   switch (join_type_) {
     case JoinType::LEFT:
@@ -292,7 +292,7 @@ void AbstractJoinExecutor::BufferLeftTile(LogicalTile *left_tile) {
  * to the new result tile
  */
 void AbstractJoinExecutor::BufferRightTile(LogicalTile *right_tile) {
-  PL_ASSERT(join_type_ != JoinType::INVALID);
+  PELOTON_ASSERT(join_type_ != JoinType::INVALID);
   right_result_tiles_.emplace_back(right_tile);
   switch (join_type_) {
     case JoinType::RIGHT:
@@ -312,7 +312,7 @@ void AbstractJoinExecutor::BufferRightTile(LogicalTile *right_tile) {
  * should be updated when new result tile is buffered
  */
 void AbstractJoinExecutor::UpdateJoinRowSets() {
-  PL_ASSERT(join_type_ != JoinType::INVALID);
+  PELOTON_ASSERT(join_type_ != JoinType::INVALID);
   switch (join_type_) {
     case JoinType::LEFT:
       UpdateLeftJoinRowSets();
@@ -332,7 +332,7 @@ void AbstractJoinExecutor::UpdateJoinRowSets() {
   * Update the row set with all rows from the last tile from left child
   */
 void AbstractJoinExecutor::UpdateLeftJoinRowSets() {
-  PL_ASSERT(left_result_tiles_.size() - no_matching_left_row_sets_.size() == 1);
+  PELOTON_ASSERT(left_result_tiles_.size() - no_matching_left_row_sets_.size() == 1);
   no_matching_left_row_sets_.emplace_back(left_result_tiles_.back()->begin(),
                                           left_result_tiles_.back()->end());
 }
@@ -341,7 +341,7 @@ void AbstractJoinExecutor::UpdateLeftJoinRowSets() {
   * Update the row set with all rows from the last tile from right child
   */
 void AbstractJoinExecutor::UpdateRightJoinRowSets() {
-  PL_ASSERT(right_result_tiles_.size() - no_matching_right_row_sets_.size() ==
+  PELOTON_ASSERT(right_result_tiles_.size() - no_matching_right_row_sets_.size() ==
             1);
   no_matching_right_row_sets_.emplace_back(right_result_tiles_.back()->begin(),
                                            right_result_tiles_.back()->end());
@@ -363,7 +363,7 @@ void AbstractJoinExecutor::UpdateFullJoinRowSets() {
  * there will be a match later.
  */
 bool AbstractJoinExecutor::BuildOuterJoinOutput() {
-  PL_ASSERT(join_type_ != JoinType::INVALID);
+  PELOTON_ASSERT(join_type_ != JoinType::INVALID);
 
   switch (join_type_) {
     case JoinType::LEFT: { return BuildLeftJoinOutput(); }
@@ -413,7 +413,7 @@ bool AbstractJoinExecutor::BuildLeftJoinOutput() {
       pos_lists_builder = LogicalTile::PositionListsBuilder(
           &(left_tile->GetPositionLists()), nullptr);
     } else {
-      PL_ASSERT(right_result_tiles_.size() > 0);
+      PELOTON_ASSERT(right_result_tiles_.size() > 0);
       // construct the output tile from both children tiles
       auto right_tile = right_result_tiles_.front().get();
       output_tile = BuildOutputLogicalTile(left_tile, right_tile);
@@ -425,7 +425,7 @@ bool AbstractJoinExecutor::BuildLeftJoinOutput() {
       pos_lists_builder.AddRightNullRow(left_row_itr);
     }
 
-    PL_ASSERT(pos_lists_builder.Size() > 0);
+    PELOTON_ASSERT(pos_lists_builder.Size() > 0);
     output_tile->SetPositionListsAndVisibility(pos_lists_builder.Release());
     SetOutput(output_tile.release());
     left_matching_idx++;
@@ -455,7 +455,7 @@ bool AbstractJoinExecutor::BuildRightJoinOutput() {
       pos_lists_builder = LogicalTile::PositionListsBuilder(
           nullptr, &(right_tile->GetPositionLists()));
     } else {
-      PL_ASSERT(left_result_tiles_.size() > 0);
+      PELOTON_ASSERT(left_result_tiles_.size() > 0);
       // construct the output tile from both children tiles
       auto left_tile = left_result_tiles_.front().get();
       output_tile = BuildOutputLogicalTile(left_tile, right_tile);
@@ -466,7 +466,7 @@ bool AbstractJoinExecutor::BuildRightJoinOutput() {
     for (auto right_row_itr : no_matching_right_row_sets_[right_matching_idx]) {
       pos_lists_builder.AddLeftNullRow(right_row_itr);
     }
-    PL_ASSERT(pos_lists_builder.Size() > 0);
+    PELOTON_ASSERT(pos_lists_builder.Size() > 0);
     output_tile->SetPositionListsAndVisibility(pos_lists_builder.Release());
 
     SetOutput(output_tile.release());

--- a/src/executor/abstract_scan_executor.cpp
+++ b/src/executor/abstract_scan_executor.cpp
@@ -38,8 +38,8 @@ AbstractScanExecutor::AbstractScanExecutor(const planner::AbstractPlan *node,
  * @return true on success, false otherwise.
  */
 bool AbstractScanExecutor::DInit() {
-  PL_ASSERT(children_.size() == 0 || children_.size() == 1);
-  PL_ASSERT(executor_context_);
+  PELOTON_ASSERT(children_.size() == 0 || children_.size() == 1);
+  PELOTON_ASSERT(executor_context_);
 
   // Grab data from plan node.
   const planner::AbstractScan &node = GetPlanNode<planner::AbstractScan>();

--- a/src/executor/aggregate_executor.cpp
+++ b/src/executor/aggregate_executor.cpp
@@ -41,7 +41,7 @@ AggregateExecutor::~AggregateExecutor() {
  * @return true on success, false otherwise.
  */
 bool AggregateExecutor::DInit() {
-  PL_ASSERT(children_.size() == 1);
+  PELOTON_ASSERT(children_.size() == 1);
 
   LOG_TRACE("Aggregate executor :: 1 child ");
 
@@ -52,7 +52,7 @@ bool AggregateExecutor::DInit() {
   auto output_table_schema =
       const_cast<catalog::Schema *>(node.GetOutputSchema());
 
-  PL_ASSERT(output_table_schema->GetColumnCount() >= 1);
+  PELOTON_ASSERT(output_table_schema->GetColumnCount() >= 1);
 
   // clean up result
   result_itr = START_OID;
@@ -163,7 +163,7 @@ bool AggregateExecutor::DExecute() {
         tuple->SetAllNulls();
       }
       UNUSED_ATTRIBUTE auto location = output_table->InsertTuple(tuple.get());
-      PL_ASSERT(location.block != INVALID_OID);
+      PELOTON_ASSERT(location.block != INVALID_OID);
     } else {
       done = true;
       return false;
@@ -178,7 +178,7 @@ bool AggregateExecutor::DExecute() {
   for (oid_t tile_group_itr = 0; tile_group_itr < tile_group_count;
        tile_group_itr++) {
     auto tile_group = output_table->GetTileGroup(tile_group_itr);
-    PL_ASSERT(tile_group != nullptr);
+    PELOTON_ASSERT(tile_group != nullptr);
     LOG_TRACE("\n%s", tile_group->GetInfo().c_str());
 
     // Get the logical tiles corresponding to the given tile group

--- a/src/executor/aggregator.cpp
+++ b/src/executor/aggregator.cpp
@@ -254,7 +254,7 @@ SortedAggregator::SortedAggregator(const planner::AggregatePlan *node,
       num_input_columns_(num_input_columns) {
   aggregates = new AbstractAttributeAggregator *[node->GetUniqueAggTerms().size()]();
 
-  PL_ASSERT(delegate_tuple_values_.empty());
+  PELOTON_ASSERT(delegate_tuple_values_.empty());
 }
 
 SortedAggregator::~SortedAggregator() {
@@ -274,7 +274,7 @@ bool SortedAggregator::Advance(AbstractTuple *next_tuple) {
     LOG_TRACE("Current group keys are empty!");
     start_new_agg = true;
   } else {  // Current group exists
-    PL_ASSERT(delegate_tuple_values_.size() == num_input_columns_);
+    PELOTON_ASSERT(delegate_tuple_values_.size() == num_input_columns_);
     // Check whether crossed group boundary
     for (oid_t grpColOffset = 0; grpColOffset < node->GetGroupbyColIds().size();
          grpColOffset++) {

--- a/src/executor/append_executor.cpp
+++ b/src/executor/append_executor.cpp
@@ -31,8 +31,8 @@ AppendExecutor::AppendExecutor(const planner::AbstractPlan *node,
  */
 bool AppendExecutor::DInit() {
   // should have >= 2 children, otherwise pointless.
-  PL_ASSERT(children_.size() >= 2);
-  PL_ASSERT(cur_child_id_ == 0);
+  PELOTON_ASSERT(children_.size() >= 2);
+  PELOTON_ASSERT(cur_child_id_ == 0);
 
   return true;
 }

--- a/src/executor/copy_executor.cpp
+++ b/src/executor/copy_executor.cpp
@@ -42,7 +42,7 @@ CopyExecutor::~CopyExecutor() {}
  * @return true on success, false otherwise.
  */
 bool CopyExecutor::DInit() {
-  PL_ASSERT(children_.size() == 1);
+  PELOTON_ASSERT(children_.size() == 1);
 
   // Grab info from plan node and check it
   const planner::CopyPlan &node = GetPlanNode<planner::CopyPlan>();
@@ -92,8 +92,8 @@ bool CopyExecutor::InitFileHandle(const char *name, const char *mode) {
  * does many sanity checks. We use local buffer to amortize that.
  */
 void CopyExecutor::FlushBuffer() {
-  PL_ASSERT(buff_ptr < COPY_BUFFER_SIZE);
-  PL_ASSERT(buff_size + buff_ptr <= COPY_BUFFER_SIZE);
+  PELOTON_ASSERT(buff_ptr < COPY_BUFFER_SIZE);
+  PELOTON_ASSERT(buff_size + buff_ptr <= COPY_BUFFER_SIZE);
   while (buff_size > 0) {
     size_t bytes_written =
         fwrite(buff + buff_ptr, sizeof(char), buff_size, file_handle_.file);
@@ -109,7 +109,7 @@ void CopyExecutor::FlushBuffer() {
 
 void CopyExecutor::FFlushFsync() {
   // First, flush
-  PL_ASSERT(file_handle_.fd != -1);
+  PELOTON_ASSERT(file_handle_.fd != -1);
   if (file_handle_.fd == -1) return;
   int ret = fflush(file_handle_.file);
   if (ret != 0) {
@@ -175,7 +175,7 @@ void CopyExecutor::Copy(const char *data, int len, bool end_of_line) {
   } else {
     buff[buff_size++] = new_line;
   }
-  PL_ASSERT(buff_size <= COPY_BUFFER_SIZE);
+  PELOTON_ASSERT(buff_size <= COPY_BUFFER_SIZE);
 }
 
 /**
@@ -226,7 +226,7 @@ bool CopyExecutor::DExecute() {
 
         } else if (origin_col_id == param_type_col_id) {
           // param_types column
-          PL_ASSERT(output_schema->GetColumn(col_index).GetType() ==
+          PELOTON_ASSERT(output_schema->GetColumn(col_index).GetType() ==
                     type::TypeId::VARBINARY);
 
           network::InputPacket packet(len, val);
@@ -243,7 +243,7 @@ bool CopyExecutor::DExecute() {
           }
         } else if (origin_col_id == param_format_col_id) {
           // param_formats column
-          PL_ASSERT(output_schema->GetColumn(col_index).GetType() ==
+          PELOTON_ASSERT(output_schema->GetColumn(col_index).GetType() ==
                     type::TypeId::VARBINARY);
 
           network::InputPacket packet(len, val);
@@ -255,7 +255,7 @@ bool CopyExecutor::DExecute() {
 
         } else if (origin_col_id == param_val_col_id) {
           // param_values column
-          PL_ASSERT(output_schema->GetColumn(col_index).GetType() ==
+          PELOTON_ASSERT(output_schema->GetColumn(col_index).GetType() ==
                     type::TypeId::VARBINARY);
 
           network::InputPacket packet(len, val);

--- a/src/executor/create_executor.cpp
+++ b/src/executor/create_executor.cpp
@@ -135,7 +135,7 @@ bool CreateExecutor::CreateTable(const planner::CreatePlan &node) {
           }
           source_col_ids.push_back(col_id);
         }  // FOR
-        PL_ASSERT(source_col_ids.size() == fk.foreign_key_sources.size());
+        PELOTON_ASSERT(source_col_ids.size() == fk.foreign_key_sources.size());
 
         // Sink Column Offsets
         std::vector<oid_t> sink_col_ids;
@@ -150,7 +150,7 @@ bool CreateExecutor::CreateTable(const planner::CreatePlan &node) {
           }
           sink_col_ids.push_back(col_id);
         }  // FOR
-        PL_ASSERT(sink_col_ids.size() == fk.foreign_key_sinks.size());
+        PELOTON_ASSERT(sink_col_ids.size() == fk.foreign_key_sinks.size());
 
         // Create the catalog object and shove it into the table
         auto catalog_fk = new catalog::ForeignKey(INVALID_OID,

--- a/src/executor/delete_executor.cpp
+++ b/src/executor/delete_executor.cpp
@@ -47,10 +47,10 @@ DeleteExecutor::DeleteExecutor(const planner::AbstractPlan *node,
  * @return true on success, false otherwise.
  */
 bool DeleteExecutor::DInit() {
-  PL_ASSERT(children_.size() == 1);
-  PL_ASSERT(executor_context_);
+  PELOTON_ASSERT(children_.size() == 1);
+  PELOTON_ASSERT(executor_context_);
 
-  PL_ASSERT(target_table_ == nullptr);
+  PELOTON_ASSERT(target_table_ == nullptr);
 
   // Delete tuples in logical tile
   LOG_TRACE("Delete executor :: 1 child ");
@@ -58,7 +58,7 @@ bool DeleteExecutor::DInit() {
   // Grab data from plan node.
   const planner::DeletePlan &node = GetPlanNode<planner::DeletePlan>();
   target_table_ = node.GetTable();
-  PL_ASSERT(target_table_);
+  PELOTON_ASSERT(target_table_);
 
   return true;
 }
@@ -70,7 +70,7 @@ bool DeleteExecutor::DInit() {
  * @return true on success, false otherwise.
  */
 bool DeleteExecutor::DExecute() {
-  PL_ASSERT(target_table_);
+  PELOTON_ASSERT(target_table_);
   // Retrieve next tile.
   if (!children_[0]->Execute()) {
     return false;

--- a/src/executor/hash_executor.cpp
+++ b/src/executor/hash_executor.cpp
@@ -32,7 +32,7 @@ HashExecutor::HashExecutor(const planner::AbstractPlan *node,
  * @return true on success, false otherwise.
  */
 bool HashExecutor::DInit() {
-  PL_ASSERT(children_.size() == 1);
+  PELOTON_ASSERT(children_.size() == 1);
 
   // Initialize executor state
   done_ = false;
@@ -67,7 +67,7 @@ bool HashExecutor::DExecute() {
 
     // Construct a logical tile
     for (auto &hashkey : hashkeys) {
-      PL_ASSERT(hashkey->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+      PELOTON_ASSERT(hashkey->GetExpressionType() == ExpressionType::VALUE_TUPLE);
       auto tuple_value =
           reinterpret_cast<const expression::TupleValueExpression *>(
               hashkey.get());

--- a/src/executor/hash_join_executor.cpp
+++ b/src/executor/hash_join_executor.cpp
@@ -30,12 +30,12 @@ HashJoinExecutor::HashJoinExecutor(const planner::AbstractPlan *node,
     : AbstractJoinExecutor(node, executor_context) {}
 
 bool HashJoinExecutor::DInit() {
-  PL_ASSERT(children_.size() == 2);
+  PELOTON_ASSERT(children_.size() == 2);
 
   auto status = AbstractJoinExecutor::DInit();
   if (status == false) return status;
 
-  PL_ASSERT(children_[1]->GetRawNode()->GetPlanNodeType() ==
+  PELOTON_ASSERT(children_[1]->GetRawNode()->GetPlanNodeType() ==
             PlanNodeType::HASH);
 
   hash_executor_ = reinterpret_cast<HashExecutor *>(children_[1]);
@@ -106,7 +106,7 @@ bool HashJoinExecutor::DExecute() {
 
     std::vector<oid_t> left_hashed_col_ids;
     for (auto &hashkey : left_hashed_cols) {
-      PL_ASSERT(hashkey->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+      PELOTON_ASSERT(hashkey->GetExpressionType() == ExpressionType::VALUE_TUPLE);
       auto tuple_value =
           reinterpret_cast<const expression::TupleValueExpression *>(hashkey);
       left_hashed_col_ids.push_back(tuple_value->GetColumnId());

--- a/src/executor/hash_set_op_executor.cpp
+++ b/src/executor/hash_set_op_executor.cpp
@@ -32,9 +32,9 @@ HashSetOpExecutor::HashSetOpExecutor(const planner::AbstractPlan *node,
  * @return true on success, false otherwise.
  */
 bool HashSetOpExecutor::DInit() {
-  PL_ASSERT(children_.size() == 2);
-  PL_ASSERT(!hash_done_);
-  PL_ASSERT(set_op_ == SetOpType::INVALID);
+  PELOTON_ASSERT(children_.size() == 2);
+  PELOTON_ASSERT(!hash_done_);
+  PELOTON_ASSERT(set_op_ == SetOpType::INVALID);
 
   return true;
 }
@@ -44,7 +44,7 @@ bool HashSetOpExecutor::DExecute() {
 
   if (!hash_done_) ExecuteHelper();
 
-  PL_ASSERT(hash_done_);
+  PELOTON_ASSERT(hash_done_);
 
   // Avoid returning empty tiles
   while (next_tile_to_return_ < left_tiles_.size()) {
@@ -59,13 +59,13 @@ bool HashSetOpExecutor::DExecute() {
 }
 
 bool HashSetOpExecutor::ExecuteHelper() {
-  PL_ASSERT(children_.size() == 2);
-  PL_ASSERT(!hash_done_);
+  PELOTON_ASSERT(children_.size() == 2);
+  PELOTON_ASSERT(!hash_done_);
 
   // Grab data from plan node
   const planner::SetOpPlan &node = GetPlanNode<planner::SetOpPlan>();
   set_op_ = node.GetSetOp();
-  PL_ASSERT(set_op_ != SetOpType::INVALID);
+  PELOTON_ASSERT(set_op_ != SetOpType::INVALID);
 
   // Extract all input from left child
   while (children_[0]->Execute()) {
@@ -128,7 +128,7 @@ bool HashSetOpExecutor::ExecuteHelper() {
     for (oid_t tuple_id : *tile) {
       auto it = htable_.find(HashSetOpMapType::key_type(tile.get(), tuple_id));
 
-      PL_ASSERT(it != htable_.end());
+      PELOTON_ASSERT(it != htable_.end());
 
       if (it->first.GetContainer() == tile.get() &&
           it->first.GetTupleId() == tuple_id)
@@ -143,7 +143,7 @@ bool HashSetOpExecutor::ExecuteHelper() {
   // 2nd round
   for (auto &item : htable_) {
     // We should have at most one quota left
-    PL_ASSERT(item.second.left == 1 || item.second.left == 0);
+    PELOTON_ASSERT(item.second.left == 1 || item.second.left == 0);
     if (item.second.left == 0) {
       item.first.GetContainer()->RemoveVisibility(item.first.GetTupleId());
     }

--- a/src/executor/hybrid_scan_executor.cpp
+++ b/src/executor/hybrid_scan_executor.cpp
@@ -41,7 +41,7 @@ bool HybridScanExecutor::DInit() {
   table_ = node.GetTable();
   index_ = node.GetDataIndex();
   type_ = node.GetHybridType();
-  PL_ASSERT(table_ != nullptr);
+  PELOTON_ASSERT(table_ != nullptr);
 
   // SEQUENTIAL SCAN
   if (type_ == HybridScanType::SEQUENTIAL) {
@@ -63,7 +63,7 @@ bool HybridScanExecutor::DInit() {
     index_done_ = false;
     result_.clear();
 
-    PL_ASSERT(index_ != nullptr);
+    PELOTON_ASSERT(index_ != nullptr);
     column_ids_ = node.GetColumnIds();
     auto key_column_ids_ = node.GetKeyColumnIds();
     auto expr_types_ = node.GetExprTypes();
@@ -276,7 +276,7 @@ bool HybridScanExecutor::DExecute() {
   // INDEX SCAN
   else if (type_ == HybridScanType::INDEX) {
     LOG_TRACE("Index Scan");
-    PL_ASSERT(children_.size() == 0);
+    PELOTON_ASSERT(children_.size() == 0);
 
     if (index_done_ == false) {
       if (index_->GetIndexType() == IndexConstraintType::PRIMARY_KEY) {
@@ -318,7 +318,7 @@ bool HybridScanExecutor::DExecute() {
 }
 
 bool HybridScanExecutor::ExecPrimaryIndexLookup() {
-  PL_ASSERT(index_done_ == false);
+  PELOTON_ASSERT(index_done_ == false);
 
   const planner::HybridScanPlan &node = GetPlanNode<planner::HybridScanPlan>();
   bool acquire_owner = GetPlanNode<planner::AbstractScan>().IsForUpdate();
@@ -328,7 +328,7 @@ bool HybridScanExecutor::ExecPrimaryIndexLookup() {
 
   std::vector<ItemPointer *> tuple_location_ptrs;
 
-  PL_ASSERT(index_->GetIndexType() == IndexConstraintType::PRIMARY_KEY);
+  PELOTON_ASSERT(index_->GetIndexType() == IndexConstraintType::PRIMARY_KEY);
 
   if (0 == key_column_ids_.size()) {
     LOG_TRACE("Scan all keys");

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -53,13 +53,13 @@ bool IndexScanExecutor::DInit() {
 
   if (!status) return false;
 
-  PL_ASSERT(children_.size() == 0);
+  PELOTON_ASSERT(children_.size() == 0);
 
   // Grab info from plan node and check it
   const planner::IndexScanPlan &node = GetPlanNode<planner::IndexScanPlan>();
 
   index_ = node.GetIndex();
-  PL_ASSERT(index_ != nullptr);
+  PELOTON_ASSERT(index_ != nullptr);
 
   index_predicate_ = node.GetIndexPredicate();
 
@@ -84,7 +84,7 @@ bool IndexScanExecutor::DInit() {
   descend_ = node.GetDescend();
 
   if (runtime_keys_.size() != 0) {
-    PL_ASSERT(runtime_keys_.size() == values_.size());
+    PELOTON_ASSERT(runtime_keys_.size() == values_.size());
 
     if (!key_ready_) {
       values_.clear();
@@ -127,7 +127,7 @@ bool IndexScanExecutor::DExecute() {
     }
   }
   // Already performed the index lookup
-  PL_ASSERT(done_);
+  PELOTON_ASSERT(done_);
 
   while (result_itr_ < result_.size()) {  // Avoid returning empty tiles
     if (result_[result_itr_]->GetTupleCount() == 0) {
@@ -146,14 +146,14 @@ bool IndexScanExecutor::DExecute() {
 }
 
 bool IndexScanExecutor::ExecPrimaryIndexLookup() {
-  PL_ASSERT(!done_);
+  PELOTON_ASSERT(!done_);
 
   std::vector<ItemPointer *> tuple_location_ptrs;
 
   // Grab info from plan node
   bool acquire_owner = GetPlanNode<planner::AbstractScan>().IsForUpdate();
 
-  PL_ASSERT(index_->GetIndexType() == IndexConstraintType::PRIMARY_KEY);
+  PELOTON_ASSERT(index_->GetIndexType() == IndexConstraintType::PRIMARY_KEY);
 
   if (0 == key_column_ids_.size()) {
     index_->ScanAllKeys(tuple_location_ptrs);
@@ -263,7 +263,7 @@ bool IndexScanExecutor::ExecPrimaryIndexLookup() {
       }
       // if the tuple is not visible.
       else {
-        PL_ASSERT(visibility == VisibilityType::INVISIBLE);
+        PELOTON_ASSERT(visibility == VisibilityType::INVISIBLE);
 
         LOG_TRACE("Invisible read: %u, %u", tuple_location.block,
                   tuple_location.offset);
@@ -356,8 +356,8 @@ bool IndexScanExecutor::ExecPrimaryIndexLookup() {
 
 bool IndexScanExecutor::ExecSecondaryIndexLookup() {
   LOG_TRACE("ExecSecondaryIndexLookup");
-  PL_ASSERT(!done_);
-  PL_ASSERT(index_->GetIndexType() != IndexConstraintType::PRIMARY_KEY);
+  PELOTON_ASSERT(!done_);
+  PELOTON_ASSERT(index_->GetIndexType() != IndexConstraintType::PRIMARY_KEY);
 
   std::vector<ItemPointer *> tuple_location_ptrs;
 
@@ -507,7 +507,7 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
       }
       // if the tuple is not visible.
       else {
-        PL_ASSERT(visibility == VisibilityType::INVISIBLE);
+        PELOTON_ASSERT(visibility == VisibilityType::INVISIBLE);
 
         LOG_TRACE("Invisible read: %u, %u", tuple_location.block,
                   tuple_location.offset);
@@ -622,8 +622,8 @@ void IndexScanExecutor::CheckOpenRangeWithReturnedTuples(
 
 bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
   // The size of these three arrays must be the same
-  PL_ASSERT(key_column_ids_.size() == expr_types_.size());
-  PL_ASSERT(expr_types_.size() == values_.size());
+  PELOTON_ASSERT(key_column_ids_.size() == expr_types_.size());
+  PELOTON_ASSERT(expr_types_.size() == values_.size());
 
   LOG_TRACE("Examining key conditions for the returned tuple.");
 
@@ -754,7 +754,7 @@ void IndexScanExecutor::UpdatePredicate(
 
   std::vector<oid_t> key_column_ids;
 
-  PL_ASSERT(column_ids.size() <= column_ids_.size());
+  PELOTON_ASSERT(column_ids.size() <= column_ids_.size());
   // Get the real physical ids
   for (auto column_id : column_ids) {
     key_column_ids.push_back(column_ids_[column_id]);
@@ -764,8 +764,8 @@ void IndexScanExecutor::UpdatePredicate(
   }
 
   // Update values in index plan node
-  PL_ASSERT(key_column_ids.size() == values.size());
-  PL_ASSERT(key_column_ids_.size() == values_.size());
+  PELOTON_ASSERT(key_column_ids.size() == values.size());
+  PELOTON_ASSERT(key_column_ids_.size() == values_.size());
 
   // Find out the position (offset) where is key_column_id
   for (oid_t new_idx = 0; new_idx < key_column_ids.size(); new_idx++) {

--- a/src/executor/insert_executor.cpp
+++ b/src/executor/insert_executor.cpp
@@ -42,8 +42,8 @@ InsertExecutor::InsertExecutor(const planner::AbstractPlan *node,
  * @return true on success, false otherwise.
  */
 bool InsertExecutor::DInit() {
-  PL_ASSERT(children_.size() == 0 || children_.size() == 1);
-  PL_ASSERT(executor_context_);
+  PELOTON_ASSERT(children_.size() == 0 || children_.size() == 1);
+  PELOTON_ASSERT(executor_context_);
 
   done_ = false;
   return true;
@@ -56,8 +56,8 @@ bool InsertExecutor::DInit() {
 bool InsertExecutor::DExecute() {
   if (done_) return false;
 
-  PL_ASSERT(!done_);
-  PL_ASSERT(executor_context_ != nullptr);
+  PELOTON_ASSERT(!done_);
+  PELOTON_ASSERT(executor_context_ != nullptr);
 
   const planner::InsertPlan &node = GetPlanNode<planner::InsertPlan>();
   storage::DataTable *target_table = node.GetTable();
@@ -98,7 +98,7 @@ bool InsertExecutor::DExecute() {
     std::unique_ptr<LogicalTile> logical_tile(children_[0]->GetOutput());
 
     // FIXME: Wrong? What if the result of select is nothing? Michael
-    PL_ASSERT(logical_tile.get() != nullptr);
+    PELOTON_ASSERT(logical_tile.get() != nullptr);
 
     auto target_table_schema = target_table->GetSchema();
     auto column_count = target_table_schema->GetColumnCount();
@@ -166,9 +166,9 @@ bool InsertExecutor::DExecute() {
     // Check if this is not a raw tuple
     if (project_info) {
       // Otherwise, there must exist a project info
-      PL_ASSERT(project_info);
+      PELOTON_ASSERT(project_info);
       // There should be no direct maps
-      PL_ASSERT(project_info->GetDirectMapList().size() == 0);
+      PELOTON_ASSERT(project_info->GetDirectMapList().size() == 0);
 
       storage_tuple.reset(new storage::Tuple(schema, true));
 

--- a/src/executor/limit_executor.cpp
+++ b/src/executor/limit_executor.cpp
@@ -33,7 +33,7 @@ LimitExecutor::LimitExecutor(const planner::AbstractPlan *node,
  * @return true on success, false otherwise.
  */
 bool LimitExecutor::DInit() {
-  PL_ASSERT(children_.size() == 1);
+  PELOTON_ASSERT(children_.size() == 1);
 
   num_skipped_ = 0;
   num_returned_ = 0;

--- a/src/executor/logical_tile.cpp
+++ b/src/executor/logical_tile.cpp
@@ -114,7 +114,7 @@ void LogicalTile::SetPositionListsAndVisibility(
  * @return Position list index of newly added list.
  */
 int LogicalTile::AddPositionList(LogicalTile::PositionList &&position_list) {
-  PL_ASSERT(position_lists_.size() == 0 ||
+  PELOTON_ASSERT(position_lists_.size() == 0 ||
             position_lists_[0].size() == position_list.size());
 
   if (position_lists_.size() == 0) {
@@ -134,8 +134,8 @@ int LogicalTile::AddPositionList(LogicalTile::PositionList &&position_list) {
  * @param tuple_id Id of the specified tuple.
  */
 void LogicalTile::RemoveVisibility(oid_t tuple_id) {
-  PL_ASSERT(tuple_id < total_tuples_);
-  PL_ASSERT(visible_rows_[tuple_id]);
+  PELOTON_ASSERT(tuple_id < total_tuples_);
+  PELOTON_ASSERT(visible_rows_[tuple_id]);
 
   visible_rows_[tuple_id] = false;
   visible_tuples_--;
@@ -161,8 +161,8 @@ storage::Tile *LogicalTile::GetBaseTile(oid_t column_id) {
  */
 // TODO: Deprecated. Avoid calling this function if possible.
 type::Value LogicalTile::GetValue(oid_t tuple_id, oid_t column_id) {
-  PL_ASSERT(column_id < schema_.size());
-  PL_ASSERT(tuple_id < total_tuples_);
+  PELOTON_ASSERT(column_id < schema_.size());
+  PELOTON_ASSERT(tuple_id < total_tuples_);
 
   ColumnInfo &cp = schema_[column_id];
   oid_t base_tuple_id = position_lists_[cp.position_list_idx][tuple_id];
@@ -180,7 +180,7 @@ type::Value LogicalTile::GetValue(oid_t tuple_id, oid_t column_id) {
 void LogicalTile::SetValue(type::Value &value UNUSED_ATTRIBUTE,
                            oid_t tuple_id UNUSED_ATTRIBUTE,
                            oid_t column_id UNUSED_ATTRIBUTE) {
-  PL_ASSERT(false);
+  PELOTON_ASSERT(false);
 }
 
 /**
@@ -324,7 +324,7 @@ LogicalTile::PositionListsBuilder::PositionListsBuilder(
     non_empty_pos_list = left_pos_list;
     SetLeftSource(left_pos_list);
   }
-  PL_ASSERT(non_empty_pos_list != nullptr);
+  PELOTON_ASSERT(non_empty_pos_list != nullptr);
   output_lists_.push_back(std::vector<oid_t>());
   // reserve one extra pos list for the empty tile
   for (size_t column_itr = 0; column_itr < non_empty_pos_list->size() + 1;
@@ -347,8 +347,8 @@ LogicalTile::PositionListsBuilder::PositionListsBuilder(LogicalTile *left_tile,
   size_t output_tile_column_count =
       left_tile_column_count + right_tile_column_count;
 
-  PL_ASSERT(left_tile_column_count > 0);
-  PL_ASSERT(right_tile_column_count > 0);
+  PELOTON_ASSERT(left_tile_column_count > 0);
+  PELOTON_ASSERT(right_tile_column_count > 0);
 
   // Construct position lists for output tile
   for (size_t column_itr = 0; column_itr < output_tile_column_count;
@@ -421,7 +421,7 @@ void LogicalTile::ProjectColumns(const std::vector<oid_t> &original_column_ids,
   for (auto id : column_ids) {
     auto ret =
         std::find(original_column_ids.begin(), original_column_ids.end(), id);
-    PL_ASSERT(ret != original_column_ids.end());
+    PELOTON_ASSERT(ret != original_column_ids.end());
     new_schema.push_back(schema_[*ret]);
   }
 
@@ -624,7 +624,7 @@ void LogicalTile::MaterializeRowAtAtATime(
 
       // Old to new column mapping
       auto it = old_to_new_cols.find(old_col_id);
-      PL_ASSERT(it != old_to_new_cols.end());
+      PELOTON_ASSERT(it != old_to_new_cols.end());
 
       // Get new column information
       oid_t new_column_id = it->second;
@@ -638,7 +638,7 @@ void LogicalTile::MaterializeRowAtAtATime(
       new_column_lengths.push_back(new_column_length);
     }
 
-    PL_ASSERT(new_column_offsets.size() == old_column_ids.size());
+    PELOTON_ASSERT(new_column_offsets.size() == old_column_ids.size());
 
     ///////////////////////////
     // EACH TUPLE
@@ -710,7 +710,7 @@ void LogicalTile::MaterializeColumnAtATime(
 
       // Old to new column mapping
       auto it = old_to_new_cols.find(old_col_id);
-      PL_ASSERT(it != old_to_new_cols.end());
+      PELOTON_ASSERT(it != old_to_new_cols.end());
 
       // Get new column information
       oid_t new_column_id = it->second;

--- a/src/executor/logical_tile_factory.cpp
+++ b/src/executor/logical_tile_factory.cpp
@@ -51,7 +51,7 @@ LogicalTile *LogicalTileFactory::GetTile() { return new LogicalTile(); }
  */
 LogicalTile *LogicalTileFactory::WrapTiles(
     const std::vector<std::shared_ptr<storage::Tile>> &base_tile_refs) {
-  PL_ASSERT(base_tile_refs.size() > 0);
+  PELOTON_ASSERT(base_tile_refs.size() > 0);
 
   // TODO ASSERT all base tiles have the same height.
   std::unique_ptr<LogicalTile> new_tile(new LogicalTile());
@@ -90,7 +90,7 @@ LogicalTile *LogicalTileFactory::WrapTileGroup(
 
   // Construct schema.
   std::vector<catalog::Schema> &schemas = tile_group->GetTileSchemas();
-  PL_ASSERT(schemas.size() == tile_group->NumTiles());
+  PELOTON_ASSERT(schemas.size() == tile_group->NumTiles());
   for (unsigned int i = 0; i < schemas.size(); i++) {
     auto base_tile_ref = tile_group->GetTileReference(i);
     for (oid_t col_id = 0; col_id < schemas[i].GetColumnCount(); col_id++) {

--- a/src/executor/materialization_executor.cpp
+++ b/src/executor/materialization_executor.cpp
@@ -52,7 +52,7 @@ MaterializationExecutor::MaterializationExecutor(
  * @return true on success, false otherwise.
  */
 bool MaterializationExecutor::DInit() {
-  PL_ASSERT(children_.size() == 1);
+  PELOTON_ASSERT(children_.size() == 1);
 
   return true;
 }
@@ -168,7 +168,7 @@ void MaterializeRowAtAtATime(
 
       // Old to new column mapping
       auto it = old_to_new_cols.find(old_col_id);
-      PL_ASSERT(it != old_to_new_cols.end());
+      PELOTON_ASSERT(it != old_to_new_cols.end());
 
       // Get new column information
       oid_t new_column_id = it->second;
@@ -182,7 +182,7 @@ void MaterializeRowAtAtATime(
       new_column_lengths.push_back(new_column_length);
     }
 
-    PL_ASSERT(new_column_offsets.size() == old_column_ids.size());
+    PELOTON_ASSERT(new_column_offsets.size() == old_column_ids.size());
 
     ///////////////////////////
     // EACH TUPLE
@@ -254,7 +254,7 @@ void MaterializeColumnAtATime(
 
       // Old to new column mapping
       auto it = old_to_new_cols.find(old_col_id);
-      PL_ASSERT(it != old_to_new_cols.end());
+      PELOTON_ASSERT(it != old_to_new_cols.end());
 
       // Get new column information
       oid_t new_column_id = it->second;

--- a/src/executor/nested_loop_join_executor.cpp
+++ b/src/executor/nested_loop_join_executor.cpp
@@ -43,11 +43,11 @@ bool NestedLoopJoinExecutor::DInit() {
     return status;
   }
 
-  PL_ASSERT(right_result_tiles_.empty());
+  PELOTON_ASSERT(right_result_tiles_.empty());
   right_child_done_ = false;
   right_result_itr_ = 0;
 
-  PL_ASSERT(left_result_tiles_.empty());
+  PELOTON_ASSERT(left_result_tiles_.empty());
 
   return true;
 }
@@ -128,7 +128,7 @@ bool NestedLoopJoinExecutor::DExecute() {
         LOG_TRACE("Advance the Right child.");
         std::unique_ptr<LogicalTile> right_tile(children_[1]->GetOutput());
 
-        PL_ASSERT(right_tile != nullptr);
+        PELOTON_ASSERT(right_tile != nullptr);
 
         // Construct output result
         auto output_tile =

--- a/src/executor/order_by_executor.cpp
+++ b/src/executor/order_by_executor.cpp
@@ -35,7 +35,7 @@ OrderByExecutor::OrderByExecutor(const planner::AbstractPlan *node,
 OrderByExecutor::~OrderByExecutor() {}
 
 bool OrderByExecutor::DInit() {
-  PL_ASSERT(children_.size() == 1);
+  PELOTON_ASSERT(children_.size() == 1);
 
   sort_done_ = false;
   num_tuples_returned_ = 0;
@@ -67,9 +67,9 @@ bool OrderByExecutor::DExecute() {
     return false;
   }
 
-  PL_ASSERT(sort_done_);
-  PL_ASSERT(output_schema_.get());
-  PL_ASSERT(input_tiles_.size() > 0);
+  PELOTON_ASSERT(sort_done_);
+  PELOTON_ASSERT(output_schema_.get());
+  PELOTON_ASSERT(input_tiles_.size() > 0);
 
   // Returned tiles must be newly created physical tiles.
   // NOTE: the schema of these tiles might not match the input tiles when some of the order by columns are not be part of the output schema
@@ -97,22 +97,22 @@ bool OrderByExecutor::DExecute() {
   // Create an owner wrapper of this physical tile
   std::vector<std::shared_ptr<storage::Tile>> singleton({ptile});
   std::unique_ptr<LogicalTile> ltile(LogicalTileFactory::WrapTiles(singleton));
-  PL_ASSERT(ltile->GetTupleCount() == tile_size);
+  PELOTON_ASSERT(ltile->GetTupleCount() == tile_size);
 
   SetOutput(ltile.release());
 
   num_tuples_returned_ += tile_size;
 
-  PL_ASSERT(num_tuples_returned_ <= sort_buffer_.size());
+  PELOTON_ASSERT(num_tuples_returned_ <= sort_buffer_.size());
 
   return true;
 }
 
 bool OrderByExecutor::DoSort() {
-  PL_ASSERT(children_.size() == 1);
-  PL_ASSERT(children_[0] != nullptr);
-  PL_ASSERT(!sort_done_);
-  PL_ASSERT(executor_context_ != nullptr);
+  PELOTON_ASSERT(children_.size() == 1);
+  PELOTON_ASSERT(children_[0] != nullptr);
+  PELOTON_ASSERT(!sort_done_);
+  PELOTON_ASSERT(executor_context_ != nullptr);
 
   // Extract all data from child
   while (children_[0]->Execute()) {
@@ -179,7 +179,7 @@ bool OrderByExecutor::DoSort() {
     }
   }
 
-  PL_ASSERT(count == sort_buffer_.size());
+  PELOTON_ASSERT(count == sort_buffer_.size());
 
   // If the underlying result has the same order, it is not necessary to sort
   // the result again. Instead, go to the end.

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -141,7 +141,7 @@ void PlanExecutor::ExecutePlan(
     const std::vector<int> &result_format,
     std::function<void(executor::ExecutionResult, std::vector<ResultValue> &&)>
         on_complete) {
-  PL_ASSERT(plan != nullptr && txn != nullptr);
+  PELOTON_ASSERT(plan != nullptr && txn != nullptr);
   LOG_TRACE("PlanExecutor Start (Txn ID=%" PRId64 ")", txn->GetTransactionId());
 
   bool codegen_enabled =
@@ -166,12 +166,12 @@ void PlanExecutor::ExecutePlan(
 int PlanExecutor::ExecutePlan(
     const planner::AbstractPlan *plan, const std::vector<type::Value> &params,
     std::vector<std::unique_ptr<executor::LogicalTile>> &logical_tile_list) {
-  PL_ASSERT(plan != nullptr);
+  PELOTON_ASSERT(plan != nullptr);
   LOG_TRACE("PlanExecutor Start with transaction");
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
-  PL_ASSERT(txn);
+  PELOTON_ASSERT(txn);
   LOG_TRACE("Txn ID = %" PRId64, txn->GetTransactionId());
 
   std::unique_ptr<executor::ExecutorContext> executor_context(

--- a/src/executor/populate_index_executor.cpp
+++ b/src/executor/populate_index_executor.cpp
@@ -35,8 +35,8 @@ PopulateIndexExecutor::PopulateIndexExecutor(const planner::AbstractPlan *node,
  * @return true on success, false otherwise.
  */
 bool PopulateIndexExecutor::DInit() {
-  PL_ASSERT(children_.size() == 1);
-  PL_ASSERT(executor_context_);
+  PELOTON_ASSERT(children_.size() == 1);
+  PELOTON_ASSERT(executor_context_);
 
   // Initialize executor state
   const planner::PopulateIndexPlan &node =
@@ -50,7 +50,7 @@ bool PopulateIndexExecutor::DInit() {
 
 bool PopulateIndexExecutor::DExecute() {
   LOG_TRACE("Populate Index Executor");
-  PL_ASSERT(executor_context_ != nullptr);
+  PELOTON_ASSERT(executor_context_ != nullptr);
   auto current_txn = executor_context_->GetTransaction();
   auto executor_pool = executor_context_->GetPool();
   if (done_ == false) {

--- a/src/executor/projection_executor.cpp
+++ b/src/executor/projection_executor.cpp
@@ -38,7 +38,7 @@ ProjectionExecutor::ProjectionExecutor(const planner::AbstractPlan *node,
  */
 bool ProjectionExecutor::DInit() {
   // NOTE: We only handle 1 child or no child for now
-  PL_ASSERT(children_.size() < 2);
+  PELOTON_ASSERT(children_.size() < 2);
 
   // Grab settings from plan node
   const planner::ProjectionPlan &node = GetPlanNode<planner::ProjectionPlan>();
@@ -55,10 +55,10 @@ bool ProjectionExecutor::DInit() {
  * @return true on success, false otherwise.
  */
 bool ProjectionExecutor::DExecute() {
-  PL_ASSERT(project_info_);
-  PL_ASSERT(schema_);
+  PELOTON_ASSERT(project_info_);
+  PELOTON_ASSERT(schema_);
   // NOTE: We only handle 1 child or no child for now
-  PL_ASSERT(children_.size() < 2);
+  PELOTON_ASSERT(children_.size() < 2);
 
   if (children_.size() == 0) {
     if (finished_) return false;

--- a/src/executor/seq_scan_executor.cpp
+++ b/src/executor/seq_scan_executor.cpp
@@ -89,8 +89,8 @@ bool SeqScanExecutor::DExecute() {
     // FIXME Check all requirements for children_.size() == 0 case.
     LOG_TRACE("Seq Scan executor :: 1 child ");
 
-    PL_ASSERT(target_table_ == nullptr);
-    PL_ASSERT(column_ids_.size() == 0);
+    PELOTON_ASSERT(target_table_ == nullptr);
+    PELOTON_ASSERT(column_ids_.size() == 0);
 
     while (children_[0]->Execute()) {
       std::unique_ptr<LogicalTile> tile(children_[0]->GetOutput());
@@ -134,8 +134,8 @@ bool SeqScanExecutor::DExecute() {
                     ->GetCreateType() == CreateType::INDEX)) {
     LOG_TRACE("Seq Scan executor :: 0 child ");
 
-    PL_ASSERT(target_table_ != nullptr);
-    PL_ASSERT(column_ids_.size() > 0);
+    PELOTON_ASSERT(target_table_ != nullptr);
+    PELOTON_ASSERT(column_ids_.size() > 0);
     if (children_.size() > 0 && !index_done_) {
       children_[0]->Execute();
       // This stops continuous executions due to
@@ -227,7 +227,7 @@ void SeqScanExecutor::UpdatePredicate(const std::vector<oid_t> &column_ids,
                                       const std::vector<type::Value> &values) {
   std::vector<oid_t> predicate_column_ids;
 
-  PL_ASSERT(column_ids.size() <= column_ids_.size());
+  PELOTON_ASSERT(column_ids.size() <= column_ids_.size());
 
   // columns_ids is the column id
   // in the join executor, should

--- a/src/executor/update_executor.cpp
+++ b/src/executor/update_executor.cpp
@@ -41,17 +41,17 @@ UpdateExecutor::UpdateExecutor(const planner::AbstractPlan *node,
  * @return true on success, false otherwise.
  */
 bool UpdateExecutor::DInit() {
-  PL_ASSERT(children_.size() == 1);
-  PL_ASSERT(target_table_ == nullptr);
-  PL_ASSERT(project_info_ == nullptr);
+  PELOTON_ASSERT(children_.size() == 1);
+  PELOTON_ASSERT(target_table_ == nullptr);
+  PELOTON_ASSERT(project_info_ == nullptr);
 
   // Grab settings from node
   const planner::UpdatePlan &node = GetPlanNode<planner::UpdatePlan>();
   target_table_ = node.GetTable();
   project_info_ = node.GetProjectInfo();
 
-  PL_ASSERT(target_table_);
-  PL_ASSERT(project_info_);
+  PELOTON_ASSERT(target_table_);
+  PELOTON_ASSERT(project_info_);
 
   return true;
 }
@@ -145,8 +145,8 @@ bool UpdateExecutor::PerformUpdatePrimaryKey(
  * @return true on success, false otherwise.
  */
 bool UpdateExecutor::DExecute() {
-  PL_ASSERT(children_.size() == 1);
-  PL_ASSERT(executor_context_);
+  PELOTON_ASSERT(children_.size() == 1);
+  PELOTON_ASSERT(executor_context_);
 
   // We are scanning over a logical tile.
   LOG_TRACE("Update executor :: 1 child ");

--- a/src/expression/abstract_expression.cpp
+++ b/src/expression/abstract_expression.cpp
@@ -80,7 +80,7 @@ void AbstractExpression::DeduceExpressionName() {
     }
     expr_name_.append(")");
   } else {
-    PL_ASSERT(children_size <= 2);
+    PELOTON_ASSERT(children_size <= 2);
     if (children_size == 2) {
       expr_name_ = GetChild(0)->expr_name_ + " " + op_str + " " +
                    GetChild(1)->expr_name_;

--- a/src/expression/comparison_expression.cpp
+++ b/src/expression/comparison_expression.cpp
@@ -23,7 +23,7 @@ ComparisonExpression::ComparisonExpression(ExpressionType type,
 type::Value ComparisonExpression::Evaluate(
     const AbstractTuple *tuple1, const AbstractTuple *tuple2,
     executor::ExecutorContext *context) const {
-  PL_ASSERT(children_.size() == 2);
+  PELOTON_ASSERT(children_.size() == 2);
   auto vl = children_[0]->Evaluate(tuple1, tuple2, context);
   auto vr = children_[1]->Evaluate(tuple1, tuple2, context);
   switch (exp_type_) {

--- a/src/expression/function_expression.cpp
+++ b/src/expression/function_expression.cpp
@@ -45,7 +45,7 @@ type::Value FunctionExpression::Evaluate(
     UNUSED_ATTRIBUTE executor::ExecutorContext *context) const {
   std::vector<type::Value> child_values;
 
-  PL_ASSERT(func_.impl != nullptr);
+  PELOTON_ASSERT(func_.impl != nullptr);
   for (auto &child : children_) {
     child_values.push_back(child->Evaluate(tuple1, tuple2, context));
   }

--- a/src/expression/tuple_value_expression.cpp
+++ b/src/expression/tuple_value_expression.cpp
@@ -23,10 +23,10 @@ type::Value TupleValueExpression::Evaluate(
     const AbstractTuple *tuple1, const AbstractTuple *tuple2,
     UNUSED_ATTRIBUTE executor::ExecutorContext *context) const {
   if (tuple_idx_ == 0) {
-    PL_ASSERT(tuple1 != nullptr);
+    PELOTON_ASSERT(tuple1 != nullptr);
     return (tuple1->GetValue(value_idx_));
   } else {
-    PL_ASSERT(tuple2 != nullptr);
+    PELOTON_ASSERT(tuple2 != nullptr);
     return (tuple2->GetValue(value_idx_));
   }
 }
@@ -35,7 +35,7 @@ void TupleValueExpression::PerformBinding(
     const std::vector<const planner::BindingContext *> &binding_contexts) {
   const auto &context = binding_contexts[GetTupleId()];
   ai_ = context->Find(GetColumnId());
-  PL_ASSERT(ai_ != nullptr);
+  PELOTON_ASSERT(ai_ != nullptr);
   LOG_TRACE("TVE Column ID %u.%u binds to AI %p (%s)", GetTupleId(),
             GetColumnId(), ai_, ai_->name.c_str());
 }

--- a/src/function/date_functions.cpp
+++ b/src/function/date_functions.cpp
@@ -61,7 +61,7 @@ int64_t DateFunctions::Now() {
 }
 
 type::Value DateFunctions::_Now(const UNUSED_ATTRIBUTE std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 0);
+  PELOTON_ASSERT(args.size() == 0);
   int64_t now = Now();
   return type::ValueFactory::GetTimestampValue(now);
 }

--- a/src/function/decimal_functions.cpp
+++ b/src/function/decimal_functions.cpp
@@ -18,7 +18,7 @@ namespace function {
 
 // Get square root of the value
 type::Value DecimalFunctions::Sqrt(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
+  PELOTON_ASSERT(args.size() == 1);
   if (args[0].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::DECIMAL);
   }
@@ -27,7 +27,7 @@ type::Value DecimalFunctions::Sqrt(const std::vector<type::Value> &args) {
 
 // Get Abs of value
 type::Value DecimalFunctions::_Abs(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
+  PELOTON_ASSERT(args.size() == 1);
   if (args[0].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::DECIMAL);
   }
@@ -76,7 +76,7 @@ double DecimalFunctions::Abs(const double args) { return fabs(args); }
 
 // Get ceiling of value
 type::Value DecimalFunctions::_Ceil(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
+  PELOTON_ASSERT(args.size() == 1);
   if (args[0].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::DECIMAL);
   }
@@ -107,7 +107,7 @@ double DecimalFunctions::Ceil(const double args) { return ceil(args); }
 
 // Get floor value
 type::Value DecimalFunctions::_Floor(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
+  PELOTON_ASSERT(args.size() == 1);
   if (args[0].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::DECIMAL);
   }
@@ -138,7 +138,7 @@ double DecimalFunctions::Floor(const double val) { return floor(val); }
 
 // Round to nearest integer
 type::Value DecimalFunctions::_Round(const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
+  PELOTON_ASSERT(args.size() == 1);
   if (args[0].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::DECIMAL);
   }

--- a/src/function/old_engine_string_functions.cpp
+++ b/src/function/old_engine_string_functions.cpp
@@ -26,7 +26,7 @@ namespace function {
 // ASCII code of the first character of the argument.
 type::Value OldEngineStringFunctions::Ascii(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
+  PELOTON_ASSERT(args.size() == 1);
   if (args[0].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
   }
@@ -39,7 +39,7 @@ type::Value OldEngineStringFunctions::Ascii(
 
 type::Value OldEngineStringFunctions::Like(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 2);
+  PELOTON_ASSERT(args.size() == 2);
   if (args[0].IsNull() || args[1].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
   }
@@ -54,7 +54,7 @@ type::Value OldEngineStringFunctions::Like(
 // Get Character from integer
 type::Value OldEngineStringFunctions::Chr(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
+  PELOTON_ASSERT(args.size() == 1);
   if (args[0].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
   }
@@ -66,7 +66,7 @@ type::Value OldEngineStringFunctions::Chr(
 // substring
 type::Value OldEngineStringFunctions::Substr(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 3);
+  PELOTON_ASSERT(args.size() == 3);
   if (args[0].IsNull() || args[1].IsNull() || args[2].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
   }
@@ -80,7 +80,7 @@ type::Value OldEngineStringFunctions::Substr(
 // Number of characters in string
 type::Value OldEngineStringFunctions::CharLength(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
+  PELOTON_ASSERT(args.size() == 1);
   if (args[0].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
   }
@@ -92,7 +92,7 @@ type::Value OldEngineStringFunctions::CharLength(
 // Concatenate two strings
 type::Value OldEngineStringFunctions::Concat(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 2);
+  PELOTON_ASSERT(args.size() == 2);
   if (args[0].IsNull() || args[1].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
   }
@@ -103,7 +103,7 @@ type::Value OldEngineStringFunctions::Concat(
 // Number of bytes in string
 type::Value OldEngineStringFunctions::OctetLength(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
+  PELOTON_ASSERT(args.size() == 1);
   std::string str = args[0].ToString();
   int32_t len = str.length();
   return (type::ValueFactory::GetIntegerValue(len));
@@ -112,7 +112,7 @@ type::Value OldEngineStringFunctions::OctetLength(
 // Repeat string the specified number of times
 type::Value OldEngineStringFunctions::Repeat(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 2);
+  PELOTON_ASSERT(args.size() == 2);
   if (args[0].IsNull() || args[1].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
   }
@@ -136,7 +136,7 @@ type::Value OldEngineStringFunctions::Repeat(
 // Replace all occurrences in string of substring from with substring to
 type::Value OldEngineStringFunctions::Replace(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 3);
+  PELOTON_ASSERT(args.size() == 3);
   if (args[0].IsNull() || args[1].IsNull() || args[2].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
   }
@@ -155,7 +155,7 @@ type::Value OldEngineStringFunctions::Replace(
 // from the start of string
 type::Value OldEngineStringFunctions::LTrim(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 2);
+  PELOTON_ASSERT(args.size() == 2);
   if (args[0].IsNull() || args[1].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
   }
@@ -173,7 +173,7 @@ type::Value OldEngineStringFunctions::LTrim(
 // from the end of string
 type::Value OldEngineStringFunctions::RTrim(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 2);
+  PELOTON_ASSERT(args.size() == 2);
   if (args[0].IsNull() || args[1].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
   }
@@ -189,7 +189,7 @@ type::Value OldEngineStringFunctions::RTrim(
 
 type::Value OldEngineStringFunctions::Trim(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
+  PELOTON_ASSERT(args.size() == 1);
   return BTrim({args[0], type::ValueFactory::GetVarcharValue(" ")});
 }
 
@@ -197,7 +197,7 @@ type::Value OldEngineStringFunctions::Trim(
 // the start and end of string
 type::Value OldEngineStringFunctions::BTrim(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 2);
+  PELOTON_ASSERT(args.size() == 2);
   if (args[0].IsNull() || args[1].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR);
   }
@@ -214,7 +214,7 @@ type::Value OldEngineStringFunctions::BTrim(
 // The length of the string
 type::Value OldEngineStringFunctions::Length(
     const std::vector<type::Value> &args) {
-  PL_ASSERT(args.size() == 1);
+  PELOTON_ASSERT(args.size() == 1);
   if (args[0].IsNull()) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER);
   }

--- a/src/function/string_functions.cpp
+++ b/src/function/string_functions.cpp
@@ -20,7 +20,7 @@ namespace function {
 
 uint32_t StringFunctions::Ascii(UNUSED_ATTRIBUTE executor::ExecutorContext &ctx,
                                 const char *str, uint32_t length) {
-  PL_ASSERT(str != nullptr);
+  PELOTON_ASSERT(str != nullptr);
   return length <= 1 ? 0 : static_cast<uint32_t>(str[0]);
 }
 
@@ -29,8 +29,8 @@ uint32_t StringFunctions::Ascii(UNUSED_ATTRIBUTE executor::ExecutorContext &ctx,
 bool StringFunctions::Like(UNUSED_ATTRIBUTE executor::ExecutorContext &ctx,
                            const char *t, uint32_t tlen, const char *p,
                            uint32_t plen) {
-  PL_ASSERT(t != nullptr);
-  PL_ASSERT(p != nullptr);
+  PELOTON_ASSERT(t != nullptr);
+  PELOTON_ASSERT(p != nullptr);
   if (plen == 1 && *p == '%') return true;
 
   while (tlen > 0 && plen > 0) {
@@ -127,7 +127,7 @@ StringFunctions::StrWithLen StringFunctions::Repeat(
   // Perform repeat
   char *ptr = new_str;
   for (uint32_t i = 0; i < num_repeat; i++) {
-    PL_MEMCPY(ptr, str, length - 1);
+    PELOTON_MEMCPY(ptr, str, length - 1);
     ptr += (length - 1);
   }
 
@@ -138,7 +138,7 @@ StringFunctions::StrWithLen StringFunctions::Repeat(
 StringFunctions::StrWithLen StringFunctions::LTrim(
     UNUSED_ATTRIBUTE executor::ExecutorContext &ctx, const char *str,
     uint32_t str_len, const char *from, UNUSED_ATTRIBUTE uint32_t from_len) {
-  PL_ASSERT(str != nullptr && from != nullptr);
+  PELOTON_ASSERT(str != nullptr && from != nullptr);
 
   // llvm expects the len to include the terminating '\0'
   if (str_len == 1) {
@@ -160,7 +160,7 @@ StringFunctions::StrWithLen StringFunctions::LTrim(
 StringFunctions::StrWithLen StringFunctions::RTrim(
     UNUSED_ATTRIBUTE executor::ExecutorContext &ctx, const char *str,
     uint32_t str_len, const char *from, UNUSED_ATTRIBUTE uint32_t from_len) {
-  PL_ASSERT(str != nullptr && from != nullptr);
+  PELOTON_ASSERT(str != nullptr && from != nullptr);
 
   // llvm expects the len to include the terminating '\0'
   if (str_len == 1) {
@@ -186,7 +186,7 @@ StringFunctions::StrWithLen StringFunctions::Trim(
 StringFunctions::StrWithLen StringFunctions::BTrim(
     UNUSED_ATTRIBUTE executor::ExecutorContext &ctx, const char *str,
     uint32_t str_len, const char *from, UNUSED_ATTRIBUTE uint32_t from_len) {
-  PL_ASSERT(str != nullptr && from != nullptr);
+  PELOTON_ASSERT(str != nullptr && from != nullptr);
 
   // Skip the tailing 0
   str_len--;
@@ -216,7 +216,7 @@ StringFunctions::StrWithLen StringFunctions::BTrim(
 uint32_t StringFunctions::Length(
     UNUSED_ATTRIBUTE executor::ExecutorContext &ctx,
     UNUSED_ATTRIBUTE const char *str, uint32_t length) {
-  PL_ASSERT(str != nullptr);
+  PELOTON_ASSERT(str != nullptr);
   return length;
 }
 

--- a/src/function/timestamp_functions.cpp
+++ b/src/function/timestamp_functions.cpp
@@ -25,7 +25,7 @@ namespace function {
 
 uint64_t TimestampFunctions::DateTrunc(const char *date_part_type,
                                        uint64_t value) {
-  PL_ASSERT(date_part_type != nullptr);
+  PELOTON_ASSERT(date_part_type != nullptr);
 
   std::string date_part_string(date_part_type);
   DatePartType date_part = StringToDatePartType(date_part_string);
@@ -36,8 +36,8 @@ uint64_t TimestampFunctions::DateTrunc(const char *date_part_type,
   // TODO(lma): A more efficient NULL check is to implement something like the
   // value::CallBinaryOp() for arithmetic operations. Right now the timestamp
   // functions doesn't have that infrastructure.
-  if (timestamp == type::PELOTON_TIMESTAMP_NULL) {
-    return type::PELOTON_TIMESTAMP_NULL;
+  if (timestamp == type::PELOTON_VALUE_TIMESTAMP_NULL) {
+    return type::PELOTON_VALUE_TIMESTAMP_NULL;
   }
 
   uint32_t micro = timestamp % 1000000;
@@ -136,7 +136,7 @@ uint64_t TimestampFunctions::DateTrunc(const char *date_part_type,
           ((((uint64_t)32 + 1) * 27 + tz) * 10000 + year) * 100000 * 1000000;
       break;
     }
-    default: { result = type::PELOTON_TIMESTAMP_NULL; }
+    default: { result = type::PELOTON_VALUE_TIMESTAMP_NULL; }
   };
 
   return (result);
@@ -149,7 +149,7 @@ type::Value TimestampFunctions::_DateTrunc(
   uint64_t timestamp = args[1].GetAs<uint64_t>();
   type::Value result;
 
-  if (timestamp == type::PELOTON_TIMESTAMP_NULL) {
+  if (timestamp == type::PELOTON_VALUE_TIMESTAMP_NULL) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::TIMESTAMP);
   }
 
@@ -159,7 +159,7 @@ type::Value TimestampFunctions::_DateTrunc(
 
 double TimestampFunctions::DatePart(const char *date_part_type,
                                     uint64_t value) {
-  PL_ASSERT(date_part_type != nullptr);
+  PELOTON_ASSERT(date_part_type != nullptr);
 
   std::string date_part_string(date_part_type);
   DatePartType date_part = StringToDatePartType(date_part_string);
@@ -167,8 +167,8 @@ double TimestampFunctions::DatePart(const char *date_part_type,
   uint64_t timestamp = value;
   double result = 0.0;
 
-  if (timestamp == type::PELOTON_TIMESTAMP_NULL) {
-    return type::PELOTON_DECIMAL_NULL;
+  if (timestamp == type::PELOTON_VALUE_TIMESTAMP_NULL) {
+    return type::PELOTON_VALUE_DECIMAL_NULL;
   }
 
   uint32_t micro = timestamp % 1000000;
@@ -269,7 +269,7 @@ double TimestampFunctions::DatePart(const char *date_part_type,
       result = year;
       break;
     }
-    default: { result = type::PELOTON_DECIMAL_NULL; }
+    default: { result = type::PELOTON_VALUE_DECIMAL_NULL; }
   };
 
   return (result);
@@ -282,7 +282,7 @@ type::Value TimestampFunctions::_DatePart(
   uint64_t timestamp = args[1].GetAs<uint64_t>();
   type::Value result;
 
-  if (timestamp == type::PELOTON_TIMESTAMP_NULL) {
+  if (timestamp == type::PELOTON_VALUE_TIMESTAMP_NULL) {
     return type::ValueFactory::GetNullValueByType(type::TypeId::TIMESTAMP);
   }
 

--- a/src/gc/gc_manager.cpp
+++ b/src/gc/gc_manager.cpp
@@ -37,7 +37,7 @@ void GCManager::CheckAndReclaimVarlenColumns(storage::TileGroup *tg, oid_t tuple
         tile_col_count = schema.GetColumnCount();
 
         storage::Tile *tile = tg->GetTile(tile_itr);
-        PL_ASSERT(tile);
+        PELOTON_ASSERT(tile);
         for (oid_t tile_col_itr = 0; tile_col_itr < tile_col_count; ++tile_col_itr) {
             type_id = schema.GetType(tile_col_itr);
 

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -41,7 +41,7 @@ bool TransactionLevelGCManager::ResetTuple(const ItemPointer &location) {
   tile_group_header->SetPrevItemPointer(location.offset, INVALID_ITEMPOINTER);
   tile_group_header->SetNextItemPointer(location.offset, INVALID_ITEMPOINTER);
 
-  PL_MEMSET(tile_group_header->GetReservedFieldRef(location.offset), 0,
+  PELOTON_MEMSET(tile_group_header->GetReservedFieldRef(location.offset), 0,
             storage::TileGroupHeader::GetReservedSize());
 
   // Reclaim the varlen pool
@@ -52,7 +52,7 @@ bool TransactionLevelGCManager::ResetTuple(const ItemPointer &location) {
 }
 
 void TransactionLevelGCManager::Running(const int &thread_id) {
-  PL_ASSERT(is_running_ == true);
+  PELOTON_ASSERT(is_running_ == true);
   uint32_t backoff_shifts = 0;
   while (true) {
     auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
@@ -226,15 +226,15 @@ void TransactionLevelGCManager::AddToRecycleMap(
       return;
     }
 
-    PL_ASSERT(tile_group != nullptr);
+    PELOTON_ASSERT(tile_group != nullptr);
 
     storage::DataTable *table =
         dynamic_cast<storage::DataTable *>(tile_group->GetAbstractTable());
-    PL_ASSERT(table != nullptr);
+    PELOTON_ASSERT(table != nullptr);
 
     oid_t table_id = table->GetOid();
     auto tile_group_header = tile_group->GetHeader();
-    PL_ASSERT(tile_group_header != nullptr);
+    PELOTON_ASSERT(tile_group_header != nullptr);
     bool immutable = tile_group_header->GetImmutability();
 
     for (auto &element : entry.second) {
@@ -259,22 +259,22 @@ void TransactionLevelGCManager::AddToRecycleMap(
     oid_t database_oid = std::get<0>(entry);
     oid_t table_oid = std::get<1>(entry);
     oid_t index_oid = std::get<2>(entry);
-    PL_ASSERT(database_oid != INVALID_OID);
+    PELOTON_ASSERT(database_oid != INVALID_OID);
     auto database = storage_manager->GetDatabaseWithOid(database_oid);
-    PL_ASSERT(database != nullptr);
+    PELOTON_ASSERT(database != nullptr);
     if (table_oid == INVALID_OID) {
       storage_manager->RemoveDatabaseFromStorageManager(database_oid);
       continue;
     }
     auto table = database->GetTableWithOid(table_oid);
-    PL_ASSERT(table != nullptr);
+    PELOTON_ASSERT(table != nullptr);
     if (index_oid == INVALID_OID) {
       database->DropTableWithOid(table_oid);
       LOG_DEBUG("GCing table %u", table_oid);
       continue;
     }
     auto index = table->GetIndexWithOid(index_oid);
-    PL_ASSERT(index != nullptr);
+    PELOTON_ASSERT(index != nullptr);
     table->DropIndexWithOid(index_oid);
   }
 
@@ -289,7 +289,7 @@ ItemPointer TransactionLevelGCManager::ReturnFreeSlot(const oid_t &table_id) {
     return INVALID_ITEMPOINTER;
   }
   ItemPointer location;
-  PL_ASSERT(recycle_queue_map_.find(table_id) != recycle_queue_map_.end());
+  PELOTON_ASSERT(recycle_queue_map_.find(table_id) != recycle_queue_map_.end());
   auto recycle_queue = recycle_queue_map_[table_id];
 
   if (recycle_queue->Dequeue(location) == true) {
@@ -359,7 +359,7 @@ void TransactionLevelGCManager::UnlinkVersion(const ItemPointer location,
 
   storage::DataTable *table =
       dynamic_cast<storage::DataTable *>(tile_group->GetAbstractTable());
-  PL_ASSERT(table != nullptr);
+  PELOTON_ASSERT(table != nullptr);
 
   // NOTE: for now, we only consider unlinking tuple versions from primary
   // indexes.
@@ -385,7 +385,7 @@ void TransactionLevelGCManager::UnlinkVersion(const ItemPointer location,
     // need to recycle this version.
     // no index manipulation needs to be made.
   } else {
-    PL_ASSERT(type == GCVersionType::ABORT_INSERT ||
+    PELOTON_ASSERT(type == GCVersionType::ABORT_INSERT ||
               type == GCVersionType::COMMIT_INS_DEL ||
               type == GCVersionType::ABORT_INS_DEL);
 

--- a/src/include/catalog/column.h
+++ b/src/include/catalog/column.h
@@ -45,7 +45,7 @@ class Column : public Printable {
 
     // We should not have an inline value of length 0
     if (is_inlined && column_length == 0) {
-      PL_ASSERT(false);
+      PELOTON_ASSERT(false);
     }
 
     SetLength(column_length);

--- a/src/include/codegen/auxiliary_producer_function.h
+++ b/src/include/codegen/auxiliary_producer_function.h
@@ -47,7 +47,7 @@ inline AuxiliaryProducerFunction::AuxiliaryProducerFunction(
 
 inline llvm::Value *AuxiliaryProducerFunction::Call(CodeGen &codegen) const {
   // At this point, the function cannot be NULL!
-  PL_ASSERT(function_ != nullptr);
+  PELOTON_ASSERT(function_ != nullptr);
   auto *runtime_state_ptr = codegen.GetState();
   return codegen.CallFunc(function_, {runtime_state_ptr});
 }

--- a/src/include/codegen/query_parameters_map.h
+++ b/src/include/codegen/query_parameters_map.h
@@ -45,7 +45,7 @@ class QueryParametersMap {
 
   uint32_t GetIndex(const expression::AbstractExpression *expression) const {
     auto param = map_.find(expression);
-    PL_ASSERT(param != map_.end());
+    PELOTON_ASSERT(param != map_.end());
     return param->second;
   }
 

--- a/src/include/common/cast.h
+++ b/src/include/common/cast.h
@@ -21,9 +21,9 @@ namespace peloton {
 // Cast from signed to unsigned types.
 template <typename DestinationType, typename SourceType>
 DestinationType ALWAYS_ASSERT_range_cast_signed_to_unsigned(SourceType value) {
-  PL_ASSERT(0 == std::numeric_limits<DestinationType>::min());
-  PL_ASSERT(0 <= value);
-  PL_ASSERT(value <= std::numeric_limits<DestinationType>::max());
+  PELOTON_ASSERT(0 == std::numeric_limits<DestinationType>::min());
+  PELOTON_ASSERT(0 <= value);
+  PELOTON_ASSERT(value <= std::numeric_limits<DestinationType>::max());
 
   return static_cast<DestinationType>(value);
 }
@@ -32,8 +32,8 @@ DestinationType ALWAYS_ASSERT_range_cast_signed_to_unsigned(SourceType value) {
 // bound
 template <typename DestinationType, typename SourceType>
 DestinationType ALWAYS_ASSERT_range_cast_unsigned_to_signed(SourceType value) {
-  PL_ASSERT(0 == std::numeric_limits<SourceType>::min());
-  PL_ASSERT(value <= std::numeric_limits<DestinationType>::max());
+  PELOTON_ASSERT(0 == std::numeric_limits<SourceType>::min());
+  PELOTON_ASSERT(value <= std::numeric_limits<DestinationType>::max());
 
   return static_cast<DestinationType>(value);
 }
@@ -41,8 +41,8 @@ DestinationType ALWAYS_ASSERT_range_cast_unsigned_to_signed(SourceType value) {
 // Cast between types of the same signs
 template <typename DestinationType, typename SourceType>
 DestinationType ALWAYS_ASSERT_range_cast_same(SourceType value) {
-  PL_ASSERT(std::numeric_limits<DestinationType>::min() <= value);
-  PL_ASSERT(value <= std::numeric_limits<DestinationType>::max());
+  PELOTON_ASSERT(std::numeric_limits<DestinationType>::min() <= value);
+  PELOTON_ASSERT(value <= std::numeric_limits<DestinationType>::max());
   return static_cast<DestinationType>(value);
 }
 

--- a/src/include/common/container_tuple.h
+++ b/src/include/common/container_tuple.h
@@ -55,7 +55,7 @@ class ContainerTuple : public AbstractTuple {
 
   /// \brief Get the value at the given column id
   type::Value GetValue(oid_t column_id) const override {
-    PL_ASSERT(container_ != nullptr);
+    PELOTON_ASSERT(container_ != nullptr);
     return container_->GetValue(tuple_id_, column_id);
   }
 
@@ -183,8 +183,8 @@ class ContainerTuple<std::vector<type::Value>> : public AbstractTuple {
 
   /// \brief Get the value at the given column id
   type::Value GetValue(oid_t column_id) const override {
-    PL_ASSERT(container_ != nullptr);
-    PL_ASSERT(column_id < container_->size());
+    PELOTON_ASSERT(container_ != nullptr);
+    PELOTON_ASSERT(column_id < container_->size());
 
     return (*container_)[column_id];
   }
@@ -212,7 +212,7 @@ class ContainerTuple<std::vector<type::Value>> : public AbstractTuple {
   /// schema of other tuple.Is the same as this. No check.
   bool EqualsNoSchemaCheck(
       const ContainerTuple<std::vector<type::Value>> &other) const {
-    PL_ASSERT(container_->size() == other.container_->size());
+    PELOTON_ASSERT(container_->size() == other.container_->size());
 
     for (size_t column_itr = 0; column_itr < container_->size(); column_itr++) {
       type::Value lhs = GetValue(column_itr);
@@ -258,7 +258,7 @@ class ContainerTuple<storage::TileGroup> : public AbstractTuple {
 
   /// \brief Get the value at the given column id
   type::Value GetValue(oid_t column_id) const override {
-    PL_ASSERT(container_ != nullptr);
+    PELOTON_ASSERT(container_ != nullptr);
     return container_->GetValue(tuple_id_, column_id);
   }
 

--- a/src/include/common/macros.h
+++ b/src/include/common/macros.h
@@ -40,11 +40,11 @@ namespace peloton {
 #define USE_BUILTIN_MEMFUNCS
 
 #ifdef USE_BUILTIN_MEMFUNCS
-#define PL_MEMCPY __builtin_memcpy
-#define PL_MEMSET __builtin_memset
+#define PELOTON_MEMCPY __builtin_memcpy
+#define PELOTON_MEMSET __builtin_memset
 #else
-#define PL_MEMCPY memcpy
-#define PL_MEMSET memset
+#define PELOTON_MEMCPY memcpy
+#define PELOTON_MEMSET memset
 #endif
 
 //===--------------------------------------------------------------------===//
@@ -63,7 +63,7 @@ namespace peloton {
 //===--------------------------------------------------------------------===//
 
 #ifdef CHECK_INVARIANTS
-#define INVARIANT(expr) PL_ASSERT(expr)
+#define INVARIANT(expr) PELOTON_ASSERT(expr)
 #else
 #define INVARIANT(expr) ((void)0)
 #endif /* CHECK_INVARIANTS */
@@ -74,9 +74,9 @@ namespace peloton {
 
 // throw exception after the assert(), so that GCC knows
 // we'll never return
-#define PL_UNIMPLEMENTED(what)        \
+#define PELOTON_UNIMPLEMENTED(what)        \
   do {                                \
-    PL_ASSERT(false);                 \
+    PELOTON_ASSERT(false);                 \
     throw ::std::runtime_error(what); \
   } while (0)
 
@@ -85,13 +85,13 @@ namespace peloton {
 //===--------------------------------------------------------------------===//
 
 #ifdef NDEBUG
-#define PL_ASSERT(expr) ((void)0)
+#define PELOTON_ASSERT(expr) ((void)0)
 #else
-#define PL_ASSERT(expr) assert((expr))
+#define PELOTON_ASSERT(expr) assert((expr))
 #endif /* NDEBUG */
 
 #ifdef CHECK_INVARIANTS
-#define INVARIANT(expr) PL_ASSERT(expr)
+#define INVARIANT(expr) PELOTON_ASSERT(expr)
 #else
 #define INVARIANT(expr) ((void)0)
 #endif /* CHECK_INVARIANTS */

--- a/src/include/common/platform.h
+++ b/src/include/common/platform.h
@@ -59,7 +59,7 @@ static inline uint64_t CountLeadingZeroes(uint64_t i) {
 //===--------------------------------------------------------------------===//
 static inline uint64_t NextPowerOf2(uint64_t n) {
 #if defined __GNUC__ || defined __clang__
-  PL_ASSERT(n > 0);
+  PELOTON_ASSERT(n > 0);
   return 1ul << (64 - CountLeadingZeroes(n - 1));
 #else
   n--;

--- a/src/include/common/synchronization/condition.h
+++ b/src/include/common/synchronization/condition.h
@@ -33,12 +33,12 @@ class Condition {
    */
   explicit Condition(DirtyMutexLatch *mutex) : mutex_(mutex) {
     UNUSED_ATTRIBUTE int status = pthread_cond_init(&cond_, NULL);
-    PL_ASSERT(status == 0);
+    PELOTON_ASSERT(status == 0);
   }
 
   ~Condition() {
     UNUSED_ATTRIBUTE int status = pthread_cond_destroy(&cond_);
-    PL_ASSERT(status == 0);
+    PELOTON_ASSERT(status == 0);
   }
 
   /**
@@ -50,7 +50,7 @@ class Condition {
   void Wait() {
     UNUSED_ATTRIBUTE int status =
         pthread_cond_wait(&cond_, mutex_->RawDirtyMutexLatch());
-    PL_ASSERT(status == 0);
+    PELOTON_ASSERT(status == 0);
   }
 
   /**
@@ -59,7 +59,7 @@ class Condition {
    * @return
    */
   bool TimedwaitRelative(const struct timespec &relative_time) {
-    PL_ASSERT(0 <= relative_time.tv_nsec &&
+    PELOTON_ASSERT(0 <= relative_time.tv_nsec &&
               relative_time.tv_nsec < ONE_S_IN_NS);
 
     struct timespec absolute;
@@ -67,14 +67,14 @@ class Condition {
     // int status = clock_gettime(CLOCK_REALTIME, &absolute);
     struct timeval tv;
     UNUSED_ATTRIBUTE int status = gettimeofday(&tv, NULL);
-    PL_ASSERT(status == 0);
+    PELOTON_ASSERT(status == 0);
     absolute.tv_sec = tv.tv_sec + relative_time.tv_sec;
     absolute.tv_nsec = tv.tv_usec * 1000 + relative_time.tv_nsec;
     if (absolute.tv_nsec >= ONE_S_IN_NS) {
       absolute.tv_nsec -= ONE_S_IN_NS;
       absolute.tv_sec += 1;
     }
-    PL_ASSERT(0 <= absolute.tv_nsec && absolute.tv_nsec < ONE_S_IN_NS);
+    PELOTON_ASSERT(0 <= absolute.tv_nsec && absolute.tv_nsec < ONE_S_IN_NS);
 
     return Timedwait(absolute);
   }
@@ -86,7 +86,7 @@ class Condition {
    * @return
    */
   bool Timedwait(const struct timespec &absolute_time) {
-    PL_ASSERT(0 <= absolute_time.tv_nsec &&
+    PELOTON_ASSERT(0 <= absolute_time.tv_nsec &&
               absolute_time.tv_nsec < ONE_S_IN_NS);
 
     UNUSED_ATTRIBUTE int status = pthread_cond_timedwait(
@@ -94,13 +94,13 @@ class Condition {
     if (status == ETIMEDOUT) {
       return false;
     }
-    PL_ASSERT(status == 0);
+    PELOTON_ASSERT(status == 0);
     return true;
   }
 
   void Signal() {
     UNUSED_ATTRIBUTE int status = pthread_cond_signal(&cond_);
-    PL_ASSERT(status == 0);
+    PELOTON_ASSERT(status == 0);
   }
 
   /**
@@ -108,7 +108,7 @@ class Condition {
    */
   void Broadcast() {
     UNUSED_ATTRIBUTE int status = pthread_cond_broadcast(&cond_);
-    PL_ASSERT(status == 0);
+    PELOTON_ASSERT(status == 0);
   }
 
  private:

--- a/src/include/common/synchronization/mutex_latch.h
+++ b/src/include/common/synchronization/mutex_latch.h
@@ -32,30 +32,30 @@ class DirtyMutexLatch {
  public:
   DirtyMutexLatch() {
     UNUSED_ATTRIBUTE int status = pthread_mutex_init(&mutex_, NULL);
-    PL_ASSERT(status == 0);
+    PELOTON_ASSERT(status == 0);
   }
 
   ~DirtyMutexLatch() {
     UNUSED_ATTRIBUTE int status = pthread_mutex_destroy(&mutex_);
-    PL_ASSERT(status == 0);
+    PELOTON_ASSERT(status == 0);
   }
 
   void Lock() {
     UNUSED_ATTRIBUTE int status = pthread_mutex_lock(&mutex_);
-    PL_ASSERT(status == 0);
+    PELOTON_ASSERT(status == 0);
   }
 
   // Returns true if the lock is acquired.
   bool TryLock() {
     UNUSED_ATTRIBUTE int status = pthread_mutex_trylock(&mutex_);
     if (status == 0) return true;
-    PL_ASSERT(status == EBUSY);
+    PELOTON_ASSERT(status == EBUSY);
     return false;
   }
 
   void UnLock() {
     UNUSED_ATTRIBUTE int status = pthread_mutex_unlock(&mutex_);
-    PL_ASSERT(status == 0);
+    PELOTON_ASSERT(status == 0);
   }
 
   pthread_mutex_t *RawDirtyMutexLatch() { return &mutex_; }

--- a/src/include/common/thread_pool.h
+++ b/src/include/common/thread_pool.h
@@ -35,7 +35,7 @@ class ThreadPool {
                   const size_t &dedicated_thread_count) {
     current_thread_count_ = ATOMIC_VAR_INIT(0);
     pool_size_ = pool_size;
-    // PL_ASSERT(pool_size_ != 0);
+    // PELOTON_ASSERT(pool_size_ != 0);
 
     dedicated_thread_count_ = dedicated_thread_count;
 

--- a/src/include/concurrency/decentralized_epoch_manager.h
+++ b/src/include/concurrency/decentralized_epoch_manager.h
@@ -52,7 +52,7 @@ public:
 
   virtual void Reset(const uint64_t current_epoch_id) override {
     // epoch should be always larger than 0
-    PL_ASSERT(current_epoch_id != 0);
+    PELOTON_ASSERT(current_epoch_id != 0);
     current_global_epoch_id_ = current_epoch_id;
     next_txn_id_ = 0;
     snapshot_global_epoch_id_ = 1;
@@ -131,7 +131,7 @@ private:
 
   void Running() {
 
-    PL_ASSERT(is_running_ == true);
+    PELOTON_ASSERT(is_running_ == true);
 
     while (is_running_ == true) {
       // the epoch advances every EPOCH_LENGTH milliseconds.

--- a/src/include/executor/abstract_executor.h
+++ b/src/include/executor/abstract_executor.h
@@ -96,7 +96,7 @@ class AbstractExecutor {
   template <class T>
   inline const T &GetPlanNode() {
     const T *node = dynamic_cast<const T *>(node_);
-    PL_ASSERT(node);
+    PELOTON_ASSERT(node);
     return *node;
   }
 

--- a/src/include/executor/abstract_join_executor.h
+++ b/src/include/executor/abstract_join_executor.h
@@ -125,7 +125,7 @@ class AbstractJoinExecutor : public AbstractExecutor {
     if (right_tile == nullptr) {
       non_empty_tile = left_tile;
     }
-    PL_ASSERT(non_empty_tile != nullptr);
+    PELOTON_ASSERT(non_empty_tile != nullptr);
     return non_empty_tile;
   }
 

--- a/src/include/executor/logical_tile.h
+++ b/src/include/executor/logical_tile.h
@@ -195,7 +195,7 @@ class LogicalTile : public Printable {
     }
 
     inline void AddRow(size_t left_itr, size_t right_itr) {
-      PL_ASSERT(!invalid_);
+      PELOTON_ASSERT(!invalid_);
       // First, copy the elements in left logical tile's tuple
       for (size_t output_tile_column_itr = 0;
            output_tile_column_itr < left_source_->size();
@@ -214,7 +214,7 @@ class LogicalTile : public Printable {
     }
 
     inline void AddLeftNullRow(size_t right_itr) {
-      PL_ASSERT(!invalid_);
+      PELOTON_ASSERT(!invalid_);
       // Determine the number of null position list on the left
       oid_t left_pos_list_size;
       if (left_source_ == nullptr) {
@@ -240,7 +240,7 @@ class LogicalTile : public Printable {
     }
 
     inline void AddRightNullRow(size_t left_itr) {
-      PL_ASSERT(!invalid_);
+      PELOTON_ASSERT(!invalid_);
       // Determine the number of null position list on the right
       oid_t right_pos_list_size;
       if (right_source_ == nullptr) {

--- a/src/include/expression/aggregate_expression.h
+++ b/src/include/expression/aggregate_expression.h
@@ -74,7 +74,7 @@ class AggregateExpression : public AbstractExpression {
       const AbstractTuple *tuple1, UNUSED_ATTRIBUTE const AbstractTuple *tuple2,
       UNUSED_ATTRIBUTE executor::ExecutorContext *context) const override {
     // for now support only one child
-    PL_ASSERT(tuple1 != nullptr);
+    PELOTON_ASSERT(tuple1 != nullptr);
     return tuple1->GetValue(value_idx_);
   }
 
@@ -83,7 +83,7 @@ class AggregateExpression : public AbstractExpression {
                           binding_contexts) override {
     const auto &context = binding_contexts[0];
     ai_ = context->Find(value_idx_);
-    PL_ASSERT(ai_ != nullptr);
+    PELOTON_ASSERT(ai_ != nullptr);
     LOG_DEBUG("AggregateOutput Column ID %u.%u binds to AI %p (%s)", 0,
               value_idx_, ai_, ai_->name.c_str());
   }
@@ -107,7 +107,7 @@ class AggregateExpression : public AbstractExpression {
       case ExpressionType::AGGREGATE_MAX:
       case ExpressionType::AGGREGATE_MIN:
       case ExpressionType::AGGREGATE_SUM:
-        PL_ASSERT(children_.size() >= 1);
+        PELOTON_ASSERT(children_.size() >= 1);
         return_value_type_ = children_[0]->GetValueType();
         break;
       case ExpressionType::AGGREGATE_AVG:

--- a/src/include/expression/conjunction_expression.h
+++ b/src/include/expression/conjunction_expression.h
@@ -36,7 +36,7 @@ class ConjunctionExpression : public AbstractExpression {
       UNUSED_ATTRIBUTE const AbstractTuple *tuple1,
       UNUSED_ATTRIBUTE const AbstractTuple *tuple2,
       UNUSED_ATTRIBUTE executor::ExecutorContext *context) const override {
-    PL_ASSERT(children_.size() == 2);
+    PELOTON_ASSERT(children_.size() == 2);
     auto vl = children_[0]->Evaluate(tuple1, tuple2, context);
     auto vr = children_[1]->Evaluate(tuple1, tuple2, context);
     switch (exp_type_) {
@@ -45,14 +45,14 @@ class ConjunctionExpression : public AbstractExpression {
           return type::ValueFactory::GetBooleanValue(true);
         if (vl.IsFalse() || vr.IsFalse())
           return type::ValueFactory::GetBooleanValue(false);
-        return type::ValueFactory::GetBooleanValue(type::PELOTON_BOOLEAN_NULL);
+        return type::ValueFactory::GetBooleanValue(type::PELOTON_VALUE_BOOLEAN_NULL);
       }
       case (ExpressionType::CONJUNCTION_OR): {
         if (vl.IsFalse() && vr.IsFalse())
           return type::ValueFactory::GetBooleanValue(false);
         if (vl.IsTrue() || vr.IsTrue())
           return type::ValueFactory::GetBooleanValue(true);
-        return type::ValueFactory::GetBooleanValue(type::PELOTON_BOOLEAN_NULL);
+        return type::ValueFactory::GetBooleanValue(type::PELOTON_VALUE_BOOLEAN_NULL);
       }
       default:
         throw Exception("Invalid conjunction expression type.");

--- a/src/include/expression/expression_util.h
+++ b/src/include/expression/expression_util.h
@@ -147,7 +147,7 @@ class ExpressionUtil {
     // ConstantValueExpression/ParameterValueExpression, then it's removable.
     // Right now I couldn't think of other cases, so otherwise it's not handled.
     if (children_size == 0) {
-      PL_ASSERT(
+      PELOTON_ASSERT(
           expression->GetExpressionType() == ExpressionType::VALUE_TUPLE ||
           expression->GetExpressionType() == ExpressionType::VALUE_CONSTANT ||
           expression->GetExpressionType() == ExpressionType::VALUE_PARAMETER);
@@ -356,8 +356,8 @@ class ExpressionUtil {
   //  static std::vector<catalog::Column> GetReferencedColumns(
   //		  catalog::Catalog *catalog,
   //		  AbstractExpression *expr) {
-  //	  PL_ASSERT(catalog != nullptr);
-  //	  PL_ASSERT(expr != nullptr);
+  //	  PELOTON_ASSERT(catalog != nullptr);
+  //	  PELOTON_ASSERT(expr != nullptr);
   //	  std::vector<catalog::Column> columns;
   //
   //	  GetReferencedColumns(catalog, expr, columns);

--- a/src/include/expression/operator_expression.h
+++ b/src/include/expression/operator_expression.h
@@ -39,7 +39,7 @@ class OperatorExpression : public AbstractExpression {
       UNUSED_ATTRIBUTE const AbstractTuple *tuple2,
       UNUSED_ATTRIBUTE executor::ExecutorContext *context) const override {
     if (exp_type_ == ExpressionType::OPERATOR_NOT) {
-      PL_ASSERT(children_.size() == 1);
+      PELOTON_ASSERT(children_.size() == 1);
       type::Value vl = children_[0]->Evaluate(tuple1, tuple2, context);
       if (vl.IsTrue())
         return (type::ValueFactory::GetBooleanValue(false));
@@ -47,10 +47,10 @@ class OperatorExpression : public AbstractExpression {
         return (type::ValueFactory::GetBooleanValue(true));
       else
         return (
-            type::ValueFactory::GetBooleanValue(type::PELOTON_BOOLEAN_NULL));
+            type::ValueFactory::GetBooleanValue(type::PELOTON_VALUE_BOOLEAN_NULL));
     }
     if (exp_type_ == ExpressionType::OPERATOR_EXISTS) {
-      PL_ASSERT(children_.size() == 1);
+      PELOTON_ASSERT(children_.size() == 1);
       type::Value vl = children_[0]->Evaluate(tuple1, tuple2, context);
       if (vl.IsNull())
         return (type::ValueFactory::GetBooleanValue(false));
@@ -59,7 +59,7 @@ class OperatorExpression : public AbstractExpression {
     }
     if (exp_type_ == ExpressionType::OPERATOR_IS_NULL ||
         exp_type_ == ExpressionType::OPERATOR_IS_NOT_NULL) {
-      PL_ASSERT(children_.size() == 1);
+      PELOTON_ASSERT(children_.size() == 1);
       type::Value vl = children_[0]->Evaluate(tuple1, tuple2, context);
       if (exp_type_ == ExpressionType::OPERATOR_IS_NULL) {
         return type::ValueFactory::GetBooleanValue(vl.IsNull());
@@ -67,7 +67,7 @@ class OperatorExpression : public AbstractExpression {
         return type::ValueFactory::GetBooleanValue(!vl.IsNull());
       }
     }
-    PL_ASSERT(children_.size() == 2);
+    PELOTON_ASSERT(children_.size() == 2);
     type::Value vl = children_[0]->Evaluate(tuple1, tuple2, context);
     type::Value vr = children_[1]->Evaluate(tuple1, tuple2, context);
 
@@ -100,7 +100,7 @@ class OperatorExpression : public AbstractExpression {
     }
     auto type =
         std::max(children_[0]->GetValueType(), children_[1]->GetValueType());
-    PL_ASSERT(type <= type::TypeId::DECIMAL);
+    PELOTON_ASSERT(type <= type::TypeId::DECIMAL);
     return_value_type_ = type;
   }
 
@@ -127,7 +127,7 @@ class OperatorUnaryMinusExpression : public AbstractExpression {
 
   type::Value Evaluate(const AbstractTuple *tuple1, const AbstractTuple *tuple2,
                        executor::ExecutorContext *context) const override {
-    PL_ASSERT(children_.size() == 1);
+    PELOTON_ASSERT(children_.size() == 1);
     auto vl = children_[0]->Evaluate(tuple1, tuple2, context);
     type::Value zero(type::ValueFactory::GetIntegerValue(0));
     return zero.Subtract(vl);

--- a/src/include/expression/tuple_value_expression.h
+++ b/src/include/expression/tuple_value_expression.h
@@ -89,7 +89,7 @@ class TupleValueExpression : public AbstractExpression {
   // Return the attributes this expression uses
   void GetUsedAttributes(std::unordered_set<const planner::AttributeInfo *> &
                              attributes) const override {
-    PL_ASSERT(GetAttributeRef() != nullptr);
+    PELOTON_ASSERT(GetAttributeRef() != nullptr);
     attributes.insert(GetAttributeRef());
   }
 
@@ -165,7 +165,7 @@ class TupleValueExpression : public AbstractExpression {
   }
 
   std::tuple<oid_t, oid_t, oid_t> GetBoundOid() {
-    PL_ASSERT(is_bound_);
+    PELOTON_ASSERT(is_bound_);
     return bound_obj_id_;
   }
 

--- a/src/include/index/bwtree.h
+++ b/src/include/index/bwtree.h
@@ -304,11 +304,11 @@ class BwTreeBase {
     LOG_TRACE("Destroy %lu thread local slots", thread_num);
 
     // There must already be metadata allocated
-    PL_ASSERT(original_p != nullptr);
+    PELOTON_ASSERT(original_p != nullptr);
 
     // Manually call destructor
     for (size_t i = 0; i < thread_num; i++) {
-      PL_ASSERT((gc_metadata_p + i)->data.header.next_p == nullptr);
+      PELOTON_ASSERT((gc_metadata_p + i)->data.header.next_p == nullptr);
 
       (gc_metadata_p + i)->~PaddedGCMetadata();
     }
@@ -332,7 +332,7 @@ class BwTreeBase {
     // for doing alignment
     original_p = static_cast<unsigned char *>(
         malloc(CACHE_LINE_SIZE * (thread_num + 1)));
-    PL_ASSERT(original_p != nullptr);
+    PELOTON_ASSERT(original_p != nullptr);
 
     // Align the address to cache line boundary
     gc_metadata_p = reinterpret_cast<PaddedGCMetadata *>(
@@ -340,10 +340,10 @@ class BwTreeBase {
         CACHE_LINE_MASK);
 
     // Make sure it is aligned
-    PL_ASSERT(((size_t)gc_metadata_p % CACHE_LINE_SIZE) == 0);
+    PELOTON_ASSERT(((size_t)gc_metadata_p % CACHE_LINE_SIZE) == 0);
 
     // Make sure we do not overflow the chunk of memory
-    PL_ASSERT(((size_t)gc_metadata_p + thread_num * CACHE_LINE_SIZE) <=
+    PELOTON_ASSERT(((size_t)gc_metadata_p + thread_num * CACHE_LINE_SIZE) <=
               ((size_t)original_p + (thread_num + 1) * CACHE_LINE_SIZE));
 
     // At last call constructor of the class; we use placement new
@@ -486,7 +486,7 @@ class BwTreeBase {
    */
   inline GCMetaData *GetGCMetaData(int thread_id) {
     // The thread ID must be within the range
-    PL_ASSERT(thread_id >= 0 && thread_id < static_cast<int>(thread_num));
+    PELOTON_ASSERT(thread_id >= 0 && thread_id < static_cast<int>(thread_num));
 
     return &(gc_metadata_p + thread_id)->data;
   }
@@ -504,7 +504,7 @@ class BwTreeBase {
    * one thread participating into the GC process
    */
   uint64_t SummarizeGCEpoch() {
-    PL_ASSERT(thread_num >= 1);
+    PELOTON_ASSERT(thread_num >= 1);
 
     // Use the first metadata's epoch as min and update it on the fly
     uint64_t min_epoch = GetGCMetaData(0)->last_active_epoch;
@@ -1215,7 +1215,7 @@ class BwTree : public BwTreeBase {
      * since the low key node ID for leaf node is not defined
      */
     inline NodeID GetLowKeyNodeID() const {
-      PL_ASSERT(IsOnLeafDeltaChain() == false);
+      PELOTON_ASSERT(IsOnLeafDeltaChain() == false);
 
       return metadata.low_key_p->second;
     }
@@ -1856,13 +1856,13 @@ class BwTree : public BwTreeBase {
           // but since the linked list itself is supposed to be relatively short
           // even under contention, we do not worry about it right now
           meta_p = meta_p->GrowChunk();
-          PL_ASSERT(meta_p != nullptr);
+          PELOTON_ASSERT(meta_p != nullptr);
         } else {
           return p;
         }
       }
 
-      PL_ASSERT(false);
+      PELOTON_ASSERT(false);
       return nullptr;
     }
 
@@ -2047,7 +2047,7 @@ class BwTree : public BwTreeBase {
     inline void PushBack(const ElementType *copy_start_p,
                          const ElementType *copy_end_p) {
       // Make sure the loop will come to an end
-      PL_ASSERT(copy_start_p <= copy_end_p);
+      PELOTON_ASSERT(copy_start_p <= copy_end_p);
 
       while (copy_start_p != copy_end_p) {
         PushBack(*copy_start_p);
@@ -2075,7 +2075,7 @@ class BwTree : public BwTreeBase {
                                    const KeyNodeIDPair &p_high_key) {
       // Currently this is always true - if we want a larger array then
       // just remove this line
-      PL_ASSERT(size == p_item_count);
+      PELOTON_ASSERT(size == p_item_count);
 
       // Allocte memory for
       //   1. AllocationMeta (chunk)
@@ -2087,7 +2087,7 @@ class BwTree : public BwTreeBase {
       char *alloc_base =
           new char[sizeof(ElasticNode) + size * sizeof(ElementType) +
                    AllocationMeta::CHUNK_SIZE()];
-      PL_ASSERT(alloc_base != nullptr);
+      PELOTON_ASSERT(alloc_base != nullptr);
 
       // Initialize the AllocationMeta - tail points to the first byte inside
       // class ElasticNode; limit points to the first byte after class
@@ -2146,13 +2146,13 @@ class BwTree : public BwTreeBase {
      */
     static void *InlineAllocate(const KeyNodeIDPair *low_key_p, size_t size) {
       const ElasticNode *node_p = GetNodeHeader(low_key_p);
-      PL_ASSERT(&node_p->low_key == low_key_p);
+      PELOTON_ASSERT(&node_p->low_key == low_key_p);
 
       // Jump over chunk content
       AllocationMeta *meta_p = GetAllocationHeader(node_p);
 
       void *p = meta_p->Allocate(size);
-      PL_ASSERT(p != nullptr);
+      PELOTON_ASSERT(p != nullptr);
 
       return p;
     }
@@ -2162,14 +2162,14 @@ class BwTree : public BwTreeBase {
      */
     inline ElementType &At(const int index) {
       // The index must be inside the valid range
-      PL_ASSERT(index < GetSize());
+      PELOTON_ASSERT(index < GetSize());
 
       return *(Begin() + index);
     }
 
     inline const ElementType &At(const int index) const {
       // The index must be inside the valid range
-      PL_ASSERT(index < GetSize());
+      PELOTON_ASSERT(index < GetSize());
 
       return *(Begin() + index);
     }
@@ -2209,12 +2209,12 @@ class BwTree : public BwTreeBase {
       int key_num = this->GetSize();
 
       // Inner node size must be > 2 to avoid empty split node
-      PL_ASSERT(key_num >= 2);
+      PELOTON_ASSERT(key_num >= 2);
 
       // Same reason as in leaf node - since we only split inner node
       // without a delta chain on top of it, the sep list size must equal
       // the recorded item count
-      PL_ASSERT(key_num == this->GetItemCount());
+      PELOTON_ASSERT(key_num == this->GetItemCount());
 
       int split_item_index = key_num / 2;
 
@@ -2236,8 +2236,8 @@ class BwTree : public BwTreeBase {
       inner_node_p->PushBack(copy_start_it, this->End());
 
       // Since we copy exactly that many elements
-      PL_ASSERT(inner_node_p->GetSize() == sibling_size);
-      PL_ASSERT(inner_node_p->GetSize() == inner_node_p->GetItemCount());
+      PELOTON_ASSERT(inner_node_p->GetSize() == sibling_size);
+      PELOTON_ASSERT(inner_node_p->GetSize() == inner_node_p->GetItemCount());
 
       return inner_node_p;
     }
@@ -2282,7 +2282,7 @@ class BwTree : public BwTreeBase {
      */
     int FindSplitPoint(const BwTree *t) const {
       int central_index = this->GetSize() / 2;
-      PL_ASSERT(central_index > 1);
+      PELOTON_ASSERT(central_index > 1);
 
       // This will used as upper_bound and lower_bound key
       const KeyValuePair &central_kvp = this->At(central_index);
@@ -2359,7 +2359,7 @@ class BwTree : public BwTreeBase {
       // When we split a leaf node, it is certain that there is no delta
       // chain on top of it. As a result, the number of items must equal
       // the actual size of the data list
-      PL_ASSERT(this->GetSize() == this->GetItemCount());
+      PELOTON_ASSERT(this->GetSize() == this->GetItemCount());
 
       // This is the index of the actual key-value pair in data_list
       // We need to substract this value from the prefix sum in the new
@@ -2400,8 +2400,8 @@ class BwTree : public BwTreeBase {
       // Copy data item into the new node using PushBack()
       leaf_node_p->PushBack(copy_start_it, copy_end_it);
 
-      PL_ASSERT(leaf_node_p->GetSize() == sibling_size);
-      PL_ASSERT(leaf_node_p->GetSize() == leaf_node_p->GetItemCount());
+      PELOTON_ASSERT(leaf_node_p->GetSize() == sibling_size);
+      PELOTON_ASSERT(leaf_node_p->GetSize() == leaf_node_p->GetItemCount());
 
       return leaf_node_p;
     }
@@ -2530,7 +2530,7 @@ class BwTree : public BwTreeBase {
 
       // This will collect all nodes since we have adjusted the currenr thread
       // GC ID
-      PL_ASSERT(GetGCMetaData(i)->node_count == 0);
+      PELOTON_ASSERT(GetGCMetaData(i)->node_count == 0);
     }
 
     return;
@@ -2639,7 +2639,7 @@ class BwTree : public BwTreeBase {
 
     while (1) {
       node_p = next_node_p;
-      PL_ASSERT(node_p != nullptr);
+      PELOTON_ASSERT(node_p != nullptr);
 
       NodeType type = node_p->GetType();
 
@@ -2762,12 +2762,12 @@ class BwTree : public BwTreeBase {
           // has been finished)
           LOG_DEBUG("Unknown node type: %d", (int)type);
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
           return 0;
       }  // switch
     }    // while 1
 
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return 0;
   }
 
@@ -2781,12 +2781,12 @@ class BwTree : public BwTreeBase {
     LOG_TRACE("Initializing node layout for root and first page...");
 
     root_id = GetNextNodeID();
-    PL_ASSERT(root_id == 1UL);
+    PELOTON_ASSERT(root_id == 1UL);
 
     // This is important since in the iterator we will use NodeID = 2
     // as the starting point of the traversal
     first_leaf_id = GetNextNodeID();
-    PL_ASSERT(first_leaf_id == FIRST_LEAF_NODE_ID);
+    PELOTON_ASSERT(first_leaf_id == FIRST_LEAF_NODE_ID);
 
 #ifdef BWTREE_PELOTON
 
@@ -2902,8 +2902,8 @@ class BwTree : public BwTreeBase {
   inline bool InstallNodeToReplace(NodeID node_id, const BaseNode *node_p,
                                    const BaseNode *prev_p) {
     // Make sure node id is valid and does not exceed maximum
-    PL_ASSERT(node_id != INVALID_NODE_ID);
-    PL_ASSERT(node_id < MAPPING_TABLE_SIZE);
+    PELOTON_ASSERT(node_id != INVALID_NODE_ID);
+    PELOTON_ASSERT(node_id < MAPPING_TABLE_SIZE);
 
 // If idb is activated, then all operation will be blocked before
 // they could call CAS and change the key
@@ -2952,8 +2952,8 @@ class BwTree : public BwTreeBase {
    * call GetNode() once and stick to that physical pointer
    */
   inline const BaseNode *GetNode(const NodeID node_id) {
-    PL_ASSERT(node_id != INVALID_NODE_ID);
-    PL_ASSERT(node_id < MAPPING_TABLE_SIZE);
+    PELOTON_ASSERT(node_id != INVALID_NODE_ID);
+    PELOTON_ASSERT(node_id < MAPPING_TABLE_SIZE);
 
     return mapping_table[node_id].load();
   }
@@ -2991,9 +2991,9 @@ class BwTree : public BwTreeBase {
     const KeyValuePair *found_pair_p = nullptr;
 
   retry_traverse:
-    PL_ASSERT(context_p->abort_flag == false);
+    PELOTON_ASSERT(context_p->abort_flag == false);
 #ifdef BWTREE_DEBUG
-    PL_ASSERT(context_p->current_level == -1);
+    PELOTON_ASSERT(context_p->current_level == -1);
 #endif
 
     // This is the serialization point for reading/writing root node
@@ -3033,7 +3033,7 @@ class BwTree : public BwTreeBase {
         // as a double check
         // This is the only situation that this function returns
         // INVALID_NODE_ID
-        PL_ASSERT(child_node_id == INVALID_NODE_ID);
+        PELOTON_ASSERT(child_node_id == INVALID_NODE_ID);
 
         goto abort_traverse;
       }
@@ -3062,7 +3062,7 @@ class BwTree : public BwTreeBase {
 
     if (value_p == nullptr) {
       // We are using an iterator just to get a leaf page
-      PL_ASSERT(index_pair_p == nullptr);
+      PELOTON_ASSERT(index_pair_p == nullptr);
 
       // If both are nullptr then we just navigate the sibling chain
       // to find the correct node with the correct range
@@ -3096,7 +3096,7 @@ class BwTree : public BwTreeBase {
   abort_traverse:
 #ifdef BWTREE_DEBUG
 
-    PL_ASSERT(context_p->current_level >= 0);
+    PELOTON_ASSERT(context_p->current_level >= 0);
 
     context_p->current_level = -1;
 
@@ -3111,7 +3111,7 @@ class BwTree : public BwTreeBase {
 
     goto retry_traverse;
 
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return nullptr;
   }
 
@@ -3222,7 +3222,7 @@ class BwTree : public BwTreeBase {
                                      const KeyNodeIDPair *start_p,
                                      const KeyNodeIDPair *end_p) {
     // Inner node could not be empty
-    PL_ASSERT(inner_node_p->GetSize() != 0UL);
+    PELOTON_ASSERT(inner_node_p->GetSize() != 0UL);
     (void)inner_node_p;
 
     // Hopefully std::upper_bound would use binary search here
@@ -3236,7 +3236,7 @@ class BwTree : public BwTreeBase {
 //                           std::make_pair(search_key, INVALID_NODE_ID),
 //                           key_node_id_pair_cmp_obj) - 1;
 
-// PL_ASSERT(it == it2);
+// PELOTON_ASSERT(it == it2);
 #endif
 
     // Since upper_bound returns the first element > given key
@@ -3257,7 +3257,7 @@ class BwTree : public BwTreeBase {
    */
   inline NodeID LocateSeparatorByKeyBI(const KeyType &search_key,
                                        const InnerNode *inner_node_p) {
-    PL_ASSERT(inner_node_p->GetSize() != 0UL);
+    PELOTON_ASSERT(inner_node_p->GetSize() != 0UL);
     auto it = std::upper_bound(inner_node_p->Begin() + 1, inner_node_p->End(),
                                std::make_pair(search_key, INVALID_NODE_ID),
                                key_node_id_pair_cmp_obj) -
@@ -3266,7 +3266,7 @@ class BwTree : public BwTreeBase {
     if (KeyCmpEqual(it->first, search_key) == true) {
       // If search key is the low key then we know we should have already
       // gone left on the parent node
-      PL_ASSERT(it != inner_node_p->Begin());
+      PELOTON_ASSERT(it != inner_node_p->Begin());
 
       // Go to the left separator to find the left node with range < search key
       // After decreament it might or might not be the low key
@@ -3326,13 +3326,13 @@ class BwTree : public BwTreeBase {
     const BaseNode *node_p = snapshot_p->node_p;
 
     // Make sure the structure is valid
-    PL_ASSERT(snapshot_p->IsLeaf() == false);
-    PL_ASSERT(snapshot_p->node_p != nullptr);
+    PELOTON_ASSERT(snapshot_p->IsLeaf() == false);
+    PELOTON_ASSERT(snapshot_p->node_p != nullptr);
 
     // For read only workload this is always true since we do not need
     // to remember the node ID for read - read is always stateless until
     // it has reached a leaf node
-    PL_ASSERT(snapshot_p->node_id != INVALID_NODE_ID);
+    PELOTON_ASSERT(snapshot_p->node_id != INVALID_NODE_ID);
 
     LOG_TRACE("Navigating inner node delta chain...");
 
@@ -3469,7 +3469,7 @@ class BwTree : public BwTreeBase {
         default: {
           LOG_TRACE("ERROR: Unknown node type = %d", static_cast<int>(type));
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
         }
       }  // switch type
 
@@ -3477,7 +3477,7 @@ class BwTree : public BwTreeBase {
     }  // while 1
 
     // Should not reach here
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return INVALID_NODE_ID;
   }
 
@@ -3503,8 +3503,8 @@ class BwTree : public BwTreeBase {
     NodeSnapshot *snapshot_p = GetLatestNodeSnapshot(context_p);
     const BaseNode *node_p = snapshot_p->node_p;
 
-    PL_ASSERT(snapshot_p->IsLeaf() == false);
-    PL_ASSERT(snapshot_p->node_p != nullptr);
+    PELOTON_ASSERT(snapshot_p->IsLeaf() == false);
+    PELOTON_ASSERT(snapshot_p->node_p != nullptr);
     LOG_TRACE("Navigating inner node delta chain for BI...");
 
     while (1) {
@@ -3602,13 +3602,13 @@ class BwTree : public BwTreeBase {
           LOG_ERROR("ERROR: Unknown or unsupported node type = %d",
                     static_cast<int>(type));
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
         }
       }  // switch type
     }    // while 1
 
     // Should not reach here
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return INVALID_NODE_ID;
   }
 
@@ -3675,8 +3675,8 @@ class BwTree : public BwTreeBase {
     // Since consolidation would not change item count they must be equal
     // Also allocated space should be used exactly as described in the
     // construction function
-    PL_ASSERT(inner_node_p->GetSize() == node_p->GetItemCount());
-    PL_ASSERT(inner_node_p->GetSize() == inner_node_p->GetItemCount());
+    PELOTON_ASSERT(inner_node_p->GetSize() == node_p->GetItemCount());
+    PELOTON_ASSERT(inner_node_p->GetSize() == inner_node_p->GetItemCount());
 
     return inner_node_p;
   }
@@ -3727,7 +3727,7 @@ class BwTree : public BwTreeBase {
           }
 
           // Since we want to access its first element
-          PL_ASSERT(inner_node_p->GetSize() > 0);
+          PELOTON_ASSERT(inner_node_p->GetSize() > 0);
 
           // If the first element in the sep list equals the low key pair's
           // NodeID then we are at the leftmost node of the merge tree
@@ -3855,7 +3855,7 @@ class BwTree : public BwTreeBase {
         case NodeType::InnerRemoveType: {
           LOG_ERROR("ERROR: InnerRemoveNode not allowed");
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
           return;
         }  // case InnerRemoveType
         case NodeType::InnerInsertType: {
@@ -3864,7 +3864,7 @@ class BwTree : public BwTreeBase {
 
           // delta nodes must be consistent with the most up-to-date
           // node high key
-          PL_ASSERT(
+          PELOTON_ASSERT(
               (high_key_pair.second == INVALID_NODE_ID) ||
               (KeyCmpLess(insert_node_p->item.first, high_key_pair.first)));
 
@@ -3883,7 +3883,7 @@ class BwTree : public BwTreeBase {
           // this must be true
           // i.e. delta nodes must be consistent with the most up-to-date
           // node high key
-          PL_ASSERT(
+          PELOTON_ASSERT(
               (high_key_pair.second == INVALID_NODE_ID) ||
               (KeyCmpLess(delete_node_p->item.first, high_key_pair.first)));
 
@@ -3922,14 +3922,14 @@ class BwTree : public BwTreeBase {
           LOG_ERROR("ERROR: Unknown inner node type = %d",
                     static_cast<int>(type));
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
           return;
         }
       }  // switch type
     }    // while(1)
 
     // Should not get to here
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return;
   }
 
@@ -3984,7 +3984,7 @@ class BwTree : public BwTreeBase {
     NodeSnapshot *snapshot_p = GetLatestNodeSnapshot(context_p);
     const BaseNode *node_p = snapshot_p->node_p;
 
-    PL_ASSERT(snapshot_p->IsLeaf() == true);
+    PELOTON_ASSERT(snapshot_p->IsLeaf() == true);
 
     // We only collect values for this key
     const KeyType &search_key = context_p->search_key;
@@ -4101,7 +4101,7 @@ class BwTree : public BwTreeBase {
         case NodeType::LeafRemoveType: {
           LOG_ERROR("ERROR: Observed LeafRemoveNode in delta chain");
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
           PELOTON_FALLTHROUGH;
         }  // case LeafRemoveType
         case NodeType::LeafMergeType: {
@@ -4141,13 +4141,13 @@ class BwTree : public BwTreeBase {
           LOG_ERROR("ERROR: Unknown leaf delta node type: %d",
                     static_cast<int>(node_p->GetType()));
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
         }  // default
       }    // switch
     }      // while
 
     // We cannot reach here
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return;
   }
 
@@ -4189,7 +4189,7 @@ class BwTree : public BwTreeBase {
     // Snapshot pointer, node pointer, and metadata reference all need
     // updating once LoadNodeID() returns with success
     NodeSnapshot *snapshot_p = GetLatestNodeSnapshot(context_p);
-    PL_ASSERT(snapshot_p->IsLeaf() == true);
+    PELOTON_ASSERT(snapshot_p->IsLeaf() == true);
 
     const BaseNode *node_p = snapshot_p->node_p;
 
@@ -4280,7 +4280,7 @@ class BwTree : public BwTreeBase {
         case NodeType::LeafRemoveType: {
           LOG_ERROR("ERROR: Observed LeafRemoveNode in delta chain");
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
           PELOTON_FALLTHROUGH;
         }  // case LeafRemoveType
         case NodeType::LeafMergeType: {
@@ -4317,13 +4317,13 @@ class BwTree : public BwTreeBase {
           LOG_ERROR("ERROR: Unknown leaf delta node type: %d",
                     static_cast<int>(node_p->GetType()));
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
         }  // default
       }    // switch
     }      // while
 
     // We cannot reach here
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return nullptr;
   }
 
@@ -4364,7 +4364,7 @@ class BwTree : public BwTreeBase {
     NodeSnapshot *snapshot_p = GetLatestNodeSnapshot(context_p);
     const BaseNode *node_p = snapshot_p->node_p;
 
-    PL_ASSERT(snapshot_p->IsLeaf() == true);
+    PELOTON_ASSERT(snapshot_p->IsLeaf() == true);
 
     const KeyType &search_key = context_p->search_key;
 
@@ -4470,7 +4470,7 @@ class BwTree : public BwTreeBase {
         case NodeType::LeafRemoveType: {
           LOG_ERROR("ERROR: Observed LeafRemoveNode in delta chain");
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
           PELOTON_FALLTHROUGH;
         }  // case LeafRemoveType
         case NodeType::LeafMergeType: {
@@ -4505,13 +4505,13 @@ class BwTree : public BwTreeBase {
           LOG_ERROR("ERROR: Unknown leaf delta node type: %d",
                     static_cast<int>(node_p->GetType()));
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
         }  // default
       }    // switch
     }      // while
 
     // We cannot reach here
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return nullptr;
   }
 
@@ -4530,7 +4530,7 @@ class BwTree : public BwTreeBase {
    */
   LeafNode *CollectAllValuesOnLeaf(NodeSnapshot *snapshot_p,
                                    LeafNode *leaf_node_p = nullptr) {
-    PL_ASSERT(snapshot_p->IsLeaf() == true);
+    PELOTON_ASSERT(snapshot_p->IsLeaf() == true);
 
     const BaseNode *node_p = snapshot_p->node_p;
 
@@ -4544,7 +4544,7 @@ class BwTree : public BwTreeBase {
           node_p->GetLowKeyPair(), node_p->GetHighKeyPair()));
     }
 
-    PL_ASSERT(leaf_node_p != nullptr);
+    PELOTON_ASSERT(leaf_node_p != nullptr);
 
     /////////////////////////////////////////////////////////////////
     // Prepare Delta Set
@@ -4591,7 +4591,7 @@ class BwTree : public BwTreeBase {
       (void)ldn1;
       (void)ldn2;
 
-      PL_ASSERT(false);
+      PELOTON_ASSERT(false);
       return false;
     };
 
@@ -4609,7 +4609,7 @@ class BwTree : public BwTreeBase {
     CollectAllValuesOnLeafRecursive(node_p, sss, delta_set, leaf_node_p);
 
     // Item count would not change during consolidation
-    PL_ASSERT(leaf_node_p->GetSize() == node_p->GetItemCount());
+    PELOTON_ASSERT(leaf_node_p->GetSize() == node_p->GetItemCount());
 
     return leaf_node_p;
   }
@@ -4712,8 +4712,8 @@ class BwTree : public BwTreeBase {
             // we also copy the old item in leaf node
             bool item_overwritten = false;
 
-            PL_ASSERT(copy_start_index <= current_index);
-            PL_ASSERT(current_index <= copy_end_index);
+            PELOTON_ASSERT(copy_start_index <= current_index);
+            PELOTON_ASSERT(current_index <= copy_end_index);
 
             // First copy all items before the current index
             new_leaf_node_p->PushBack(leaf_node_p->Begin() + copy_start_index,
@@ -4735,7 +4735,7 @@ class BwTree : public BwTreeBase {
                 // We remove the element from sss here
                 new_leaf_node_p->PushBack(sss.PopFront()->item);
               } else {
-                PL_ASSERT(sss.GetFront()->GetType() ==
+                PELOTON_ASSERT(sss.GetFront()->GetType() ==
                           NodeType::LeafDeleteType);
 
                 // ... and here
@@ -4792,7 +4792,7 @@ class BwTree : public BwTreeBase {
         case NodeType::LeafRemoveType: {
           LOG_ERROR("ERROR: LeafRemoveNode not allowed");
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
           PELOTON_FALLTHROUGH;
         }  // case LeafRemoveType
         case NodeType::LeafSplitType: {
@@ -4819,7 +4819,7 @@ class BwTree : public BwTreeBase {
         default: {
           LOG_ERROR("ERROR: Unknown node type: %d", static_cast<int>(type));
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
         }  // default
       }    // switch
     }      // while(1)
@@ -4842,7 +4842,7 @@ class BwTree : public BwTreeBase {
    */
   static inline NodeSnapshot *GetLatestNodeSnapshot(Context *context_p) {
 #ifdef BWTREE_DEBUG
-    PL_ASSERT(context_p->current_level >= 0);
+    PELOTON_ASSERT(context_p->current_level >= 0);
 #endif
 
     return &context_p->current_snapshot;
@@ -4861,7 +4861,7 @@ class BwTree : public BwTreeBase {
   inline NodeSnapshot *GetLatestParentNodeSnapshot(Context *context_p) {
 #ifdef BWTREE_DEBUG
     // Make sure the current node has a parent
-    PL_ASSERT(context_p->current_level >= 1);
+    PELOTON_ASSERT(context_p->current_level >= 1);
 #endif
     // This is the address of the parent node
     return &context_p->parent_snapshot;
@@ -4879,7 +4879,7 @@ class BwTree : public BwTreeBase {
    */
   inline bool IsOnLeftMostChild(Context *context_p) {
 #ifdef BWTREE_DEBUG
-    PL_ASSERT(context_p->current_level >= 1);
+    PELOTON_ASSERT(context_p->current_level >= 1);
 #endif
 
     return GetLatestParentNodeSnapshot(context_p)->node_p->GetLowKeyNodeID() ==
@@ -4910,7 +4910,7 @@ class BwTree : public BwTreeBase {
     LOG_TRACE("Jumping to the left sibling");
 
 #ifdef BWTREE_DEBUG
-    PL_ASSERT(context_p->HasParentNode());
+    PELOTON_ASSERT(context_p->HasParentNode());
 #endif
 
     // Get last record which is the current node's context
@@ -4918,7 +4918,7 @@ class BwTree : public BwTreeBase {
     NodeSnapshot *snapshot_p = GetLatestNodeSnapshot(context_p);
 
     // Check currently we are on a remove node
-    PL_ASSERT(snapshot_p->node_p->IsRemoveNode());
+    PELOTON_ASSERT(snapshot_p->node_p->IsRemoveNode());
 
     // This is not necessarily true. e.g. if the parent node was merged into
     // its left sibling before we take the snapshot of its previou left child
@@ -4944,7 +4944,7 @@ class BwTree : public BwTreeBase {
 
     // Get its parent node
     NodeSnapshot *parent_snapshot_p = GetLatestParentNodeSnapshot(context_p);
-    PL_ASSERT(parent_snapshot_p->IsLeaf() == false);
+    PELOTON_ASSERT(parent_snapshot_p->IsLeaf() == false);
 
     // If the parent has changed then abort
     // This is to avoid missing InnerInsertNode which is fatal in our case
@@ -5063,10 +5063,10 @@ class BwTree : public BwTreeBase {
 
     // Assume we always use this function to traverse on the same
     // level
-    PL_ASSERT(node_p->IsOnLeafDeltaChain() == snapshot_p->IsLeaf());
+    PELOTON_ASSERT(node_p->IsOnLeafDeltaChain() == snapshot_p->IsLeaf());
 
     // Make sure we are not switching to itself
-    PL_ASSERT(snapshot_p->node_id != node_id);
+    PELOTON_ASSERT(snapshot_p->node_id != node_id);
 
     snapshot_p->node_id = node_id;
     snapshot_p->node_p = node_p;
@@ -5189,7 +5189,7 @@ class BwTree : public BwTreeBase {
       default: { return; }
     }  // switch
 
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return;
   }
 
@@ -5254,9 +5254,9 @@ class BwTree : public BwTreeBase {
    */
   void TraverseBI(Context *context_p) {
   retry_traverse:
-    PL_ASSERT(context_p->abort_flag == false);
+    PELOTON_ASSERT(context_p->abort_flag == false);
 #ifdef BWTREE_DEBUG
-    PL_ASSERT(context_p->current_level == -1);
+    PELOTON_ASSERT(context_p->current_level == -1);
 #endif
 
     NodeID start_node_id = root_id.load();
@@ -5272,7 +5272,7 @@ class BwTree : public BwTreeBase {
       NodeID child_node_id = NavigateInnerNodeBI(context_p);
       if (context_p->abort_flag == true) {
         LOG_TRACE("Navigate Inner Node abort (BI). ABORT");
-        PL_ASSERT(child_node_id == INVALID_NODE_ID);
+        PELOTON_ASSERT(child_node_id == INVALID_NODE_ID);
         goto abort_traverse;
       }
 
@@ -5301,7 +5301,7 @@ class BwTree : public BwTreeBase {
 
   abort_traverse:
 #ifdef BWTREE_DEBUG
-    PL_ASSERT(context_p->current_level >= 0);
+    PELOTON_ASSERT(context_p->current_level >= 0);
     context_p->current_level = -1;
     context_p->abort_counter++;
 #endif
@@ -5311,16 +5311,16 @@ class BwTree : public BwTreeBase {
     context_p->abort_flag = false;
     goto retry_traverse;
 
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return;
   }
 
   void TraverseReadOptimized(Context *context_p,
                              std::vector<ValueType> *value_list_p) {
   retry_traverse:
-    PL_ASSERT(context_p->abort_flag == false);
+    PELOTON_ASSERT(context_p->abort_flag == false);
 #ifdef BWTREE_DEBUG
-    PL_ASSERT(context_p->current_level == -1);
+    PELOTON_ASSERT(context_p->current_level == -1);
 #endif
     // This is the serialization point for reading/writing root node
     NodeID child_node_id = root_id.load();
@@ -5347,7 +5347,7 @@ class BwTree : public BwTreeBase {
         // as a double check
         // This is the only situation that this function returns
         // INVALID_NODE_ID
-        PL_ASSERT(child_node_id == INVALID_NODE_ID);
+        PELOTON_ASSERT(child_node_id == INVALID_NODE_ID);
 
         goto abort_traverse;
       }
@@ -5399,7 +5399,7 @@ class BwTree : public BwTreeBase {
   abort_traverse:
 #ifdef BWTREE_DEBUG
 
-    PL_ASSERT(context_p->current_level >= 0);
+    PELOTON_ASSERT(context_p->current_level >= 0);
 
     context_p->current_level = -1;
 
@@ -5413,7 +5413,7 @@ class BwTree : public BwTreeBase {
 
     goto retry_traverse;
 
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return;
   }
 
@@ -5475,7 +5475,7 @@ class BwTree : public BwTreeBase {
       return false;
     }  // if CAS succeeds/fails
 
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return false;
   }
 
@@ -5521,7 +5521,7 @@ class BwTree : public BwTreeBase {
       // The deleted node ID must resolve to a RemoveNode of either
       // Inner or Leaf category
       const BaseNode *garbage_node_p = GetNode(delete_item.second);
-      PL_ASSERT(garbage_node_p->IsRemoveNode());
+      PELOTON_ASSERT(garbage_node_p->IsRemoveNode());
 
       // Put the remove node into garbage chain
       // This will not remove the child node of the remove node, which
@@ -5558,7 +5558,7 @@ class BwTree : public BwTreeBase {
       return false;
     }
 
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return false;
   }
 
@@ -5721,7 +5721,7 @@ class BwTree : public BwTreeBase {
         } else {
           LOG_ERROR("ERROR: Illegal node type: %d", static_cast<int>(type));
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
         }  // If on type of merge node
 
         const KeyNodeIDPair *location;
@@ -5732,7 +5732,7 @@ class BwTree : public BwTreeBase {
 
         // If the item is found then next we post InnerDeleteNode
         if (found_pair_p != nullptr) {
-          PL_ASSERT(found_pair_p->second == delete_item_p->second);
+          PELOTON_ASSERT(found_pair_p->second == delete_item_p->second);
         } else {
           return;
         }
@@ -5789,7 +5789,7 @@ class BwTree : public BwTreeBase {
         }
 
 #ifdef BWTREE_DEBUG
-        PL_ASSERT(context_p->current_level >= 0);
+        PELOTON_ASSERT(context_p->current_level >= 0);
 #endif
 
         // If the parent snapshot has an invalid node ID then it must be the
@@ -5936,7 +5936,7 @@ class BwTree : public BwTreeBase {
               // InnerInsertNode) we need to abort and restart traversing
               const BaseNode *node_p = GetNode(found_item_p->second);
 
-              PL_ASSERT(node_p->GetType() == NodeType::InnerRemoveType ||
+              PELOTON_ASSERT(node_p->GetType() == NodeType::InnerRemoveType ||
                         node_p->GetType() == NodeType::LeafRemoveType);
 
 #endif
@@ -5967,7 +5967,7 @@ class BwTree : public BwTreeBase {
       }
     }  // switch
 
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return;
   }
 
@@ -5977,7 +5977,7 @@ class BwTree : public BwTreeBase {
    * This function does not check delta chain size
    */
   inline void ConsolidateLeafNode(NodeSnapshot *snapshot_p) {
-    PL_ASSERT(snapshot_p->node_p->IsOnLeafDeltaChain() == true);
+    PELOTON_ASSERT(snapshot_p->node_p->IsOnLeafDeltaChain() == true);
 
     LeafNode *leaf_node_p = CollectAllValuesOnLeaf(snapshot_p);
 
@@ -6001,7 +6001,7 @@ class BwTree : public BwTreeBase {
    * This function does not check for inner delta chain length
    */
   inline void ConsolidateInnerNode(NodeSnapshot *snapshot_p) {
-    PL_ASSERT(snapshot_p->node_p->IsOnLeafDeltaChain() == false);
+    PELOTON_ASSERT(snapshot_p->node_p->IsOnLeafDeltaChain() == false);
 
     InnerNode *inner_node_p = CollectAllSepsOnInner(snapshot_p);
 
@@ -6073,7 +6073,7 @@ class BwTree : public BwTreeBase {
       // then parent node will have non-0 depth in order to avoid being too
       // large (see FindSplitNextKey() and FindMergePrevNextKey() and
       // JumpToLeftSibling())
-      // PL_ASSERT(node_p->metadata.depth == 0);
+      // PELOTON_ASSERT(node_p->metadata.depth == 0);
 
       return;
     }
@@ -6164,7 +6164,7 @@ class BwTree : public BwTreeBase {
         }
 
         // Since we would like to access its first element to get the low key
-        PL_ASSERT(new_leaf_node_p->GetSize() > 0);
+        PELOTON_ASSERT(new_leaf_node_p->GetSize() > 0);
 
         // The split key must be a valid key
         // Note that the lowkey for leaf node is not defined, so in the
@@ -6295,7 +6295,7 @@ class BwTree : public BwTreeBase {
         const KeyType &split_key = new_inner_node_p->GetLowKey();
 
         // New node has at least one item (this is the basic requirement)
-        PL_ASSERT(new_inner_node_p->GetSize() > 0);
+        PELOTON_ASSERT(new_inner_node_p->GetSize() > 0);
 
         const KeyNodeIDPair &first_item = new_inner_node_p->At(0);
 
@@ -6304,7 +6304,7 @@ class BwTree : public BwTreeBase {
         NodeID split_key_child_node_id = first_item.second;
 
         // This must be the split key
-        PL_ASSERT(KeyCmpEqual(first_item.first, split_key));
+        PELOTON_ASSERT(KeyCmpEqual(first_item.first, split_key));
 
         // NOTE: WE FETCH THE POINTER WITHOUT HELP ALONG SINCE WE ARE
         // NOW ON ITS PARENT
@@ -6464,7 +6464,7 @@ class BwTree : public BwTreeBase {
 
     // This CAS must succeed since nobody except this thread could remove
     // the ABORT delta on parent node
-    PL_ASSERT(ret == true);
+    PELOTON_ASSERT(ret == true);
     (void)ret;
 
     // NOTE: DO NOT FORGET TO REMOVE THE ABORT AFTER
@@ -6565,7 +6565,7 @@ class BwTree : public BwTreeBase {
     const KeyNodeIDPair &low_key_pair = node_p->GetLowKeyPair();
 
     // The caller must make sure this is true
-    PL_ASSERT(node_p->GetNextNodeID() == INVALID_NODE_ID ||
+    PELOTON_ASSERT(node_p->GetNextNodeID() == INVALID_NODE_ID ||
               KeyCmpLess(search_key, node_p->GetHighKey()));
 
     while (1) {
@@ -6639,7 +6639,7 @@ class BwTree : public BwTreeBase {
             return it;
           }
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
           return nullptr;
         }  // InnerNode
         case NodeType::InnerSplitType: {
@@ -6668,13 +6668,13 @@ class BwTree : public BwTreeBase {
         default: {
           LOG_DEBUG("Unknown InnerNode type: %d", (int)node_p->GetType());
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
           return nullptr;
         }  // default
       }    // switch
     }      // while(1)
 
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return nullptr;
   }
 
@@ -6704,11 +6704,11 @@ class BwTree : public BwTreeBase {
     const BaseNode *node_p = snapshot_p->node_p;
 
     // First check that the node is always in the range of the inner node
-    PL_ASSERT(node_p->GetNextNodeID() == INVALID_NODE_ID ||
+    PELOTON_ASSERT(node_p->GetNextNodeID() == INVALID_NODE_ID ||
               KeyCmpLess(search_key, node_p->GetHighKey()));
 
     // We can only search for left sibling on inner delta chain
-    PL_ASSERT(node_p->IsOnLeafDeltaChain() == false);
+    PELOTON_ASSERT(node_p->IsOnLeafDeltaChain() == false);
 
     const InnerDataNode *data_node_list[node_p->GetDepth()];
 
@@ -6915,13 +6915,13 @@ class BwTree : public BwTreeBase {
         default: {
           LOG_ERROR("ERROR: Unknown node type = %d", static_cast<int>(type));
 
-          PL_ASSERT(false);
+          PELOTON_ASSERT(false);
         }
       }  // switch type
     }    // while 1
 
     // Should not reach here
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
     return INVALID_NODE_ID;
   }
 
@@ -7585,7 +7585,7 @@ class BwTree : public BwTreeBase {
         ClearEpoch();
       }
 
-      PL_ASSERT(head_epoch_p == nullptr);
+      PELOTON_ASSERT(head_epoch_p == nullptr);
       LOG_TRACE("Garbage Collector has finished freeing all garbage nodes");
 
 #ifdef BWTREE_DEBUG
@@ -7802,7 +7802,7 @@ class BwTree : public BwTreeBase {
 
       while (1) {
         node_p = next_node_p;
-        PL_ASSERT(node_p != nullptr);
+        PELOTON_ASSERT(node_p != nullptr);
 
         NodeType type = node_p->GetType();
 
@@ -7958,7 +7958,7 @@ class BwTree : public BwTreeBase {
             // This does not include INNER ABORT node
             LOG_ERROR("Unknown node type: %d", (int)type);
 
-            PL_ASSERT(false);
+            PELOTON_ASSERT(false);
             return;
         }  // switch
       }    // while 1
@@ -7989,7 +7989,7 @@ class BwTree : public BwTreeBase {
         // Since it could only be acquired and released by worker thread
         // the value must be >= 0
         int active_thread_count = head_epoch_p->active_thread_count.load();
-        PL_ASSERT(active_thread_count >= 0);
+        PELOTON_ASSERT(active_thread_count >= 0);
 
         // If we have seen an epoch whose count is not zero then all
         // epochs after that are protected and we stop
@@ -8212,7 +8212,7 @@ class BwTree : public BwTreeBase {
      */
     inline void IncRef() {
       ref_count++;
-      PL_ASSERT(ref_count != 0UL);
+      PELOTON_ASSERT(ref_count != 0UL);
 
       return;
     }
@@ -8240,7 +8240,7 @@ class BwTree : public BwTreeBase {
     inline void DecRef() {
       // for unsigned long the only thing we could ensure
       // is that it does not cross 0 boundary
-      PL_ASSERT(ref_count != 0UL);
+      PELOTON_ASSERT(ref_count != 0UL);
 
       ref_count--;
       if (ref_count == 0UL) {
@@ -8281,7 +8281,7 @@ class BwTree : public BwTreeBase {
       // plus data
       IteratorContext *ic_p =
           reinterpret_cast<IteratorContext *>(new char[size]);
-      PL_ASSERT(ic_p != nullptr);
+      PELOTON_ASSERT(ic_p != nullptr);
 
       // Initialize class IteratorContext part
       new (ic_p) IteratorContext{p_tree_p};
@@ -8294,7 +8294,7 @@ class BwTree : public BwTreeBase {
 
       // So after this function returns the ref count should be exactly 1
       ic_p->IncRef();
-      PL_ASSERT(ic_p->GetRefCount() == 1UL);
+      PELOTON_ASSERT(ic_p->GetRefCount() == 1UL);
 
       return ic_p;
     }
@@ -8361,14 +8361,14 @@ class BwTree : public BwTreeBase {
 
       // Load the first leaf page
       const BaseNode *node_p = p_tree_p->GetNode(FIRST_LEAF_NODE_ID);
-      PL_ASSERT(node_p != nullptr);
-      PL_ASSERT(node_p->IsOnLeafDeltaChain() == true);
+      PELOTON_ASSERT(node_p != nullptr);
+      PELOTON_ASSERT(node_p->IsOnLeafDeltaChain() == true);
 
       // Allocate space for IteratorContext + LeafNode Metadata + LeafNode data
       ic_p = IteratorContext::Get(p_tree_p, node_p);
       // This does not change after CollectAllValuesOnLeaf() is called
       kv_p = ic_p->GetLeafNode()->Begin();
-      PL_ASSERT(ic_p->GetRefCount() == 1UL);
+      PELOTON_ASSERT(ic_p->GetRefCount() == 1UL);
 
       // Use this to collect all values
       NodeSnapshot snapshot{FIRST_LEAF_NODE_ID, node_p};
@@ -8431,9 +8431,9 @@ class BwTree : public BwTreeBase {
       // If this is an empty iterator then do nothing; otherwise need to
       // release a reference to the current ic_p first
       if (ic_p == nullptr) {
-        PL_ASSERT(kv_p == nullptr);
+        PELOTON_ASSERT(kv_p == nullptr);
       } else {
-        PL_ASSERT(kv_p != nullptr);
+        PELOTON_ASSERT(kv_p != nullptr);
         ic_p->DecRef();
       }
 
@@ -8462,9 +8462,9 @@ class BwTree : public BwTreeBase {
       // For move assignment we do not touch the ref count
       // and just nullify the other object
       if (ic_p == nullptr) {
-        PL_ASSERT(kv_p == nullptr);
+        PELOTON_ASSERT(kv_p == nullptr);
       } else {
-        PL_ASSERT(kv_p != nullptr);
+        PELOTON_ASSERT(kv_p != nullptr);
       }
 
       // Add a reference to the IteratorContext
@@ -8500,7 +8500,7 @@ class BwTree : public BwTreeBase {
     bool IsEnd() const {
       // Empty iterator is naturally end iterator
       if (ic_p == nullptr) {
-        PL_ASSERT(kv_p == nullptr);
+        PELOTON_ASSERT(kv_p == nullptr);
 
         return true;
       }
@@ -8522,7 +8522,7 @@ class BwTree : public BwTreeBase {
     bool IsBegin() const {
       // This is both Begin() and End()
       if (ic_p == nullptr) {
-        PL_ASSERT(kv_p == nullptr);
+        PELOTON_ASSERT(kv_p == nullptr);
 
         return true;
       }
@@ -8542,7 +8542,7 @@ class BwTree : public BwTreeBase {
      */
     bool IsREnd() const {
       if (ic_p == nullptr) {
-        PL_ASSERT(kv_p == nullptr);
+        PELOTON_ASSERT(kv_p == nullptr);
 
         return true;
       }
@@ -8649,13 +8649,13 @@ class BwTree : public BwTreeBase {
      */
     ~ForwardIterator() {
       if (ic_p != nullptr) {
-        PL_ASSERT(kv_p != nullptr);
+        PELOTON_ASSERT(kv_p != nullptr);
         // If ic_p is not nullptr we know it is a valid reference and
         // just decrease reference counter for it. This might also call
         // destructor for ic_p instance if we release the last reference
         ic_p->DecRef();
       } else {
-        PL_ASSERT(kv_p == nullptr);
+        PELOTON_ASSERT(kv_p == nullptr);
       }
 
       return;
@@ -8748,7 +8748,7 @@ class BwTree : public BwTreeBase {
      * instance
      */
     void LowerBound(BwTree *p_tree_p, const KeyType *start_key_p) {
-      PL_ASSERT(start_key_p != nullptr);
+      PELOTON_ASSERT(start_key_p != nullptr);
       // This is required since start_key_p might be pointing inside the
       // currently buffered IteratorContext which will be destroyed
       // after new IteratorContext is created
@@ -8768,7 +8768,7 @@ class BwTree : public BwTreeBase {
 
         NodeSnapshot *snapshot_p = BwTree::GetLatestNodeSnapshot(&context);
         const BaseNode *node_p = snapshot_p->node_p;
-        PL_ASSERT(node_p->IsOnLeafDeltaChain() == true);
+        PELOTON_ASSERT(node_p->IsOnLeafDeltaChain() == true);
 
         // After this point, start_key_p from the last page becomes invalid
 
@@ -8780,7 +8780,7 @@ class BwTree : public BwTreeBase {
 
         // Refresh the IteratorContext object and also refresh kv_p
         ic_p = IteratorContext::Get(p_tree_p, node_p);
-        PL_ASSERT(ic_p->GetRefCount() == 1UL);
+        PELOTON_ASSERT(ic_p->GetRefCount() == 1UL);
 
         // Consolidate the current node and store all key value pairs
         // to the embedded leaf node
@@ -8835,12 +8835,12 @@ class BwTree : public BwTreeBase {
      *   (2) The current status must not be Begin() status
      */
     void MoveBackByOne() {
-      PL_ASSERT(kv_p != nullptr);
-      PL_ASSERT(ic_p != nullptr);
-      PL_ASSERT(IsREnd() == false);
+      PELOTON_ASSERT(kv_p != nullptr);
+      PELOTON_ASSERT(ic_p != nullptr);
+      PELOTON_ASSERT(IsREnd() == false);
 
       // This is an invalid state
-      PL_ASSERT(kv_p != ic_p->GetLeafNode()->REnd());
+      PELOTON_ASSERT(kv_p != ic_p->GetLeafNode()->REnd());
 
       // This will be used to call BwTree functions
       BwTree *tree_p = ic_p->GetTree();
@@ -8874,13 +8874,13 @@ class BwTree : public BwTreeBase {
         // We must have reached a node whose low key is less than the
         // low key we used as the search key
         // Either it has a -Inf low key, or the low key could be compared
-        PL_ASSERT((node_p->GetLowKeyPair().second == INVALID_NODE_ID) ||
+        PELOTON_ASSERT((node_p->GetLowKeyPair().second == INVALID_NODE_ID) ||
                   (tree_p->KeyCmpLess(node_p->GetLowKey(), low_key) == true));
 
         // Release the current leaf page, and
         ic_p->DecRef();
         ic_p = IteratorContext::Get(tree_p, node_p);
-        PL_ASSERT(ic_p->GetRefCount() == 1UL);
+        PELOTON_ASSERT(ic_p->GetRefCount() == 1UL);
         tree_p->CollectAllValuesOnLeaf(snapshot_p, ic_p->GetLeafNode());
 
         // Now we could safely release the reference
@@ -8929,13 +8929,13 @@ class BwTree : public BwTreeBase {
      */
     inline void MoveAheadByOne() {
       // Could not do this on an empty iterator
-      PL_ASSERT(ic_p != nullptr);
-      PL_ASSERT(kv_p != nullptr);
+      PELOTON_ASSERT(ic_p != nullptr);
+      PELOTON_ASSERT(kv_p != nullptr);
 
       // We could not be on the last page, since before calling this
       // function whether we are on the last page should be
       // checked
-      PL_ASSERT(IsEnd() == false);
+      PELOTON_ASSERT(IsEnd() == false);
 
       kv_p++;
 
@@ -8970,7 +8970,7 @@ class BwTree : public BwTreeBase {
   void AddGarbageNode(const BaseNode *node_p) {
     GarbageNode *garbage_node_p =
         new GarbageNode{GetGlobalEpoch(), (void *)(node_p)};
-    PL_ASSERT(garbage_node_p != nullptr);
+    PELOTON_ASSERT(garbage_node_p != nullptr);
 
     // Link this new node to the end of the linked list
     // and then update last_p
@@ -9024,7 +9024,7 @@ class BwTree : public BwTreeBase {
       epoch_manager.FreeEpochDeltaChain((const BaseNode *)first_p->node_p);
 
       delete first_p;
-      PL_ASSERT(GetGCMetaData(thread_id)->node_count != 0UL);
+      PELOTON_ASSERT(GetGCMetaData(thread_id)->node_count != 0UL);
       GetGCMetaData(thread_id)->node_count--;
 
       first_p = header_p->next_p;

--- a/src/include/index/compact_ints_key.h
+++ b/src/include/index/compact_ints_key.h
@@ -424,8 +424,8 @@ class CompactIntsKey {
    * to indicate index column
    */
   inline void SetFromKey(const storage::Tuple *tuple) {
-    PL_ASSERT(tuple != nullptr);
-    PL_ASSERT(tuple->GetSchema() != nullptr);
+    PELOTON_ASSERT(tuple != nullptr);
+    PELOTON_ASSERT(tuple->GetSchema() != nullptr);
 
     // Must clear previous result first
     ZeroOut();
@@ -454,7 +454,7 @@ class CompactIntsKey {
       offset = SetFromColumn(column_id, column_id, key_schema, tuple, offset);
 
       // We could either have it just after the array or inside the array
-      PL_ASSERT(offset <= key_size_byte);
+      PELOTON_ASSERT(offset <= key_size_byte);
     }
 
     return;
@@ -472,9 +472,9 @@ class CompactIntsKey {
    */
   inline void SetFromTuple(const storage::Tuple *tuple, const int *indices,
                            const catalog::Schema *key_schema) {
-    PL_ASSERT(tuple != nullptr);
-    PL_ASSERT(indices != nullptr);
-    PL_ASSERT(key_schema != nullptr);
+    PELOTON_ASSERT(tuple != nullptr);
+    PELOTON_ASSERT(indices != nullptr);
+    PELOTON_ASSERT(key_schema != nullptr);
 
     ZeroOut();
 
@@ -489,7 +489,7 @@ class CompactIntsKey {
 
       offset = SetFromColumn(key_column_id, tuple_column_id, key_schema, tuple,
                              offset);
-      PL_ASSERT(offset <= key_size_byte);
+      PELOTON_ASSERT(offset <= key_size_byte);
     }
 
     return;
@@ -502,7 +502,7 @@ class CompactIntsKey {
    */
   const storage::Tuple GetTupleForComparison(
       const catalog::Schema *key_schema) const {
-    PL_ASSERT(key_schema != nullptr);
+    PELOTON_ASSERT(key_schema != nullptr);
 
     size_t offset = 0;
     // Yes the tuple has an allocated chunk of memory and is not just a wrapper

--- a/src/include/index/generic_key.h
+++ b/src/include/index/generic_key.h
@@ -28,8 +28,8 @@ template <std::size_t KeySize>
 class GenericKey {
  public:
   inline void SetFromKey(const storage::Tuple *tuple) {
-    PL_ASSERT(tuple);
-    PL_MEMCPY(data, tuple->GetData(), tuple->GetLength());
+    PELOTON_ASSERT(tuple);
+    PELOTON_MEMCPY(data, tuple->GetData(), tuple->GetLength());
     schema = tuple->GetSchema();
   }
 

--- a/src/include/index/scan_optimizer.h
+++ b/src/include/index/scan_optimizer.h
@@ -107,12 +107,12 @@ class ConjunctionScanPredicate {
                                  const std::vector<type::Value> &new_value_list,
                                  storage::Tuple *key_p) {
     // Since we used low key and high key, this cannot be a point query
-    PL_ASSERT(is_point_query_ == false);
-    PL_ASSERT(new_value_list.size() == column_id_list.size());
+    PELOTON_ASSERT(is_point_query_ == false);
+    PELOTON_ASSERT(new_value_list.size() == column_id_list.size());
 
     // We do not accept using other keys except
     // low key and high key of this instance
-    PL_ASSERT(key_p == low_key_p_ || key_p == high_key_p_);
+    PELOTON_ASSERT(key_p == low_key_p_ || key_p == high_key_p_);
 
     int i = 0;
     for (oid_t tuple_column : column_id_list) {
@@ -121,7 +121,7 @@ class ConjunctionScanPredicate {
       UNUSED_ATTRIBUTE oid_t bind_ret =
           BindValueToIndexKey(index_p, new_value_list[i], key_p, index_column);
 
-      PL_ASSERT(bind_ret == INVALID_OID);
+      PELOTON_ASSERT(bind_ret == INVALID_OID);
       i++;
     }
 
@@ -231,7 +231,7 @@ class ConjunctionScanPredicate {
     if (low_key_p_ != nullptr) {
       delete low_key_p_;
 
-      PL_ASSERT(high_key_p_ != nullptr);
+      PELOTON_ASSERT(high_key_p_ != nullptr);
     }
 
     delete high_key_p_;
@@ -261,7 +261,7 @@ class ConjunctionScanPredicate {
                            const std::vector<oid_t> &column_id_list,
                            const std::vector<type::Value> &new_value_list) {
     // They are one to one
-    PL_ASSERT(new_value_list.size() == column_id_list.size());
+    PELOTON_ASSERT(new_value_list.size() == column_id_list.size());
 
     // This is used to address new_value_list
     int i = 0;
@@ -277,14 +277,14 @@ class ConjunctionScanPredicate {
       // late binding here
       bind_ret = BindValueToIndexKey(index_p, new_value_list[i], low_key_p_,
                                      index_column);
-      PL_ASSERT(bind_ret == INVALID_OID);
+      PELOTON_ASSERT(bind_ret == INVALID_OID);
 
       // is_point_query_ is only determined by expression type
       // Also if not point query then also bind to high key
       if (is_point_query_ == true) {
         bind_ret = BindValueToIndexKey(index_p, new_value_list[i], high_key_p_,
                                        index_column);
-        PL_ASSERT(bind_ret == INVALID_OID);
+        PELOTON_ASSERT(bind_ret == INVALID_OID);
       }
 
       i++;
@@ -376,7 +376,7 @@ class ConjunctionScanPredicate {
                              const std::vector<oid_t> &tuple_column_id_list,
                              const std::vector<ExpressionType> &expr_list) {
     // This must hold for all cases
-    PL_ASSERT(tuple_column_id_list.size() == expr_list.size());
+    PELOTON_ASSERT(tuple_column_id_list.size() == expr_list.size());
 
     // We need to check index key schema
     const IndexMetadata *metadata_p = index_p->GetMetadata();
@@ -388,7 +388,7 @@ class ConjunctionScanPredicate {
 
     // value_index_list should be of the same length as the index key
     // schema, since it maps index key column to indices inside value_list
-    PL_ASSERT(metadata_p->GetColumnCount() == value_index_list_.size());
+    PELOTON_ASSERT(metadata_p->GetColumnCount() == value_index_list_.size());
 
     LOG_TRACE("Constructing scan interval. Point query = %d", is_point_query_);
 
@@ -408,7 +408,7 @@ class ConjunctionScanPredicate {
       //
       // Also do the same for upper bound
       if (index_pair.first == INVALID_OID) {
-        PL_ASSERT(is_point_query_ == false);
+        PELOTON_ASSERT(is_point_query_ == false);
 
         // We set the value using index's varlen pool, if any VARCHAR is
         // involved (this is OK since the routine only runs for once)
@@ -466,7 +466,7 @@ class ConjunctionScanPredicate {
   void LateBind(Index *index_p, const std::vector<type::Value> &value_list,
                 const std::vector<std::pair<oid_t, oid_t>> key_bind_list,
                 storage::Tuple *index_key_p) {
-    PL_ASSERT(full_index_scan_ == false);
+    PELOTON_ASSERT(full_index_scan_ == false);
 
     // Need to check there is not out of bound access
     LOG_TRACE("value list length = %lu", value_list.size());
@@ -486,7 +486,7 @@ class ConjunctionScanPredicate {
 
       // This could not be other values since all values must be
       // valid during the binding stage
-      PL_ASSERT(bind_ret == INVALID_OID);
+      PELOTON_ASSERT(bind_ret == INVALID_OID);
       (void)bind_ret;
     }
 
@@ -510,7 +510,7 @@ class ConjunctionScanPredicate {
    */
   void LateBindValues(Index *index_p,
                       const std::vector<type::Value> &value_list) {
-    PL_ASSERT(full_index_scan_ == false);
+    PELOTON_ASSERT(full_index_scan_ == false);
 
     // Bind values to low key and high key respectively
     LateBind(index_p, value_list, low_key_bind_list_, low_key_p_);
@@ -540,8 +540,8 @@ class ConjunctionScanPredicate {
    * version of the same function to get query key for point query
    */
   inline const storage::Tuple *GetLowKey() const {
-    PL_ASSERT(is_point_query_ == false);
-    PL_ASSERT(full_index_scan_ == false);
+    PELOTON_ASSERT(is_point_query_ == false);
+    PELOTON_ASSERT(full_index_scan_ == false);
 
     return low_key_p_;
   }
@@ -553,8 +553,8 @@ class ConjunctionScanPredicate {
    * for a point query
    */
   inline const storage::Tuple *GetHighKey() const {
-    PL_ASSERT(is_point_query_ == false);
-    PL_ASSERT(full_index_scan_ == false);
+    PELOTON_ASSERT(is_point_query_ == false);
+    PELOTON_ASSERT(full_index_scan_ == false);
 
     return high_key_p_;
   }
@@ -565,8 +565,8 @@ class ConjunctionScanPredicate {
    * This function could only be called if the current query is a point query
    */
   inline const storage::Tuple *GetPointQueryKey() const {
-    PL_ASSERT(is_point_query_ == true);
-    PL_ASSERT(full_index_scan_ == false);
+    PELOTON_ASSERT(is_point_query_ == true);
+    PELOTON_ASSERT(full_index_scan_ == false);
 
     return low_key_p_;
   }
@@ -678,7 +678,7 @@ class IndexScanPredicate {
     for (ConjunctionScanPredicate &conjunction_item : conjunction_list_) {
       // This should be true since this object's index scan flag is an "OR"
       // of all elements in the array
-      PL_ASSERT(conjunction_item.IsFullIndexScan() == false);
+      PELOTON_ASSERT(conjunction_item.IsFullIndexScan() == false);
 
       conjunction_item.LateBindValues(index_p, value_list);
     }

--- a/src/include/index/tuple_key.h
+++ b/src/include/index/tuple_key.h
@@ -76,7 +76,7 @@ class TupleKey {
    * tuple given here is the key without any unused column
    */
   inline void SetFromKey(const storage::Tuple *tuple) {
-    PL_ASSERT(tuple != nullptr);
+    PELOTON_ASSERT(tuple != nullptr);
 
     // Do not use the column mapping - we use all columns in the tuple
     // as index key
@@ -92,8 +92,8 @@ class TupleKey {
   // Set a key from a table-schema tuple.
   inline void SetFromTuple(const storage::Tuple *tuple, const int *indices,
                            UNUSED_ATTRIBUTE const catalog::Schema *key_schema) {
-    PL_ASSERT(tuple);
-    PL_ASSERT(indices);
+    PELOTON_ASSERT(tuple);
+    PELOTON_ASSERT(indices);
     column_indices = indices;
     key_tuple = tuple->GetData();
     key_tuple_schema = tuple->GetSchema();

--- a/src/include/logging/log_buffer.h
+++ b/src/include/logging/log_buffer.h
@@ -33,7 +33,7 @@ public:
   LogBuffer(const size_t thread_id, const size_t eid) : 
       thread_id_(thread_id), eid_(eid), size_(0){
     data_ = new char[log_buffer_capacity_];
-    PL_MEMSET(data_, 0, log_buffer_capacity_);
+    PELOTON_MEMSET(data_, 0, log_buffer_capacity_);
   }
   ~LogBuffer() {
     delete[] data_;

--- a/src/include/logging/log_record.h
+++ b/src/include/logging/log_record.h
@@ -64,20 +64,20 @@ private:
 class LogRecordFactory {
 public:
   static LogRecord CreateTupleRecord(const LogRecordType log_type, const ItemPointer &pos) {
-    PL_ASSERT(log_type == LogRecordType::TUPLE_INSERT || 
+    PELOTON_ASSERT(log_type == LogRecordType::TUPLE_INSERT || 
               log_type == LogRecordType::TUPLE_DELETE || 
               log_type == LogRecordType::TUPLE_UPDATE);
     return LogRecord(log_type, pos, INVALID_EID, INVALID_CID);
   }
 
   static LogRecord CreateTxnRecord(const LogRecordType log_type, const cid_t commit_id) {
-    PL_ASSERT(log_type == LogRecordType::TRANSACTION_BEGIN || 
+    PELOTON_ASSERT(log_type == LogRecordType::TRANSACTION_BEGIN || 
               log_type == LogRecordType::TRANSACTION_COMMIT);
     return LogRecord(log_type, INVALID_ITEMPOINTER, INVALID_EID, commit_id);
   }
 
   static LogRecord CreateEpochRecord(const LogRecordType log_type, const eid_t epoch_id) {
-    PL_ASSERT(log_type == LogRecordType::EPOCH_BEGIN || 
+    PELOTON_ASSERT(log_type == LogRecordType::EPOCH_BEGIN || 
               log_type == LogRecordType::EPOCH_END);
     return LogRecord(log_type, INVALID_ITEMPOINTER, epoch_id, INVALID_CID);
   }

--- a/src/include/network/marshal.h
+++ b/src/include/network/marshal.h
@@ -87,7 +87,7 @@ class InputPacket {
     // Copy the data from string to packet buf
     this->len = len;
     extended_buffer_.resize(len);
-    PL_MEMCPY(extended_buffer_.data(), val.data(), len);
+    PELOTON_MEMCPY(extended_buffer_.data(), val.data(), len);
     InitializePacket();
   }
 
@@ -123,7 +123,7 @@ class InputPacket {
   inline void InitializePacket() {
     this->begin = extended_buffer_.begin();
     this->end = extended_buffer_.end();
-    PL_ASSERT(extended_buffer_.size() == len);
+    PELOTON_ASSERT(extended_buffer_.size() == len);
     is_initialized = true;
   }
 

--- a/src/include/optimizer/group.h
+++ b/src/include/optimizer/group.h
@@ -86,16 +86,16 @@ class Group {
   // This is called in rewrite phase to erase the only logical expression in the
   // group
   inline void EraseLogicalExpression() {
-    PL_ASSERT(logical_expressions_.size() == 1);
-    PL_ASSERT(physical_expressions_.size() == 0);
+    PELOTON_ASSERT(logical_expressions_.size() == 1);
+    PELOTON_ASSERT(physical_expressions_.size() == 0);
     logical_expressions_.clear();
   }
 
   // This should only be called in rewrite phase to retrieve the only logical
   // expr in the group
   inline GroupExpression *GetLogicalExpression() {
-    PL_ASSERT(logical_expressions_.size() == 1);
-    PL_ASSERT(physical_expressions_.size() == 0);
+    PELOTON_ASSERT(logical_expressions_.size() == 1);
+    PELOTON_ASSERT(physical_expressions_.size() == 0);
     return logical_expressions_[0].get();
   }
 

--- a/src/include/optimizer/stats/cost.h
+++ b/src/include/optimizer/stats/cost.h
@@ -95,7 +95,7 @@ class Cost {
    */
  //  static inline double AggregateCost(
  //      const std::shared_ptr<TableStats>& input_stats) {
- //    PL_ASSERT(input_stats != nullptr);
+ //    PELOTON_ASSERT(input_stats != nullptr);
  //    return input_stats->num_rows * DEFAULT_TUPLE_COST;
  //  }
  //

--- a/src/include/optimizer/stats/histogram.h
+++ b/src/include/optimizer/stats/histogram.h
@@ -133,7 +133,7 @@ class Histogram {
    * equal to sum of all points / max_bins.
    */
   std::vector<double> Uniform() {
-    PL_ASSERT(max_bins_ > 0);
+    PELOTON_ASSERT(max_bins_ > 0);
 
     std::vector<double> res{};
     if (bins.size() <= 1 || total_ <= 0) return res;
@@ -144,7 +144,7 @@ class Histogram {
       while (i < bins.size() - 1 && Sum(bins[i + 1].p) < s) {
         i += 1;
       }
-      PL_ASSERT(i < bins.size() - 1);
+      PELOTON_ASSERT(i < bins.size() - 1);
       double pi, pi1, mi, mi1;
       std::tie(pi, pi1, mi, mi1) = GetInterval(bins, i);
 
@@ -207,7 +207,7 @@ class Histogram {
         min_gap_idx = i;
       }
     }
-    //		PL_ASSERT(min_gap_idx >= 0 && min_gap_idx < bins.size());
+    //		PELOTON_ASSERT(min_gap_idx >= 0 && min_gap_idx < bins.size());
     Bin &prev_bin = bins[min_gap_idx];
     Bin &next_bin = bins[min_gap_idx + 1];
     prev_bin.MergeWith(next_bin);
@@ -238,7 +238,7 @@ class Histogram {
 
   inline std::tuple<double, double, double, double> GetInterval(
       std::vector<Bin> bins, uint8_t i) {
-    PL_ASSERT(i < bins.size() - 1);
+    PELOTON_ASSERT(i < bins.size() - 1);
     return std::make_tuple(bins[i].p, bins[i + 1].p, bins[i].m, bins[i + 1].m);
   }
 

--- a/src/include/optimizer/stats/hyperloglog.h
+++ b/src/include/optimizer/stats/hyperloglog.h
@@ -49,7 +49,7 @@ class HyperLogLog {
 
   // Estimate relative error for HLL.
   inline double RelativeError() {
-    PL_ASSERT(register_count_ > 0);
+    PELOTON_ASSERT(register_count_ > 0);
     return 1.04 / std::sqrt(register_count_);
   }
 

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -55,12 +55,12 @@ struct ColumnDefinition {
 
   ColumnDefinition(DataType type) : type(type) {
     // Set varlen to TEXT_MAX_LENGTH if the data type is TEXT
-    if (type == DataType::TEXT) varlen = type::PELOTON_TEXT_MAX_LEN;
+    if (type == DataType::TEXT) varlen = type::PELOTON_VALUE_TEXT_MAX_LEN;
   }
 
   ColumnDefinition(char *name, DataType type) : name(name), type(type) {
     // Set varlen to TEXT_MAX_LENGTH if the data type is TEXT
-    if (type == DataType::TEXT) varlen = type::PELOTON_TEXT_MAX_LEN;
+    if (type == DataType::TEXT) varlen = type::PELOTON_VALUE_TEXT_MAX_LEN;
   }
 
   virtual ~ColumnDefinition() {}

--- a/src/include/statistics/latency_metric.h
+++ b/src/include/statistics/latency_metric.h
@@ -76,7 +76,7 @@ class LatencyMetric : public AbstractMetric {
 
   // Returns the first latency value recorded
   inline double GetFirstLatencyValue() {
-    PL_ASSERT(latencies_.begin() != latencies_.end());
+    PELOTON_ASSERT(latencies_.begin() != latencies_.end());
     return *(latencies_.begin());
   }
 

--- a/src/include/statistics/processor_metric.h
+++ b/src/include/statistics/processor_metric.h
@@ -49,13 +49,13 @@ class ProcessorMetric : public AbstractMetric {
 
   // Get the CPU time for user execution (ms)
   inline double GetUserDuration() const {
-    PL_ASSERT(user_time_end_ - user_time_begin_ >= 0);
+    PELOTON_ASSERT(user_time_end_ - user_time_begin_ >= 0);
     return user_time_end_ - user_time_begin_;
   }
 
   // Get the CPU time for system execution (ms)
   inline double GetSystemDuration() const {
-    PL_ASSERT(sys_time_end_ - sys_time_begin_ >= 0);
+    PELOTON_ASSERT(sys_time_end_ - sys_time_begin_ >= 0);
     return sys_time_end_ - sys_time_begin_;
   }
 

--- a/src/include/storage/masked_tuple.h
+++ b/src/include/storage/masked_tuple.h
@@ -43,7 +43,7 @@ class MaskedTuple : public AbstractTuple {
   }
 
   inline void SetMask(const std::vector<oid_t> &mask) {
-    // PL_ASSERT(mask_ == nullptr);
+    // PELOTON_ASSERT(mask_ == nullptr);
     mask_ = mask;
   }
 

--- a/src/include/storage/tile_group.h
+++ b/src/include/storage/tile_group.h
@@ -131,7 +131,7 @@ class TileGroup : public Printable {
 
   // Get the tile at given offset in the tile group
   inline Tile *GetTile(const oid_t tile_offset) const {
-    PL_ASSERT(tile_offset < tile_count);
+    PELOTON_ASSERT(tile_offset < tile_count);
     Tile *tile = tiles[tile_offset].get();
     return tile;
   }
@@ -165,7 +165,7 @@ class TileGroup : public Printable {
   // the specified tile group column id.
   inline void LocateTileAndColumn(oid_t column_offset, oid_t &tile_offset,
                                   oid_t &tile_column_offset) const {
-    PL_ASSERT(column_map.count(column_offset) != 0);
+    PELOTON_ASSERT(column_map.count(column_offset) != 0);
     // get the entry in the column map
     auto entry = column_map.at(column_offset);
     tile_offset = entry.first;

--- a/src/include/storage/tile_group_header.h
+++ b/src/include/storage/tile_group_header.h
@@ -78,7 +78,7 @@ class TileGroupHeader : public Printable {
     header_size = other.header_size;
 
     // copy over all the data
-    PL_MEMCPY(data, other.data, header_size);
+    PELOTON_MEMCPY(data, other.data, header_size);
 
     num_tuple_slots = other.num_tuple_slots;
     oid_t val = other.next_tuple_slot;
@@ -141,7 +141,7 @@ class TileGroupHeader : public Printable {
 
   // Getters
   inline const TileGroup *GetTileGroup() const {
-    PL_ASSERT(tile_group);
+    PELOTON_ASSERT(tile_group);
     return tile_group;
   }
 

--- a/src/include/storage/tuple.h
+++ b/src/include/storage/tuple.h
@@ -47,20 +47,20 @@ class Tuple : public AbstractTuple {
   // Setup the tuple given a schema
   inline Tuple(const catalog::Schema *schema)
       : tuple_schema_(schema), tuple_data_(nullptr), allocated_(false) {
-    PL_ASSERT(tuple_schema_);
+    PELOTON_ASSERT(tuple_schema_);
   }
 
   // Setup the tuple given a schema and location
   inline Tuple(const catalog::Schema *schema, char *data)
       : tuple_schema_(schema), tuple_data_(data), allocated_(false) {
-    PL_ASSERT(tuple_schema_);
-    PL_ASSERT(tuple_data_);
+    PELOTON_ASSERT(tuple_schema_);
+    PELOTON_ASSERT(tuple_data_);
   }
 
   // Setup the tuple given a schema and allocate space
   inline Tuple(const catalog::Schema *schema, bool allocate)
       : tuple_schema_(schema), tuple_data_(nullptr), allocated_(allocate) {
-    PL_ASSERT(tuple_schema_);
+    PELOTON_ASSERT(tuple_schema_);
 
     if (allocated_) {
       // initialize heap allocation
@@ -234,8 +234,8 @@ class Tuple : public AbstractTuple {
 template <typename ColumnType>
 inline ColumnType Tuple::GetInlinedDataOfType(oid_t column_id) const {
   // The requested field must be inlined
-  PL_ASSERT(tuple_schema_->IsInlined(column_id) == true);
-  PL_ASSERT(column_id < GetColumnCount());
+  PELOTON_ASSERT(tuple_schema_->IsInlined(column_id) == true);
+  PELOTON_ASSERT(column_id < GetColumnCount());
 
   // Translates column ID into a pointer and converts it to the
   // requested type
@@ -247,8 +247,8 @@ inline ColumnType Tuple::GetInlinedDataOfType(oid_t column_id) const {
 
 // Setup the tuple given the specified data location and schema
 inline Tuple::Tuple(char *data, catalog::Schema *schema) {
-  PL_ASSERT(data);
-  PL_ASSERT(schema);
+  PELOTON_ASSERT(data);
+  PELOTON_ASSERT(schema);
 
   tuple_data_ = data;
   tuple_schema_ = schema;

--- a/src/include/type/byte_array.h
+++ b/src/include/type/byte_array.h
@@ -88,21 +88,21 @@ class GenericArray {
 
   // corresponds to "bar = new byte[len];" in Java
   void resetAndExpand(int newLength) {
-    PL_ASSERT(newLength >= 0);
+    PELOTON_ASSERT(newLength >= 0);
     //data_ = boost::shared_array<T>(new T[newLength]);
     data_ = std::shared_ptr<T>(new T[newLength], std::default_delete<T[]>{});
-    PL_MEMSET(data_.get(), 0, newLength * sizeof(T));
+    PELOTON_MEMSET(data_.get(), 0, newLength * sizeof(T));
     length_ = newLength;
   };
 
   // corresponds to "tmp = new byte[newlen]; System.arraycopy(bar to tmp); bar = tmp;" in Java
   void copyAndExpand(int newLength) {
-    PL_ASSERT(newLength >= 0);
-    PL_ASSERT(newLength > length_);
+    PELOTON_ASSERT(newLength >= 0);
+    PELOTON_ASSERT(newLength > length_);
     //boost::shared_array<T> newData(new T[newLength]);
     std::shared_ptr<T> newData(new T[newLength], std::default_delete<T[]>{});
-    PL_MEMSET(newData.get(), 0, newLength * sizeof(T)); // makes valgrind happy.
-    PL_MEMCPY(newData.get(), data_.get(), length_ * sizeof(T));
+    PELOTON_MEMSET(newData.get(), 0, newLength * sizeof(T)); // makes valgrind happy.
+    PELOTON_MEMCPY(newData.get(), data_.get(), length_ * sizeof(T));
     data_ = newData;
     length_ = newLength;
   };
@@ -114,15 +114,15 @@ class GenericArray {
 
   // helper functions for convenience.
   void assign(const T* assignedData, int offset, int assignedLength) {
-    PL_ASSERT(!isNull());
-    PL_ASSERT(length_ >= offset + assignedLength);
-    PL_ASSERT(offset >= 0);
-    PL_MEMCPY(data_.get() + offset, assignedData, assignedLength * sizeof(T));
+    PELOTON_ASSERT(!isNull());
+    PELOTON_ASSERT(length_ >= offset + assignedLength);
+    PELOTON_ASSERT(offset >= 0);
+    PELOTON_MEMCPY(data_.get() + offset, assignedData, assignedLength * sizeof(T));
   };
 
   GenericArray<T> operator+(const GenericArray<T> &tail) const {
-    PL_ASSERT(!isNull());
-    PL_ASSERT(!tail.isNull());
+    PELOTON_ASSERT(!isNull());
+    PELOTON_ASSERT(!tail.isNull());
     GenericArray<T> concated(this->length_ + tail.length_);
     concated.assign(this->data_.get(), 0, this->length_);
     concated.assign(tail.data_.get(), this->length_, tail.length_);
@@ -130,14 +130,14 @@ class GenericArray {
   };
 
   const T& operator[](int index) const {
-    PL_ASSERT(!isNull());
-    PL_ASSERT(length_ > index);
+    PELOTON_ASSERT(!isNull());
+    PELOTON_ASSERT(length_ > index);
     return data_.get()[index];
   };
 
   T& operator[](int index) {
-    PL_ASSERT(!isNull());
-    PL_ASSERT(length_ > index);
+    PELOTON_ASSERT(!isNull());
+    PELOTON_ASSERT(length_ > index);
     return data_.get()[index];
   };
 

--- a/src/include/type/limits.h
+++ b/src/include/type/limits.h
@@ -20,39 +20,39 @@ namespace type {
 static const double DBL_LOWEST = std::numeric_limits<double>::lowest();
 static const double FLT_LOWEST = std::numeric_limits<float>::lowest();
 
-static const int8_t PELOTON_INT8_MIN = (SCHAR_MIN + 1);
-static const int16_t PELOTON_INT16_MIN = (SHRT_MIN + 1);
-static const int32_t PELOTON_INT32_MIN = (INT_MIN + 1);
-static const int64_t PELOTON_INT64_MIN = (LLONG_MIN + 1);
-static const double PELOTON_DECIMAL_MIN = FLT_LOWEST;
-static const uint64_t PELOTON_TIMESTAMP_MIN = 0;
-static const int32_t PELOTON_DATE_MIN = (INT_MIN + 1);
-static const int8_t PELOTON_BOOLEAN_MIN = 0;
+static const int8_t PELOTON_VALUE_INT8_MIN = (SCHAR_MIN + 1);
+static const int16_t PELOTON_VALUE_INT16_MIN = (SHRT_MIN + 1);
+static const int32_t PELOTON_VALUE_INT32_MIN = (INT_MIN + 1);
+static const int64_t PELOTON_VALUE_INT64_MIN = (LLONG_MIN + 1);
+static const double PELOTON_VALUE_DECIMAL_MIN = FLT_LOWEST;
+static const uint64_t PELOTON_VALUE_TIMESTAMP_MIN = 0;
+static const int32_t PELOTON_VALUE_DATE_MIN = (INT_MIN + 1);
+static const int8_t PELOTON_VALUE_BOOLEAN_MIN = 0;
 
-static const int8_t PELOTON_INT8_MAX = SCHAR_MAX;
-static const int16_t PELOTON_INT16_MAX = SHRT_MAX;
-static const int32_t PELOTON_INT32_MAX = INT_MAX;
-static const int64_t PELOTON_INT64_MAX = LLONG_MAX;
-static const uint64_t PELOTON_UINT64_MAX = ULLONG_MAX - 1;
-static const double PELOTON_DECIMAL_MAX = DBL_MAX;
-static const uint64_t PELOTON_TIMESTAMP_MAX = 11231999986399999999U; // ???
-static const int32_t PELOTON_DATE_MAX = INT_MAX;
-static const int8_t PELOTON_BOOLEAN_MAX = 1;
+static const int8_t PELOTON_VALUE_INT8_MAX = SCHAR_MAX;
+static const int16_t PELOTON_VALUE_INT16_MAX = SHRT_MAX;
+static const int32_t PELOTON_VALUE_INT32_MAX = INT_MAX;
+static const int64_t PELOTON_VALUE_INT64_MAX = LLONG_MAX;
+static const uint64_t PELOTON_VALUE_UINT64_MAX = ULLONG_MAX - 1;
+static const double PELOTON_VALUE_DECIMAL_MAX = DBL_MAX;
+static const uint64_t PELOTON_VALUE_TIMESTAMP_MAX = 11231999986399999999U; // ???
+static const int32_t PELOTON_VALUE_DATE_MAX = INT_MAX;
+static const int8_t PELOTON_VALUE_BOOLEAN_MAX = 1;
 
 static const uint32_t PELOTON_VALUE_NULL = UINT_MAX;
-static const int8_t PELOTON_INT8_NULL = SCHAR_MIN;
-static const int16_t PELOTON_INT16_NULL = SHRT_MIN;
-static const int32_t PELOTON_INT32_NULL = INT_MIN;
-static const int64_t PELOTON_INT64_NULL = LLONG_MIN;
-static const int32_t PELOTON_DATE_NULL = INT_MIN;
-static const uint64_t PELOTON_TIMESTAMP_NULL = ULLONG_MAX;
-static const double PELOTON_DECIMAL_NULL = DBL_LOWEST;
-static const int8_t PELOTON_BOOLEAN_NULL = SCHAR_MIN;
+static const int8_t PELOTON_VALUE_INT8_NULL = SCHAR_MIN;
+static const int16_t PELOTON_VALUE_INT16_NULL = SHRT_MIN;
+static const int32_t PELOTON_VALUE_INT32_NULL = INT_MIN;
+static const int64_t PELOTON_VALUE_INT64_NULL = LLONG_MIN;
+static const int32_t PELOTON_VALUE_DATE_NULL = INT_MIN;
+static const uint64_t PELOTON_VALUE_TIMESTAMP_NULL = ULLONG_MAX;
+static const double PELOTON_VALUE_DECIMAL_NULL = DBL_LOWEST;
+static const int8_t PELOTON_VALUE_BOOLEAN_NULL = SCHAR_MIN;
 
-static const uint32_t PELOTON_VARCHAR_MAX_LEN = UINT_MAX;
+static const uint32_t PELOTON_VALUE_VARCHAR_MAX_LEN = UINT_MAX;
 
 // Use to make TEXT type as the alias of VARCHAR(TEXT_MAX_LENGTH)
-static const uint32_t PELOTON_TEXT_MAX_LEN = 1000000000;
+static const uint32_t PELOTON_VALUE_TEXT_MAX_LEN = 1000000000;
 
 // Objects (i.e., VARCHAR) with length prefix of -1 are NULL
 #define OBJECTLENGTH_NULL -1

--- a/src/include/type/serializer.h
+++ b/src/include/type/serializer.h
@@ -64,14 +64,14 @@ class ExportSerializeInput {
   inline float ReadFloat() {
     int32_t value = ReadPrimitive<int32_t>();
     float retval;
-    PL_MEMCPY(&retval, &value, sizeof(retval));
+    PELOTON_MEMCPY(&retval, &value, sizeof(retval));
     return retval;
   }
 
   inline double ReadDouble() {
     int64_t value = ReadPrimitive<int64_t>();
     double retval;
-    PL_MEMCPY(&retval, &value, sizeof(retval));
+    PELOTON_MEMCPY(&retval, &value, sizeof(retval));
     return retval;
   }
 
@@ -80,14 +80,14 @@ class ExportSerializeInput {
   const void *getRawPointer(size_t length) {
     const void *result = current_;
     current_ += length;
-    PL_ASSERT(current_ <= end_);
+    PELOTON_ASSERT(current_ <= end_);
     return result;
   }
 
   /** Copy a string from the buffer. */
   inline std::string ReadTextString() {
     int32_t stringLength = ReadInt();
-    PL_ASSERT(stringLength >= 0);
+    PELOTON_ASSERT(stringLength >= 0);
     return std::string(
         reinterpret_cast<const char *>(getRawPointer(stringLength)),
         stringLength);
@@ -95,7 +95,7 @@ class ExportSerializeInput {
 
   /** Copy the next length bytes from the buffer to destination. */
   inline void ReadBytes(void *destination, size_t length) {
-    ::PL_MEMCPY(destination, getRawPointer(length), length);
+    ::PELOTON_MEMCPY(destination, getRawPointer(length), length);
   };
 
   /** Move the Read Position back by bytes. Warning: this method is
@@ -108,7 +108,7 @@ class ExportSerializeInput {
   template <typename T>
   T ReadPrimitive() {
     T value;
-    ::PL_MEMCPY(&value, current_, sizeof(value));
+    ::PELOTON_MEMCPY(&value, current_, sizeof(value));
     current_ += sizeof(value);
     return value;
   }
@@ -129,7 +129,7 @@ class ExportSerializeOutput {
   ExportSerializeOutput(void *buffer, size_t capacity)
       : buffer_(NULL), position_(0), capacity_(0) {
     buffer_ = reinterpret_cast<char *>(buffer);
-    PL_ASSERT(position_ <= capacity);
+    PELOTON_ASSERT(position_ <= capacity);
     capacity_ = capacity;
   }
 
@@ -163,18 +163,18 @@ class ExportSerializeOutput {
 
   inline void WriteFloat(float value) {
     int32_t Data;
-    PL_MEMCPY(&Data, &value, sizeof(Data));
+    PELOTON_MEMCPY(&Data, &value, sizeof(Data));
     WritePrimitive(Data);
   }
 
   inline void WriteDouble(double value) {
     int64_t Data;
-    PL_MEMCPY(&Data, &value, sizeof(Data));
+    PELOTON_MEMCPY(&Data, &value, sizeof(Data));
     WritePrimitive(Data);
   }
 
   inline void WriteEnumInSingleByte(int value) {
-    PL_ASSERT(std::numeric_limits<int8_t>::min() <= value &&
+    PELOTON_ASSERT(std::numeric_limits<int8_t>::min() <= value &&
               value <= std::numeric_limits<int8_t>::max());
     WriteByte(static_cast<int8_t>(value));
   }
@@ -186,9 +186,9 @@ class ExportSerializeOutput {
     AssureExpand(length + sizeof(stringLength));
 
     char *current = buffer_ + position_;
-    PL_MEMCPY(current, &stringLength, sizeof(stringLength));
+    PELOTON_MEMCPY(current, &stringLength, sizeof(stringLength));
     current += sizeof(stringLength);
-    PL_MEMCPY(current, value, length);
+    PELOTON_MEMCPY(current, value, length);
     position_ += sizeof(stringLength) + length;
   }
 
@@ -198,13 +198,13 @@ class ExportSerializeOutput {
 
   inline void WriteBytes(const void *value, size_t length) {
     AssureExpand(length);
-    PL_MEMCPY(buffer_ + position_, value, length);
+    PELOTON_MEMCPY(buffer_ + position_, value, length);
     position_ += length;
   }
 
   inline void WriteZeros(size_t length) {
     AssureExpand(length);
-    PL_MEMSET(buffer_ + position_, 0, length);
+    PELOTON_MEMSET(buffer_ + position_, 0, length);
     position_ += length;
   }
 
@@ -225,7 +225,7 @@ class ExportSerializeOutput {
   template <typename T>
   void WritePrimitive(T value) {
     AssureExpand(sizeof(value));
-    PL_MEMCPY(buffer_ + position_, &value, sizeof(value));
+    PELOTON_MEMCPY(buffer_ + position_, &value, sizeof(value));
     position_ += sizeof(value);
   }
 
@@ -239,7 +239,7 @@ class ExportSerializeOutput {
     if (minimum_desired > capacity_) {
       // TODO: die
     }
-    PL_ASSERT(capacity_ >= minimum_desired);
+    PELOTON_ASSERT(capacity_ >= minimum_desired);
   }
 
   // Beginning of the buffer.

--- a/src/include/type/type_util.h
+++ b/src/include/type/type_util.h
@@ -32,10 +32,10 @@ class TypeUtil {
    */
   static inline int CompareStrings(const char* str1, int len1, const char* str2,
                                    int len2) {
-    PL_ASSERT(str1 != nullptr);
-    PL_ASSERT(len1 >= 0);
-    PL_ASSERT(str2 != nullptr);
-    PL_ASSERT(len2 >= 0);
+    PELOTON_ASSERT(str1 != nullptr);
+    PELOTON_ASSERT(len1 >= 0);
+    PELOTON_ASSERT(str2 != nullptr);
+    PELOTON_ASSERT(len2 >= 0);
     // PAVLO: 2017-04-04
     // The reason why we use memcmp here is that our inputs are
     // not null-terminated strings, so we can't use strncmp

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -176,12 +176,12 @@ class Value : public Printable {
   bool CheckComparable(const Value &o) const;
 
   inline bool IsTrue() const {
-    PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
+    PELOTON_ASSERT(GetTypeId() == TypeId::BOOLEAN);
     return (value_.boolean == 1);
   }
 
   inline bool IsFalse() const {
-    PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
+    PELOTON_ASSERT(GetTypeId() == TypeId::BOOLEAN);
     return (value_.boolean == 0);
   }
 

--- a/src/include/type/value_factory.h
+++ b/src/include/type/value_factory.h
@@ -60,7 +60,7 @@ class ValueFactory {
 
   static inline Value GetBooleanValue(CmpBool value) {
     return Value(TypeId::BOOLEAN,
-                 value == CmpBool::NULL_ ? PELOTON_BOOLEAN_NULL : (int8_t)value);
+                 value == CmpBool::NULL_ ? PELOTON_VALUE_BOOLEAN_NULL : (int8_t)value);
   }
 
   static inline Value GetBooleanValue(bool value) {
@@ -106,28 +106,28 @@ class ValueFactory {
     Value ret_value;
     switch (type_id) {
       case TypeId::BOOLEAN:
-        ret_value = GetBooleanValue(PELOTON_BOOLEAN_NULL);
+        ret_value = GetBooleanValue(PELOTON_VALUE_BOOLEAN_NULL);
         break;
       case TypeId::TINYINT:
-        ret_value = GetTinyIntValue(PELOTON_INT8_NULL);
+        ret_value = GetTinyIntValue(PELOTON_VALUE_INT8_NULL);
         break;
       case TypeId::SMALLINT:
-        ret_value = GetSmallIntValue(PELOTON_INT16_NULL);
+        ret_value = GetSmallIntValue(PELOTON_VALUE_INT16_NULL);
         break;
       case TypeId::INTEGER:
-        ret_value = GetIntegerValue(PELOTON_INT32_NULL);
+        ret_value = GetIntegerValue(PELOTON_VALUE_INT32_NULL);
         break;
       case TypeId::BIGINT:
-        ret_value = GetBigIntValue(PELOTON_INT64_NULL);
+        ret_value = GetBigIntValue(PELOTON_VALUE_INT64_NULL);
         break;
       case TypeId::DECIMAL:
-        ret_value = GetDecimalValue(PELOTON_DECIMAL_NULL);
+        ret_value = GetDecimalValue(PELOTON_VALUE_DECIMAL_NULL);
         break;
       case TypeId::TIMESTAMP:
-        ret_value = GetTimestampValue(PELOTON_TIMESTAMP_NULL);
+        ret_value = GetTimestampValue(PELOTON_VALUE_TIMESTAMP_NULL);
         break;
       case TypeId::DATE:
-        ret_value = GetDateValue(PELOTON_DATE_NULL);
+        ret_value = GetDateValue(PELOTON_VALUE_DATE_NULL);
         break;
       case TypeId::VARCHAR:
         ret_value = GetVarcharValue(nullptr, false, nullptr);
@@ -181,7 +181,7 @@ class ValueFactory {
   static inline Value CastAsBigInt(const Value &value) {
     if (Type::GetInstance(TypeId::BIGINT)->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull())
-        return ValueFactory::GetBigIntValue((int64_t)PELOTON_INT64_NULL);
+        return ValueFactory::GetBigIntValue((int64_t)PELOTON_VALUE_INT64_NULL);
       switch (value.GetTypeId()) {
         case TypeId::TINYINT:
           return ValueFactory::GetBigIntValue((int64_t)value.GetAs<int8_t>());
@@ -192,8 +192,8 @@ class ValueFactory {
         case TypeId::BIGINT:
           return ValueFactory::GetBigIntValue(value.GetAs<int64_t>());
         case TypeId::DECIMAL: {
-          if (value.GetAs<double>() > (double)PELOTON_INT64_MAX ||
-              value.GetAs<double>() < (double)PELOTON_INT64_MIN)
+          if (value.GetAs<double>() > (double)PELOTON_VALUE_INT64_MAX ||
+              value.GetAs<double>() < (double)PELOTON_VALUE_INT64_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetBigIntValue((int64_t)value.GetAs<double>());
@@ -207,7 +207,7 @@ class ValueFactory {
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           }
-          if (bigint > PELOTON_INT64_MAX || bigint < PELOTON_INT64_MIN)
+          if (bigint > PELOTON_VALUE_INT64_MAX || bigint < PELOTON_VALUE_INT64_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetBigIntValue(bigint);
@@ -224,7 +224,7 @@ class ValueFactory {
     if (Type::GetInstance(TypeId::INTEGER)
             ->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull())
-        return ValueFactory::GetIntegerValue((int32_t)PELOTON_INT32_NULL);
+        return ValueFactory::GetIntegerValue((int32_t)PELOTON_VALUE_INT32_NULL);
       switch (value.GetTypeId()) {
         case TypeId::TINYINT:
           return ValueFactory::GetIntegerValue((int32_t)value.GetAs<int8_t>());
@@ -233,15 +233,15 @@ class ValueFactory {
         case TypeId::INTEGER:
           return ValueFactory::GetIntegerValue(value.GetAs<int32_t>());
         case TypeId::BIGINT: {
-          if (value.GetAs<int64_t>() > (int64_t)PELOTON_INT32_MAX ||
-              value.GetAs<int64_t>() < (int64_t)PELOTON_INT32_MIN)
+          if (value.GetAs<int64_t>() > (int64_t)PELOTON_VALUE_INT32_MAX ||
+              value.GetAs<int64_t>() < (int64_t)PELOTON_VALUE_INT32_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetIntegerValue((int32_t)value.GetAs<int64_t>());
         }
         case TypeId::DECIMAL: {
-          if (value.GetAs<double>() > (double)PELOTON_INT32_MAX ||
-              value.GetAs<double>() < (double)PELOTON_INT32_MIN)
+          if (value.GetAs<double>() > (double)PELOTON_VALUE_INT32_MAX ||
+              value.GetAs<double>() < (double)PELOTON_VALUE_INT32_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetIntegerValue((int32_t)value.GetAs<double>());
@@ -255,7 +255,7 @@ class ValueFactory {
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           }
-          if (integer > PELOTON_INT32_MAX || integer < PELOTON_INT32_MIN)
+          if (integer > PELOTON_VALUE_INT32_MAX || integer < PELOTON_VALUE_INT32_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetIntegerValue(integer);
@@ -272,31 +272,31 @@ class ValueFactory {
     if (Type::GetInstance(TypeId::SMALLINT)
             ->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull())
-        return ValueFactory::GetSmallIntValue((int16_t)PELOTON_INT16_NULL);
+        return ValueFactory::GetSmallIntValue((int16_t)PELOTON_VALUE_INT16_NULL);
       switch (value.GetTypeId()) {
         case TypeId::TINYINT:
           return ValueFactory::GetSmallIntValue((int16_t)value.GetAs<int8_t>());
         case TypeId::SMALLINT:
           return ValueFactory::GetSmallIntValue(value.GetAs<int16_t>());
         case TypeId::INTEGER: {
-          if (value.GetAs<int32_t>() > (int32_t)PELOTON_INT16_MAX ||
-              value.GetAs<int32_t>() < (int32_t)PELOTON_INT16_MIN)
+          if (value.GetAs<int32_t>() > (int32_t)PELOTON_VALUE_INT16_MAX ||
+              value.GetAs<int32_t>() < (int32_t)PELOTON_VALUE_INT16_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetSmallIntValue(
               (int16_t)value.GetAs<int32_t>());
         }
         case TypeId::BIGINT: {
-          if (value.GetAs<int64_t>() > (int64_t)PELOTON_INT16_MAX ||
-              value.GetAs<int64_t>() < (int64_t)PELOTON_INT16_MIN)
+          if (value.GetAs<int64_t>() > (int64_t)PELOTON_VALUE_INT16_MAX ||
+              value.GetAs<int64_t>() < (int64_t)PELOTON_VALUE_INT16_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetSmallIntValue(
               (int16_t)value.GetAs<int64_t>());
         }
         case TypeId::DECIMAL: {
-          if (value.GetAs<double>() > (double)PELOTON_INT16_MAX ||
-              value.GetAs<double>() < (double)PELOTON_INT16_MIN)
+          if (value.GetAs<double>() > (double)PELOTON_VALUE_INT16_MAX ||
+              value.GetAs<double>() < (double)PELOTON_VALUE_INT16_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetSmallIntValue((int16_t)value.GetAs<double>());
@@ -310,7 +310,7 @@ class ValueFactory {
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           }
-          if (smallint < PELOTON_INT16_MIN)
+          if (smallint < PELOTON_VALUE_INT16_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetSmallIntValue(smallint);
@@ -327,34 +327,34 @@ class ValueFactory {
     if (Type::GetInstance(TypeId::TINYINT)
             ->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull())
-        return ValueFactory::GetTinyIntValue(PELOTON_INT8_NULL);
+        return ValueFactory::GetTinyIntValue(PELOTON_VALUE_INT8_NULL);
       switch (value.GetTypeId()) {
         case TypeId::TINYINT:
           return ValueFactory::GetTinyIntValue(value.GetAs<int8_t>());
         case TypeId::SMALLINT: {
-          if (value.GetAs<int16_t>() > PELOTON_INT8_MAX ||
-              value.GetAs<int16_t>() < PELOTON_INT8_MIN)
+          if (value.GetAs<int16_t>() > PELOTON_VALUE_INT8_MAX ||
+              value.GetAs<int16_t>() < PELOTON_VALUE_INT8_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetTinyIntValue((int8_t)value.GetAs<int16_t>());
         }
         case TypeId::INTEGER: {
-          if (value.GetAs<int32_t>() > (int32_t)PELOTON_INT8_MAX ||
-              value.GetAs<int32_t>() < (int32_t)PELOTON_INT8_MIN)
+          if (value.GetAs<int32_t>() > (int32_t)PELOTON_VALUE_INT8_MAX ||
+              value.GetAs<int32_t>() < (int32_t)PELOTON_VALUE_INT8_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetTinyIntValue((int8_t)value.GetAs<int32_t>());
         }
         case TypeId::BIGINT: {
-          if (value.GetAs<int64_t>() > (int64_t)PELOTON_INT8_MAX ||
-              value.GetAs<int64_t>() < (int64_t)PELOTON_INT8_MIN)
+          if (value.GetAs<int64_t>() > (int64_t)PELOTON_VALUE_INT8_MAX ||
+              value.GetAs<int64_t>() < (int64_t)PELOTON_VALUE_INT8_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetTinyIntValue((int8_t)value.GetAs<int64_t>());
         }
         case TypeId::DECIMAL: {
-          if (value.GetAs<double>() > (double)PELOTON_INT8_MAX ||
-              value.GetAs<double>() < (double)PELOTON_INT8_MIN)
+          if (value.GetAs<double>() > (double)PELOTON_VALUE_INT8_MAX ||
+              value.GetAs<double>() < (double)PELOTON_VALUE_INT8_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetTinyIntValue((int8_t)value.GetAs<double>());
@@ -368,7 +368,7 @@ class ValueFactory {
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           }
-          if (tinyint < PELOTON_INT8_MIN)
+          if (tinyint < PELOTON_VALUE_INT8_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetTinyIntValue(tinyint);
@@ -385,7 +385,7 @@ class ValueFactory {
     if (Type::GetInstance(TypeId::DECIMAL)
             ->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull())
-        return ValueFactory::GetDecimalValue((double)PELOTON_DECIMAL_NULL);
+        return ValueFactory::GetDecimalValue((double)PELOTON_VALUE_DECIMAL_NULL);
       switch (value.GetTypeId()) {
         case TypeId::TINYINT:
           return ValueFactory::GetDecimalValue((double)value.GetAs<int8_t>());
@@ -406,7 +406,7 @@ class ValueFactory {
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           }
-          if (res > PELOTON_DECIMAL_MAX || res < PELOTON_DECIMAL_MIN)
+          if (res > PELOTON_VALUE_DECIMAL_MAX || res < PELOTON_VALUE_DECIMAL_MIN)
             throw Exception(ExceptionType::OUT_OF_RANGE,
                             "Numeric value out of range.");
           return ValueFactory::GetDecimalValue(res);
@@ -445,7 +445,7 @@ class ValueFactory {
     if (Type::GetInstance(TypeId::TIMESTAMP)
             ->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull())
-        return ValueFactory::GetTimestampValue(PELOTON_TIMESTAMP_NULL);
+        return ValueFactory::GetTimestampValue(PELOTON_VALUE_TIMESTAMP_NULL);
       switch (value.GetTypeId()) {
         case TypeId::TIMESTAMP:
           return ValueFactory::GetTimestampValue(value.GetAs<uint64_t>());
@@ -517,7 +517,7 @@ class ValueFactory {
 
   static Value CastAsDate(const Value &value) {
     if (Type::GetInstance(TypeId::DATE)->IsCoercableFrom(value.GetTypeId())) {
-      if (value.IsNull()) return ValueFactory::GetDateValue(PELOTON_DATE_NULL);
+      if (value.IsNull()) return ValueFactory::GetDateValue(PELOTON_VALUE_DATE_NULL);
       switch (value.GetTypeId()) {
         case TypeId::DATE:
           return ValueFactory::GetDateValue(value.GetAs<uint32_t>());
@@ -570,7 +570,7 @@ class ValueFactory {
     if (Type::GetInstance(TypeId::BOOLEAN)
             ->IsCoercableFrom(value.GetTypeId())) {
       if (value.IsNull())
-        return ValueFactory::GetBooleanValue(PELOTON_BOOLEAN_NULL);
+        return ValueFactory::GetBooleanValue(PELOTON_VALUE_BOOLEAN_NULL);
       switch (value.GetTypeId()) {
         case TypeId::BOOLEAN:
           return ValueFactory::GetBooleanValue(value.GetAs<int8_t>());

--- a/src/include/type/value_peeker.h
+++ b/src/include/type/value_peeker.h
@@ -29,57 +29,57 @@ namespace type {
 class ValuePeeker {
  public:
   static inline int32_t PeekParameterOffset(const Value &value) {
-    PL_ASSERT(value.GetTypeId() == TypeId::PARAMETER_OFFSET);
+    PELOTON_ASSERT(value.GetTypeId() == TypeId::PARAMETER_OFFSET);
     return value.GetAs<int32_t>();
   }
   
   static inline bool PeekBoolean(const Value &value) {
-    PL_ASSERT(value.GetTypeId() == TypeId::BOOLEAN);
+    PELOTON_ASSERT(value.GetTypeId() == TypeId::BOOLEAN);
     return ((bool)value.GetAs<int8_t>());
   }
 
   static inline int8_t PeekTinyInt(const Value &value) {
-    PL_ASSERT(value.GetTypeId() == TypeId::TINYINT);
+    PELOTON_ASSERT(value.GetTypeId() == TypeId::TINYINT);
     return value.GetAs<int8_t>();
   }
 
   static inline int16_t PeekSmallInt(const Value &value) {
-    PL_ASSERT(value.GetTypeId() == TypeId::SMALLINT);
+    PELOTON_ASSERT(value.GetTypeId() == TypeId::SMALLINT);
     return value.GetAs<int16_t>();
   }
 
   static inline int32_t PeekInteger(const Value &value) {
-    PL_ASSERT(value.GetTypeId() == TypeId::INTEGER);
+    PELOTON_ASSERT(value.GetTypeId() == TypeId::INTEGER);
     return value.GetAs<int32_t>();
   }
 
   static inline int64_t PeekBigInt(const Value &value) {
-    PL_ASSERT(value.GetTypeId() == TypeId::BIGINT);
+    PELOTON_ASSERT(value.GetTypeId() == TypeId::BIGINT);
     return value.GetAs<int64_t>();
   }
 
   static inline double PeekDouble(const Value &value) {
-    PL_ASSERT(value.GetTypeId() == TypeId::DECIMAL);
+    PELOTON_ASSERT(value.GetTypeId() == TypeId::DECIMAL);
     return value.GetAs<double>();
   }
 
   static inline int32_t PeekDate(const Value &value) {
-    PL_ASSERT(value.GetTypeId() == TypeId::DATE);
+    PELOTON_ASSERT(value.GetTypeId() == TypeId::DATE);
     return value.GetAs<uint32_t>();
   }
 
   static inline uint64_t PeekTimestamp(const Value &value) {
-    PL_ASSERT(value.GetTypeId() == TypeId::TIMESTAMP);
+    PELOTON_ASSERT(value.GetTypeId() == TypeId::TIMESTAMP);
     return value.GetAs<uint64_t>();
   }
 
   static inline const char *PeekVarchar(const Value &value) {
-    PL_ASSERT(value.GetTypeId() == TypeId::VARCHAR);
+    PELOTON_ASSERT(value.GetTypeId() == TypeId::VARCHAR);
     return value.GetData();
   }
 
   static inline const char *PeekVarbinary(const Value &value) {
-    PL_ASSERT(value.GetTypeId() == TypeId::VARBINARY);
+    PELOTON_ASSERT(value.GetTypeId() == TypeId::VARBINARY);
     return value.GetData();
   }
 };

--- a/src/index/index.cpp
+++ b/src/index/index.cpp
@@ -75,7 +75,7 @@ IndexMetadata::IndexMetadata(std::string index_name, oid_t index_oid,
 
     // The tuple column must be included into key_attrs, otherwise
     // the construction argument is malformed
-    PL_ASSERT(tuple_column_id < tuple_attrs.size());
+    PELOTON_ASSERT(tuple_column_id < tuple_attrs.size());
 
     tuple_attrs[tuple_column_id] = i;
   }
@@ -173,11 +173,11 @@ oid_t Index::TupleColumnToKeyColumn(oid_t tuple_column_id) const {
   const std::vector<oid_t> &mapping = metadata->GetTupleToIndexMapping();
 
   // First check whether the table column ID is valid
-  PL_ASSERT(tuple_column_id < mapping.size());
+  PELOTON_ASSERT(tuple_column_id < mapping.size());
   oid_t key_column_id = mapping[tuple_column_id];
 
   // Then check the table column actually have a index key column
-  PL_ASSERT(key_column_id != INVALID_OID);
+  PELOTON_ASSERT(key_column_id != INVALID_OID);
 
   return key_column_id;
 }
@@ -214,8 +214,8 @@ bool Index::Compare(const AbstractTuple &index_key,
   // int diff;
 
   // The size of these three arrays must be the same
-  PL_ASSERT(tuple_column_id_list.size() == expr_list.size());
-  PL_ASSERT(expr_list.size() == value_list.size());
+  PELOTON_ASSERT(tuple_column_id_list.size() == expr_list.size());
+  PELOTON_ASSERT(expr_list.size() == value_list.size());
 
   // Need the mapping
   const IndexMetadata *metadata_p = GetMetadata();

--- a/src/index/index_factory.cpp
+++ b/src/index/index_factory.cpp
@@ -82,7 +82,7 @@ Index *IndexFactory::GetIndex(IndexMetadata *metadata) {
   } else {
     throw IndexException("Unsupported index scheme.");
   }
-  PL_ASSERT(index != nullptr);
+  PELOTON_ASSERT(index != nullptr);
 
   return (index);
 }

--- a/src/index/index_util.cpp
+++ b/src/index/index_util.cpp
@@ -101,7 +101,7 @@ bool IndexUtil::FindValueIndex(const IndexMetadata *metadata_p,
                     std::vector<std::pair<oid_t, oid_t>> &value_index_list) {
 
   // Make sure these two are consistent at least on legnth
-  PL_ASSERT(tuple_column_id_list.size() == expr_list.size());
+  PELOTON_ASSERT(tuple_column_id_list.size() == expr_list.size());
 
   // Number of columns in index key
   size_t index_column_count = metadata_p->GetColumnCount();
@@ -129,8 +129,8 @@ bool IndexUtil::FindValueIndex(const IndexMetadata *metadata_p,
       
     // Make sure the mapping exists (i.e. the tuple column is in
     // index columns)
-    PL_ASSERT(index_column_id != INVALID_OID);
-    PL_ASSERT(index_column_id < index_column_count);
+    PELOTON_ASSERT(index_column_id != INVALID_OID);
+    PELOTON_ASSERT(index_column_id < index_column_count);
     
     ExpressionType e_type = expr_list[i];
     
@@ -158,7 +158,7 @@ bool IndexUtil::FindValueIndex(const IndexMetadata *metadata_p,
         // just checking whether these two equals suffices
         if(value_index_list[index_column_id].second == \
            value_index_list[index_column_id].first) {
-          PL_ASSERT(value_index_list[index_column_id].second != INVALID_OID);
+          PELOTON_ASSERT(value_index_list[index_column_id].second != INVALID_OID);
           
           // We have seen an equality relation
           counter++;
@@ -223,7 +223,7 @@ void IndexUtil::ConstructIntervals(oid_t leading_column_id,
       // Currently if it is not >  < <= then it must be ==
       // *** I could not find BETWEEN expression in types.h so did not add it
       // into the list
-      PL_ASSERT(expr_types[i] == ExpressionType::COMPARE_EQUAL);
+      PELOTON_ASSERT(expr_types[i] == ExpressionType::COMPARE_EQUAL);
       
       nums.push_back(std::pair<type::Value, int>(values[i], -1));
       nums.push_back(std::pair<type::Value, int>(values[i], 1));
@@ -235,7 +235,7 @@ void IndexUtil::ConstructIntervals(oid_t leading_column_id,
   
   // This enforces that there must be at least one constraint on the
   // leading column, if the search is eligible for optimization
-  PL_ASSERT(nums.size() > 0);
+  PELOTON_ASSERT(nums.size() > 0);
 
   // Build intervals.
   // get some dummy value

--- a/src/logging/log_buffer.cpp
+++ b/src/logging/log_buffer.cpp
@@ -21,9 +21,9 @@ bool LogBuffer::WriteData(const char *data, size_t len) {
   if (unlikely_branch(size_ + len > log_buffer_capacity_)) {
     return false;
   } else {
-    PL_ASSERT(data);
-    PL_ASSERT(len);
-    PL_MEMCPY(data_ + size_, data, len);
+    PELOTON_ASSERT(data);
+    PELOTON_ASSERT(len);
+    PELOTON_MEMCPY(data_ + size_, data, len);
     size_ += len;
     return true;
   }

--- a/src/logging/log_buffer_pool.cpp
+++ b/src/logging/log_buffer_pool.cpp
@@ -43,17 +43,17 @@ namespace logging {
 
   // This function is called only by the corresponding logger.
   void LogBufferPool::PutBuffer(std::unique_ptr<LogBuffer> buf) {
-    PL_ASSERT(buf.get() != nullptr);
-    PL_ASSERT(buf->GetThreadId() == thread_id_);
+    PELOTON_ASSERT(buf.get() != nullptr);
+    PELOTON_ASSERT(buf->GetThreadId() == thread_id_);
 
     size_t tail_idx = tail_ % buffer_queue_size_;
     
     // The buffer pool must not be full
-    PL_ASSERT(tail_idx != head_ % buffer_queue_size_);
+    PELOTON_ASSERT(tail_idx != head_ % buffer_queue_size_);
     // The tail pos must be null
-    PL_ASSERT(local_buffer_queue_[tail_idx].get() == nullptr);
+    PELOTON_ASSERT(local_buffer_queue_[tail_idx].get() == nullptr);
     // The returned buffer must be empty
-    PL_ASSERT(buf->Empty() == true);
+    PELOTON_ASSERT(buf->Empty() == true);
     local_buffer_queue_[tail_idx].reset(buf.release());
     
     tail_.fetch_add(1, std::memory_order_relaxed);

--- a/src/main/logger/logger.cpp
+++ b/src/main/logger/logger.cpp
@@ -79,7 +79,7 @@
 //   //===--------------------------------------------------------------------===//
 //   else if (logging::LoggingUtil::IsBasedOnWriteBehindLogging(peloton_logging_mode)) {
 //     LOG_ERROR("currently, we do not support write behind logging.");
-//     PL_ASSERT(false);
+//     PELOTON_ASSERT(false);
 //     // Test a simple log process
 //     PrepareLogFile();
 

--- a/src/main/logger/logger_workload.cpp
+++ b/src/main/logger/logger_workload.cpp
@@ -257,7 +257,7 @@
 //         logging::WriteAheadFrontendLogger::wal_directory_path);
 //   } else {
 //     LOG_ERROR("currently, we do not support write behind logging.");
-//     PL_ASSERT(false);
+//     PELOTON_ASSERT(false);
 //   }
 
 //   UNUSED_ATTRIBUTE auto& checkpoint_manager =

--- a/src/main/tpcc/tpcc.cpp
+++ b/src/main/tpcc/tpcc.cpp
@@ -76,12 +76,12 @@ void RunBenchmark() {
 
   // join all gc threads
   for (auto &gc_thread : gc_threads) {
-    PL_ASSERT(gc_thread != nullptr);
+    PELOTON_ASSERT(gc_thread != nullptr);
     gc_thread->join();
   }
 
   // join epoch thread
-  PL_ASSERT(epoch_thread != nullptr);
+  PELOTON_ASSERT(epoch_thread != nullptr);
   epoch_thread->join();
 
 

--- a/src/main/tpcc/tpcc_loader.cpp
+++ b/src/main/tpcc/tpcc_loader.cpp
@@ -1012,7 +1012,7 @@ NURandConstant::NURandConstant() {
 
 // A non-uniform random number, as defined by TPC-C 2.1.6. (page 20).
 int GetNURand(int a, int x, int y) {
-  PL_ASSERT(x <= y);
+  PELOTON_ASSERT(x <= y);
   int c = nu_rand_const.c_last;
 
   if (a == 255) {
@@ -1022,7 +1022,7 @@ int GetNURand(int a, int x, int y) {
   } else if (a == 8191) {
     c = nu_rand_const.order_line_itme_id;
   } else {
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
   }
 
   return (((GetRandomInteger(0, a) | GetRandomInteger(x, y)) + c) %
@@ -1032,7 +1032,7 @@ int GetNURand(int a, int x, int y) {
 
 // A last name as defined by TPC-C 4.3.2.3. Not actually random.
 std::string GetLastName(int number) {
-  PL_ASSERT(number >= 0 && number <= 999);
+  PELOTON_ASSERT(number >= 0 && number <= 999);
 
   int idx1 = number / 100;
   int idx2 = (number / 10 % 10);
@@ -1102,8 +1102,8 @@ double GetRandomDouble(const double lower_bound, const double upper_bound) {
 }
 
 double GetRandomFixedPoint(int decimal_places, double minimum, double maximum) {
-  PL_ASSERT(decimal_places > 0);
-  PL_ASSERT(minimum < maximum);
+  PELOTON_ASSERT(decimal_places > 0);
+  PELOTON_ASSERT(minimum < maximum);
 
   int multiplier = 1;
   for (int i = 0; i < decimal_places; ++i) {
@@ -1271,7 +1271,7 @@ std::unique_ptr<storage::Tuple> BuildCustomerTuple(
     const int customer_id, const int district_id, const int warehouse_id,
     const std::unique_ptr<type::AbstractPool> &pool) {
   // Customer id begins from 0
-  PL_ASSERT(customer_id >= 0 && customer_id < state.customers_per_district);
+  PELOTON_ASSERT(customer_id >= 0 && customer_id < state.customers_per_district);
 
   auto customer_table_schema = customer_table->GetSchema();
   std::unique_ptr<storage::Tuple> customer_tuple(
@@ -1488,7 +1488,7 @@ std::unique_ptr<storage::Tuple> BuildOrderLineTuple(
   // OL_DELIVERY_D
   int64_t ol_delivery_d = GetTimeStamp();
   if (new_order == true) {
-    ol_delivery_d = type::PELOTON_INT64_MIN;
+    ol_delivery_d = type::PELOTON_VALUE_INT64_MIN;
   }
   order_line_tuple->SetValue(6, type::ValueFactory::GetTimestampValue(ol_delivery_d),
                              nullptr);

--- a/src/main/tpcc/tpcc_new_order.cpp
+++ b/src/main/tpcc/tpcc_new_order.cpp
@@ -177,7 +177,7 @@ bool RunNewOrder(const size_t &thread_id){
 
     if (gii_lists_values.size() != 1) {
       LOG_ERROR("getItemInfo return size incorrect : %lu", gii_lists_values.size());
-      PL_ASSERT(false);
+      PELOTON_ASSERT(false);
     }
 
   }
@@ -220,7 +220,7 @@ bool RunNewOrder(const size_t &thread_id){
 
   if (gwtr_lists_values.size() != 1) {
     LOG_ERROR("getWarehouseTaxRate return size incorrect : %lu", gwtr_lists_values.size());
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
   }
 
   UNUSED_ATTRIBUTE auto w_tax = gwtr_lists_values[0][0];
@@ -270,7 +270,7 @@ bool RunNewOrder(const size_t &thread_id){
 
   if (gd_lists_values.size() != 1) {
     LOG_ERROR("getDistrict return size incorrect : %lu", gd_lists_values.size());
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
   }
 
   UNUSED_ATTRIBUTE auto d_tax = gd_lists_values[0][0];
@@ -326,7 +326,7 @@ bool RunNewOrder(const size_t &thread_id){
 
   if (gc_lists_values.size() != 1) {
     LOG_ERROR("getCustomer return size incorrect : %lu", gc_lists_values.size());
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
   }
 
   UNUSED_ATTRIBUTE auto c_last = gc_lists_values[0][0];
@@ -508,7 +508,7 @@ bool RunNewOrder(const size_t &thread_id){
 
     if (gsi_lists_values.size() != 1) {
       LOG_ERROR("getStockInfo return size incorrect : %lu", gsi_lists_values.size());
-      PL_ASSERT(false);
+      PELOTON_ASSERT(false);
     }
 
     int s_quantity = type::ValuePeeker::PeekInteger(gsi_lists_values[0][0]);
@@ -629,7 +629,7 @@ bool RunNewOrder(const size_t &thread_id){
   }
 
   // transaction passed execution.
-  PL_ASSERT(txn->GetResult() == ResultType::SUCCESS);
+  PELOTON_ASSERT(txn->GetResult() == ResultType::SUCCESS);
 
   auto result = txn_manager.CommitTransaction(txn);
 
@@ -640,7 +640,7 @@ bool RunNewOrder(const size_t &thread_id){
     
   } else {
     // transaction failed commitment.
-    PL_ASSERT(result == ResultType::ABORTED ||
+    PELOTON_ASSERT(result == ResultType::ABORTED ||
            result == ResultType::FAILURE);
     LOG_TRACE("abort txn, thread_id = %d, d_id = %d, next_o_id = %d", (int)thread_id, (int)district_id, (int)type::ValuePeeker::PeekInteger(d_next_o_id));
     return false;

--- a/src/main/tpcc/tpcc_order_status.cpp
+++ b/src/main/tpcc/tpcc_order_status.cpp
@@ -153,11 +153,11 @@ bool RunOrderStatus(const size_t &thread_id){
 
     if (result.size() == 0) {
       LOG_ERROR("wrong result size : %lu", result.size());
-      PL_ASSERT(false);
+      PELOTON_ASSERT(false);
     }
     if (result[0].size() == 0) {
       LOG_ERROR("wrong result[0] size : %lu", result[0].size());
-      PL_ASSERT(false);
+      PELOTON_ASSERT(false);
     }
   } else {
     LOG_ERROR("getCustomersByLastName: SELECT C_ID, C_FIRST, C_MIDDLE, C_LAST, C_BALANCE FROM CUSTOMER WHERE C_W_ID = ? AND C_D_ID = ? AND C_LAST = ? ORDER BY C_FIRST, # w_id, d_id, c_last");
@@ -207,17 +207,17 @@ bool RunOrderStatus(const size_t &thread_id){
       return false;
     }
 
-    PL_ASSERT(result.size() > 0);
+    PELOTON_ASSERT(result.size() > 0);
     // Get the middle one
     size_t name_count = result.size();
     auto &customer = result[name_count/2];
-    PL_ASSERT(customer.size() > 0);
+    PELOTON_ASSERT(customer.size() > 0);
     c_id = type::ValuePeeker::PeekInteger(customer[0]);
   }
 
   if (c_id < 0) {
     LOG_ERROR("wrong c_id");
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
   }
 
   LOG_TRACE("getLastOrder: SELECT O_ID, O_CARRIER_ID, O_ENTRY_D FROM ORDERS WHERE O_W_ID = ? AND O_D_ID = ? AND O_C_ID = ? ORDER BY O_ID DESC LIMIT 1, # w_id, d_id, c_id");
@@ -309,7 +309,7 @@ bool RunOrderStatus(const size_t &thread_id){
     }
   }
 
-  PL_ASSERT(txn->GetResult() == ResultType::SUCCESS);
+  PELOTON_ASSERT(txn->GetResult() == ResultType::SUCCESS);
 
   auto result = txn_manager.CommitTransaction(txn);
 

--- a/src/main/tpcc/tpcc_payment.cpp
+++ b/src/main/tpcc/tpcc_payment.cpp
@@ -122,7 +122,7 @@ bool RunPayment(const size_t &thread_id){
   // 15%: paying through another warehouse
   else {
     customer_warehouse_id = GetRandomIntegerExcluding(0, state.warehouse_count - 1, warehouse_id);
-    PL_ASSERT(customer_warehouse_id != warehouse_id);
+    PELOTON_ASSERT(customer_warehouse_id != warehouse_id);
     customer_district_id = GetRandomInteger(0, state.districts_per_warehouse - 1);
   }
 
@@ -194,13 +194,13 @@ bool RunPayment(const size_t &thread_id){
     }
 
     if (customer_list.size() != 1) {
-      PL_ASSERT(false);
+      PELOTON_ASSERT(false);
     }
 
     customer = customer_list[0];
 
   } else {
-    PL_ASSERT(customer_lastname.empty() == false);
+    PELOTON_ASSERT(customer_lastname.empty() == false);
 
     LOG_TRACE("getCustomersByLastName: WHERE C_W_ID = ? AND C_D_ID = ? AND C_LAST = ? ORDER BY C_FIRST, # w_id = %d, d_id = %d, c_last = %s", warehouse_id, district_id, customer_lastname.c_str());
 
@@ -222,7 +222,7 @@ bool RunPayment(const size_t &thread_id){
     customer_key_values.push_back(type::ValueFactory::GetVarcharValue(customer_lastname).Copy());
 
     auto customer_skey_index = customer_table->GetIndexWithOid(customer_table_skey_index_oid);
-    PL_ASSERT(customer_skey_index != nullptr);
+    PELOTON_ASSERT(customer_skey_index != nullptr);
 
     planner::IndexScanPlan::IndexScanDesc customer_index_scan_desc(
       customer_skey_index, customer_key_column_ids, customer_expr_types,
@@ -245,7 +245,7 @@ bool RunPayment(const size_t &thread_id){
 
     if (customer_list.size() < 1) {
       LOG_INFO("C_W_ID=%d, C_D_ID=%d", warehouse_id, district_id);
-      PL_ASSERT(false);
+      PELOTON_ASSERT(false);
     }
 
     // Get the midpoint customer's id
@@ -290,7 +290,7 @@ bool RunPayment(const size_t &thread_id){
   }
 
   if (warehouse_list.size() != 1) {
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
   }
 
 
@@ -335,7 +335,7 @@ bool RunPayment(const size_t &thread_id){
   }
 
   if (district_list.size() != 1) {
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
   }
 
   
@@ -656,14 +656,14 @@ bool RunPayment(const size_t &thread_id){
     return false;
   }
 
-  PL_ASSERT(txn->GetResult() == ResultType::SUCCESS);
+  PELOTON_ASSERT(txn->GetResult() == ResultType::SUCCESS);
 
   auto result = txn_manager.CommitTransaction(txn);
 
   if (result == ResultType::SUCCESS) {
     return true;
   } else {
-    PL_ASSERT(result == ResultType::ABORTED || 
+    PELOTON_ASSERT(result == ResultType::ABORTED || 
            result == ResultType::FAILURE);
     return false;
   }

--- a/src/main/tpcc/tpcc_stock_level.cpp
+++ b/src/main/tpcc/tpcc_stock_level.cpp
@@ -135,7 +135,7 @@ bool RunStockLevel(const size_t &thread_id) {
   }
   if (districts.size() != 1) {
     LOG_ERROR("incorrect districts size : %lu", districts.size());
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
   }
 
   type::Value  o_id = districts[0][0];
@@ -246,7 +246,7 @@ bool RunStockLevel(const size_t &thread_id) {
   }
   LOG_TRACE("number of distinct items=%lu", distinct_items.size());
 
-  PL_ASSERT(txn->GetResult() == ResultType::SUCCESS);
+  PELOTON_ASSERT(txn->GetResult() == ResultType::SUCCESS);
 
   auto result = txn_manager.CommitTransaction(txn);
 

--- a/src/main/tpcc/tpcc_workload.cpp
+++ b/src/main/tpcc/tpcc_workload.cpp
@@ -243,10 +243,10 @@ void RunWorkload() {
   size_t num_threads = state.backend_count;
   
   abort_counts = new PadInt[num_threads];
-  PL_MEMSET(abort_counts, 0, sizeof(PadInt) * num_threads);
+  PELOTON_MEMSET(abort_counts, 0, sizeof(PadInt) * num_threads);
 
   commit_counts = new PadInt[num_threads];
-  PL_MEMSET(commit_counts, 0, sizeof(PadInt) * num_threads);
+  PELOTON_MEMSET(commit_counts, 0, sizeof(PadInt) * num_threads);
 
   size_t profile_round = (size_t)(state.duration / state.profile_duration);
 
@@ -269,9 +269,9 @@ void RunWorkload() {
   for (size_t round_id = 0; round_id < profile_round; ++round_id) {
     std::this_thread::sleep_for(
         std::chrono::milliseconds(int(state.profile_duration * 1000)));
-    PL_MEMCPY(abort_counts_profiles[round_id], abort_counts,
+    PELOTON_MEMCPY(abort_counts_profiles[round_id], abort_counts,
            sizeof(PadInt) * num_threads);
-    PL_MEMCPY(commit_counts_profiles[round_id], commit_counts,
+    PELOTON_MEMCPY(commit_counts_profiles[round_id], commit_counts,
            sizeof(PadInt) * num_threads);
     
     auto& manager = catalog::Manager::GetInstance();

--- a/src/main/tpch/tpch_database.cpp
+++ b/src/main/tpch/tpch_database.cpp
@@ -64,7 +64,7 @@ void ForEachLine(const std::string fname, std::function<void(char *)> cb) {
 
     size_t tail_size = end - line_start;
     if (tail_size > 0) {
-      PL_MEMCPY(buffer, line_start, tail_size);
+      PELOTON_MEMCPY(buffer, line_start, tail_size);
       buf_pos = buffer + tail_size;
       bytes_to_read -= tail_size;
     }
@@ -75,7 +75,7 @@ void ForEachLine(const std::string fname, std::function<void(char *)> cb) {
 // Convert the given string into a i32 date
 uint32_t ConvertDate(char *p) {
   std::tm t_shipdate;
-  PL_MEMSET(&t_shipdate, 0, sizeof(std::tm));
+  PELOTON_MEMSET(&t_shipdate, 0, sizeof(std::tm));
   strptime(p, "%Y-%m-%d", &t_shipdate);
   t_shipdate.tm_isdst = -1;
   return static_cast<uint32_t>(mktime(&t_shipdate));
@@ -442,8 +442,8 @@ void TPCHDatabase::LoadPartTable() {
 
     // Insert into table
     ItemPointer tuple_slot_id = table.InsertTuple(&tuple);
-    PL_ASSERT(tuple_slot_id.block != INVALID_OID);
-    PL_ASSERT(tuple_slot_id.offset != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.block != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.offset != INVALID_OID);
     txn_manager.PerformInsert(txn, tuple_slot_id);
 
     num_tuples++;
@@ -451,7 +451,7 @@ void TPCHDatabase::LoadPartTable() {
   });
 
   // Commit
-  PL_ASSERT(txn_manager.CommitTransaction(txn) == ResultType::SUCCESS);
+  PELOTON_ASSERT(txn_manager.CommitTransaction(txn) == ResultType::SUCCESS);
 
   timer.Stop();
   LOG_INFO("Loading Part finished: %.2f ms (%lu tuples)\n",
@@ -542,15 +542,15 @@ void TPCHDatabase::LoadCustomerTable() {
 
     // Insert into table
     ItemPointer tuple_slot_id = table.InsertTuple(&tuple);
-    PL_ASSERT(tuple_slot_id.block != INVALID_OID);
-    PL_ASSERT(tuple_slot_id.offset != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.block != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.offset != INVALID_OID);
     txn_manager.PerformInsert(txn, tuple_slot_id);
 
     num_tuples++;
   });
 
   // Commit
-  PL_ASSERT(txn_manager.CommitTransaction(txn) == ResultType::SUCCESS);
+  PELOTON_ASSERT(txn_manager.CommitTransaction(txn) == ResultType::SUCCESS);
 
   timer.Stop();
   LOG_INFO("Loading Customer finished: %.2f ms (%lu tuples)\n",
@@ -659,8 +659,8 @@ void TPCHDatabase::LoadLineitemTable() {
 
     // Insert into table
     ItemPointer tuple_slot_id = table.InsertTuple(&tuple);
-    PL_ASSERT(tuple_slot_id.block != INVALID_OID);
-    PL_ASSERT(tuple_slot_id.offset != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.block != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.offset != INVALID_OID);
     txn_manager.PerformInsert(txn, tuple_slot_id);
 
     num_tuples++;
@@ -668,7 +668,7 @@ void TPCHDatabase::LoadLineitemTable() {
 
   // Commit
   auto res = txn_manager.CommitTransaction(txn);
-  PL_ASSERT(res == ResultType::SUCCESS);
+  PELOTON_ASSERT(res == ResultType::SUCCESS);
   if (res != ResultType::SUCCESS) {
     LOG_ERROR("Could not commit transaction during load!");
   }

--- a/src/main/ycsb/ycsb.cpp
+++ b/src/main/ycsb/ycsb.cpp
@@ -76,12 +76,12 @@ void RunBenchmark() {
 
   // join all gc threads
   for (auto &gc_thread : gc_threads) {
-    PL_ASSERT(gc_thread != nullptr);
+    PELOTON_ASSERT(gc_thread != nullptr);
     gc_thread->join();
   }
 
   // join epoch thread
-  PL_ASSERT(epoch_thread != nullptr);
+  PELOTON_ASSERT(epoch_thread != nullptr);
   epoch_thread->join();
 
   // Emit throughput

--- a/src/main/ycsb/ycsb_mixed.cpp
+++ b/src/main/ycsb/ycsb_mixed.cpp
@@ -221,7 +221,7 @@ bool RunMixed(const size_t thread_id, ZipfDistribution &zipf, FastRandom &rng) {
   }
 
   // transaction passed execution.
-  PL_ASSERT(txn->GetResult() == ResultType::SUCCESS);
+  PELOTON_ASSERT(txn->GetResult() == ResultType::SUCCESS);
 
   auto result = txn_manager.CommitTransaction(txn);
 
@@ -230,7 +230,7 @@ bool RunMixed(const size_t thread_id, ZipfDistribution &zipf, FastRandom &rng) {
     
   } else {
     // transaction failed commitment.
-    PL_ASSERT(result == ResultType::ABORTED ||
+    PELOTON_ASSERT(result == ResultType::ABORTED ||
            result == ResultType::FAILURE);
     return false;
   }

--- a/src/main/ycsb/ycsb_workload.cpp
+++ b/src/main/ycsb/ycsb_workload.cpp
@@ -143,10 +143,10 @@ void RunWorkload() {
   size_t num_threads = state.backend_count;
 
   abort_counts = new PadInt[num_threads];
-  PL_MEMSET(abort_counts, 0, sizeof(PadInt) * num_threads);
+  PELOTON_MEMSET(abort_counts, 0, sizeof(PadInt) * num_threads);
 
   commit_counts = new PadInt[num_threads];
-  PL_MEMSET(commit_counts, 0, sizeof(PadInt) * num_threads);
+  PELOTON_MEMSET(commit_counts, 0, sizeof(PadInt) * num_threads);
 
   size_t profile_round = (size_t)(state.duration / state.profile_duration);
 
@@ -170,9 +170,9 @@ void RunWorkload() {
   for (size_t round_id = 0; round_id < profile_round; ++round_id) {
     std::this_thread::sleep_for(
         std::chrono::milliseconds(int(state.profile_duration * 1000)));
-    PL_MEMCPY(abort_counts_profiles[round_id], abort_counts,
+    PELOTON_MEMCPY(abort_counts_profiles[round_id], abort_counts,
            sizeof(PadInt) * num_threads);
-    PL_MEMCPY(commit_counts_profiles[round_id], commit_counts,
+    PELOTON_MEMCPY(commit_counts_profiles[round_id], commit_counts,
            sizeof(PadInt) * num_threads);
     
     auto& manager = catalog::Manager::GetInstance();

--- a/src/network/connection_handle.cpp
+++ b/src/network/connection_handle.cpp
@@ -212,7 +212,7 @@ Transition ConnectionHandle::FillReadBuffer() {
   if (rbuf_->buf_ptr == rbuf_->buf_size) rbuf_->Reset();
 
   // buf_ptr shouldn't overflow
-  PL_ASSERT(rbuf_->buf_ptr <= rbuf_->buf_size);
+  PELOTON_ASSERT(rbuf_->buf_ptr <= rbuf_->buf_size);
 
   /* Do we have leftover data and are we at the end of the buffer?
    * Move the data to the head of the buffer and clear out all the old data
@@ -439,7 +439,7 @@ ProcessResult ConnectionHandle::ProcessInitial() {
       return ProcessResult::MORE_DATA_REQUIRED;
     }
   }
-  PL_ASSERT(initial_packet_.header_parsed == true);
+  PELOTON_ASSERT(initial_packet_.header_parsed == true);
 
   if (initial_packet_.is_initialized == false) {
     // packet needs to be initialized with rest of the contents
@@ -651,7 +651,7 @@ Transition ConnectionHandle::Process() {
       SSL_set_session_id_context(conn_SSL_context, nullptr, 0);
       if (SSL_set_fd(conn_SSL_context, sock_fd_) == 0) {
         LOG_ERROR("Failed to set SSL fd");
-        PL_ASSERT(false);
+        PELOTON_ASSERT(false);
       }
 
       bool handshake_fail = false;
@@ -764,7 +764,7 @@ Transition ConnectionHandle::GetResult() {
   // TODO(tianyu) We probably can collapse this state with some other state.
   if (event_add(network_event, nullptr) < 0) {
     LOG_ERROR("Failed to add event");
-    PL_ASSERT(false);
+    PELOTON_ASSERT(false);
   }
   protocol_handler_->GetResult();
   traffic_cop_.SetQueuing(false);

--- a/src/network/marshal.cpp
+++ b/src/network/marshal.cpp
@@ -24,7 +24,7 @@ namespace network {
 inline void CheckOverflow(UNUSED_ATTRIBUTE InputPacket *rpkt,
                           UNUSED_ATTRIBUTE size_t size) {
   LOG_TRACE("request->len: %lu", rpkt->len);
-  PL_ASSERT(rpkt->ptr + size - 1 < rpkt->len);
+  PELOTON_ASSERT(rpkt->ptr + size - 1 < rpkt->len);
 }
 
 size_t Buffer::GetUInt32BigEndian() {
@@ -126,7 +126,7 @@ void GetStringToken(InputPacket *rpkt, std::string &result) {
 
 uchar *PacketCopyBytes(ByteBuf::const_iterator begin, int len) {
   uchar *result = new uchar[len];
-  PL_MEMCPY(result, &(*begin), len);
+  PELOTON_MEMCPY(result, &(*begin), len);
   return result;
 }
 

--- a/src/network/peloton_server.cpp
+++ b/src/network/peloton_server.cpp
@@ -240,7 +240,7 @@ PelotonServer &PelotonServer::SetupServer() {
     throw ConnectionException("Unsupported socket family");
 
   struct sockaddr_in sin;
-  PL_MEMSET(&sin, 0, sizeof(sin));
+  PELOTON_MEMSET(&sin, 0, sizeof(sin));
   sin.sin_family = AF_INET;
   sin.sin_addr.s_addr = INADDR_ANY;
   sin.sin_port = htons(port_);

--- a/src/network/postgres_protocol_handler.cpp
+++ b/src/network/postgres_protocol_handler.cpp
@@ -626,13 +626,13 @@ void PostgresProtocolHandler::ExecBindMessage(InputPacket *pkt) {
     stats::QueryMetric::QueryParamBuf param_format_buf;
     param_format_buf.len = format_buf_len;
     param_format_buf.buf = PacketCopyBytes(format_buf_begin, format_buf_len);
-    PL_ASSERT(format_buf_len > 0);
+    PELOTON_ASSERT(format_buf_len > 0);
 
     // Make a copy of value for stat collection
     stats::QueryMetric::QueryParamBuf param_val_buf;
     param_val_buf.len = val_buf_len;
     param_val_buf.buf = PacketCopyBytes(val_buf_begin, val_buf_len);
-    PL_ASSERT(val_buf_len > 0);
+    PELOTON_ASSERT(val_buf_len > 0);
 
     param_stat.reset(new stats::QueryMetric::QueryParams(
         param_format_buf, param_type_buf, param_val_buf, num_params));
@@ -721,7 +721,7 @@ size_t PostgresProtocolHandler::ReadParamValue(
                   .CastAs(PostgresValueTypeToPelotonValueType(
                       (PostgresValueType)param_types[param_idx]));
         }
-        PL_ASSERT(param_values[param_idx].GetTypeId() != type::TypeId::INVALID);
+        PELOTON_ASSERT(param_values[param_idx].GetTypeId() != type::TypeId::INVALID);
       } else {
         // BINARY mode
         PostgresValueType pg_value_type =
@@ -778,7 +778,7 @@ size_t PostgresProtocolHandler::ReadParamValue(
             for (size_t i = 0; i < sizeof(double); ++i) {
               buf = (buf << 8) | param[i];
             }
-            PL_MEMCPY(&float_val, &buf, sizeof(double));
+            PELOTON_MEMCPY(&float_val, &buf, sizeof(double));
             bind_parameters[param_idx] = std::make_pair(
                 type::TypeId::DECIMAL, std::to_string(float_val));
             param_values[param_idx] =
@@ -801,7 +801,7 @@ size_t PostgresProtocolHandler::ReadParamValue(
             break;
           }
         }
-        PL_ASSERT(param_values[param_idx].GetTypeId() != type::TypeId::INVALID);
+        PELOTON_ASSERT(param_values[param_idx].GetTypeId() != type::TypeId::INVALID);
       }
     }
   }
@@ -1151,7 +1151,7 @@ ProcessResult PostgresProtocolHandler::Process(Buffer &rbuf,
       return ProcessResult::MORE_DATA_REQUIRED;
     }
   }
-  PL_ASSERT(request.header_parsed == true);
+  PELOTON_ASSERT(request.header_parsed == true);
 
   if (request.is_initialized == false) {
     // packet needs to be initialized with rest of the contents

--- a/src/network/service/connection_manager.cpp
+++ b/src/network/service/connection_manager.cpp
@@ -34,7 +34,7 @@ ConnectionManager::~ConnectionManager() {
   std::map<NetworkAddress, Connection *>::iterator iter;
 
   for (iter = conn_pool_.begin(); iter != conn_pool_.end(); iter++) {
-    PL_ASSERT(iter->second != NULL);
+    PELOTON_ASSERT(iter->second != NULL);
     delete iter->second;
   }
 }
@@ -47,7 +47,7 @@ void ConnectionManager::ResterRpcServer(RpcServer *server) {
 }
 
 RpcServer *ConnectionManager::GetRpcServer() {
-  PL_ASSERT(rpc_server_ != NULL);
+  PELOTON_ASSERT(rpc_server_ != NULL);
   return rpc_server_;
 }
 
@@ -97,7 +97,7 @@ Connection *ConnectionManager::GetConn(NetworkAddress &addr) {
 
     /* A connection should know rpc server, which is used to find RPC method */
     RpcServer *server = GetRpcServer();
-    PL_ASSERT(server != NULL);
+    PELOTON_ASSERT(server != NULL);
 
     /* For a client connection, the socket fd is -1 (required by libevent)
      * After new a connection, a bufferevent is created and callback is set
@@ -159,7 +159,7 @@ Connection *ConnectionManager::CreateConn(NetworkAddress &addr) {
 
     /* A connection should know rpc server, which is used to find RPC method */
     RpcServer *server = GetRpcServer();
-    PL_ASSERT(server != NULL);
+    PELOTON_ASSERT(server != NULL);
 
     /* For a client connection, the socket fd is -1 (required by libevent)
      * After new a connection, a bufferevent is created and callback is set
@@ -248,7 +248,7 @@ bool ConnectionManager::DeleteConn(NetworkAddress &addr) {
     mutex_.UnLock();
     return false;
   }
-  PL_ASSERT(iter->second != NULL);
+  PELOTON_ASSERT(iter->second != NULL);
   delete iter->second;
   conn_pool_.erase(iter);
   mutex_.UnLock();

--- a/src/network/service/network_address.cpp
+++ b/src/network/service/network_address.cpp
@@ -161,7 +161,7 @@ void NetworkAddress::FillAddr(struct sockaddr_in *addr) const {
   addr->sin_family = AF_INET;
   addr->sin_port = port_;
   addr->sin_addr.s_addr = ip_address_;
-  PL_MEMSET(addr->sin_zero, 0, sizeof(addr->sin_zero));
+  PELOTON_MEMSET(addr->sin_zero, 0, sizeof(addr->sin_zero));
 }
 
 sockaddr_in NetworkAddress::Sockaddr() const {
@@ -173,7 +173,7 @@ sockaddr_in NetworkAddress::Sockaddr() const {
 uint16_t NetworkAddress::GetPort() const { return ntohs(port_); }
 
 void NetworkAddress::SetPort(uint16_t port) {
-  PL_ASSERT(port != 0);
+  PELOTON_ASSERT(port != 0);
   port_ = htons(port);
 }
 

--- a/src/network/service/peloton_service.cpp
+++ b/src/network/service/peloton_service.cpp
@@ -417,11 +417,11 @@ void PelotonService::QueryPlan(::google::protobuf::RpcController *controller,
   else {
     // Process the response
     LOG_TRACE("proecess the Query response");
-    PL_ASSERT(response);
+    PELOTON_ASSERT(response);
 
     UNUSED_ATTRIBUTE int tile_count = response->tile_count();
     UNUSED_ATTRIBUTE int result_size = response->result_size();
-    PL_ASSERT(result_size == tile_count);
+    PELOTON_ASSERT(result_size == tile_count);
 
     for (int idx = 0; idx < result_size; idx++) {
       // Get the tile bytes

--- a/src/network/service/rpc_channel.cpp
+++ b/src/network/service/rpc_channel.cpp
@@ -51,7 +51,7 @@ void RpcChannel::CallMethod(
     const google::protobuf::Message *request,
     UNUSED_ATTRIBUTE google::protobuf::Message *response,
     google::protobuf::Closure *done) {
-  PL_ASSERT(request != nullptr);
+  PELOTON_ASSERT(request != nullptr);
   /*  run call back function */
   if (done != NULL) {
     done->Run();
@@ -73,19 +73,19 @@ void RpcChannel::CallMethod(
 
   /* total length of the message: header length (4bytes) + message length
    * (8bytes + ...) */
-  PL_ASSERT(HEADERLEN == sizeof(msg_len));
+  PELOTON_ASSERT(HEADERLEN == sizeof(msg_len));
   char buf[HEADERLEN + msg_len];
 
   /* copy the header into the buf */
-  PL_MEMCPY(buf, &msg_len, sizeof(msg_len));
+  PELOTON_MEMCPY(buf, &msg_len, sizeof(msg_len));
 
   /* copy the type into the buf, following the header */
-  PL_ASSERT(TYPELEN == sizeof(type));
-  PL_MEMCPY(buf + HEADERLEN, &type, TYPELEN);
+  PELOTON_ASSERT(TYPELEN == sizeof(type));
+  PELOTON_MEMCPY(buf + HEADERLEN, &type, TYPELEN);
 
   /*  copy the hashcode into the buf, following the type */
-  PL_ASSERT(OPCODELEN == sizeof(opcode));
-  PL_MEMCPY(buf + HEADERLEN + TYPELEN, &opcode, OPCODELEN);
+  PELOTON_ASSERT(OPCODELEN == sizeof(opcode));
+  PELOTON_MEMCPY(buf + HEADERLEN + TYPELEN, &opcode, OPCODELEN);
 
   /*  call protobuf to serialize the request message into sending buf */
   request->SerializeToArray(buf + HEADERLEN + TYPELEN + OPCODELEN,

--- a/src/network/service/tcp_connection.cpp
+++ b/src/network/service/tcp_connection.cpp
@@ -41,7 +41,7 @@ Connection::Connection(int fd, struct event_base *base, void *arg,
                        NetworkAddress &addr)
     : addr_(addr), close_(false), status_(INIT), base_(base) {
   // we must pass rpc_server when new a connection
-  PL_ASSERT(arg != NULL);
+  PELOTON_ASSERT(arg != NULL);
   rpc_server_ = (RpcServer *)arg;
 
   // BEV_OPT_THREADSAFE must be specified
@@ -101,7 +101,7 @@ void Connection::Close() {
  *          corresponding RPC method.
  */
 void *Connection::ProcessMessage(void *connection) {
-  PL_ASSERT(connection != NULL);
+  PELOTON_ASSERT(connection != NULL);
 
   Connection *conn = (Connection *)connection;
 
@@ -148,11 +148,11 @@ void *Connection::ProcessMessage(void *connection) {
 
     // Get the message type
     uint16_t type = 0;
-    PL_MEMCPY((char *)(&type), buf + HEADERLEN, sizeof(type));
+    PELOTON_MEMCPY((char *)(&type), buf + HEADERLEN, sizeof(type));
 
     // Get the hashcode of the rpc method
     uint64_t opcode = 0;
-    PL_MEMCPY((char *)(&opcode), buf + HEADERLEN + TYPELEN, sizeof(opcode));
+    PELOTON_MEMCPY((char *)(&opcode), buf + HEADERLEN + TYPELEN, sizeof(opcode));
 
     // Get the rpc method meta info: method descriptor
     RpcMethod *rpc_method = conn->GetRpcServer()->FindMethod(opcode);
@@ -186,20 +186,20 @@ void *Connection::ProcessMessage(void *connection) {
         msg_len = response->ByteSize() + OPCODELEN + TYPELEN;
 
         char send_buf[sizeof(msg_len) + msg_len];
-        PL_ASSERT(sizeof(msg_len) == HEADERLEN);
+        PELOTON_ASSERT(sizeof(msg_len) == HEADERLEN);
 
         // copy the header into the buf
-        PL_MEMCPY(send_buf, &msg_len, sizeof(msg_len));
+        PELOTON_MEMCPY(send_buf, &msg_len, sizeof(msg_len));
 
         // copy the type into the buf
         type = MSG_TYPE_REP;
 
-        PL_ASSERT(sizeof(type) == TYPELEN);
-        PL_MEMCPY(send_buf + HEADERLEN, &type, TYPELEN);
+        PELOTON_ASSERT(sizeof(type) == TYPELEN);
+        PELOTON_MEMCPY(send_buf + HEADERLEN, &type, TYPELEN);
 
         // copy the opcode into the buf
-        PL_ASSERT(sizeof(opcode) == OPCODELEN);
-        PL_MEMCPY(send_buf + HEADERLEN + TYPELEN, &opcode, OPCODELEN);
+        PELOTON_ASSERT(sizeof(opcode) == OPCODELEN);
+        PELOTON_MEMCPY(send_buf + HEADERLEN + TYPELEN, &opcode, OPCODELEN);
 
         // call protobuf to serialize the request message into sending buf
         response->SerializeToArray(send_buf + HEADERLEN + TYPELEN + OPCODELEN,
@@ -274,7 +274,7 @@ void *Connection::ProcessMessage(void *connection) {
  */
 void Connection::ReadCb(UNUSED_ATTRIBUTE struct bufferevent *bev, void *ctx) {
   // TODO: We might use bev in future
-  PL_ASSERT(bev != NULL);
+  PELOTON_ASSERT(bev != NULL);
 
   Connection *conn = (Connection *)ctx;
 
@@ -305,7 +305,7 @@ void Connection::ReadCb(UNUSED_ATTRIBUTE struct bufferevent *bev, void *ctx) {
 void Connection::EventCb(UNUSED_ATTRIBUTE struct bufferevent *bev, short events,
                          void *ctx) {
   Connection *conn = (Connection *)ctx;
-  PL_ASSERT(conn != NULL && bev != NULL);
+  PELOTON_ASSERT(conn != NULL && bev != NULL);
 
   if (events & BEV_EVENT_ERROR) {
     LOG_TRACE("Error from client bufferevent: %s",

--- a/src/network/service/tcp_listener.cpp
+++ b/src/network/service/tcp_listener.cpp
@@ -32,8 +32,8 @@ Listener::Listener(int port)
   // make libevent support multiple threads (pthread)
   // TODO: put evthread_use_pthreads before event_base_new()?
 
-  PL_ASSERT(listen_base_ != NULL);
-  PL_ASSERT(port_ > 0 && port_ < 65535);
+  PELOTON_ASSERT(listen_base_ != NULL);
+  PELOTON_ASSERT(port_ > 0 && port_ < 65535);
 }
 
 Listener::~Listener() {
@@ -57,7 +57,7 @@ void Listener::Run(void *arg) {
 
   /* Clear the sockaddr before using it, in case there are extra
    *          * platform-specific fields that can mess us up. */
-  PL_MEMSET(&sin, 0, sizeof(sin));
+  PELOTON_MEMSET(&sin, 0, sizeof(sin));
 
   /* This is an INET address */
   sin.sin_family = AF_INET;
@@ -101,7 +101,7 @@ void Listener::Run(void *arg) {
 void Listener::AcceptConnCb(struct evconnlistener *listener, evutil_socket_t fd,
                             struct sockaddr *address,
                             UNUSED_ATTRIBUTE int socklen, void *ctx) {
-  PL_ASSERT(listener != NULL && address != NULL && socklen >= 0 && ctx != NULL);
+  PELOTON_ASSERT(listener != NULL && address != NULL && socklen >= 0 && ctx != NULL);
 
   LOG_TRACE("Server: connection received");
 
@@ -122,7 +122,7 @@ void Listener::AcceptConnCb(struct evconnlistener *listener, evutil_socket_t fd,
 
 void Listener::AcceptErrorCb(struct evconnlistener *listener,
                              UNUSED_ATTRIBUTE void *ctx) {
-  PL_ASSERT(ctx != NULL);
+  PELOTON_ASSERT(ctx != NULL);
 
   struct event_base *base = evconnlistener_get_base(listener);
 

--- a/src/optimizer/child_stats_deriver.cpp
+++ b/src/optimizer/child_stats_deriver.cpp
@@ -61,7 +61,7 @@ void ChildStatsDeriver::PassDownRequiredCols() {
 }
 
 void ChildStatsDeriver::PassDownColumn(expression::AbstractExpression *col) {
-  PL_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+  PELOTON_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
   auto tv_expr = reinterpret_cast<expression::TupleValueExpression *>(col);
   for (size_t idx = 0; idx < gexpr_->GetChildrenGroupsSize(); ++idx) {
     auto child_group = memo_->GetGroupByID(gexpr_->GetChildGroupId(idx));

--- a/src/optimizer/group.cpp
+++ b/src/optimizer/group.cpp
@@ -71,7 +71,7 @@ std::shared_ptr<ColumnStats> Group::GetStats(std::string column_name) {
 
 void Group::AddStats(std::string column_name,
                      std::shared_ptr<ColumnStats> stats) {
-  PL_ASSERT((size_t)GetNumRows() == stats->num_rows);
+  PELOTON_ASSERT((size_t)GetNumRows() == stats->num_rows);
   stats_[column_name] = stats;
 }
 

--- a/src/optimizer/input_column_deriver.cpp
+++ b/src/optimizer/input_column_deriver.cpp
@@ -87,7 +87,7 @@ void InputColumnDeriver::Visit(const PhysicalLimit *) { Passdown(); }
 void InputColumnDeriver::Visit(const PhysicalOrderBy *) {
   // we need to pass down both required columns and sort columns
   auto prop = properties_->GetPropertyOfType(PropertyType::SORT);
-  PL_ASSERT(prop.get() != nullptr);
+  PELOTON_ASSERT(prop.get() != nullptr);
   ExprSet input_cols_set;
   for (auto expr : required_cols_) {
     if (expression::ExpressionUtil::IsAggregateExpression(expr))
@@ -244,9 +244,9 @@ void InputColumnDeriver::JoinHelper(const BaseOperatorNode *op) {
 
   ExprSet input_cols_set;
 
-  PL_ASSERT(left_keys != nullptr);
-  PL_ASSERT(right_keys != nullptr);
-  PL_ASSERT(join_conds != nullptr);
+  PELOTON_ASSERT(left_keys != nullptr);
+  PELOTON_ASSERT(right_keys != nullptr);
+  PELOTON_ASSERT(join_conds != nullptr);
   for (auto &left_key : *left_keys) {
     expression::ExpressionUtil::GetTupleValueExprs(input_cols_set,
                                                    left_key.get());
@@ -274,12 +274,12 @@ void InputColumnDeriver::JoinHelper(const BaseOperatorNode *op) {
   UNUSED_ATTRIBUTE auto &probe_table_aliases =
       memo_->GetGroupByID(gexpr_->GetChildGroupId(1))->GetTableAliases();
   for (auto &col : input_cols_set) {
-    PL_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+    PELOTON_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
     auto tv_expr = reinterpret_cast<expression::TupleValueExpression *>(col);
     if (build_table_aliases.count(tv_expr->GetTableName())) {
       build_table_cols_set.insert(col);
     } else {
-      PL_ASSERT(probe_table_aliases.count(tv_expr->GetTableName()));
+      PELOTON_ASSERT(probe_table_aliases.count(tv_expr->GetTableName()));
       probe_table_cols_set.insert(col);
     }
   }

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -298,14 +298,14 @@ unique_ptr<planner::AbstractPlan> Optimizer::ChooseBestPlan(
 
   vector<GroupID> child_groups = gexpr->GetChildGroupIDs();
   auto required_input_props = gexpr->GetInputProperties(required_props);
-  PL_ASSERT(required_input_props.size() == child_groups.size());
+  PELOTON_ASSERT(required_input_props.size() == child_groups.size());
   // Firstly derive input/output columns
   InputColumnDeriver deriver;
   auto output_input_cols_pair = deriver.DeriveInputColumns(
       gexpr, required_props, required_cols, &metadata_.memo);
   auto &output_cols = output_input_cols_pair.first;
   auto &input_cols = output_input_cols_pair.second;
-  PL_ASSERT(input_cols.size() == required_input_props.size());
+  PELOTON_ASSERT(input_cols.size() == required_input_props.size());
 
   // Derive chidren plans first because they are useful in the derivation of
   // root plan. Also keep propagate expression to column offset mapping
@@ -314,13 +314,13 @@ unique_ptr<planner::AbstractPlan> Optimizer::ChooseBestPlan(
   for (size_t i = 0; i < child_groups.size(); ++i) {
     ExprMap child_expr_map;
     for (unsigned offset = 0; offset < input_cols[i].size(); ++offset) {
-      PL_ASSERT(input_cols[i][offset] != nullptr);
+      PELOTON_ASSERT(input_cols[i][offset] != nullptr);
       child_expr_map[input_cols[i][offset]] = offset;
     }
     auto child_plan =
         ChooseBestPlan(child_groups[i], required_input_props[i], input_cols[i]);
     children_expr_map.push_back(move(child_expr_map));
-    PL_ASSERT(child_plan != nullptr);
+    PELOTON_ASSERT(child_plan != nullptr);
     children_plans.push_back(move(child_plan));
   }
 

--- a/src/optimizer/optimizer_task.cpp
+++ b/src/optimizer/optimizer_task.cpp
@@ -223,7 +223,7 @@ void DeriveStats::execute() {
   bool derive_children = false;
   // If we haven't got enough stats to compute the current stats, derive them
   // from the child first
-  PL_ASSERT(children_required_stats.size() == gexpr_->GetChildrenGroupsSize());
+  PELOTON_ASSERT(children_required_stats.size() == gexpr_->GetChildrenGroupsSize());
   for (size_t idx = 0; idx < children_required_stats.size(); ++idx) {
     auto &child_required_stats = children_required_stats[idx];
     auto child_group_id = gexpr_->GetChildGroupId(idx);
@@ -424,12 +424,12 @@ void TopDownRewrite::execute() {
                                       r.rule->GetMatchPattern());
     if (iterator.HasNext()) {
       auto before = iterator.Next();
-      PL_ASSERT(!iterator.HasNext());
+      PELOTON_ASSERT(!iterator.HasNext());
       std::vector<std::shared_ptr<OperatorExpression>> after;
       r.rule->Transform(before, after, context_.get());
 
       // Rewrite rule should provide at most 1 expression
-      PL_ASSERT(after.size() <= 1);
+      PELOTON_ASSERT(after.size() <= 1);
       // If a rule is applied, we replace the old expression and optimize this
       // group again, this will ensure that we apply rule for this level until
       // saturated
@@ -483,12 +483,12 @@ void BottomUpRewrite::execute() {
                                       r.rule->GetMatchPattern());
     if (iterator.HasNext()) {
       auto before = iterator.Next();
-      PL_ASSERT(!iterator.HasNext());
+      PELOTON_ASSERT(!iterator.HasNext());
       std::vector<std::shared_ptr<OperatorExpression>> after;
       r.rule->Transform(before, after, context_.get());
 
       // Rewrite rule should provide at most 1 expression
-      PL_ASSERT(after.size() <= 1);
+      PELOTON_ASSERT(after.size() <= 1);
       // If a rule is applied, we replace the old expression and optimize this
       // group again, this will ensure that we apply rule for this level until
       // saturated, also childs are already been rewritten

--- a/src/optimizer/plan_generator.cpp
+++ b/src/optimizer/plan_generator.cpp
@@ -107,7 +107,7 @@ void PlanGenerator::Visit(const PhysicalIndexScan *op) {
 }
 
 void PlanGenerator::Visit(const QueryDerivedScan *) {
-  PL_ASSERT(children_plans_.size() == 1);
+  PELOTON_ASSERT(children_plans_.size() == 1);
   output_plan_ = move(children_plans_[0]);
 }
 
@@ -120,7 +120,7 @@ void PlanGenerator::Visit(const PhysicalLimit *op) {
 
 void PlanGenerator::Visit(const PhysicalOrderBy *) {
   vector<oid_t> column_ids;
-  PL_ASSERT(children_expr_map_.size() == 1);
+  PELOTON_ASSERT(children_expr_map_.size() == 1);
   auto &child_cols_map = children_expr_map_[0];
   for (size_t i = 0; i < output_cols_.size(); ++i) {
     column_ids.push_back(child_cols_map[output_cols_[i]]);
@@ -166,12 +166,12 @@ void PlanGenerator::Visit(const PhysicalAggregate *) {
 void PlanGenerator::Visit(const PhysicalDistinct *) {
   // Now distinct is a flag in the parser, so we only support
   // distinct on all output columns
-  PL_ASSERT(children_expr_map_.size() == 1);
-  PL_ASSERT(children_plans_.size() == 1);
+  PELOTON_ASSERT(children_expr_map_.size() == 1);
+  PELOTON_ASSERT(children_plans_.size() == 1);
   auto &child_expr_map = children_expr_map_[0];
   std::vector<std::unique_ptr<const expression::AbstractExpression>> hash_keys;
   for (auto &col : output_cols_) {
-    PL_ASSERT(child_expr_map.count(col) > 0);
+    PELOTON_ASSERT(child_expr_map.count(col) > 0);
     auto &column_offset = child_expr_map[col];
     hash_keys.emplace_back(new expression::TupleValueExpression(
         col->GetValueType(), 0, column_offset));
@@ -194,12 +194,12 @@ void PlanGenerator::Visit(const PhysicalInnerNLJoin *op) {
   vector<oid_t> left_keys;
   vector<oid_t> right_keys;
   for (auto &expr : op->left_keys) {
-    PL_ASSERT(children_expr_map_[0].find(expr.get()) !=
+    PELOTON_ASSERT(children_expr_map_[0].find(expr.get()) !=
               children_expr_map_[0].end());
     left_keys.push_back(children_expr_map_[0][expr.get()]);
   }
   for (auto &expr : op->right_keys) {
-    PL_ASSERT(children_expr_map_[1].find(expr.get()) !=
+    PELOTON_ASSERT(children_expr_map_[1].find(expr.get()) !=
               children_expr_map_[1].end());
     right_keys.emplace_back(children_expr_map_[1][expr.get()]);
   }
@@ -372,12 +372,12 @@ vector<oid_t> PlanGenerator::GenerateColumnsForScan() {
   vector<oid_t> column_ids;
   for (oid_t idx = 0; idx < output_cols_.size(); ++idx) {
     auto &output_expr = output_cols_[idx];
-    PL_ASSERT(output_expr->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+    PELOTON_ASSERT(output_expr->GetExpressionType() == ExpressionType::VALUE_TUPLE);
     auto output_tvexpr =
         reinterpret_cast<expression::TupleValueExpression *>(output_expr);
 
     // Set column offset
-    PL_ASSERT(output_tvexpr->GetIsBound() == true);
+    PELOTON_ASSERT(output_tvexpr->GetIsBound() == true);
     auto col_id = std::get<2>(output_tvexpr->GetBoundOid());
     column_ids.push_back(col_id);
   }
@@ -462,7 +462,7 @@ void PlanGenerator::BuildAggregatePlan(
   vector<catalog::Column> output_schema_columns;
   DirectMapList dml;
   TargetList tl;
-  PL_ASSERT(children_expr_map_.size() == 1);
+  PELOTON_ASSERT(children_expr_map_.size() == 1);
   auto &child_expr_map = children_expr_map_[0];
 
   auto agg_id = 0;
@@ -517,8 +517,8 @@ void PlanGenerator::BuildAggregatePlan(
 void PlanGenerator::GenerateProjectionForJoin(
     std::unique_ptr<const planner::ProjectInfo> &proj_info,
     std::shared_ptr<const catalog::Schema> &proj_schema) {
-  PL_ASSERT(children_expr_map_.size() == 2);
-  PL_ASSERT(children_plans_.size() == 2);
+  PELOTON_ASSERT(children_expr_map_.size() == 2);
+  PELOTON_ASSERT(children_plans_.size() == 2);
 
   TargetList tl = TargetList();
   // columns which can be returned directly

--- a/src/optimizer/properties.cpp
+++ b/src/optimizer/properties.cpp
@@ -36,7 +36,7 @@ bool PropertySort::operator>=(const Property &r) const {
   // All the sorting orders in r must be satisfied
   size_t l_num_sort_columns = sort_columns_.size();
   size_t r_num_sort_columns = r_sort.sort_columns_.size();
-  PL_ASSERT(r_num_sort_columns == r_sort.sort_ascending_.size());
+  PELOTON_ASSERT(r_num_sort_columns == r_sort.sort_ascending_.size());
   // We want to ensure that Sort(a, b, c, d, e) >= Sort(a, b, c)
   if (l_num_sort_columns < r_num_sort_columns) {
     return false;

--- a/src/optimizer/query_to_operator_transformer.cpp
+++ b/src/optimizer/query_to_operator_transformer.cpp
@@ -201,7 +201,7 @@ void QueryToOperatorTransformer::Visit(parser::TableRef *node) {
           std::make_shared<OperatorExpression>(LogicalInnerJoin::make());
       join_expr->PushChild(prev_expr);
       join_expr->PushChild(output_expr_);
-      PL_ASSERT(join_expr->Children().size() == 2);
+      PELOTON_ASSERT(join_expr->Children().size() == 2);
       prev_expr = join_expr;
     }
     output_expr_ = prev_expr;
@@ -350,7 +350,7 @@ void QueryToOperatorTransformer::Visit(expression::OperatorExpression *expr) {
     std::vector<expression::AbstractExpression *> select_list;
     if (GenerateSubquerytree(expr->GetModifiableChild(0), select_list) ==
         true) {
-      PL_ASSERT(!select_list.empty());
+      PELOTON_ASSERT(!select_list.empty());
 
       // Set the right child as the output of the subquery
       expr->SetExpressionType(ExpressionType::OPERATOR_IS_NOT_NULL);

--- a/src/optimizer/rule_impls.cpp
+++ b/src/optimizer/rule_impls.cpp
@@ -58,7 +58,7 @@ void InnerJoinCommutativity::Transform(
   auto result_plan = std::make_shared<OperatorExpression>(
       LogicalInnerJoin::make(join_predicates));
   std::vector<std::shared_ptr<OperatorExpression>> children = input->Children();
-  PL_ASSERT(children.size() == 2);
+  PELOTON_ASSERT(children.size() == 2);
   LOG_TRACE(
       "Reorder left child with op %s and right child with op %s for inner join",
       children[0]->Op().name().c_str(), children[1]->Op().name().c_str());
@@ -123,7 +123,7 @@ void GetToSeqScan::Transform(
 
   UNUSED_ATTRIBUTE std::vector<std::shared_ptr<OperatorExpression>> children =
       input->Children();
-  PL_ASSERT(children.size() == 0);
+  PELOTON_ASSERT(children.size() == 0);
 
   transformed.push_back(result_plan);
 }
@@ -156,7 +156,7 @@ void GetToIndexScan::Transform(
     UNUSED_ATTRIBUTE OptimizeContext *context) const {
   UNUSED_ATTRIBUTE std::vector<std::shared_ptr<OperatorExpression>> children =
       input->Children();
-  PL_ASSERT(children.size() == 0);
+  PELOTON_ASSERT(children.size() == 0);
 
   const LogicalGet *get = input->Op().As<LogicalGet>();
 
@@ -362,7 +362,7 @@ void LogicalDeleteToPhysical::Transform(
   const LogicalDelete *delete_op = input->Op().As<LogicalDelete>();
   auto result = std::make_shared<OperatorExpression>(
       PhysicalDelete::make(delete_op->target_table));
-  PL_ASSERT(input->Children().size() == 1);
+  PELOTON_ASSERT(input->Children().size() == 1);
   result->PushChild(input->Children().at(0));
   transformed.push_back(result);
 }
@@ -390,7 +390,7 @@ void LogicalUpdateToPhysical::Transform(
   const LogicalUpdate *update_op = input->Op().As<LogicalUpdate>();
   auto result = std::make_shared<OperatorExpression>(
       PhysicalUpdate::make(update_op->target_table, update_op->updates));
-  PL_ASSERT(input->Children().size() != 0);
+  PELOTON_ASSERT(input->Children().size() != 0);
   result->PushChild(input->Children().at(0));
   transformed.push_back(result);
 }
@@ -418,7 +418,7 @@ void LogicalInsertToPhysical::Transform(
   const LogicalInsert *insert_op = input->Op().As<LogicalInsert>();
   auto result = std::make_shared<OperatorExpression>(PhysicalInsert::make(
       insert_op->target_table, insert_op->columns, insert_op->values));
-  PL_ASSERT(input->Children().size() == 0);
+  PELOTON_ASSERT(input->Children().size() == 0);
   //  result->PushChild(input->Children().at(0));
   transformed.push_back(result);
 }
@@ -446,7 +446,7 @@ void LogicalInsertSelectToPhysical::Transform(
   const LogicalInsertSelect *insert_op = input->Op().As<LogicalInsertSelect>();
   auto result = std::make_shared<OperatorExpression>(
       PhysicalInsertSelect::make(insert_op->target_table));
-  PL_ASSERT(input->Children().size() == 1);
+  PELOTON_ASSERT(input->Children().size() == 1);
   result->PushChild(input->Children().at(0));
   transformed.push_back(result);
 }
@@ -477,7 +477,7 @@ void LogicalGroupByToHashGroupBy::Transform(
       input->Op().As<LogicalAggregateAndGroupBy>();
   auto result = std::make_shared<OperatorExpression>(
       PhysicalHashGroupBy::make(agg_op->columns, agg_op->having));
-  PL_ASSERT(input->Children().size() == 1);
+  PELOTON_ASSERT(input->Children().size() == 1);
   result->PushChild(input->Children().at(0));
   transformed.push_back(result);
 }
@@ -505,7 +505,7 @@ void LogicalAggregateToPhysical::Transform(
     std::vector<std::shared_ptr<OperatorExpression>> &transformed,
     UNUSED_ATTRIBUTE OptimizeContext *context) const {
   auto result = std::make_shared<OperatorExpression>(PhysicalAggregate::make());
-  PL_ASSERT(input->Children().size() == 1);
+  PELOTON_ASSERT(input->Children().size() == 1);
   result->PushChild(input->Children().at(0));
   transformed.push_back(result);
 }
@@ -544,7 +544,7 @@ void InnerJoinToInnerNLJoin::Transform(
   const LogicalInnerJoin *inner_join = input->Op().As<LogicalInnerJoin>();
 
   auto children = input->Children();
-  PL_ASSERT(children.size() == 2);
+  PELOTON_ASSERT(children.size() == 2);
   auto left_group_id = children[0]->Op().As<LeafOperator>()->origin_group;
   auto right_group_id = children[1]->Op().As<LeafOperator>()->origin_group;
   auto &left_group_alias =
@@ -557,7 +557,7 @@ void InnerJoinToInnerNLJoin::Transform(
   util::ExtractEquiJoinKeys(inner_join->join_predicates, left_keys, right_keys,
                             left_group_alias, right_group_alias);
 
-  PL_ASSERT(right_keys.size() == left_keys.size());
+  PELOTON_ASSERT(right_keys.size() == left_keys.size());
   auto result_plan =
       std::make_shared<OperatorExpression>(PhysicalInnerNLJoin::make(
           inner_join->join_predicates, left_keys, right_keys));
@@ -605,7 +605,7 @@ void InnerJoinToInnerHashJoin::Transform(
   const LogicalInnerJoin *inner_join = input->Op().As<LogicalInnerJoin>();
 
   auto children = input->Children();
-  PL_ASSERT(children.size() == 2);
+  PELOTON_ASSERT(children.size() == 2);
   auto left_group_id = children[0]->Op().As<LeafOperator>()->origin_group;
   auto right_group_id = children[1]->Op().As<LeafOperator>()->origin_group;
   auto &left_group_alias =
@@ -618,7 +618,7 @@ void InnerJoinToInnerHashJoin::Transform(
   util::ExtractEquiJoinKeys(inner_join->join_predicates, left_keys, right_keys,
                             left_group_alias, right_group_alias);
 
-  PL_ASSERT(right_keys.size() == left_keys.size());
+  PELOTON_ASSERT(right_keys.size() == left_keys.size());
   if (!left_keys.empty()) {
     auto result_plan =
         std::make_shared<OperatorExpression>(PhysicalInnerHashJoin::make(
@@ -656,7 +656,7 @@ void ImplementDistinct::Transform(
   auto result_plan =
       std::make_shared<OperatorExpression>(PhysicalDistinct::make());
   std::vector<std::shared_ptr<OperatorExpression>> children = input->Children();
-  PL_ASSERT(children.size() == 1);
+  PELOTON_ASSERT(children.size() == 1);
 
   result_plan->PushChild(children[0]);
 
@@ -689,7 +689,7 @@ void ImplementLimit::Transform(
   auto result_plan = std::make_shared<OperatorExpression>(
       PhysicalLimit::make(limit_op->offset, limit_op->limit));
   std::vector<std::shared_ptr<OperatorExpression>> children = input->Children();
-  PL_ASSERT(children.size() == 1);
+  PELOTON_ASSERT(children.size() == 1);
 
   result_plan->PushChild(children[0]);
 
@@ -785,7 +785,7 @@ void PushFilterThroughJoin::Transform(
     output->PushChild(join_op_expr->Children()[1]);
   }
 
-  PL_ASSERT(output->Children().size() == 2);
+  PELOTON_ASSERT(output->Children().size() == 2);
 
   transformed.push_back(output);
 }
@@ -810,10 +810,10 @@ bool CombineConsecutiveFilter::Check(std::shared_ptr<OperatorExpression> plan,
 
   auto &children = plan->Children();
   (void)children;
-  PL_ASSERT(children.size() == 1);
+  PELOTON_ASSERT(children.size() == 1);
   auto &filter = children.at(0);
   (void)filter;
-  PL_ASSERT(filter->Children().size() == 1);
+  PELOTON_ASSERT(filter->Children().size() == 1);
 
   return true;
 }
@@ -889,7 +889,7 @@ bool MarkJoinGetToInnerJoin::Check(std::shared_ptr<OperatorExpression> plan,
   (void)plan;
 
   UNUSED_ATTRIBUTE auto &children = plan->Children();
-  PL_ASSERT(children.size() == 2);
+  PELOTON_ASSERT(children.size() == 2);
 
   return true;
 }
@@ -901,7 +901,7 @@ void MarkJoinGetToInnerJoin::Transform(
   UNUSED_ATTRIBUTE auto mark_join = input->Op().As<LogicalMarkJoin>();
   auto &join_children = input->Children();
 
-  PL_ASSERT(mark_join->join_predicates.empty());
+  PELOTON_ASSERT(mark_join->join_predicates.empty());
 
   std::shared_ptr<OperatorExpression> output =
       std::make_shared<OperatorExpression>(LogicalInnerJoin::make());
@@ -931,7 +931,7 @@ bool MarkJoinInnerJoinToInnerJoin::Check(
   (void)plan;
 
   UNUSED_ATTRIBUTE auto &children = plan->Children();
-  PL_ASSERT(children.size() == 2);
+  PELOTON_ASSERT(children.size() == 2);
 
   return true;
 }
@@ -943,7 +943,7 @@ void MarkJoinInnerJoinToInnerJoin::Transform(
   UNUSED_ATTRIBUTE auto mark_join = input->Op().As<LogicalMarkJoin>();
   auto &join_children = input->Children();
 
-  PL_ASSERT(mark_join->join_predicates.empty());
+  PELOTON_ASSERT(mark_join->join_predicates.empty());
 
   std::shared_ptr<OperatorExpression> output =
       std::make_shared<OperatorExpression>(LogicalInnerJoin::make());
@@ -972,9 +972,9 @@ bool PullFilterThroughMarkJoin::Check(std::shared_ptr<OperatorExpression> plan,
   (void)plan;
 
   auto &children = plan->Children();
-  PL_ASSERT(children.size() == 2);
+  PELOTON_ASSERT(children.size() == 2);
   UNUSED_ATTRIBUTE auto &r_grandchildren = children[1]->Children();
-  PL_ASSERT(r_grandchildren.size() == 1);
+  PELOTON_ASSERT(r_grandchildren.size() == 1);
 
   return true;
 }
@@ -988,7 +988,7 @@ void PullFilterThroughMarkJoin::Transform(
   auto filter = join_children[1]->Op();
   auto &filter_children = join_children[1]->Children();
 
-  PL_ASSERT(mark_join->join_predicates.empty());
+  PELOTON_ASSERT(mark_join->join_predicates.empty());
 
   std::shared_ptr<OperatorExpression> output =
       std::make_shared<OperatorExpression>(filter);

--- a/src/optimizer/stats/cost.cpp
+++ b/src/optimizer/stats/cost.cpp
@@ -28,8 +28,8 @@ namespace optimizer {
 //     const std::shared_ptr<TableStats> &input_stats,
 //     const ValueCondition &condition,
 //     std::shared_ptr<TableStats> &output_stats) {
-//   // PL_ASSERT(input_stats != nullptr);
-//   // PL_ASSERT(condition != nullptr);
+//   // PELOTON_ASSERT(input_stats != nullptr);
+//   // PELOTON_ASSERT(condition != nullptr);
 //
 //   UpdateConditionStats(input_stats, condition, output_stats);
 //
@@ -56,9 +56,9 @@ namespace optimizer {
 //                                    const size_t num_rows,
 //                                    const ExpressionType type,
 //                                    std::shared_ptr<TableStats> &output_stats) {
-//   PL_ASSERT(lhs != nullptr);
-//   PL_ASSERT(rhs != nullptr);
-//   PL_ASSERT(num_rows > 0);
+//   PELOTON_ASSERT(lhs != nullptr);
+//   PELOTON_ASSERT(rhs != nullptr);
+//   PELOTON_ASSERT(num_rows > 0);
 //
 //   size_t num_tuples = 1;
 //   double sel1 = lhs->num_rows / static_cast<double>(num_rows);
@@ -89,8 +89,8 @@ namespace optimizer {
 // double Cost::SortGroupByCost(const std::shared_ptr<TableStats> &input_stats,
 //                              std::vector<std::string> columns,
 //                              std::shared_ptr<TableStats> &output_stats) {
-//   PL_ASSERT(input_stats);
-//   PL_ASSERT(columns.size() > 0);
+//   PELOTON_ASSERT(input_stats);
+//   PELOTON_ASSERT(columns.size() > 0);
 //
 //   //    if (output_stats != nullptr) {
 //   if (false) {
@@ -114,7 +114,7 @@ namespace optimizer {
 // double Cost::HashGroupByCost(const std::shared_ptr<TableStats> &input_stats,
 //                              std::vector<std::string> columns,
 //                              std::shared_ptr<TableStats> &output_stats) {
-//   PL_ASSERT(input_stats);
+//   PELOTON_ASSERT(input_stats);
 //
 //   if (output_stats != nullptr) {
 //     output_stats->num_rows = GetEstimatedGroupByRows(input_stats, columns);
@@ -132,7 +132,7 @@ namespace optimizer {
 // double Cost::DistinctCost(const std::shared_ptr<TableStats> &input_stats,
 //                           std::string column_name,
 //                           std::shared_ptr<TableStats> &output_stats) {
-//   PL_ASSERT(input_stats);
+//   PELOTON_ASSERT(input_stats);
 //
 //   if (output_stats != nullptr) {
 //     // update number of rows to be number of unique element of column
@@ -147,7 +147,7 @@ namespace optimizer {
 // double Cost::ProjectCost(const std::shared_ptr<TableStats> &input_stats,
 //                          UNUSED_ATTRIBUTE std::vector<oid_t> columns,
 //                          std::shared_ptr<TableStats> &output_stats) {
-//   PL_ASSERT(input_stats);
+//   PELOTON_ASSERT(input_stats);
 //
 //   if (output_stats != nullptr) {
 //     // update column information for output_stats table
@@ -162,7 +162,7 @@ namespace optimizer {
 // double Cost::LimitCost(const std::shared_ptr<TableStats> &input_stats,
 //                        size_t limit,
 //                        std::shared_ptr<TableStats> &output_stats) {
-//   PL_ASSERT(input_stats != nullptr);
+//   PELOTON_ASSERT(input_stats != nullptr);
 //   if (output_stats != nullptr) {
 //     output_stats->num_rows = std::max(input_stats->num_rows, limit);
 //   }
@@ -176,7 +176,7 @@ namespace optimizer {
 //                          const std::vector<std::string> &columns,
 //                          const std::vector<bool> &orders,
 //                          std::shared_ptr<TableStats> &output_stats) {
-//   PL_ASSERT(input_stats);
+//   PELOTON_ASSERT(input_stats);
 //   // Invalid case.
 //   if (columns.size() == 0 || columns.size() != orders.size()) {
 //     return DEFAULT_COST;
@@ -285,7 +285,7 @@ namespace optimizer {
 //     return column_ids;
 //   }
 //   // index_stats should be base table and have non-null sampler
-//   PL_ASSERT(index_stats->GetSampler() != nullptr);
+//   PELOTON_ASSERT(index_stats->GetSampler() != nullptr);
 //
 //   // Already have tuple sampled, copy the sampled tuples
 //   if (!index_stats->GetSampler()->GetSampledTuples().empty()) {

--- a/src/optimizer/stats/selectivity.cpp
+++ b/src/optimizer/stats/selectivity.cpp
@@ -69,12 +69,12 @@ double Selectivity::LessThan(const std::shared_ptr<TableStats> &table_stats,
   // Use histogram to estimate selectivity
   std::vector<double> histogram = column_stats->histogram_bounds;
   size_t n = histogram.size();
-  PL_ASSERT(n > 0);
+  PELOTON_ASSERT(n > 0);
   // find correspond bin using binary search
   auto it = std::lower_bound(histogram.begin(), histogram.end(), v);
   double res = (it - histogram.begin()) * 1.0 / n;
-  PL_ASSERT(res >= 0);
-  PL_ASSERT(res <= 1);
+  PELOTON_ASSERT(res >= 0);
+  PELOTON_ASSERT(res <= 1);
   return res;
 }
 
@@ -130,8 +130,8 @@ double Selectivity::Equal(const std::shared_ptr<TableStats> &table_stats,
     res = (1 - sum_mvf / (double)numrows) /
           (column_stats->cardinality - most_common_vals.size());
   }
-  PL_ASSERT(res >= 0);
-  PL_ASSERT(res <= 1);
+  PELOTON_ASSERT(res >= 0);
+  PELOTON_ASSERT(res <= 1);
   return res;
 }
 
@@ -157,14 +157,14 @@ double Selectivity::Like(const std::shared_ptr<TableStats> &table_stats,
 
   // Sample on the fly
   auto sampler = table_stats->GetSampler();
-  PL_ASSERT(sampler != nullptr);
+  PELOTON_ASSERT(sampler != nullptr);
   if (sampler->GetSampledTuples().empty()) {
     sampler->AcquireSampleTuples(DEFAULT_SAMPLE_SIZE);
   }
   auto &sample_tuples = sampler->GetSampledTuples();
   for (size_t i = 0; i < sample_tuples.size(); i++) {
     auto value = sample_tuples[i]->GetValue(column_id);
-    PL_ASSERT(value.GetTypeId() == type::TypeId::VARCHAR);
+    PELOTON_ASSERT(value.GetTypeId() == type::TypeId::VARCHAR);
     executor::ExecutorContext dummy_context(nullptr);
     if (function::StringFunctions::Like(dummy_context, value.GetData(),
                                         value.GetLength(), pattern,

--- a/src/optimizer/stats/table_stats_collector.cpp
+++ b/src/optimizer/stats/table_stats_collector.cpp
@@ -82,7 +82,7 @@ void TableStatsCollector::InitColumnStatsCollectors() {
 }
 
 ColumnStatsCollector *TableStatsCollector::GetColumnStats(oid_t column_id) {
-  PL_ASSERT(column_id < column_stats_collectors_.size());
+  PELOTON_ASSERT(column_id < column_stats_collectors_.size());
   return column_stats_collectors_[column_id].get();
 }
 

--- a/src/optimizer/stats_calculator.cpp
+++ b/src/optimizer/stats_calculator.cpp
@@ -82,7 +82,7 @@ void StatsCalculator::Visit(const LogicalQueryDerivedGet *) {
   auto root_group = memo_->GetGroupByID(gexpr_->GetGroupID());
   root_group->SetNumRows(0);
   for (auto &col : required_cols_) {
-    PL_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+    PELOTON_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
     auto tv_expr = reinterpret_cast<expression::TupleValueExpression *>(col);
     auto bound_ids = tv_expr->GetBoundOid();
     root_group->AddStats(tv_expr->GetColFullName(),
@@ -96,7 +96,7 @@ void StatsCalculator::Visit(const LogicalQueryDerivedGet *) {
 
 void StatsCalculator::Visit(const LogicalInnerJoin *op) {
   // Check if there's join condition
-  PL_ASSERT(gexpr_->GetChildrenGroupsSize() == 2);
+  PELOTON_ASSERT(gexpr_->GetChildrenGroupsSize() == 2);
   auto left_child_group = memo_->GetGroupByID(gexpr_->GetChildGroupId(0));
   auto right_child_group = memo_->GetGroupByID(gexpr_->GetChildGroupId(1));
   auto root_group = memo_->GetGroupByID(gexpr_->GetGroupID());
@@ -133,7 +133,7 @@ void StatsCalculator::Visit(const LogicalInnerJoin *op) {
   }
   size_t num_rows = root_group->GetNumRows();
   for (auto &col : required_cols_) {
-    PL_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+    PELOTON_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
     auto tv_expr = reinterpret_cast<expression::TupleValueExpression *>(col);
     std::shared_ptr<ColumnStats> column_stats;
     // Make a copy from the child stats
@@ -141,7 +141,7 @@ void StatsCalculator::Visit(const LogicalInnerJoin *op) {
       column_stats = std::make_shared<ColumnStats>(
           *left_child_group->GetStats(tv_expr->GetColFullName()));
     } else {
-      PL_ASSERT(right_child_group->HasColumnStats(tv_expr->GetColFullName()));
+      PELOTON_ASSERT(right_child_group->HasColumnStats(tv_expr->GetColFullName()));
       column_stats = std::make_shared<ColumnStats>(
           *right_child_group->GetStats(tv_expr->GetColFullName()));
     }
@@ -160,13 +160,13 @@ void StatsCalculator::Visit(const LogicalAggregateAndGroupBy *) {
   // TODO(boweic): For now we just pass the stats needed without any
   // computation,
   // We need to implement stats computation for aggregation
-  PL_ASSERT(gexpr_->GetChildrenGroupsSize() == 1);
+  PELOTON_ASSERT(gexpr_->GetChildrenGroupsSize() == 1);
   // First, set num rows
   memo_->GetGroupByID(gexpr_->GetGroupID())
       ->SetNumRows(
           memo_->GetGroupByID(gexpr_->GetChildGroupId(0))->GetNumRows());
   for (auto &col : required_cols_) {
-    PL_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+    PELOTON_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
     auto column_name = reinterpret_cast<expression::TupleValueExpression *>(col)
                            ->GetColFullName();
     memo_->GetGroupByID(gexpr_->GetGroupID())
@@ -176,13 +176,13 @@ void StatsCalculator::Visit(const LogicalAggregateAndGroupBy *) {
 }
 
 void StatsCalculator::Visit(const LogicalLimit *op) {
-  PL_ASSERT(gexpr_->GetChildrenGroupsSize() == 1);
+  PELOTON_ASSERT(gexpr_->GetChildrenGroupsSize() == 1);
   auto group = memo_->GetGroupByID(gexpr_->GetGroupID());
   group->SetNumRows(std::min(
       (size_t)op->limit,
       (size_t)memo_->GetGroupByID(gexpr_->GetChildGroupId(0))->GetNumRows()));
   for (auto &col : required_cols_) {
-    PL_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+    PELOTON_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
     auto column_name = reinterpret_cast<expression::TupleValueExpression *>(col)
                            ->GetColFullName();
     std::shared_ptr<ColumnStats> column_stats = std::make_shared<ColumnStats>(
@@ -198,9 +198,9 @@ void StatsCalculator::Visit(const LogicalDistinct *) {
   memo_->GetGroupByID(gexpr_->GetGroupID())
       ->SetNumRows(
           memo_->GetGroupByID(gexpr_->GetChildGroupId(0))->GetNumRows());
-  PL_ASSERT(gexpr_->GetChildrenGroupsSize() == 1);
+  PELOTON_ASSERT(gexpr_->GetChildrenGroupsSize() == 1);
   for (auto &col : required_cols_) {
-    PL_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+    PELOTON_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
     auto column_name = reinterpret_cast<expression::TupleValueExpression *>(col)
                            ->GetColFullName();
     memo_->GetGroupByID(gexpr_->GetGroupID())
@@ -214,7 +214,7 @@ void StatsCalculator::AddBaseTableStats(
     std::shared_ptr<TableStats> table_stats,
     std::unordered_map<std::string, std::shared_ptr<ColumnStats>> &stats,
     bool copy) {
-  PL_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+  PELOTON_ASSERT(col->GetExpressionType() == ExpressionType::VALUE_TUPLE);
   auto tv_expr = reinterpret_cast<expression::TupleValueExpression *>(col);
   auto bound_ids = tv_expr->GetBoundOid();
   if (table_stats->GetColumnCount() == 0) {
@@ -283,7 +283,7 @@ double StatsCalculator::CalculateSelectivityForPredicate(
             : 0;
 
     auto left_expr = expr->GetChild(1 - right_index);
-    PL_ASSERT(left_expr->GetExpressionType() == ExpressionType::VALUE_TUPLE);
+    PELOTON_ASSERT(left_expr->GetExpressionType() == ExpressionType::VALUE_TUPLE);
     auto col_name =
         reinterpret_cast<const expression::TupleValueExpression *>(left_expr)
             ->GetColFullName();

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1601,7 +1601,7 @@ PostgresParser::ParamListTransform(List *root) {
 parser::SQLStatement *PostgresParser::InsertTransform(InsertStmt *root) {
   // selectStmt must exist. It would either select from table or directly select
   // some values
-  PL_ASSERT(root->selectStmt != NULL);
+  PELOTON_ASSERT(root->selectStmt != NULL);
 
   auto select_stmt = reinterpret_cast<SelectStmt *>(root->selectStmt);
 
@@ -1617,7 +1617,7 @@ parser::SQLStatement *PostgresParser::InsertTransform(InsertStmt *root) {
     // Directly insert some values
     result = new parser::InsertStatement(InsertType::VALUES);
 
-    PL_ASSERT(select_stmt->valuesLists != NULL);
+    PELOTON_ASSERT(select_stmt->valuesLists != NULL);
     std::vector<std::vector<std::unique_ptr<expression::AbstractExpression>>>
         *insert_values = nullptr;
     try {

--- a/src/planner/abstract_join_plan.cpp
+++ b/src/planner/abstract_join_plan.cpp
@@ -24,7 +24,7 @@ void AbstractJoinPlan::GetOutputColumns(std::vector<oid_t> &columns) const {
 
 void AbstractJoinPlan::PerformBinding(BindingContext &context) {
   const auto &children = GetChildren();
-  PL_ASSERT(children.size() == 2);
+  PELOTON_ASSERT(children.size() == 2);
 
   // Let the left and right child populate bind their attributes
   BindingContext left_context, right_context;

--- a/src/planner/abstract_plan.cpp
+++ b/src/planner/abstract_plan.cpp
@@ -34,7 +34,7 @@ const std::vector<std::unique_ptr<AbstractPlan>> &AbstractPlan::GetChildren()
 }
 
 const AbstractPlan *AbstractPlan::GetChild(uint32_t child_index) const {
-  PL_ASSERT(child_index < children_.size());
+  PELOTON_ASSERT(child_index < children_.size());
   return children_[child_index].get();
 }
 

--- a/src/planner/aggregate_plan.cpp
+++ b/src/planner/aggregate_plan.cpp
@@ -43,7 +43,7 @@ void AggregatePlan::AggTerm::PerformBinding(BindingContext &binding_context) {
       // AVG() must have an input expression (that has been bound earlier).
       // The return type of the AVG() aggregate is always a SQL DECIMAL that
       // may or may not be NULL depending on the input expression.
-      PL_ASSERT(expression != nullptr);
+      PELOTON_ASSERT(expression != nullptr);
       // TODO: Move this logic into the SQL type
       const auto &input_type = expression->ResultType();
       agg_ai.type = codegen::type::Type{codegen::type::Decimal::Instance(),
@@ -55,7 +55,7 @@ void AggregatePlan::AggTerm::PerformBinding(BindingContext &binding_context) {
     case ExpressionType::AGGREGATE_SUM: {
       // These aggregates must have an input expression and takes on the same
       // return type as its input expression.
-      PL_ASSERT(expression != nullptr);
+      PELOTON_ASSERT(expression != nullptr);
       agg_ai.type = expression->ResultType();
       break;
     }
@@ -74,17 +74,17 @@ void AggregatePlan::PerformBinding(BindingContext &binding_context) {
   BindingContext input_context;
 
   const auto &children = GetChildren();
-  PL_ASSERT(children.size() == 1);
+  PELOTON_ASSERT(children.size() == 1);
 
   children[0]->PerformBinding(input_context);
 
-  PL_ASSERT(groupby_ais_.empty());
+  PELOTON_ASSERT(groupby_ais_.empty());
 
   // First get bindings for the grouping keys
   for (oid_t gb_col_id : GetGroupbyColIds()) {
     auto *ai = input_context.Find(gb_col_id);
     LOG_DEBUG("Grouping col %u binds to AI %p", gb_col_id, ai);
-    PL_ASSERT(ai != nullptr);
+    PELOTON_ASSERT(ai != nullptr);
     groupby_ais_.push_back(ai);
   }
 

--- a/src/planner/delete_plan.cpp
+++ b/src/planner/delete_plan.cpp
@@ -44,7 +44,7 @@ bool DeletePlan::operator==(const AbstractPlan &rhs) const {
 
   auto *table = GetTable();
   auto *other_table = other.GetTable();
-  PL_ASSERT(table && other_table);
+  PELOTON_ASSERT(table && other_table);
   if (*table != *other_table)
     return false;
 

--- a/src/planner/insert_plan.cpp
+++ b/src/planner/insert_plan.cpp
@@ -27,7 +27,7 @@ InsertPlan::InsertPlan(storage::DataTable *table,
         std::unique_ptr<expression::AbstractExpression>>> *insert_values)
     : target_table_(table), bulk_insert_count_(insert_values->size()) {
   LOG_TRACE("Creating an Insert Plan with multiple expressions");
-  PL_ASSERT(target_table_);
+  PELOTON_ASSERT(target_table_);
   parameter_vector_.reset(new std::vector<std::tuple<oid_t, oid_t, oid_t>>());
   params_value_type_.reset(new std::vector<type::TypeId>);
 
@@ -37,7 +37,7 @@ InsertPlan::InsertPlan(storage::DataTable *table,
     for (uint32_t tuple_idx = 0; tuple_idx < insert_values->size();
          tuple_idx++) {
       auto &values = (*insert_values)[tuple_idx];
-      PL_ASSERT(values.size() <= schema->GetColumnCount());
+      PELOTON_ASSERT(values.size() <= schema->GetColumnCount());
       uint32_t param_idx = 0;
       for (uint32_t column_id = 0; column_id < values.size(); column_id++) {
         auto &exp = values[column_id];
@@ -55,7 +55,7 @@ InsertPlan::InsertPlan(storage::DataTable *table,
           parameter_vector_->push_back(pair);
           params_value_type_->push_back(type);
         } else {
-          PL_ASSERT(exp->GetExpressionType() == ExpressionType::VALUE_CONSTANT);
+          PELOTON_ASSERT(exp->GetExpressionType() == ExpressionType::VALUE_CONSTANT);
           auto *const_exp =
               dynamic_cast<expression::ConstantValueExpression *>(exp.get());
           type::Value value = const_exp->GetValue().CastAs(type);
@@ -66,7 +66,7 @@ InsertPlan::InsertPlan(storage::DataTable *table,
   }
   // INSERT INTO table_name (col1, col2, ...) VALUES (val1, val2, ...);
   else {
-    PL_ASSERT(columns->size() <= schema->GetColumnCount());
+    PELOTON_ASSERT(columns->size() <= schema->GetColumnCount());
     for (uint32_t tuple_idx = 0; tuple_idx < insert_values->size();
          tuple_idx++) {
       auto &values = (*insert_values)[tuple_idx];
@@ -95,7 +95,7 @@ InsertPlan::InsertPlan(storage::DataTable *table,
           parameter_vector_->push_back(pair);
           params_value_type_->push_back(type);
         } else {
-          PL_ASSERT(exp->GetExpressionType() == ExpressionType::VALUE_CONSTANT);
+          PELOTON_ASSERT(exp->GetExpressionType() == ExpressionType::VALUE_CONSTANT);
           auto *const_exp =
               dynamic_cast<expression::ConstantValueExpression *>(exp.get());
           type::Value value = const_exp->GetValue().CastAs(type);
@@ -114,8 +114,8 @@ type::AbstractPool *InsertPlan::GetPlanPool() {
 
 void InsertPlan::SetParameterValues(std::vector<type::Value> *values) {
   LOG_TRACE("Set Parameter Values in Insert");
-  PL_ASSERT(values->size() == parameter_vector_->size());
-  PL_ASSERT(values->size() == params_value_type_->size());
+  PELOTON_ASSERT(values->size() == parameter_vector_->size());
+  PELOTON_ASSERT(values->size() == params_value_type_->size());
   for (unsigned int i = 0; i < values->size(); i++) {
     auto type = params_value_type_->at(i);
     auto &param_info = parameter_vector_->at(i);
@@ -164,7 +164,7 @@ bool InsertPlan::operator==(const AbstractPlan &rhs) const {
 
   auto *table = GetTable();
   auto *other_table = other.GetTable();
-  PL_ASSERT(table && other_table);
+  PELOTON_ASSERT(table && other_table);
   if (*table != *other_table)
     return false;
 
@@ -194,7 +194,7 @@ void InsertPlan::VisitParameters(
       values.push_back(value);
     }
   } else {
-    PL_ASSERT(GetChildren().size() == 1);
+    PELOTON_ASSERT(GetChildren().size() == 1);
     auto *plan = const_cast<planner::AbstractPlan *>(GetChild(0));
     plan->VisitParameters(map, values, values_from_user);
   }

--- a/src/planner/nested_loop_join_plan.cpp
+++ b/src/planner/nested_loop_join_plan.cpp
@@ -36,13 +36,13 @@ void NestedLoopJoinPlan::HandleSubplanBinding(bool from_left,
   if (from_left) {
     for (const auto left_col_id : join_column_ids_left_) {
       const auto *ai = ctx.Find(left_col_id);
-      PL_ASSERT(ai != nullptr);
+      PELOTON_ASSERT(ai != nullptr);
       join_ais_left_.push_back(ai);
     }
   } else {
     for (const auto right_col_id : join_column_ids_right_) {
       const auto *ai = ctx.Find(right_col_id);
-      PL_ASSERT(ai != nullptr);
+      PELOTON_ASSERT(ai != nullptr);
       join_ais_right_.push_back(ai);
     }
   }

--- a/src/planner/order_by_plan.cpp
+++ b/src/planner/order_by_plan.cpp
@@ -33,13 +33,13 @@ void OrderByPlan::PerformBinding(BindingContext &binding_context) {
 
   for (const oid_t col_id : GetOutputColumnIds()) {
     auto* ai = binding_context.Find(col_id);
-    PL_ASSERT(ai != nullptr);
+    PELOTON_ASSERT(ai != nullptr);
     output_ais_.push_back(ai);
   }
 
   for (const oid_t sort_key_col_id : GetSortKeys()) {
     auto* ai = binding_context.Find(sort_key_col_id);
-    PL_ASSERT(ai != nullptr);
+    PELOTON_ASSERT(ai != nullptr);
     sort_key_ais_.push_back(ai);
   }
 }

--- a/src/planner/project_info.cpp
+++ b/src/planner/project_info.cpp
@@ -130,7 +130,7 @@ void ProjectInfo::PerformRebinding(
     oid_t dest_col_id = target.first;
     auto &derived_attribute = const_cast<DerivedAttribute &>(target.second);
 
-    PL_ASSERT(derived_attribute.expr != nullptr);
+    PELOTON_ASSERT(derived_attribute.expr != nullptr);
 
     LOG_TRACE("Binding target-list expressions ...");
     auto *expr =
@@ -261,7 +261,7 @@ void ProjectInfo::VisitParameters(
 
     for (auto &target : GetTargetList()) {
       const auto &derived_attribute = target.second;
-      PL_ASSERT(derived_attribute.expr != nullptr);
+      PELOTON_ASSERT(derived_attribute.expr != nullptr);
 
       auto *expr =
           const_cast<expression::AbstractExpression *>(derived_attribute.expr);

--- a/src/planner/projection_plan.cpp
+++ b/src/planner/projection_plan.cpp
@@ -26,7 +26,7 @@ void ProjectionPlan::PerformBinding(BindingContext &context) {
   const auto& children = GetChildren();
   if (children.empty())
     return;
-  PL_ASSERT(children.size() == 1);
+  PELOTON_ASSERT(children.size() == 1);
 
   // Let the child do its binding first
   BindingContext child_context;

--- a/src/planner/seq_scan_plan.cpp
+++ b/src/planner/seq_scan_plan.cpp
@@ -105,7 +105,7 @@ bool SeqScanPlan::SerializeTo(SerializeOutput &output) const {
 
   // Write the total length
   int32_t sz = static_cast<int32_t>(output.Position() - start - sizeof(int));
-  PL_ASSERT(sz > 0);
+  PELOTON_ASSERT(sz > 0);
   output.WriteIntAt(start, sz);
 
   return true;
@@ -131,7 +131,7 @@ bool SeqScanPlan::DeserializeFrom(SerializeInput &input) {
   // Read the type
   UNUSED_ATTRIBUTE PlanNodeType plan_type =
       (PlanNodeType)input.ReadEnumInSingleByte();
-  PL_ASSERT(plan_type == GetPlanNodeType());
+  PELOTON_ASSERT(plan_type == GetPlanNodeType());
 
   // Read database id
   oid_t database_oid = input.ReadInt();
@@ -292,7 +292,7 @@ bool SeqScanPlan::operator==(const AbstractPlan &rhs) const {
   auto &other = static_cast<const planner::SeqScanPlan &>(rhs);
   auto *table = GetTable();
   auto *other_table = other.GetTable();
-  PL_ASSERT(table && other_table);
+  PELOTON_ASSERT(table && other_table);
   if (*table != *other_table)
     return false;
 

--- a/src/planner/update_plan.cpp
+++ b/src/planner/update_plan.cpp
@@ -48,7 +48,7 @@ void UpdatePlan::PerformBinding(BindingContext &binding_context) {
   BindingContext input_context;
 
   const auto &children = GetChildren();
-  PL_ASSERT(children.size() == 1);
+  PELOTON_ASSERT(children.size() == 1);
 
   children[0]->PerformBinding(input_context);
 
@@ -88,7 +88,7 @@ bool UpdatePlan::operator==(const AbstractPlan &rhs) const {
   auto &other = static_cast<const planner::UpdatePlan &>(rhs);
   auto *table = GetTable();
   auto *other_table = other.GetTable();
-  PL_ASSERT(table && other_table);
+  PELOTON_ASSERT(table && other_table);
   if (*table != *other_table)
     return false;
 

--- a/src/statistics/access_metric.cpp
+++ b/src/statistics/access_metric.cpp
@@ -17,7 +17,7 @@ namespace peloton {
 namespace stats {
 
 void AccessMetric::Aggregate(AbstractMetric &source) {
-  PL_ASSERT(source.GetType() == MetricType::ACCESS);
+  PELOTON_ASSERT(source.GetType() == MetricType::ACCESS);
 
   auto access_metric = static_cast<AccessMetric &>(source);
   for (size_t i = 0; i < NUM_COUNTERS; ++i) {

--- a/src/statistics/backend_stats_context.cpp
+++ b/src/statistics/backend_stats_context.cpp
@@ -114,7 +114,7 @@ void BackendStatsContext::IncrementTableReads(oid_t tile_group_id) {
                           .GetTileGroup(tile_group_id)
                           ->GetDatabaseId();
   auto table_metric = GetTableMetric(database_id, table_id);
-  PL_ASSERT(table_metric != nullptr);
+  PELOTON_ASSERT(table_metric != nullptr);
   table_metric->GetTableAccess().IncrementReads();
   if (ongoing_query_metric_ != nullptr) {
     ongoing_query_metric_->GetQueryAccess().IncrementReads();
@@ -128,7 +128,7 @@ void BackendStatsContext::IncrementTableInserts(oid_t tile_group_id) {
                           .GetTileGroup(tile_group_id)
                           ->GetDatabaseId();
   auto table_metric = GetTableMetric(database_id, table_id);
-  PL_ASSERT(table_metric != nullptr);
+  PELOTON_ASSERT(table_metric != nullptr);
   table_metric->GetTableAccess().IncrementInserts();
   if (ongoing_query_metric_ != nullptr) {
     ongoing_query_metric_->GetQueryAccess().IncrementInserts();
@@ -142,7 +142,7 @@ void BackendStatsContext::IncrementTableUpdates(oid_t tile_group_id) {
                           .GetTileGroup(tile_group_id)
                           ->GetDatabaseId();
   auto table_metric = GetTableMetric(database_id, table_id);
-  PL_ASSERT(table_metric != nullptr);
+  PELOTON_ASSERT(table_metric != nullptr);
   table_metric->GetTableAccess().IncrementUpdates();
   if (ongoing_query_metric_ != nullptr) {
     ongoing_query_metric_->GetQueryAccess().IncrementUpdates();
@@ -156,7 +156,7 @@ void BackendStatsContext::IncrementTableDeletes(oid_t tile_group_id) {
                           .GetTileGroup(tile_group_id)
                           ->GetDatabaseId();
   auto table_metric = GetTableMetric(database_id, table_id);
-  PL_ASSERT(table_metric != nullptr);
+  PELOTON_ASSERT(table_metric != nullptr);
   table_metric->GetTableAccess().IncrementDeletes();
   if (ongoing_query_metric_ != nullptr) {
     ongoing_query_metric_->GetQueryAccess().IncrementDeletes();
@@ -169,7 +169,7 @@ void BackendStatsContext::IncrementIndexReads(size_t read_count,
   oid_t table_id = metadata->GetTableOid();
   oid_t database_id = metadata->GetDatabaseOid();
   auto index_metric = GetIndexMetric(database_id, table_id, index_id);
-  PL_ASSERT(index_metric != nullptr);
+  PELOTON_ASSERT(index_metric != nullptr);
   index_metric->GetIndexAccess().IncrementReads(read_count);
 }
 
@@ -179,7 +179,7 @@ void BackendStatsContext::IncrementIndexInserts(
   oid_t table_id = metadata->GetTableOid();
   oid_t database_id = metadata->GetDatabaseOid();
   auto index_metric = GetIndexMetric(database_id, table_id, index_id);
-  PL_ASSERT(index_metric != nullptr);
+  PELOTON_ASSERT(index_metric != nullptr);
   index_metric->GetIndexAccess().IncrementInserts();
 }
 
@@ -189,7 +189,7 @@ void BackendStatsContext::IncrementIndexUpdates(
   oid_t table_id = metadata->GetTableOid();
   oid_t database_id = metadata->GetDatabaseOid();
   auto index_metric = GetIndexMetric(database_id, table_id, index_id);
-  PL_ASSERT(index_metric != nullptr);
+  PELOTON_ASSERT(index_metric != nullptr);
   index_metric->GetIndexAccess().IncrementUpdates();
 }
 
@@ -199,20 +199,20 @@ void BackendStatsContext::IncrementIndexDeletes(
   oid_t table_id = metadata->GetTableOid();
   oid_t database_id = metadata->GetDatabaseOid();
   auto index_metric = GetIndexMetric(database_id, table_id, index_id);
-  PL_ASSERT(index_metric != nullptr);
+  PELOTON_ASSERT(index_metric != nullptr);
   index_metric->GetIndexAccess().IncrementDeletes(delete_count);
 }
 
 void BackendStatsContext::IncrementTxnCommitted(oid_t database_id) {
   auto database_metric = GetDatabaseMetric(database_id);
-  PL_ASSERT(database_metric != nullptr);
+  PELOTON_ASSERT(database_metric != nullptr);
   database_metric->IncrementTxnCommitted();
   CompleteQueryMetric();
 }
 
 void BackendStatsContext::IncrementTxnAborted(oid_t database_id) {
   auto database_metric = GetDatabaseMetric(database_id);
-  PL_ASSERT(database_metric != nullptr);
+  PELOTON_ASSERT(database_metric != nullptr);
   database_metric->IncrementTxnAborted();
   CompleteQueryMetric();
 }

--- a/src/statistics/counter_metric.cpp
+++ b/src/statistics/counter_metric.cpp
@@ -21,7 +21,7 @@ CounterMetric::CounterMetric(MetricType type) : AbstractMetric(type) {
 }
 
 void CounterMetric::Aggregate(AbstractMetric &source) {
-  PL_ASSERT(source.GetType() == MetricType::COUNTER);
+  PELOTON_ASSERT(source.GetType() == MetricType::COUNTER);
   count_ += static_cast<CounterMetric &>(source).GetCounter();
 }
 

--- a/src/statistics/database_metric.cpp
+++ b/src/statistics/database_metric.cpp
@@ -21,7 +21,7 @@ DatabaseMetric::DatabaseMetric(MetricType type, oid_t database_id)
     : AbstractMetric(type), database_id_(database_id) {}
 
 void DatabaseMetric::Aggregate(AbstractMetric& source) {
-  PL_ASSERT(source.GetType() == MetricType::DATABASE);
+  PELOTON_ASSERT(source.GetType() == MetricType::DATABASE);
 
   DatabaseMetric& db_metric = static_cast<DatabaseMetric&>(source);
   txn_committed_.Aggregate(db_metric.GetTxnCommitted());

--- a/src/statistics/latency_metric.cpp
+++ b/src/statistics/latency_metric.cpp
@@ -25,7 +25,7 @@ LatencyMetric::LatencyMetric(MetricType type, size_t max_history)
 }
 
 void LatencyMetric::Aggregate(AbstractMetric& source) {
-  PL_ASSERT(source.GetType() == MetricType::LATENCY);
+  PELOTON_ASSERT(source.GetType() == MetricType::LATENCY);
 
   LatencyMetric& latency_metric = static_cast<LatencyMetric&>(source);
   CircularBuffer<double> source_latencies = latency_metric.Copy();

--- a/src/statistics/stats_aggregator.cpp
+++ b/src/statistics/stats_aggregator.cpp
@@ -160,7 +160,7 @@ void StatsAggregator::UpdateQueryMetrics(int64_t time_stamp,
       num_params = query_params->num_params;
       format_buf = query_params->format_buf_copy;
       type_buf = query_params->type_buf_copy;
-      PL_ASSERT(num_params > 0);
+      PELOTON_ASSERT(num_params > 0);
     }
 
     // Generate and insert the tuple
@@ -304,7 +304,7 @@ void StatsAggregator::RegisterContext(std::thread::id id_,
   {
     std::lock_guard<std::mutex> lock(stats_mutex_);
 
-    PL_ASSERT(backend_stats_.find(id_) == backend_stats_.end());
+    PELOTON_ASSERT(backend_stats_.find(id_) == backend_stats_.end());
 
     thread_number_++;
     backend_stats_[id_] = context_;
@@ -330,12 +330,12 @@ void StatsAggregator::UnregisterContext(std::thread::id id) {
 
 storage::DataTable *StatsAggregator::GetMetricTable(std::string table_name) {
   auto storage_manager = storage::StorageManager::GetInstance();
-  PL_ASSERT(storage_manager->GetDatabaseCount() > 0);
+  PELOTON_ASSERT(storage_manager->GetDatabaseCount() > 0);
   storage::Database *catalog_database =
       storage_manager->GetDatabaseWithOid(CATALOG_DATABASE_OID);
-  PL_ASSERT(catalog_database != nullptr);
+  PELOTON_ASSERT(catalog_database != nullptr);
   auto metrics_table = catalog_database->GetTableWithName(table_name);
-  PL_ASSERT(metrics_table != nullptr);
+  PELOTON_ASSERT(metrics_table != nullptr);
   return metrics_table;
 }
 

--- a/src/storage/backend_manager.cpp
+++ b/src/storage/backend_manager.cpp
@@ -110,7 +110,7 @@ int is_cpu_genuine_intel(void) {
     unsigned cpuinfo[3];
   } vendor;
 
-  PL_MEMSET(&vendor, 0, sizeof(vendor));
+  PELOTON_MEMSET(&vendor, 0, sizeof(vendor));
 
   cpuid(0x0, 0x0, cpuinfo);
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -386,7 +386,7 @@ bool DataTable::InsertTuple(const AbstractTuple *tuple,
     return false;
   }
 
-  PL_ASSERT((*index_entry_ptr)->block == location.block &&
+  PELOTON_ASSERT((*index_entry_ptr)->block == location.block &&
             (*index_entry_ptr)->offset == location.offset);
 
   // Increase the table's number of tuples by 1
@@ -405,7 +405,7 @@ ItemPointer DataTable::InsertTuple(const storage::Tuple *tuple) {
   LOG_TRACE("Location: %u, %u", location.block, location.offset);
 
   UNUSED_ATTRIBUTE auto index_count = GetIndexCount();
-  PL_ASSERT(index_count == 0);
+  PELOTON_ASSERT(index_count == 0);
   // Increase the table's number of tuples by 1
   IncreaseTupleCount(1);
   return location;
@@ -911,7 +911,7 @@ oid_t DataTable::AddDefaultTileGroup(const size_t &active_tile_group_id) {
 
   // Create a tile group with that partitioning
   std::shared_ptr<TileGroup> tile_group(GetTileGroupWithLayout(column_map));
-  PL_ASSERT(tile_group.get());
+  PELOTON_ASSERT(tile_group.get());
 
   tile_group_id = tile_group->GetTileGroupId();
 
@@ -937,7 +937,7 @@ oid_t DataTable::AddDefaultTileGroup(const size_t &active_tile_group_id) {
 }
 
 void DataTable::AddTileGroupWithOidForRecovery(const oid_t &tile_group_id) {
-  PL_ASSERT(tile_group_id);
+  PELOTON_ASSERT(tile_group_id);
 
   std::vector<catalog::Schema> schemas;
   schemas.push_back(*schema);
@@ -999,7 +999,7 @@ size_t DataTable::GetTileGroupCount() const { return tile_group_count_; }
 
 std::shared_ptr<storage::TileGroup> DataTable::GetTileGroup(
     const std::size_t &tile_group_offset) const {
-  PL_ASSERT(tile_group_offset < GetTileGroupCount());
+  PELOTON_ASSERT(tile_group_offset < GetTileGroupCount());
 
   auto tile_group_id =
       tile_groups_.FindValid(tile_group_offset, invalid_tile_group_id);
@@ -1088,7 +1088,7 @@ void DataTable::DropIndexWithOid(const oid_t &index_oid) {
     }
   }
 
-  PL_ASSERT(index_offset < indexes_.GetSize());
+  PELOTON_ASSERT(index_offset < indexes_.GetSize());
 
   // Drop the index
   indexes_.Update(index_offset, nullptr);
@@ -1109,7 +1109,7 @@ void DataTable::DropIndexes() {
 // that the returned index could be a nullptr once we can drop index
 // with oid (due to a limitation of LockFreeArray).
 std::shared_ptr<index::Index> DataTable::GetIndex(const oid_t &index_offset) {
-  PL_ASSERT(index_offset < indexes_.GetSize());
+  PELOTON_ASSERT(index_offset < indexes_.GetSize());
   auto ret_index = indexes_.Find(index_offset);
 
   return ret_index;
@@ -1117,7 +1117,7 @@ std::shared_ptr<index::Index> DataTable::GetIndex(const oid_t &index_offset) {
 
 //
 std::set<oid_t> DataTable::GetIndexAttrs(const oid_t &index_offset) const {
-  PL_ASSERT(index_offset < GetIndexCount());
+  PELOTON_ASSERT(index_offset < GetIndexCount());
 
   auto index_attrs = indexes_columns_.at(index_offset);
 
@@ -1173,7 +1173,7 @@ catalog::ForeignKey *DataTable::GetForeignKey(const oid_t &key_offset) const {
 void DataTable::DropForeignKey(const oid_t &key_offset) {
   {
     std::lock_guard<std::mutex> lock(data_table_mutex_);
-    PL_ASSERT(key_offset < foreign_keys_.size());
+    PELOTON_ASSERT(key_offset < foreign_keys_.size());
     foreign_keys_.erase(foreign_keys_.begin() + key_offset);
   }
 }
@@ -1239,7 +1239,7 @@ void SetTransformedTileGroup(storage::TileGroup *orig_tile_group,
   // Check the schema of the two tile groups
   auto new_column_map = new_tile_group->GetColumnMap();
   auto orig_column_map = orig_tile_group->GetColumnMap();
-  PL_ASSERT(new_column_map.size() == orig_column_map.size());
+  PELOTON_ASSERT(new_column_map.size() == orig_column_map.size());
 
   oid_t orig_tile_offset, orig_tile_column_offset;
   oid_t new_tile_offset, new_tile_column_offset;

--- a/src/storage/database.cpp
+++ b/src/storage/database.cpp
@@ -81,7 +81,7 @@ void Database::DropTableWithOid(const oid_t table_oid) {
 
     // Deregister table from GC manager.
     auto *gc_manager = &gc::GCManagerFactory::GetInstance();
-    PL_ASSERT(gc_manager != nullptr);
+    PELOTON_ASSERT(gc_manager != nullptr);
     gc_manager->DeregisterTable(table_oid);
 
     // Deregister table from Query Cache manager
@@ -95,7 +95,7 @@ void Database::DropTableWithOid(const oid_t table_oid) {
       }
       table_offset++;
     }
-    PL_ASSERT(table_offset < tables.size());
+    PELOTON_ASSERT(table_offset < tables.size());
 
     // Drop the table
     tables.erase(tables.begin() + table_offset);
@@ -103,7 +103,7 @@ void Database::DropTableWithOid(const oid_t table_oid) {
 }
 
 storage::DataTable *Database::GetTable(const oid_t table_offset) const {
-  PL_ASSERT(table_offset < tables.size());
+  PELOTON_ASSERT(table_offset < tables.size());
   auto table = tables.at(table_offset);
   return table;
 }

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -79,7 +79,7 @@ index::Index *StorageManager::GetIndexWithOid(oid_t database_oid,
 // This is used as an iterator
 Database *StorageManager::GetDatabaseWithOffset(
     oid_t database_offset) const {
-  PL_ASSERT(database_offset < databases_.size());
+  PELOTON_ASSERT(database_offset < databases_.size());
   auto database = databases_.at(database_offset);
   return database;
 }

--- a/src/storage/temp_table.cpp
+++ b/src/storage/temp_table.cpp
@@ -39,9 +39,9 @@ TempTable::~TempTable() {
 ItemPointer TempTable::InsertTuple(
     const Tuple *tuple, UNUSED_ATTRIBUTE concurrency::TransactionContext *transaction,
     UNUSED_ATTRIBUTE ItemPointer **index_entry_ptr, UNUSED_ATTRIBUTE bool check_fk) {
-  PL_ASSERT(tuple != nullptr);
-  PL_ASSERT(transaction == nullptr);
-  PL_ASSERT(index_entry_ptr == nullptr);
+  PELOTON_ASSERT(tuple != nullptr);
+  PELOTON_ASSERT(transaction == nullptr);
+  PELOTON_ASSERT(index_entry_ptr == nullptr);
 
   std::shared_ptr<storage::TileGroup> tile_group;
   oid_t tuple_slot = INVALID_OID;
@@ -86,7 +86,7 @@ ItemPointer TempTable::InsertTuple(const Tuple *tuple) {
 
 std::shared_ptr<storage::TileGroup> TempTable::GetTileGroup(
     const std::size_t &tile_group_offset) const {
-  PL_ASSERT(tile_group_offset < GetTileGroupCount());
+  PELOTON_ASSERT(tile_group_offset < GetTileGroupCount());
   return (tile_groups_[tile_group_offset]);
 }
 
@@ -121,7 +121,7 @@ oid_t TempTable::AddDefaultTileGroup() {
   std::shared_ptr<storage::TileGroup> tile_group(
       AbstractTable::GetTileGroupWithLayout(
           INVALID_OID, tile_group_id, column_map, TEMPTABLE_DEFAULT_SIZE));
-  PL_ASSERT(tile_group.get());
+  PELOTON_ASSERT(tile_group.get());
 
   tile_groups_.push_back(tile_group);
 

--- a/src/storage/tile_group.cpp
+++ b/src/storage/tile_group.cpp
@@ -64,7 +64,7 @@ TileGroup::~TileGroup() {
 }
 
 oid_t TileGroup::GetTileId(const oid_t tile_id) const {
-  PL_ASSERT(tiles[tile_id]);
+  PELOTON_ASSERT(tiles[tile_id]);
   return tiles[tile_id]->GetTileId();
 }
 
@@ -113,9 +113,9 @@ void TileGroup::CopyTuple(const Tuple *tuple, const oid_t &tuple_slot_id) {
     tile_column_count = schema.GetColumnCount();
 
     storage::Tile *tile = GetTile(tile_itr);
-    PL_ASSERT(tile);
+    PELOTON_ASSERT(tile);
     char *tile_tuple_location = tile->GetTupleLocation(tuple_slot_id);
-    PL_ASSERT(tile_tuple_location);
+    PELOTON_ASSERT(tile_tuple_location);
 
     // NOTE:: Only a tuple wrapper
     storage::Tuple tile_tuple(&schema, tile_tuple_location);
@@ -157,10 +157,10 @@ oid_t TileGroup::InsertTuple(const Tuple *tuple) {
   CopyTuple(tuple, tuple_slot_id);
 
   // Set MVCC info
-  PL_ASSERT(tile_group_header->GetTransactionId(tuple_slot_id) ==
+  PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_slot_id) ==
             INVALID_TXN_ID);
-  PL_ASSERT(tile_group_header->GetBeginCommitId(tuple_slot_id) == MAX_CID);
-  PL_ASSERT(tile_group_header->GetEndCommitId(tuple_slot_id) == MAX_CID);
+  PELOTON_ASSERT(tile_group_header->GetBeginCommitId(tuple_slot_id) == MAX_CID);
+  PELOTON_ASSERT(tile_group_header->GetEndCommitId(tuple_slot_id) == MAX_CID);
   return tuple_slot_id;
 }
 
@@ -195,9 +195,9 @@ oid_t TileGroup::InsertTupleFromRecovery(cid_t commit_id, oid_t tuple_slot_id,
     tile_column_count = schema.GetColumnCount();
 
     storage::Tile *tile = GetTile(tile_itr);
-    PL_ASSERT(tile);
+    PELOTON_ASSERT(tile);
     char *tile_tuple_location = tile->GetTupleLocation(tuple_slot_id);
-    PL_ASSERT(tile_tuple_location);
+    PELOTON_ASSERT(tile_tuple_location);
 
     // NOTE:: Only a tuple wrapper
     storage::Tuple tile_tuple(&schema, tile_tuple_location);
@@ -295,9 +295,9 @@ oid_t TileGroup::InsertTupleFromCheckpoint(oid_t tuple_slot_id,
     tile_column_count = schema.GetColumnCount();
 
     storage::Tile *tile = GetTile(tile_itr);
-    PL_ASSERT(tile);
+    PELOTON_ASSERT(tile);
     char *tile_tuple_location = tile->GetTupleLocation(tuple_slot_id);
-    PL_ASSERT(tile_tuple_location);
+    PELOTON_ASSERT(tile_tuple_location);
 
     // NOTE:: Only a tuple wrapper
     storage::Tuple tile_tuple(&schema, tile_tuple_location);
@@ -332,7 +332,7 @@ oid_t TileGroup::GetTileColumnId(oid_t column_id) {
 }
 
 type::Value TileGroup::GetValue(oid_t tuple_id, oid_t column_id) {
-  PL_ASSERT(tuple_id < GetNextTupleSlot());
+  PELOTON_ASSERT(tuple_id < GetNextTupleSlot());
   oid_t tile_column_id, tile_offset;
   LocateTileAndColumn(column_id, tile_offset, tile_column_id);
   return GetTile(tile_offset)->GetValue(tuple_id, tile_column_id);
@@ -340,7 +340,7 @@ type::Value TileGroup::GetValue(oid_t tuple_id, oid_t column_id) {
 
 void TileGroup::SetValue(type::Value &value, oid_t tuple_id,
                          oid_t column_id) {
-  PL_ASSERT(tuple_id < GetNextTupleSlot());
+  PELOTON_ASSERT(tuple_id < GetNextTupleSlot());
   oid_t tile_column_id, tile_offset;
   LocateTileAndColumn(column_id, tile_offset, tile_column_id);
   GetTile(tile_offset)->SetValue(value, tuple_id, tile_column_id);
@@ -349,7 +349,7 @@ void TileGroup::SetValue(type::Value &value, oid_t tuple_id,
 
 std::shared_ptr<Tile> TileGroup::GetTileReference(
     const oid_t tile_offset) const {
-  PL_ASSERT(tile_offset < tile_count);
+  PELOTON_ASSERT(tile_offset < tile_count);
   return tiles[tile_offset];
 }
 

--- a/src/storage/tile_group_header.cpp
+++ b/src/storage/tile_group_header.cpp
@@ -45,10 +45,10 @@ TileGroupHeader::TileGroupHeader(const BackendType &backend_type,
   // data = reinterpret_cast<char *>(
   // storage_manager.Allocate(backend_type, header_size));
   data = new char[header_size];
-  PL_ASSERT(data != nullptr);
+  PELOTON_ASSERT(data != nullptr);
 
   // zero out the data
-  PL_MEMSET(data, 0, header_size);
+  PELOTON_MEMSET(data, 0, header_size);
 
   // Set MVCC Initial Value
   for (oid_t tuple_slot_id = START_OID; tuple_slot_id < num_tuple_slots;
@@ -239,7 +239,7 @@ oid_t TileGroupHeader::GetActiveTupleCount() const {
        tuple_slot_id++) {
     txn_id_t tuple_txn_id = GetTransactionId(tuple_slot_id);
     if (tuple_txn_id != INVALID_TXN_ID) {
-      PL_ASSERT(tuple_txn_id == INITIAL_TXN_ID);
+      PELOTON_ASSERT(tuple_txn_id == INITIAL_TXN_ID);
       active_tuple_slots++;
     }
   }

--- a/src/storage/tuple.cpp
+++ b/src/storage/tuple.cpp
@@ -34,8 +34,8 @@ Tuple::~Tuple() {
 
 // Get the value of a specified column (const)
 type::Value Tuple::GetValue(oid_t column_id) const {
-  PL_ASSERT(tuple_schema_);
-  PL_ASSERT(tuple_data_);
+  PELOTON_ASSERT(tuple_schema_);
+  PELOTON_ASSERT(tuple_data_);
   const type::TypeId column_type = tuple_schema_->GetType(column_id);
   const char *data_ptr = GetDataPtr(column_id);
   const bool is_inlined = tuple_schema_->IsInlined(column_id);
@@ -93,10 +93,10 @@ void Tuple::Copy(const void *source, type::AbstractPool *pool) {
 
   if (is_inlined) {
     // copy the data
-    PL_MEMCPY(tuple_data_, source, tuple_schema_->GetLength());
+    PELOTON_MEMCPY(tuple_data_, source, tuple_schema_->GetLength());
   } else {
     // copy the data
-    PL_MEMCPY(tuple_data_, source, tuple_schema_->GetLength());
+    PELOTON_MEMCPY(tuple_data_, source, tuple_schema_->GetLength());
 
     // Copy each uninlined column doing an allocation for copies.
     for (oid_t column_itr = 0; column_itr < uninlineable_column_count;
@@ -183,8 +183,8 @@ size_t Tuple::GetUninlinedMemorySize() const {
 
 void Tuple::DeserializeFrom(UNUSED_ATTRIBUTE SerializeInput &input,
                             UNUSED_ATTRIBUTE type::AbstractPool *dataPool) {
-  /*PL_ASSERT(tuple_schema);
-  PL_ASSERT(tuple_data);
+  /*PELOTON_ASSERT(tuple_schema);
+  PELOTON_ASSERT(tuple_data);
 
   input.ReadInt();
   const int column_count = tuple_schema_->GetColumnCount();
@@ -220,8 +220,8 @@ void Tuple::DeserializeFrom(UNUSED_ATTRIBUTE SerializeInput &input,
 }
 
 void Tuple::DeserializeWithHeaderFrom(SerializeInput &input UNUSED_ATTRIBUTE) {
-  /*PL_ASSERT(tuple_schema_);
-  PL_ASSERT(tuple_data_);
+  /*PELOTON_ASSERT(tuple_schema_);
+  PELOTON_ASSERT(tuple_data_);
 
   input.ReadInt();  // Read in the tuple size, discard
 
@@ -241,8 +241,8 @@ void Tuple::DeserializeWithHeaderFrom(SerializeInput &input UNUSED_ATTRIBUTE) {
 }
 
 void Tuple::SerializeWithHeaderTo(SerializeOutput &output) {
-  PL_ASSERT(tuple_schema_);
-  PL_ASSERT(tuple_data_);
+  PELOTON_ASSERT(tuple_schema_);
+  PELOTON_ASSERT(tuple_data_);
 
   size_t start = output.Position();
   output.WriteInt(0);  // reserve first 4 bytes for the total tuple size
@@ -262,7 +262,7 @@ void Tuple::SerializeWithHeaderTo(SerializeOutput &output) {
 }
 
 void Tuple::SerializeTo(SerializeOutput &output) {
-  PL_ASSERT(tuple_schema_);
+  PELOTON_ASSERT(tuple_schema_);
   size_t start = output.ReserveBytes(4);
   const int column_count = tuple_schema_->GetColumnCount();
 
@@ -334,8 +334,8 @@ bool Tuple::EqualsNoSchemaCheck(const AbstractTuple &other,
 }
 
 void Tuple::SetAllNulls() {
-  PL_ASSERT(tuple_schema_);
-  PL_ASSERT(tuple_data_);
+  PELOTON_ASSERT(tuple_schema_);
+  PELOTON_ASSERT(tuple_data_);
   const int column_count = tuple_schema_->GetColumnCount();
 
   for (int column_itr = 0; column_itr < column_count; column_itr++) {
@@ -346,8 +346,8 @@ void Tuple::SetAllNulls() {
 }
 
 void Tuple::SetAllZeros() {
-  PL_ASSERT(tuple_schema_);
-  PL_ASSERT(tuple_data_);
+  PELOTON_ASSERT(tuple_schema_);
+  PELOTON_ASSERT(tuple_data_);
   const int column_count = tuple_schema_->GetColumnCount();
 
   for (int column_itr = 0; column_itr < column_count; column_itr++) {
@@ -402,7 +402,7 @@ size_t Tuple::HashCode(size_t seed) const {
 }
 
 void Tuple::MoveToTuple(const void *address) {
-  PL_ASSERT(tuple_schema_);
+  PELOTON_ASSERT(tuple_schema_);
   tuple_data_ = reinterpret_cast<char *>(const_cast<void *>(address));
 }
 
@@ -412,14 +412,14 @@ size_t Tuple::HashCode() const {
 }
 
 char *Tuple::GetDataPtr(const oid_t column_id) {
-  PL_ASSERT(tuple_schema_);
-  PL_ASSERT(tuple_data_);
+  PELOTON_ASSERT(tuple_schema_);
+  PELOTON_ASSERT(tuple_data_);
   return &tuple_data_[tuple_schema_->GetOffset(column_id)];
 }
 
 const char *Tuple::GetDataPtr(const oid_t column_id) const {
-  PL_ASSERT(tuple_schema_);
-  PL_ASSERT(tuple_data_);
+  PELOTON_ASSERT(tuple_schema_);
+  PELOTON_ASSERT(tuple_data_);
   return &tuple_data_[tuple_schema_->GetOffset(column_id)];
 }
 

--- a/src/storage/zone_map_manager.cpp
+++ b/src/storage/zone_map_manager.cpp
@@ -55,16 +55,16 @@ void ZoneMapManager::CreateZoneMapTableInCatalog() {
  */
 void ZoneMapManager::CreateZoneMapsForTable(storage::DataTable *table,
                                             concurrency::TransactionContext *txn) {
-  PL_ASSERT(table != nullptr);
+  PELOTON_ASSERT(table != nullptr);
   // Scan over the tile groups, check for immutable flag to be true
   // and keep adding to the zone map catalog
   size_t num_tile_groups = table->GetTileGroupCount();
   for (size_t i = 0; i < num_tile_groups; i++) {
     auto tile_group = table->GetTileGroup(i);
     auto tile_group_ptr = tile_group.get();
-    PL_ASSERT(tile_group_ptr != nullptr);
+    PELOTON_ASSERT(tile_group_ptr != nullptr);
     auto tile_group_header = tile_group_ptr->GetHeader();
-    PL_ASSERT(tile_group_header != nullptr);
+    PELOTON_ASSERT(tile_group_header != nullptr);
     bool immutable = tile_group_header->GetImmutability();
     if (immutable) {
       CreateOrUpdateZoneMapForTileGroup(table, i, txn);

--- a/src/trigger/trigger.cpp
+++ b/src/trigger/trigger.cpp
@@ -199,7 +199,7 @@ bool TriggerList::ExecTriggers(TriggerType exec_type,
     TriggerData trigger_data(trigger_type, &obj, old_tuple, new_tuple);
 
     if (IsOnCommit(exec_type)) {
-      PL_ASSERT(txn != nullptr);
+      PELOTON_ASSERT(txn != nullptr);
       txn->AddOnCommitTrigger(trigger_data);
     } else {
       // apply all triggers on the tuple

--- a/src/type/array_type.cpp
+++ b/src/type/array_type.cpp
@@ -72,7 +72,7 @@ Value ArrayType::GetElementAt(const Value &val, uint64_t idx) const {
 // Does this value exist in this array?
 Value ArrayType::InList(const Value &list, const Value &object) const {
   Value ele = (list.GetElementAt(0));
-  PL_ASSERT(ele.CheckComparable(object));
+  PELOTON_ASSERT(ele.CheckComparable(object));
   if (object.IsNull()) return ValueFactory::GetNullValueByType(TypeId::BOOLEAN);
   switch (list.GetElementType()) {
     case TypeId::BOOLEAN: {
@@ -161,8 +161,8 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
 }
 
 CmpBool ArrayType::CompareEquals(const Value &left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::ARRAY);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::ARRAY);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
                       " mismatch with " +
@@ -231,8 +231,8 @@ CmpBool ArrayType::CompareEquals(const Value &left, const Value &right) const {
 }
 
 CmpBool ArrayType::CompareNotEquals(const Value &left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::ARRAY);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::ARRAY);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
                       " mismatch with " +
@@ -301,8 +301,8 @@ CmpBool ArrayType::CompareNotEquals(const Value &left, const Value &right) const
 }
 
 CmpBool ArrayType::CompareLessThan(const Value &left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::ARRAY);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::ARRAY);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
                       " mismatch with " +
@@ -372,8 +372,8 @@ CmpBool ArrayType::CompareLessThan(const Value &left, const Value &right) const 
 
 CmpBool ArrayType::CompareLessThanEquals(const Value &left,
                                        const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::ARRAY);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::ARRAY);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
                       " mismatch with " +
@@ -443,8 +443,8 @@ CmpBool ArrayType::CompareLessThanEquals(const Value &left,
 
 CmpBool ArrayType::CompareGreaterThan(const Value &left,
                                     const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::ARRAY);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::ARRAY);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
                       " mismatch with " +
@@ -514,8 +514,8 @@ CmpBool ArrayType::CompareGreaterThan(const Value &left,
 
 CmpBool ArrayType::CompareGreaterThanEquals(const Value &left,
                                           const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::ARRAY);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::ARRAY);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (right.GetElementType() != left.GetElementType()) {
     std::string msg = Type::GetInstance(right.GetElementType())->ToString() +
                       " mismatch with " +
@@ -585,7 +585,7 @@ CmpBool ArrayType::CompareGreaterThanEquals(const Value &left,
 
 Value ArrayType::CastAs(const Value &val UNUSED_ATTRIBUTE,
                         UNUSED_ATTRIBUTE const TypeId type_id) const {
-  PL_ASSERT(false);
+  PELOTON_ASSERT(false);
   throw Exception(ExceptionType::INCOMPATIBLE_TYPE,
                   "Cannot cast array values.");
 }

--- a/src/type/bigint_type.cpp
+++ b/src/type/bigint_type.cpp
@@ -70,8 +70,8 @@ bool BigintType::IsZero(const Value& val) const {
 }
 
 Value BigintType::Add(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -81,8 +81,8 @@ Value BigintType::Add(const Value& left, const Value &right) const {
 }
 
 Value BigintType::Subtract(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -92,8 +92,8 @@ Value BigintType::Subtract(const Value& left, const Value &right) const {
 }
 
 Value BigintType::Multiply(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -103,8 +103,8 @@ Value BigintType::Multiply(const Value& left, const Value &right) const {
 }
 
 Value BigintType::Divide(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -119,8 +119,8 @@ Value BigintType::Divide(const Value& left, const Value &right) const {
 }
 
 Value BigintType::Modulo(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -153,9 +153,9 @@ Value BigintType::Modulo(const Value& left, const Value &right) const {
 }
 
 Value BigintType::Sqrt(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
   if (val.IsNull())
-    return ValueFactory::GetDecimalValue(PELOTON_DECIMAL_NULL);
+    return ValueFactory::GetDecimalValue(PELOTON_VALUE_DECIMAL_NULL);
 
   if (val.value_.bigint < 0) {
     throw Exception(ExceptionType::DECIMAL,
@@ -173,9 +173,9 @@ Value BigintType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value &r
   case TypeId::INTEGER:
   case TypeId::PARAMETER_OFFSET:
   case TypeId::BIGINT:
-    return ValueFactory::GetBigIntValue((int64_t) PELOTON_INT64_NULL);
+    return ValueFactory::GetBigIntValue((int64_t) PELOTON_VALUE_INT64_NULL);
   case TypeId::DECIMAL:
-    return ValueFactory::GetDecimalValue((double) PELOTON_DECIMAL_NULL);
+    return ValueFactory::GetDecimalValue((double) PELOTON_VALUE_DECIMAL_NULL);
   default:
     break;
   }
@@ -183,8 +183,8 @@ Value BigintType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value &r
 }
 
 CmpBool BigintType::CompareEquals(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
@@ -196,8 +196,8 @@ CmpBool BigintType::CompareEquals(const Value& left, const Value &right) const {
 
 CmpBool BigintType::CompareNotEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -208,8 +208,8 @@ CmpBool BigintType::CompareNotEquals(const Value& left,
 
 CmpBool BigintType::CompareLessThan(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -220,8 +220,8 @@ CmpBool BigintType::CompareLessThan(const Value& left,
 
 CmpBool BigintType::CompareLessThanEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -232,8 +232,8 @@ CmpBool BigintType::CompareLessThanEquals(const Value& left,
 
 CmpBool BigintType::CompareGreaterThan(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -244,8 +244,8 @@ CmpBool BigintType::CompareGreaterThan(const Value& left,
 
 CmpBool BigintType::CompareGreaterThanEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -255,7 +255,7 @@ CmpBool BigintType::CompareGreaterThanEquals(const Value& left,
 }
 
 std::string BigintType::ToString(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
 
   if (val.IsNull())
     return "bigint_null";
@@ -264,7 +264,7 @@ std::string BigintType::ToString(const Value& val) const {
 }
 
 size_t BigintType::Hash(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
 
   return std::hash<int64_t> { }(val.value_.bigint);
 
@@ -311,16 +311,16 @@ Value BigintType::CastAs(const Value& val, const TypeId type_id) const {
   switch (type_id) {
   case TypeId::TINYINT: {
     if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
-    if (val.GetAs<int64_t>() > PELOTON_INT8_MAX ||
-        val.GetAs<int64_t>() < PELOTON_INT8_MIN)
+    if (val.GetAs<int64_t>() > PELOTON_VALUE_INT8_MAX ||
+        val.GetAs<int64_t>() < PELOTON_VALUE_INT8_MIN)
       throw Exception(ExceptionType::OUT_OF_RANGE,
           "Numeric value out of range.");
     return ValueFactory::GetTinyIntValue((int8_t) val.GetAs<int64_t>());
   }
   case TypeId::SMALLINT: {
     if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
-    if (val.GetAs<int64_t>() > PELOTON_INT16_MAX ||
-        val.GetAs<int64_t>() < PELOTON_INT16_MIN)
+    if (val.GetAs<int64_t>() > PELOTON_VALUE_INT16_MAX ||
+        val.GetAs<int64_t>() < PELOTON_VALUE_INT16_MIN)
       throw Exception(ExceptionType::OUT_OF_RANGE,
           "Numeric value out of range.");
     return ValueFactory::GetSmallIntValue((int16_t) val.GetAs<int64_t>());
@@ -328,8 +328,8 @@ Value BigintType::CastAs(const Value& val, const TypeId type_id) const {
   case TypeId::INTEGER:
   case TypeId::PARAMETER_OFFSET: {
     if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
-    if (val.GetAs<int64_t>() > PELOTON_INT32_MAX ||
-        val.GetAs<int64_t>() < PELOTON_INT32_MIN)
+    if (val.GetAs<int64_t>() > PELOTON_VALUE_INT32_MAX ||
+        val.GetAs<int64_t>() < PELOTON_VALUE_INT32_MIN)
       throw Exception(ExceptionType::OUT_OF_RANGE,
           "Numeric value out of range.");
     return Value(type_id, (int32_t) val.GetAs<int64_t>());

--- a/src/type/boolean_type.cpp
+++ b/src/type/boolean_type.cpp
@@ -27,61 +27,61 @@ BooleanType::BooleanType() : Type(TypeId::BOOLEAN) {}
 
 CmpBool BooleanType::CompareEquals(const Value& left,
                                    const Value& right) const {
-  PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::BOOLEAN);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(==);
 }
 
 CmpBool BooleanType::CompareNotEquals(const Value& left,
                                       const Value& right) const {
-  PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::BOOLEAN);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(!=);
 }
 
 CmpBool BooleanType::CompareLessThan(const Value& left,
                                      const Value& right) const {
-  PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::BOOLEAN);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(<);
 }
 
 CmpBool BooleanType::CompareLessThanEquals(const Value& left,
                                            const Value& right) const {
-  PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::BOOLEAN);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(<=);
 }
 
 CmpBool BooleanType::CompareGreaterThan(const Value& left,
                                         const Value& right) const {
-  PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::BOOLEAN);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(>);
 }
 
 CmpBool BooleanType::CompareGreaterThanEquals(const Value& left,
                                               const Value& right) const {
-  PL_ASSERT(GetTypeId() == TypeId::BOOLEAN);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::BOOLEAN);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return BOOLEAN_COMPARE_FUNC(>=);
 }
 
 Value BooleanType::Min(const Value& left, const Value& right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
   if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value BooleanType::Max(const Value& left, const Value& right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
   if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();

--- a/src/type/date_type.cpp
+++ b/src/type/date_type.cpp
@@ -20,54 +20,54 @@ namespace type {
 DateType::DateType() : Type(TypeId::DATE) {}
 
 CmpBool DateType::CompareEquals(const Value& left, const Value& right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() == right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareNotEquals(const Value& left,
                                    const Value& right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() != right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareLessThan(const Value& left, const Value& right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() < right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareLessThanEquals(const Value& left,
                                         const Value& right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() <= right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareGreaterThan(const Value& left,
                                      const Value& right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() > right.GetAs<int32_t>());
 }
 
 CmpBool DateType::CompareGreaterThanEquals(const Value& left,
                                            const Value& right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int32_t>() >= right.GetAs<int32_t>());
 }
 
 Value DateType::Min(const Value& left, const Value& right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
   if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value DateType::Max(const Value& left, const Value& right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
   if (left.CompareGreaterThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();

--- a/src/type/decimal_type.cpp
+++ b/src/type/decimal_type.cpp
@@ -72,13 +72,13 @@ DecimalType::DecimalType()
 }
 
 bool DecimalType::IsZero(const Value& val) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
   return (val.value_.decimal == 0);
 }
 
 Value DecimalType::Add(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -88,8 +88,8 @@ Value DecimalType::Add(const Value& left, const Value &right) const {
 }
 
 Value DecimalType::Subtract(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -99,8 +99,8 @@ Value DecimalType::Subtract(const Value& left, const Value &right) const {
 }
 
 Value DecimalType::Multiply(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -110,8 +110,8 @@ Value DecimalType::Multiply(const Value& left, const Value &right) const {
 }
 
 Value DecimalType::Divide(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -127,8 +127,8 @@ Value DecimalType::Divide(const Value& left, const Value &right) const {
 }
 
 Value DecimalType::Modulo(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
   
@@ -158,8 +158,8 @@ Value DecimalType::Modulo(const Value& left, const Value &right) const {
 }
 
 Value DecimalType::Min(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -169,8 +169,8 @@ Value DecimalType::Min(const Value& left, const Value &right) const {
 }
 
 Value DecimalType::Max(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -180,9 +180,9 @@ Value DecimalType::Max(const Value& left, const Value &right) const {
 }
 
 Value DecimalType::Sqrt(const Value& val) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
   if (val.IsNull())
-    return ValueFactory::GetDecimalValue(PELOTON_DECIMAL_NULL);
+    return ValueFactory::GetDecimalValue(PELOTON_VALUE_DECIMAL_NULL);
   if (val.value_.decimal < 0) {
     throw Exception(ExceptionType::DECIMAL,
                     "Cannot take square root of a negative number.");
@@ -191,12 +191,12 @@ Value DecimalType::Sqrt(const Value& val) const {
 }
 
 Value DecimalType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value &right UNUSED_ATTRIBUTE) const {
-  return ValueFactory::GetDecimalValue(PELOTON_DECIMAL_NULL);
+  return ValueFactory::GetDecimalValue(PELOTON_VALUE_DECIMAL_NULL);
 }
 
 CmpBool DecimalType::CompareEquals(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
     
@@ -206,8 +206,8 @@ CmpBool DecimalType::CompareEquals(const Value& left, const Value &right) const 
 }
 
 CmpBool DecimalType::CompareNotEquals(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -217,8 +217,8 @@ CmpBool DecimalType::CompareNotEquals(const Value& left, const Value &right) con
 }
 
 CmpBool DecimalType::CompareLessThan(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -228,8 +228,8 @@ CmpBool DecimalType::CompareLessThan(const Value& left, const Value &right) cons
 }
 
 CmpBool DecimalType::CompareLessThanEquals(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -239,8 +239,8 @@ CmpBool DecimalType::CompareLessThanEquals(const Value& left, const Value &right
 }
 
 CmpBool DecimalType::CompareGreaterThan(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -250,8 +250,8 @@ CmpBool DecimalType::CompareGreaterThan(const Value& left, const Value &right) c
 }
 
 CmpBool DecimalType::CompareGreaterThanEquals(const Value& left, const Value &right) const {
-  PL_ASSERT(GetTypeId() == TypeId::DECIMAL);
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(GetTypeId() == TypeId::DECIMAL);
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -264,32 +264,32 @@ Value DecimalType::CastAs(const Value& val, const TypeId type_id) const {
   switch (type_id) {
     case TypeId::TINYINT: {
       if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
-      if (val.GetAs<double>() > PELOTON_INT8_MAX ||
-          val.GetAs<double>() < PELOTON_INT8_MIN)
+      if (val.GetAs<double>() > PELOTON_VALUE_INT8_MAX ||
+          val.GetAs<double>() < PELOTON_VALUE_INT8_MIN)
         throw Exception(ExceptionType::OUT_OF_RANGE,
           "Numeric value out of range.");
       return ValueFactory::GetTinyIntValue((int8_t)val.GetAs<double>());
     }
     case TypeId::SMALLINT: {
       if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
-      if (val.GetAs<double>() > PELOTON_INT16_MAX ||
-          val.GetAs<double>() < PELOTON_INT16_MIN)
+      if (val.GetAs<double>() > PELOTON_VALUE_INT16_MAX ||
+          val.GetAs<double>() < PELOTON_VALUE_INT16_MIN)
         throw Exception(ExceptionType::OUT_OF_RANGE,
           "Numeric value out of range.");
       return ValueFactory::GetSmallIntValue((int16_t)val.GetAs<double>());
     }
     case TypeId::INTEGER: {
       if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
-      if (val.GetAs<double>() > PELOTON_INT32_MAX ||
-          val.GetAs<double>() < PELOTON_INT32_MIN)
+      if (val.GetAs<double>() > PELOTON_VALUE_INT32_MAX ||
+          val.GetAs<double>() < PELOTON_VALUE_INT32_MIN)
         throw Exception(ExceptionType::OUT_OF_RANGE,
           "Numeric value out of range.");
       return ValueFactory::GetIntegerValue((int32_t)val.GetAs<double>());
     }
     case TypeId::BIGINT: {
       if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
-      if (val.GetAs<double>() > PELOTON_INT64_MAX ||
-          val.GetAs<double>() < PELOTON_INT64_MIN)
+      if (val.GetAs<double>() > PELOTON_VALUE_INT64_MAX ||
+          val.GetAs<double>() < PELOTON_VALUE_INT64_MIN)
         throw Exception(ExceptionType::OUT_OF_RANGE,
           "Numeric value out of range.");
       return ValueFactory::GetBigIntValue((int64_t)val.GetAs<double>());

--- a/src/type/integer_parent_type.cpp
+++ b/src/type/integer_parent_type.cpp
@@ -24,8 +24,8 @@ namespace type {
 IntegerParentType::IntegerParentType(TypeId type) : NumericType(type) {}
 
 Value IntegerParentType::Min(const Value& left, const Value& right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
 
   if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
@@ -33,8 +33,8 @@ Value IntegerParentType::Min(const Value& left, const Value& right) const {
 }
 
 Value IntegerParentType::Max(const Value& left, const Value& right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
 
   if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();

--- a/src/type/integer_type.cpp
+++ b/src/type/integer_type.cpp
@@ -71,8 +71,8 @@ bool IntegerType::IsZero(const Value& val) const {
 }
 
 Value IntegerType::Add(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -82,8 +82,8 @@ Value IntegerType::Add(const Value& left, const Value &right) const {
 }
 
 Value IntegerType::Subtract(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -93,8 +93,8 @@ Value IntegerType::Subtract(const Value& left, const Value &right) const {
 }
 
 Value IntegerType::Multiply(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -104,8 +104,8 @@ Value IntegerType::Multiply(const Value& left, const Value &right) const {
 }
 
 Value IntegerType::Divide(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -120,8 +120,8 @@ Value IntegerType::Divide(const Value& left, const Value &right) const {
 }
 
 Value IntegerType::Modulo(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -155,9 +155,9 @@ Value IntegerType::Modulo(const Value& left, const Value &right) const {
 }
 
 Value IntegerType::Sqrt(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
   if (val.IsNull())
-    return ValueFactory::GetDecimalValue(PELOTON_DECIMAL_NULL);
+    return ValueFactory::GetDecimalValue(PELOTON_VALUE_DECIMAL_NULL);
 
   if (val.value_.integer < 0) {
     throw Exception(ExceptionType::DECIMAL,
@@ -174,11 +174,11 @@ Value IntegerType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value &
   case TypeId::SMALLINT:
   case TypeId::INTEGER:
   case TypeId::PARAMETER_OFFSET:
-    return ValueFactory::GetIntegerValue((int32_t) PELOTON_INT32_NULL);
+    return ValueFactory::GetIntegerValue((int32_t) PELOTON_VALUE_INT32_NULL);
   case TypeId::BIGINT:
-    return ValueFactory::GetBigIntValue((int64_t) PELOTON_INT64_NULL);
+    return ValueFactory::GetBigIntValue((int64_t) PELOTON_VALUE_INT64_NULL);
   case TypeId::DECIMAL:
-    return ValueFactory::GetDecimalValue((double) PELOTON_DECIMAL_NULL);
+    return ValueFactory::GetDecimalValue((double) PELOTON_VALUE_DECIMAL_NULL);
   default:
     break;
   }
@@ -187,8 +187,8 @@ Value IntegerType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value &
 }
 
 CmpBool IntegerType::CompareEquals(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
@@ -200,8 +200,8 @@ CmpBool IntegerType::CompareEquals(const Value& left, const Value &right) const 
 
 CmpBool IntegerType::CompareNotEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -212,8 +212,8 @@ CmpBool IntegerType::CompareNotEquals(const Value& left,
 
 CmpBool IntegerType::CompareLessThan(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -224,8 +224,8 @@ CmpBool IntegerType::CompareLessThan(const Value& left,
 
 CmpBool IntegerType::CompareLessThanEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -236,8 +236,8 @@ CmpBool IntegerType::CompareLessThanEquals(const Value& left,
 
 CmpBool IntegerType::CompareGreaterThan(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -248,8 +248,8 @@ CmpBool IntegerType::CompareGreaterThan(const Value& left,
 
 CmpBool IntegerType::CompareGreaterThanEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -259,7 +259,7 @@ CmpBool IntegerType::CompareGreaterThanEquals(const Value& left,
 }
 
 std::string IntegerType::ToString(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
 
   if (val.IsNull())
     return "integer_null";
@@ -268,7 +268,7 @@ std::string IntegerType::ToString(const Value& val) const {
 }
 
 size_t IntegerType::Hash(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
 
   return std::hash<int32_t> { }(val.value_.integer);
 
@@ -306,7 +306,7 @@ Value IntegerType::DeserializeFrom(SerializeInput &in UNUSED_ATTRIBUTE,
 }
 
 Value IntegerType::Copy(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
   return Value(val.GetTypeId(), val.value_.integer);
 }
 
@@ -315,16 +315,16 @@ Value IntegerType::CastAs(const Value& val, const TypeId type_id) const {
   switch (type_id) {
   case TypeId::TINYINT: {
     if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
-    if (val.GetAs<int32_t>() > PELOTON_INT8_MAX ||
-        val.GetAs<int32_t>() < PELOTON_INT8_MIN)
+    if (val.GetAs<int32_t>() > PELOTON_VALUE_INT8_MAX ||
+        val.GetAs<int32_t>() < PELOTON_VALUE_INT8_MIN)
       throw Exception(ExceptionType::OUT_OF_RANGE,
           "Numeric value out of range.");
     return ValueFactory::GetTinyIntValue((int8_t) val.GetAs<int32_t>());
   }
   case TypeId::SMALLINT: {
     if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
-    if (val.GetAs<int32_t>() > PELOTON_INT16_MAX  ||
-        val.GetAs<int32_t>() < PELOTON_INT16_MIN)
+    if (val.GetAs<int32_t>() > PELOTON_VALUE_INT16_MAX  ||
+        val.GetAs<int32_t>() < PELOTON_VALUE_INT16_MIN)
       throw Exception(ExceptionType::OUT_OF_RANGE,
           "Numeric value out of range.");
     return ValueFactory::GetSmallIntValue((int16_t) val.GetAs<int32_t>());

--- a/src/type/smallint_type.cpp
+++ b/src/type/smallint_type.cpp
@@ -74,8 +74,8 @@ bool SmallintType::IsZero(const Value& val) const {
 }
 
 Value SmallintType::Add(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -85,8 +85,8 @@ Value SmallintType::Add(const Value& left, const Value &right) const {
 }
 
 Value SmallintType::Subtract(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -96,8 +96,8 @@ Value SmallintType::Subtract(const Value& left, const Value &right) const {
 }
 
 Value SmallintType::Multiply(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -107,8 +107,8 @@ Value SmallintType::Multiply(const Value& left, const Value &right) const {
 }
 
 Value SmallintType::Divide(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -123,8 +123,8 @@ Value SmallintType::Divide(const Value& left, const Value &right) const {
 }
 
 Value SmallintType::Modulo(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -158,9 +158,9 @@ Value SmallintType::Modulo(const Value& left, const Value &right) const {
 }
 
 Value SmallintType::Sqrt(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
   if (val.IsNull())
-    return ValueFactory::GetDecimalValue(PELOTON_DECIMAL_NULL);
+    return ValueFactory::GetDecimalValue(PELOTON_VALUE_DECIMAL_NULL);
 
   if (val.value_.smallint < 0) {
     throw Exception(ExceptionType::DECIMAL,
@@ -176,15 +176,15 @@ Value SmallintType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value 
   switch (right.GetTypeId()) {
   case TypeId::TINYINT:
   case TypeId::SMALLINT:
-    return ValueFactory::GetSmallIntValue((int16_t) PELOTON_INT16_NULL);
+    return ValueFactory::GetSmallIntValue((int16_t) PELOTON_VALUE_INT16_NULL);
   case TypeId::INTEGER:
-    return ValueFactory::GetIntegerValue((int32_t) PELOTON_INT32_NULL);
+    return ValueFactory::GetIntegerValue((int32_t) PELOTON_VALUE_INT32_NULL);
   case TypeId::PARAMETER_OFFSET:
-    return ValueFactory::GetParameterOffsetValue((int32_t) PELOTON_INT32_NULL);
+    return ValueFactory::GetParameterOffsetValue((int32_t) PELOTON_VALUE_INT32_NULL);
   case TypeId::BIGINT:
-    return ValueFactory::GetBigIntValue((int64_t) PELOTON_INT64_NULL);
+    return ValueFactory::GetBigIntValue((int64_t) PELOTON_VALUE_INT64_NULL);
   case TypeId::DECIMAL:
-    return ValueFactory::GetDecimalValue((double) PELOTON_DECIMAL_NULL);
+    return ValueFactory::GetDecimalValue((double) PELOTON_VALUE_DECIMAL_NULL);
   default:
     break;
   }
@@ -194,8 +194,8 @@ Value SmallintType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value 
 
 CmpBool SmallintType::CompareEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
@@ -207,8 +207,8 @@ CmpBool SmallintType::CompareEquals(const Value& left,
 
 CmpBool SmallintType::CompareNotEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -219,8 +219,8 @@ CmpBool SmallintType::CompareNotEquals(const Value& left,
 
 CmpBool SmallintType::CompareLessThan(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -231,8 +231,8 @@ CmpBool SmallintType::CompareLessThan(const Value& left,
 
 CmpBool SmallintType::CompareLessThanEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -243,8 +243,8 @@ CmpBool SmallintType::CompareLessThanEquals(const Value& left,
 
 CmpBool SmallintType::CompareGreaterThan(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -255,8 +255,8 @@ CmpBool SmallintType::CompareGreaterThan(const Value& left,
 
 CmpBool SmallintType::CompareGreaterThanEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -266,7 +266,7 @@ CmpBool SmallintType::CompareGreaterThanEquals(const Value& left,
 }
 
 std::string SmallintType::ToString(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
   switch (val.GetTypeId()) {
   case TypeId::TINYINT:
     if (val.IsNull())
@@ -292,7 +292,7 @@ std::string SmallintType::ToString(const Value& val) const {
 }
 
 size_t SmallintType::Hash(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
 
   return std::hash<int16_t> { }(val.value_.smallint);
 
@@ -331,7 +331,7 @@ Value SmallintType::DeserializeFrom(SerializeInput &in UNUSED_ATTRIBUTE,
 }
 
 Value SmallintType::Copy(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
 
   return ValueFactory::GetSmallIntValue(val.value_.smallint);
 
@@ -344,8 +344,8 @@ Value SmallintType::CastAs(const Value& val,
   switch (type_id) {
   case TypeId::TINYINT: {
     if (val.IsNull()) return ValueFactory::GetNullValueByType(type_id);
-    if (val.GetAs<int16_t>() > PELOTON_INT8_MAX ||
-        val.GetAs<int16_t>() < PELOTON_INT8_MIN)
+    if (val.GetAs<int16_t>() > PELOTON_VALUE_INT8_MAX ||
+        val.GetAs<int16_t>() < PELOTON_VALUE_INT8_MIN)
       throw Exception(ExceptionType::OUT_OF_RANGE,
           "Numeric value out of range.");
     return ValueFactory::GetTinyIntValue((int8_t) val.GetAs<int16_t>());

--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -24,56 +24,56 @@ TimestampType::TimestampType()
 }
 
 CmpBool TimestampType::CompareEquals(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() == right.GetAs<uint64_t>());
 }
 
 CmpBool TimestampType::CompareNotEquals(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (right.IsNull())
     return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() != right.GetAs<uint64_t>());
 }
 
 CmpBool TimestampType::CompareLessThan(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() < right.GetAs<uint64_t>());
 }
 
 CmpBool TimestampType::CompareLessThanEquals(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() <= right.GetAs<uint64_t>());
 }
 
 CmpBool TimestampType::CompareGreaterThan(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<int64_t>() > right.GetAs<int64_t>());
 }
 
 CmpBool TimestampType::CompareGreaterThanEquals(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
   return GetCmpBool(left.GetAs<uint64_t>() >= right.GetAs<uint64_t>());
 }
 
 Value TimestampType::Min(const Value& left, const Value& right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
   if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value TimestampType::Max(const Value& left, const Value& right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
   if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();

--- a/src/type/tinyint_type.cpp
+++ b/src/type/tinyint_type.cpp
@@ -70,8 +70,8 @@ bool TinyintType::IsZero(const Value& val) const {
 }
 
 Value TinyintType::Add(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -81,8 +81,8 @@ Value TinyintType::Add(const Value& left, const Value &right) const {
 }
 
 Value TinyintType::Subtract(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -92,8 +92,8 @@ Value TinyintType::Subtract(const Value& left, const Value &right) const {
 }
 
 Value TinyintType::Multiply(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -103,8 +103,8 @@ Value TinyintType::Multiply(const Value& left, const Value &right) const {
 }
 
 Value TinyintType::Divide(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -119,8 +119,8 @@ Value TinyintType::Divide(const Value& left, const Value &right) const {
 }
 
 Value TinyintType::Modulo(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
@@ -154,9 +154,9 @@ Value TinyintType::Modulo(const Value& left, const Value &right) const {
 }
 
 Value TinyintType::Sqrt(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
   if (val.IsNull())
-    return ValueFactory::GetDecimalValue(PELOTON_DECIMAL_NULL);
+    return ValueFactory::GetDecimalValue(PELOTON_VALUE_DECIMAL_NULL);
 
   if (val.value_.tinyint < 0) {
     throw Exception(ExceptionType::DECIMAL,
@@ -170,16 +170,16 @@ Value TinyintType::Sqrt(const Value& val) const {
 Value TinyintType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value &right) const {
   switch (right.GetTypeId()) {
   case TypeId::TINYINT:
-    return Value(right.GetTypeId(), (int8_t) PELOTON_INT8_NULL);
+    return Value(right.GetTypeId(), (int8_t) PELOTON_VALUE_INT8_NULL);
   case TypeId::SMALLINT:
-    return Value(right.GetTypeId(), (int16_t) PELOTON_INT16_NULL);
+    return Value(right.GetTypeId(), (int16_t) PELOTON_VALUE_INT16_NULL);
   case TypeId::INTEGER:
   case TypeId::PARAMETER_OFFSET:
-    return Value(right.GetTypeId(), (int32_t) PELOTON_INT32_NULL);
+    return Value(right.GetTypeId(), (int32_t) PELOTON_VALUE_INT32_NULL);
   case TypeId::BIGINT:
-    return Value(right.GetTypeId(), (int64_t) PELOTON_INT64_NULL);
+    return Value(right.GetTypeId(), (int64_t) PELOTON_VALUE_INT64_NULL);
   case TypeId::DECIMAL:
-    return ValueFactory::GetDecimalValue((double) PELOTON_DECIMAL_NULL);
+    return ValueFactory::GetDecimalValue((double) PELOTON_VALUE_DECIMAL_NULL);
   default:
     break;
   }
@@ -187,8 +187,8 @@ Value TinyintType::OperateNull(const Value& left UNUSED_ATTRIBUTE, const Value &
 }
 
 CmpBool TinyintType::CompareEquals(const Value& left, const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
 
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
@@ -200,8 +200,8 @@ CmpBool TinyintType::CompareEquals(const Value& left, const Value &right) const 
 
 CmpBool TinyintType::CompareNotEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -212,8 +212,8 @@ CmpBool TinyintType::CompareNotEquals(const Value& left,
 
 CmpBool TinyintType::CompareLessThan(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -224,8 +224,8 @@ CmpBool TinyintType::CompareLessThan(const Value& left,
 
 CmpBool TinyintType::CompareLessThanEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -236,8 +236,8 @@ CmpBool TinyintType::CompareLessThanEquals(const Value& left,
 
 CmpBool TinyintType::CompareGreaterThan(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -248,8 +248,8 @@ CmpBool TinyintType::CompareGreaterThan(const Value& left,
 
 CmpBool TinyintType::CompareGreaterThanEquals(const Value& left,
     const Value &right) const {
-  PL_ASSERT(left.CheckInteger());
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckInteger());
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull())
     return CmpBool::NULL_;
 
@@ -259,7 +259,7 @@ CmpBool TinyintType::CompareGreaterThanEquals(const Value& left,
 }
 
 std::string TinyintType::ToString(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
   if (val.IsNull())
     return "tinyint_null";
   return std::to_string(val.value_.tinyint);
@@ -267,7 +267,7 @@ std::string TinyintType::ToString(const Value& val) const {
 }
 
 size_t TinyintType::Hash(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
   return std::hash<int8_t> { }(val.value_.tinyint);
 }
 
@@ -300,7 +300,7 @@ Value TinyintType::DeserializeFrom(SerializeInput &in UNUSED_ATTRIBUTE,
 }
 
 Value TinyintType::Copy(const Value& val) const {
-  PL_ASSERT(val.CheckInteger());
+  PELOTON_ASSERT(val.CheckInteger());
   return ValueFactory::GetTinyIntValue(val.value_.tinyint);
 }
 

--- a/src/type/type.cpp
+++ b/src/type/type.cpp
@@ -130,19 +130,19 @@ Value Type::GetMinValue(TypeId type_id) {
     case TypeId::BOOLEAN:
       return Value(type_id, 0);
     case TypeId::TINYINT:
-      return Value(type_id, (int8_t)PELOTON_INT8_MIN);
+      return Value(type_id, (int8_t)PELOTON_VALUE_INT8_MIN);
     case TypeId::SMALLINT:
-      return Value(type_id, (int16_t)PELOTON_INT16_MIN);
+      return Value(type_id, (int16_t)PELOTON_VALUE_INT16_MIN);
     case TypeId::INTEGER:
-      return Value(type_id, (int32_t)PELOTON_INT32_MIN);
+      return Value(type_id, (int32_t)PELOTON_VALUE_INT32_MIN);
     case TypeId::BIGINT:
-      return Value(type_id, (int64_t)PELOTON_INT64_MIN);
+      return Value(type_id, (int64_t)PELOTON_VALUE_INT64_MIN);
     case TypeId::DECIMAL:
-      return Value(type_id, PELOTON_DECIMAL_MIN);
+      return Value(type_id, PELOTON_VALUE_DECIMAL_MIN);
     case TypeId::TIMESTAMP:
-      return Value(type_id, PELOTON_TIMESTAMP_MIN);
+      return Value(type_id, PELOTON_VALUE_TIMESTAMP_MIN);
     case TypeId::DATE:
-      return Value(type_id, PELOTON_DATE_MIN);
+      return Value(type_id, PELOTON_VALUE_DATE_MIN);
     case TypeId::VARCHAR:
       return Value(type_id, "");
     case TypeId::VARBINARY:
@@ -158,19 +158,19 @@ Value Type::GetMaxValue(TypeId type_id) {
     case TypeId::BOOLEAN:
       return Value(type_id, 1);
     case TypeId::TINYINT:
-      return Value(type_id, (int8_t)PELOTON_INT8_MAX);
+      return Value(type_id, (int8_t)PELOTON_VALUE_INT8_MAX);
     case TypeId::SMALLINT:
-      return Value(type_id, (int16_t)PELOTON_INT16_MAX);
+      return Value(type_id, (int16_t)PELOTON_VALUE_INT16_MAX);
     case TypeId::INTEGER:
-      return Value(type_id, (int32_t)PELOTON_INT32_MAX);
+      return Value(type_id, (int32_t)PELOTON_VALUE_INT32_MAX);
     case TypeId::BIGINT:
-      return Value(type_id, (int64_t)PELOTON_INT64_MAX);
+      return Value(type_id, (int64_t)PELOTON_VALUE_INT64_MAX);
     case TypeId::DECIMAL:
-      return Value(type_id, PELOTON_DECIMAL_MAX);
+      return Value(type_id, PELOTON_VALUE_DECIMAL_MAX);
     case TypeId::TIMESTAMP:
-      return Value(type_id, PELOTON_TIMESTAMP_MAX);
+      return Value(type_id, PELOTON_VALUE_TIMESTAMP_MAX);
     case TypeId::DATE:
-      return Value(type_id, PELOTON_DATE_MAX);
+      return Value(type_id, PELOTON_VALUE_DATE_MAX);
     case TypeId::VARCHAR:
       return Value(type_id, nullptr, 0, false);
     case TypeId::VARBINARY:

--- a/src/type/value.cpp
+++ b/src/type/value.cpp
@@ -36,7 +36,7 @@ Value::Value(const Value &other) {
       } else {
         if (manage_data_) {
           value_.varlen = new char[size_.len];
-          PL_MEMCPY(value_.varlen, other.value_.varlen, size_.len);
+          PELOTON_MEMCPY(value_.varlen, other.value_.varlen, size_.len);
         } else {
           value_ = other.value_;
         }
@@ -62,33 +62,33 @@ Value::Value(TypeId type, int8_t i) : Value(type) {
     case TypeId::BOOLEAN:
       value_.boolean = i;
       size_.len =
-          (value_.boolean == PELOTON_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.boolean == PELOTON_VALUE_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::TINYINT:
       value_.tinyint = i;
       size_.len =
-          (value_.tinyint == PELOTON_INT8_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.tinyint == PELOTON_VALUE_INT8_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::SMALLINT:
       value_.smallint = i;
       size_.len =
-          (value_.smallint == PELOTON_INT16_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.smallint == PELOTON_VALUE_INT16_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::INTEGER:
     case TypeId::PARAMETER_OFFSET:
       value_.integer = i;
       size_.len =
-          (value_.integer == PELOTON_INT32_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.integer == PELOTON_VALUE_INT32_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::BIGINT:
       value_.bigint = i;
       size_.len =
-          (value_.bigint == PELOTON_INT64_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.bigint == PELOTON_VALUE_INT64_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::TIMESTAMP:
       value_.timestamp = i;
       size_.len =
-          (value_.timestamp == PELOTON_TIMESTAMP_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.timestamp == PELOTON_VALUE_TIMESTAMP_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default: {
       std::string msg =
@@ -105,33 +105,33 @@ Value::Value(TypeId type, int16_t i) : Value(type) {
     case TypeId::BOOLEAN:
       value_.boolean = i;
       size_.len =
-          (value_.boolean == PELOTON_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.boolean == PELOTON_VALUE_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::TINYINT:
       value_.tinyint = i;
       size_.len =
-          (value_.tinyint == PELOTON_INT8_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.tinyint == PELOTON_VALUE_INT8_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::SMALLINT:
       value_.smallint = i;
       size_.len =
-          (value_.smallint == PELOTON_INT16_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.smallint == PELOTON_VALUE_INT16_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::INTEGER:
     case TypeId::PARAMETER_OFFSET:
       value_.integer = i;
       size_.len =
-          (value_.integer == PELOTON_INT32_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.integer == PELOTON_VALUE_INT32_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::BIGINT:
       value_.bigint = i;
       size_.len =
-          (value_.bigint == PELOTON_INT64_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.bigint == PELOTON_VALUE_INT64_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::TIMESTAMP:
       value_.timestamp = i;
       size_.len =
-          (value_.timestamp == PELOTON_TIMESTAMP_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.timestamp == PELOTON_VALUE_TIMESTAMP_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default: {
       std::string msg =
@@ -148,37 +148,37 @@ Value::Value(TypeId type, int32_t i) : Value(type) {
     case TypeId::BOOLEAN:
       value_.boolean = i;
       size_.len =
-          (value_.boolean == PELOTON_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.boolean == PELOTON_VALUE_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::TINYINT:
       value_.tinyint = i;
       size_.len =
-          (value_.tinyint == PELOTON_INT8_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.tinyint == PELOTON_VALUE_INT8_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::SMALLINT:
       value_.smallint = i;
       size_.len =
-          (value_.smallint == PELOTON_INT16_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.smallint == PELOTON_VALUE_INT16_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::INTEGER:
     case TypeId::PARAMETER_OFFSET:
       value_.integer = i;
       size_.len =
-          (value_.integer == PELOTON_INT32_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.integer == PELOTON_VALUE_INT32_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::BIGINT:
       value_.bigint = i;
       size_.len =
-          (value_.bigint == PELOTON_INT64_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.bigint == PELOTON_VALUE_INT64_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::DATE:
       value_.date = i;
-      size_.len = (value_.date == PELOTON_DATE_NULL ? PELOTON_VALUE_NULL : 0);
+      size_.len = (value_.date == PELOTON_VALUE_DATE_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::TIMESTAMP:
       value_.timestamp = i;
       size_.len =
-          (value_.timestamp == PELOTON_TIMESTAMP_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.timestamp == PELOTON_VALUE_TIMESTAMP_NULL ? PELOTON_VALUE_NULL : 0);
       break;
 
     default: {
@@ -196,33 +196,33 @@ Value::Value(TypeId type, int64_t i) : Value(type) {
     case TypeId::BOOLEAN:
       value_.boolean = i;
       size_.len =
-          (value_.boolean == PELOTON_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.boolean == PELOTON_VALUE_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::TINYINT:
       value_.tinyint = i;
       size_.len =
-          (value_.tinyint == PELOTON_INT8_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.tinyint == PELOTON_VALUE_INT8_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::SMALLINT:
       value_.smallint = i;
       size_.len =
-          (value_.smallint == PELOTON_INT16_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.smallint == PELOTON_VALUE_INT16_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::INTEGER:
     case TypeId::PARAMETER_OFFSET:
       value_.integer = i;
       size_.len =
-          (value_.integer == PELOTON_INT32_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.integer == PELOTON_VALUE_INT32_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::BIGINT:
       value_.bigint = i;
       size_.len =
-          (value_.bigint == PELOTON_INT64_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.bigint == PELOTON_VALUE_INT64_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::TIMESTAMP:
       value_.timestamp = i;
       size_.len =
-          (value_.timestamp == PELOTON_TIMESTAMP_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.timestamp == PELOTON_VALUE_TIMESTAMP_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default: {
       std::string msg =
@@ -239,12 +239,12 @@ Value::Value(TypeId type, uint64_t i) : Value(type) {
     case TypeId::BOOLEAN:
       value_.boolean = i;
       size_.len =
-          (value_.boolean == PELOTON_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.boolean == PELOTON_VALUE_BOOLEAN_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     case TypeId::TIMESTAMP:
       value_.timestamp = i;
       size_.len =
-          (value_.timestamp == PELOTON_TIMESTAMP_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.timestamp == PELOTON_VALUE_TIMESTAMP_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default: {
       std::string msg = StringUtil::Format(
@@ -261,7 +261,7 @@ Value::Value(TypeId type, double d) : Value(type) {
     case TypeId::DECIMAL:
       value_.decimal = d;
       size_.len =
-          (value_.decimal == PELOTON_DECIMAL_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.decimal == PELOTON_VALUE_DECIMAL_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default: {
       std::string msg =
@@ -277,7 +277,7 @@ Value::Value(TypeId type, float f) : Value(type) {
     case TypeId::DECIMAL:
       value_.decimal = f;
       size_.len =
-          (value_.decimal == PELOTON_DECIMAL_NULL ? PELOTON_VALUE_NULL : 0);
+          (value_.decimal == PELOTON_VALUE_DECIMAL_NULL ? PELOTON_VALUE_NULL : 0);
       break;
     default: {
       std::string msg =
@@ -300,11 +300,11 @@ Value::Value(TypeId type, const char *data, uint32_t len, bool manage_data)
       } else {
         manage_data_ = manage_data;
         if (manage_data_) {
-          PL_ASSERT(len < PELOTON_VARCHAR_MAX_LEN);
+          PELOTON_ASSERT(len < PELOTON_VALUE_VARCHAR_MAX_LEN);
           value_.varlen = new char[len];
-          PL_ASSERT(value_.varlen != nullptr);
+          PELOTON_ASSERT(value_.varlen != nullptr);
           size_.len = len;
-          PL_MEMCPY(value_.varlen, data, len);
+          PELOTON_MEMCPY(value_.varlen, data, len);
         } else {
           // FUCK YOU GCC I do what I want.
           value_.const_varlen = data;
@@ -329,9 +329,9 @@ Value::Value(TypeId type, const std::string &data) : Value(type) {
       // TODO: How to represent a null string here?
       uint32_t len = data.length() + (type == TypeId::VARCHAR);
       value_.varlen = new char[len];
-      PL_ASSERT(value_.varlen != nullptr);
+      PELOTON_ASSERT(value_.varlen != nullptr);
       size_.len = len;
-      PL_MEMCPY(value_.varlen, data.c_str(), len);
+      PELOTON_MEMCPY(value_.varlen, data.c_str(), len);
       break;
     }
     default: {

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -56,10 +56,10 @@ char *VarlenType::GetData(char *storage) {
 }
 
 CmpBool VarlenType::CompareEquals(const Value &left, const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
-  if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
-      GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
+  if (GetLength(left) == PELOTON_VALUE_VARCHAR_MAX_LEN ||
+      GetLength(right) == PELOTON_VALUE_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) == GetLength(right));
   }
 
@@ -68,10 +68,10 @@ CmpBool VarlenType::CompareEquals(const Value &left, const Value &right) const {
 
 CmpBool VarlenType::CompareNotEquals(const Value &left,
                                      const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
-  if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
-      GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
+  if (GetLength(left) == PELOTON_VALUE_VARCHAR_MAX_LEN ||
+      GetLength(right) == PELOTON_VALUE_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) != GetLength(right));
   }
 
@@ -80,10 +80,10 @@ CmpBool VarlenType::CompareNotEquals(const Value &left,
 
 CmpBool VarlenType::CompareLessThan(const Value &left,
                                     const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
-  if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
-      GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
+  if (GetLength(left) == PELOTON_VALUE_VARCHAR_MAX_LEN ||
+      GetLength(right) == PELOTON_VALUE_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) < GetLength(right));
   }
 
@@ -92,10 +92,10 @@ CmpBool VarlenType::CompareLessThan(const Value &left,
 
 CmpBool VarlenType::CompareLessThanEquals(const Value &left,
                                           const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
-  if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
-      GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
+  if (GetLength(left) == PELOTON_VALUE_VARCHAR_MAX_LEN ||
+      GetLength(right) == PELOTON_VALUE_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) <= GetLength(right));
   }
 
@@ -104,10 +104,10 @@ CmpBool VarlenType::CompareLessThanEquals(const Value &left,
 
 CmpBool VarlenType::CompareGreaterThan(const Value &left,
                                        const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
-  if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
-      GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
+  if (GetLength(left) == PELOTON_VALUE_VARCHAR_MAX_LEN ||
+      GetLength(right) == PELOTON_VALUE_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) > GetLength(right));
   }
 
@@ -116,10 +116,10 @@ CmpBool VarlenType::CompareGreaterThan(const Value &left,
 
 CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
                                              const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return CmpBool::NULL_;
-  if (GetLength(left) == PELOTON_VARCHAR_MAX_LEN ||
-      GetLength(right) == PELOTON_VARCHAR_MAX_LEN) {
+  if (GetLength(left) == PELOTON_VALUE_VARCHAR_MAX_LEN ||
+      GetLength(right) == PELOTON_VALUE_VARCHAR_MAX_LEN) {
     return GetCmpBool(GetLength(left) >= GetLength(right));
   }
 
@@ -127,14 +127,14 @@ CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
 }
 
 Value VarlenType::Min(const Value &left, const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
   if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
 }
 
 Value VarlenType::Max(const Value &left, const Value &right) const {
-  PL_ASSERT(left.CheckComparable(right));
+  PELOTON_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
   if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
   return right.Copy();
@@ -144,7 +144,7 @@ std::string VarlenType::ToString(const Value &val) const {
   uint32_t len = GetLength(val);
 
   if (val.IsNull()) return "varlen_null";
-  if (len == PELOTON_VARCHAR_MAX_LEN) return "varlen_max";
+  if (len == PELOTON_VALUE_VARCHAR_MAX_LEN) return "varlen_max";
   if (len == 0) {
     return "";
   }
@@ -179,8 +179,8 @@ void VarlenType::SerializeTo(const Value &val, char *storage,
   } else {
     uint32_t size = len + sizeof(uint32_t);
     data = (pool == nullptr) ? new char[size] : (char *)pool->Allocate(size);
-    PL_MEMCPY(data, &len, sizeof(uint32_t));
-    PL_MEMCPY(data + sizeof(uint32_t), val.value_.varlen,
+    PELOTON_MEMCPY(data, &len, sizeof(uint32_t));
+    PELOTON_MEMCPY(data + sizeof(uint32_t), val.value_.varlen,
               size - sizeof(uint32_t));
   }
   *reinterpret_cast<const char **>(storage) = data;

--- a/test/codegen/bloom_filter_test.cpp
+++ b/test/codegen/bloom_filter_test.cpp
@@ -347,8 +347,8 @@ void BloomFilterCodegenTest::InsertTuple(const std::vector<int> &vals,
   }
   ItemPointer *index_entry_ptr = nullptr;
   auto tuple_slot_id = table->InsertTuple(&tuple, txn, &index_entry_ptr);
-  PL_ASSERT(tuple_slot_id.block != INVALID_OID);
-  PL_ASSERT(tuple_slot_id.offset != INVALID_OID);
+  PELOTON_ASSERT(tuple_slot_id.block != INVALID_OID);
+  PELOTON_ASSERT(tuple_slot_id.offset != INVALID_OID);
   txn_manager.PerformInsert(txn, tuple_slot_id, index_entry_ptr);
 }
 

--- a/test/codegen/oa_hash_table_test.cpp
+++ b/test/codegen/oa_hash_table_test.cpp
@@ -43,7 +43,7 @@ class OAHashTableTest : public PelotonTest {
   };
 
   OAHashTableTest() {
-    PL_MEMSET(raw_hash_table, 1, sizeof(raw_hash_table));
+    PELOTON_MEMSET(raw_hash_table, 1, sizeof(raw_hash_table));
     GetHashTable().Init(sizeof(Key), sizeof(Value));
   }
 

--- a/test/codegen/table_scan_translator_test.cpp
+++ b/test/codegen/table_scan_translator_test.cpp
@@ -83,8 +83,8 @@ class TableScanTranslatorTest : public PelotonCodeGenTest {
     ItemPointer *index_entry_ptr = nullptr;
     ItemPointer tuple_slot_id =
         table.InsertTuple(&tuple, txn, &index_entry_ptr);
-    PL_ASSERT(tuple_slot_id.block != INVALID_OID);
-    PL_ASSERT(tuple_slot_id.offset != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.block != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.offset != INVALID_OID);
 
     txn_manager.PerformInsert(txn, tuple_slot_id, index_entry_ptr);
     txn_manager.CommitTransaction(txn);

--- a/test/codegen/testing_codegen_util.cpp
+++ b/test/codegen/testing_codegen_util.cpp
@@ -57,7 +57,7 @@ PelotonCodeGenTest::~PelotonCodeGenTest() {
 }
 
 catalog::Column PelotonCodeGenTest::GetTestColumn(uint32_t col_id) const {
-  PL_ASSERT(col_id < 4);
+  PELOTON_ASSERT(col_id < 4);
   static const uint64_t int_size =
       type::Type::GetTypeSize(type::TypeId::INTEGER);
   static const uint64_t dec_size =
@@ -160,8 +160,8 @@ void PelotonCodeGenTest::LoadTestTable(oid_t table_id, uint32_t num_rows,
     ItemPointer *index_entry_ptr = nullptr;
     ItemPointer tuple_slot_id =
         test_table.InsertTuple(&tuple, txn, &index_entry_ptr);
-    PL_ASSERT(tuple_slot_id.block != INVALID_OID);
-    PL_ASSERT(tuple_slot_id.offset != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.block != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.offset != INVALID_OID);
 
     auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     txn_manager.PerformInsert(txn, tuple_slot_id, index_entry_ptr);
@@ -347,7 +347,7 @@ void Printer::ConsumeResult(codegen::ConsumerContext &ctx,
     }
     first = false;
     codegen::Value val = row.DeriveValue(codegen, ai);
-    PL_ASSERT(val.GetType().type_id != peloton::type::TypeId::INVALID);
+    PELOTON_ASSERT(val.GetType().type_id != peloton::type::TypeId::INVALID);
     switch (val.GetType().type_id) {
       case type::TypeId::BOOLEAN:
       case type::TypeId::TINYINT:

--- a/test/concurrency/testing_transaction_util.cpp
+++ b/test/concurrency/testing_transaction_util.cpp
@@ -198,7 +198,7 @@ storage::DataTable *TestingTransactionUtil::CreateTable(
     LOG_TRACE("Can't find database %d! ", database_id);
     return nullptr;
   }
-  PL_ASSERT(db);
+  PELOTON_ASSERT(db);
   db->AddTable(table);
 
   // Insert tuple

--- a/test/executor/join_test.cpp
+++ b/test/executor/join_test.cpp
@@ -232,7 +232,7 @@ void PopulateTable(storage::DataTable *table, int num_rows, bool random,
   const catalog::Schema *schema = table->GetSchema();
 
   // Ensure that the tile group is as expected.
-  PL_ASSERT(schema->GetColumnCount() == 4);
+  PELOTON_ASSERT(schema->GetColumnCount() == 4);
 
   // Insert tuples into tile_group.
   const bool allocate = true;
@@ -260,8 +260,8 @@ void PopulateTable(storage::DataTable *table, int num_rows, bool random,
     ItemPointer *index_entry_ptr = nullptr;
     ItemPointer tuple_slot_id =
         table->InsertTuple(&tuple, current_txn, &index_entry_ptr);
-    PL_ASSERT(tuple_slot_id.block != INVALID_OID);
-    PL_ASSERT(tuple_slot_id.offset != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.block != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.offset != INVALID_OID);
 
     auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     txn_manager.PerformInsert(current_txn, tuple_slot_id, index_entry_ptr);
@@ -911,7 +911,7 @@ void ExecuteJoinTest(PlanNodeType join_algorithm, JoinType join_type,
 }
 
 oid_t CountTuplesWithNullFields(executor::LogicalTile *logical_tile) {
-  PL_ASSERT(logical_tile);
+  PELOTON_ASSERT(logical_tile);
 
   // Get column count
   auto column_count = logical_tile->GetColumnCount();
@@ -936,7 +936,7 @@ oid_t CountTuplesWithNullFields(executor::LogicalTile *logical_tile) {
 }
 
 void ValidateJoinLogicalTile(executor::LogicalTile *logical_tile) {
-  PL_ASSERT(logical_tile);
+  PELOTON_ASSERT(logical_tile);
 
   // Get column count
   auto column_count = logical_tile->GetColumnCount();
@@ -961,7 +961,7 @@ void ValidateJoinLogicalTile(executor::LogicalTile *logical_tile) {
 }
 
 void ValidateNestedLoopJoinLogicalTile(executor::LogicalTile *logical_tile) {
-  PL_ASSERT(logical_tile);
+  PELOTON_ASSERT(logical_tile);
 
   // Get column count
   auto column_count = logical_tile->GetColumnCount();

--- a/test/executor/logical_tile_test.cpp
+++ b/test/executor/logical_tile_test.cpp
@@ -156,7 +156,7 @@ TEST_F(LogicalTileTests, TileMaterializationTest) {
   logical_tile->AddPositionList(std::move(position_list1));
   logical_tile->AddPositionList(std::move(position_list2));
 
-  PL_ASSERT(tile_schemas.size() == 2);
+  PELOTON_ASSERT(tile_schemas.size() == 2);
   catalog::Schema *schema1 = &tile_schemas[0];
   catalog::Schema *schema2 = &tile_schemas[1];
   oid_t column_count = schema2->GetColumnCount();

--- a/test/executor/seq_scan_test.cpp
+++ b/test/executor/seq_scan_test.cpp
@@ -126,7 +126,7 @@ storage::DataTable *CreateTable() {
  */
 expression::AbstractExpression *CreatePredicate(
     const std::set<oid_t> &tuple_ids) {
-  PL_ASSERT(tuple_ids.size() >= 1);
+  PELOTON_ASSERT(tuple_ids.size() >= 1);
 
   expression::AbstractExpression *predicate =
       expression::ExpressionUtil::ConstantValueFactory(

--- a/test/executor/testing_executor_util.cpp
+++ b/test/executor/testing_executor_util.cpp
@@ -194,7 +194,7 @@ void TestingExecutorUtil::PopulateTable(storage::DataTable *table, int num_rows,
   const catalog::Schema *schema = table->GetSchema();
 
   // Ensure that the tile group is as expected.
-  PL_ASSERT(schema->GetColumnCount() == 4);
+  PELOTON_ASSERT(schema->GetColumnCount() == 4);
 
   // Insert tuples into tile_group.
   const bool allocate = true;
@@ -237,8 +237,8 @@ void TestingExecutorUtil::PopulateTable(storage::DataTable *table, int num_rows,
     ItemPointer *index_entry_ptr = nullptr;
     ItemPointer tuple_slot_id =
         table->InsertTuple(&tuple, current_txn, &index_entry_ptr);
-    PL_ASSERT(tuple_slot_id.block != INVALID_OID);
-    PL_ASSERT(tuple_slot_id.offset != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.block != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.offset != INVALID_OID);
 
     auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     txn_manager.PerformInsert(current_txn, tuple_slot_id, index_entry_ptr);
@@ -258,7 +258,7 @@ void TestingExecutorUtil::PopulateTiles(
       catalog::Schema::AppendSchemaList(tile_schemas));
 
   // Ensure that the tile group is as expected.
-  PL_ASSERT(schema->GetColumnCount() == 4);
+  PELOTON_ASSERT(schema->GetColumnCount() == 4);
 
   // Insert tuples into tile_group.
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();

--- a/test/function/timestamp_functions_test.cpp
+++ b/test/function/timestamp_functions_test.cpp
@@ -62,7 +62,7 @@ void DateTruncTestHelper(DatePartType part, std::string &date,
   // time zone 'est';
 
   // Check that result is *not* null
-  EXPECT_NE(type::PELOTON_TIMESTAMP_NULL, result);
+  EXPECT_NE(type::PELOTON_VALUE_TIMESTAMP_NULL, result);
   // Then check that it equals our expected value
   LOG_TRACE("COMPARE: %s = %" PRId64 "\n", expected.c_str(),
             static_cast<long>(result));
@@ -72,8 +72,8 @@ void DateTruncTestHelper(DatePartType part, std::string &date,
 // Invoke TimestampFunctions::DateTrunc(NULL)
 TEST_F(TimestampFunctionsTests, NullDateTruncTest) {
   auto result = function::TimestampFunctions::DateTrunc(
-      "hour", type::PELOTON_TIMESTAMP_NULL);
-  EXPECT_EQ(type::PELOTON_TIMESTAMP_NULL, result);
+      "hour", type::PELOTON_VALUE_TIMESTAMP_NULL);
+  EXPECT_EQ(type::PELOTON_VALUE_TIMESTAMP_NULL, result);
 }
 
 TEST_F(TimestampFunctionsTests, DateTruncCenturyTest) {
@@ -195,7 +195,7 @@ void DatePartTestHelper(DatePartType part, std::string &date,
            result);
 
   // Check that result is *not* null
-  EXPECT_NE(type::PELOTON_DECIMAL_NULL, result);
+  EXPECT_NE(type::PELOTON_VALUE_DECIMAL_NULL, result);
 
   // Then check that it equals our expected value
   LOG_TRACE("COMPARE: %s = %f \n", expected.c_str(), result);
@@ -205,8 +205,8 @@ void DatePartTestHelper(DatePartType part, std::string &date,
 // Invoke TimestampFunctions::DateTrunc(NULL)
 TEST_F(TimestampFunctionsTests, NullDatePartTest) {
   auto result = function::TimestampFunctions::DatePart(
-      "hour", type::PELOTON_TIMESTAMP_NULL);
-  EXPECT_EQ(type::PELOTON_DECIMAL_NULL, result);
+      "hour", type::PELOTON_VALUE_TIMESTAMP_NULL);
+  EXPECT_EQ(type::PELOTON_VALUE_DECIMAL_NULL, result);
 }
 
 TEST_F(TimestampFunctionsTests, DatePartCenturyTest) {

--- a/test/include/catalog/testing_constraints_util.h
+++ b/test/include/catalog/testing_constraints_util.h
@@ -336,7 +336,7 @@ class TestingConstraintsUtil {
                             storage::DataTable *table, int num_rows) {
     // Ensure that the tile group is as expected.
     UNUSED_ATTRIBUTE const catalog::Schema *schema = table->GetSchema();
-    PL_ASSERT(schema->GetColumnCount() == 4);
+    PELOTON_ASSERT(schema->GetColumnCount() == 4);
 
     for (int rowid = 0; rowid < num_rows; rowid++) {
       int populate_value = rowid;

--- a/test/include/concurrency/testing_transaction_util.h
+++ b/test/include/concurrency/testing_transaction_util.h
@@ -300,7 +300,7 @@ class TransactionThread {
       case TXN_OP_ABORT: {
         LOG_INFO("Txn %d Abort", schedule->schedule_id);
         // Assert last operation
-        PL_ASSERT(cur_seq == (int)schedule->operations.size());
+        PELOTON_ASSERT(cur_seq == (int)schedule->operations.size());
         schedule->txn_result = txn_manager->AbortTransaction(txn);
         txn = NULL;
         break;
@@ -395,7 +395,7 @@ class TransactionScheduler {
   }
 
   TransactionScheduler &Txn(int txn_id) {
-    PL_ASSERT(txn_id < (int)schedules.size());
+    PELOTON_ASSERT(txn_id < (int)schedules.size());
     cur_txn_id = txn_id;
     return *this;
   }

--- a/test/include/logging/testing_logging_util.h
+++ b/test/include/logging/testing_logging_util.h
@@ -228,15 +228,15 @@ class LoggingScheduler {
 
   LoggingScheduler &BackendLogger(unsigned int frontend_idx,
                                   unsigned int backend_idx) {
-    PL_ASSERT(frontend_idx < frontend_schedules.size());
-    PL_ASSERT(backend_idx < num_backend_logger_per_frontend);
+    PELOTON_ASSERT(frontend_idx < frontend_schedules.size());
+    PELOTON_ASSERT(backend_idx < num_backend_logger_per_frontend);
     cur_id.front = frontend_idx;
     cur_id.back = GetBackendLoggerId(frontend_idx, backend_idx);
     return *this;
   }
 
   LoggingScheduler &FrontendLogger(unsigned int frontend_idx) {
-    PL_ASSERT(frontend_idx < frontend_schedules.size());
+    PELOTON_ASSERT(frontend_idx < frontend_schedules.size());
     cur_id.front = frontend_idx;
     cur_id.back = INVALID_LOGGER_IDX;
     return *this;

--- a/test/index/hybrid_index_test.cpp
+++ b/test/index/hybrid_index_test.cpp
@@ -144,8 +144,8 @@ void LoadTable(std::unique_ptr<storage::DataTable> &hyadapt_table) {
     ItemPointer *index_entry_ptr = nullptr;
     ItemPointer tuple_slot_id =
         hyadapt_table->InsertTuple(&tuple, txn, &index_entry_ptr);
-    PL_ASSERT(tuple_slot_id.block != INVALID_OID);
-    PL_ASSERT(tuple_slot_id.offset != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.block != INVALID_OID);
+    PELOTON_ASSERT(tuple_slot_id.offset != INVALID_OID);
 
     txn_manager.PerformInsert(txn, tuple_slot_id, index_entry_ptr);
   }
@@ -374,7 +374,7 @@ void LaunchHybridScan(std::unique_ptr<storage::DataTable> &hyadapt_table) {
 
 void CopyTuple(const oid_t &tuple_slot_id, storage::Tuple *tuple,
                storage::TileGroup *tile_group, const size_t column_count) {
-  PL_ASSERT(tuple->GetColumnCount() == column_count);
+  PELOTON_ASSERT(tuple->GetColumnCount() == column_count);
   for (oid_t col_id = 0; col_id < column_count; ++col_id) {
     type::Value val = tile_group->GetValue(tuple_slot_id, col_id);
     tuple->SetValue(col_id, val, nullptr);

--- a/test/logging/buffer_pool_test.cpp
+++ b/test/logging/buffer_pool_test.cpp
@@ -38,7 +38,7 @@
 // void DequeueTest(logging::CircularBufferPool *buffer_pool, unsigned int count) {
 //   for (unsigned int i = 0; i < count; i++) {
 //     auto buf = std::move(buffer_pool->Get());
-//     PL_ASSERT(buf);
+//     PELOTON_ASSERT(buf);
 //     EXPECT_EQ(buf->GetSize(), i);
 //   }
 // }
@@ -110,7 +110,7 @@
 //   logging::LogBuffer log_buffer(0);
 //   size_t total_length = 0;
 //   for (auto record : records) {
-//     PL_ASSERT(record.GetTuple()->GetSchema());
+//     PELOTON_ASSERT(record.GetTuple()->GetSchema());
 //     CopySerializeOutput output_buffer;
 //     record.Serialize(output_buffer);
 //     size_t len = record.GetMessageLength();
@@ -147,7 +147,7 @@
 
 //   logging::LogBuffer log_buffer(0);
 //   size_t total_length = 0;
-//   PL_ASSERT(record.GetTuple()->GetSchema());
+//   PELOTON_ASSERT(record.GetTuple()->GetSchema());
 //   CopySerializeOutput output_buffer;
 //   record.Serialize(output_buffer);
 //   size_t len = record.GetMessageLength();

--- a/test/logging/log_buffer_test.cpp
+++ b/test/logging/log_buffer_test.cpp
@@ -54,7 +54,7 @@ TEST_F(LogBufferTests, LogBufferTest) {
 
   int num2;
 
-  PL_MEMCPY(&num2, data, sizeof(num));
+  PELOTON_MEMCPY(&num2, data, sizeof(num));
 
   EXPECT_EQ(num2, 99);
 

--- a/test/logging/recovery_test.cpp
+++ b/test/logging/recovery_test.cpp
@@ -58,7 +58,7 @@
 //   std::srand(std::time(nullptr));
 //   const catalog::Schema *schema = table->GetSchema();
 //   // Ensure that the tile group is as expected.
-//   PL_ASSERT(schema->GetColumnCount() == 4);
+//   PELOTON_ASSERT(schema->GetColumnCount() == 4);
 
 //   // Insert tuples into tile_group.
 //   const bool allocate = true;

--- a/test/logging/testing_logging_util.cpp
+++ b/test/logging/testing_logging_util.cpp
@@ -29,7 +29,7 @@
 //     for (size_t offset = 0; offset < tile_group_size; ++offset) {
 //       ItemPointer location(block, offset);
 //       auto &tuple = tuples[(block - 1) * tile_group_size + offset];
-//       PL_ASSERT(tuple->GetSchema());
+//       PELOTON_ASSERT(tuple->GetSchema());
 //       logging::TupleRecord record(
 //           LOGRECORD_TYPE_WAL_TUPLE_INSERT, INITIAL_TXN_ID, INVALID_OID,
 //           location, INVALID_ITEMPOINTER, tuple.get(), DEFAULT_DB_ID);
@@ -53,7 +53,7 @@
 //     for (size_t offset = 0; offset < tile_group_size; ++offset) {
 //       ItemPointer location(block + tile_group_start_oid, offset);
 //       auto &tuple = tuples[(block - 1) * tile_group_size + offset];
-//       PL_ASSERT(tuple->GetSchema());
+//       PELOTON_ASSERT(tuple->GetSchema());
 //       logging::TupleRecord record(LOGRECORD_TYPE_WAL_TUPLE_INSERT, block + 1,
 //                                   INVALID_OID, location, INVALID_ITEMPOINTER,
 //                                   tuple.get(), DEFAULT_DB_ID);
@@ -65,7 +65,7 @@
 //     ItemPointer location(tile_group_size + tile_group_start_oid,
 //                          table_tile_group_count + i);
 //     auto &tuple = tuples[tile_group_size * table_tile_group_count + i];
-//     PL_ASSERT(tuple->GetSchema());
+//     PELOTON_ASSERT(tuple->GetSchema());
 //     logging::TupleRecord record(LOGRECORD_TYPE_WAL_TUPLE_INSERT, 1000,
 //                                 INVALID_OID, location, INVALID_ITEMPOINTER,
 //                                 tuple.get(), DEFAULT_DB_ID);
@@ -76,7 +76,7 @@
 //     ItemPointer location(tile_group_start_oid + 1, 0);
 //     auto &tuple = tuples[tile_group_size * table_tile_group_count +
 //                          out_of_range_tuples + i];
-//     PL_ASSERT(tuple->GetSchema());
+//     PELOTON_ASSERT(tuple->GetSchema());
 //     logging::TupleRecord record(LOGRECORD_TYPE_WAL_TUPLE_DELETE, 4, INVALID_OID,
 //                                 INVALID_ITEMPOINTER, location, nullptr,
 //                                 DEFAULT_DB_ID);
@@ -97,7 +97,7 @@
 //   std::srand(std::time(nullptr));
 //   const catalog::Schema *schema = table->GetSchema();
 //   // Ensure that the tile group is as expected.
-//   PL_ASSERT(schema->GetColumnCount() == 4);
+//   PELOTON_ASSERT(schema->GetColumnCount() == 4);
 
 //   // Insert tuples into tile_group.
 //   const bool allocate = true;
@@ -132,7 +132,7 @@
 //         std::to_string(TestingExecutorUtil::PopulatedValue(
 //             random ? std::rand() % (num_rows / 3) : populate_value, 3)));
 //     tuple->SetValue(3, string_value, testing_pool);
-//     PL_ASSERT(tuple->GetSchema());
+//     PELOTON_ASSERT(tuple->GetSchema());
 //     tuples.push_back(std::move(tuple));
 //   }
 //   return tuples;
@@ -179,20 +179,20 @@
 //   switch (op) {
 //     case LOGGING_OP_COLLECT: {
 //       LOG_TRACE("Execute Collect");
-//       PL_ASSERT(frontend_logger);
+//       PELOTON_ASSERT(frontend_logger);
 //       frontend_logger->CollectLogRecordsFromBackendLoggers();
 //       break;
 //     }
 //     case LOGGING_OP_FLUSH: {
 //       LOG_TRACE("Execute Flush");
-//       PL_ASSERT(frontend_logger);
+//       PELOTON_ASSERT(frontend_logger);
 //       frontend_logger->FlushLogRecords();
 //       results.push_back(frontend_logger->GetMaxFlushedCommitId());
 //       break;
 //     }
 //     default: {
 //       LOG_TRACE("Unsupported operation type!");
-//       PL_ASSERT(false);
+//       PELOTON_ASSERT(false);
 //       break;
 //     }
 //   }
@@ -266,7 +266,7 @@
 //       LOG_TRACE("Execute Commit txn %d", (int)cid);
 //       std::unique_ptr<logging::LogRecord> record(new logging::TransactionRecord(
 //           LOGRECORD_TYPE_TRANSACTION_COMMIT, cid));
-//       PL_ASSERT(backend_logger);
+//       PELOTON_ASSERT(backend_logger);
 //       backend_logger->Log(record.get());
 //       break;
 //     }
@@ -274,7 +274,7 @@
 //       LOG_TRACE("Execute Abort txn %d", (int)cid);
 //       std::unique_ptr<logging::LogRecord> record(new logging::TransactionRecord(
 //           LOGRECORD_TYPE_TRANSACTION_ABORT, cid));
-//       PL_ASSERT(backend_logger);
+//       PELOTON_ASSERT(backend_logger);
 //       backend_logger->Log(record.get());
 //       break;
 //     }
@@ -294,7 +294,7 @@
 //     for (auto itr = sequence.begin(); itr != sequence.end(); itr++) {
 //       auto front_id = itr->second.front;
 //       auto backend_id = itr->second.back;
-//       PL_ASSERT(front_id != INVALID_LOGGER_IDX);
+//       PELOTON_ASSERT(front_id != INVALID_LOGGER_IDX);
 
 //       // frontend logger's turn
 //       if (backend_id == INVALID_LOGGER_IDX) {

--- a/test/network/rpc_client_test.cpp
+++ b/test/network/rpc_client_test.cpp
@@ -62,18 +62,18 @@ TEST_F(RpcClientTests, BasicTest) {
 
     // total length of the message: header length (4bytes) + message length
     // (8bytes + ...)
-    PL_ASSERT(HEADERLEN == sizeof(msg_len));
+    PELOTON_ASSERT(HEADERLEN == sizeof(msg_len));
     char buf[sizeof(msg_len) + msg_len];
 
     // copy the header into the buf
-    PL_MEMCPY(buf, &msg_len, sizeof(msg_len));
+    PELOTON_MEMCPY(buf, &msg_len, sizeof(msg_len));
 
     // copy the type into the buf
-    PL_MEMCPY(buf + sizeof(msg_len), &type, sizeof(type));
+    PELOTON_MEMCPY(buf + sizeof(msg_len), &type, sizeof(type));
 
     // copy the hashcode into the buf, following the header
-    PL_ASSERT(OPCODELEN == sizeof(opcode));
-    PL_MEMCPY(buf + sizeof(msg_len) + sizeof(type), &opcode, sizeof(opcode));
+    PELOTON_ASSERT(OPCODELEN == sizeof(opcode));
+    PELOTON_MEMCPY(buf + sizeof(msg_len) + sizeof(type), &opcode, sizeof(opcode));
 
     // call protobuf to serialize the request message into sending buf
     request.SerializeToArray(

--- a/test/optimizer/cost_test.cpp
+++ b/test/optimizer/cost_test.cpp
@@ -42,7 +42,7 @@ namespace test {
 
 using namespace optimizer;
 
-const int N_ROW = 100;
+//const int N_ROW = 100;
 
 class CostTests : public PelotonTest {};
 

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -951,7 +951,7 @@ TEST_F(PostgresParserTests, DataTypeTest) {
   auto column = create_stmt->columns.at(0).get();
   EXPECT_EQ("a", column->name);
   EXPECT_EQ(type::TypeId::VARCHAR, column->GetValueType(column->type));
-  EXPECT_EQ(peloton::type::PELOTON_TEXT_MAX_LEN, column->varlen);
+  EXPECT_EQ(peloton::type::PELOTON_VALUE_TEXT_MAX_LEN, column->varlen);
 
   // Check Second column
   column = create_stmt->columns.at(1).get();

--- a/test/sql/aggregate_sql_test.cpp
+++ b/test/sql/aggregate_sql_test.cpp
@@ -25,8 +25,8 @@ namespace test {
 class AggregateSQLTests : public PelotonTest {};
 
 TEST_F(AggregateSQLTests, EmptyTableTest) {
-  PL_ASSERT(&TestingSQLUtil::counter_);
-  PL_ASSERT(&TestingSQLUtil::traffic_cop_);
+  PELOTON_ASSERT(&TestingSQLUtil::counter_);
+  PELOTON_ASSERT(&TestingSQLUtil::traffic_cop_);
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -60,7 +60,7 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(
   std::string unnamed_statement = "unnamed";
   auto &peloton_parser = parser::PostgresParser::GetInstance();
   auto sql_stmt_list = peloton_parser.BuildParseTree(query);
-  PL_ASSERT(sql_stmt_list);
+  PELOTON_ASSERT(sql_stmt_list);
   if (!sql_stmt_list -> is_valid) {
     return ResultType::FAILURE;
   }
@@ -157,7 +157,7 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(const std::string query,
   std::string unnamed_statement = "unnamed";
   auto &peloton_parser = parser::PostgresParser::GetInstance();
   auto sql_stmt_list = peloton_parser.BuildParseTree(query);
-  PL_ASSERT(sql_stmt_list);
+  PELOTON_ASSERT(sql_stmt_list);
   if (!sql_stmt_list -> is_valid) {
     return ResultType::FAILURE;
   }
@@ -198,7 +198,7 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(const std::string query) {
   std::string unnamed_statement = "unnamed";
   auto &peloton_parser = parser::PostgresParser::GetInstance();
   auto sql_stmt_list = peloton_parser.BuildParseTree(query);
-  PL_ASSERT(sql_stmt_list);
+  PELOTON_ASSERT(sql_stmt_list);
   if (!sql_stmt_list -> is_valid) {
     return ResultType::FAILURE;
   }

--- a/test/sql/type_sql_test.cpp
+++ b/test/sql/type_sql_test.cpp
@@ -69,28 +69,28 @@ TEST_F(TypeSQLTests, TypeLimitSQLTest) {
     os << "INSERT INTO " << table_name << " VALUES (1, ";
     switch (col_type) {
       case type::TypeId::BOOLEAN:
-        os << (int32_t)type::PELOTON_BOOLEAN_NULL;
+        os << (int32_t)type::PELOTON_VALUE_BOOLEAN_NULL;
         break;
       case type::TypeId::TINYINT:
-        os << (int32_t)type::PELOTON_INT8_NULL;
+        os << (int32_t)type::PELOTON_VALUE_INT8_NULL;
         break;
       case type::TypeId::SMALLINT:
-        os << type::PELOTON_INT16_NULL;
+        os << type::PELOTON_VALUE_INT16_NULL;
         break;
       case type::TypeId::INTEGER:
-        os << type::PELOTON_INT32_NULL;
+        os << type::PELOTON_VALUE_INT32_NULL;
         break;
       case type::TypeId::BIGINT:
-        os << type::PELOTON_INT64_NULL;
+        os << type::PELOTON_VALUE_INT64_NULL;
         break;
       case type::TypeId::DECIMAL:
-        os << type::PELOTON_DECIMAL_NULL;
+        os << type::PELOTON_VALUE_DECIMAL_NULL;
         break;
       case type::TypeId::TIMESTAMP:
-        os << type::PELOTON_TIMESTAMP_NULL;
+        os << type::PELOTON_VALUE_TIMESTAMP_NULL;
         break;
       case type::TypeId::DATE:
-        os << type::PELOTON_DATE_NULL;
+        os << type::PELOTON_VALUE_DATE_NULL;
         break;
       default: {
         // Nothing to do!

--- a/test/statistics/stats_test.cpp
+++ b/test/statistics/stats_test.cpp
@@ -213,7 +213,7 @@ TEST_F(StatsTests, MultiThreadStatsTest) {
 //
 //  // Ensure that the tile group is as expected.
 //  const catalog::Schema *schema = data_table->GetSchema();
-//  PL_ASSERT(schema->GetColumnCount() == 4);
+//  PELOTON_ASSERT(schema->GetColumnCount() == 4);
 //
 //  // Insert tuples into tile_group.
 //  std::vector<ItemPointer> tuple_slot_ids;

--- a/test/storage/backend_manager_test.cpp
+++ b/test/storage/backend_manager_test.cpp
@@ -43,7 +43,7 @@ TEST_F(StorageManagerTests, BasicTest) {
       auto location = backend_manager.Allocate(backend_type, length);
 
       // Fill it up
-      PL_MEMSET(location, '-', length);
+      PELOTON_MEMSET(location, '-', length);
 
       // Sync
       backend_manager.Sync(backend_type, location, length);

--- a/test/type/array_value_test.cpp
+++ b/test/type/array_value_test.cpp
@@ -40,14 +40,14 @@ int16_t RANDOM16() { return ((rand() % (SHRT_MAX * 2 - 1)) - (SHRT_MAX - 1)); }
 
 int32_t RANDOM32() {
   int32_t ret = (((size_t)(rand()) << 1) | ((size_t)(rand()) & 0x1));
-  if (ret != type::PELOTON_INT32_NULL) return ret;
+  if (ret != type::PELOTON_VALUE_INT32_NULL) return ret;
   return 1;
 }
 
 int64_t RANDOM64() {
   int64_t ret = (((size_t)(rand()) << 33) | ((size_t)(rand()) << 2) |
                  ((size_t)(rand()) & 0x3));
-  if (ret != type::PELOTON_INT64_NULL) return ret;
+  if (ret != type::PELOTON_VALUE_INT64_NULL) return ret;
   return 1;
 }
 

--- a/test/type/boolean_value_test.cpp
+++ b/test/type/boolean_value_test.cpp
@@ -50,7 +50,7 @@ TEST_F(BooleanValueTests, ComparisonTest) {
       ExpressionType::COMPARE_GREATERTHAN,
       ExpressionType::COMPARE_GREATERTHANOREQUALTO};
 
-  int values[] = {true, false, type::PELOTON_BOOLEAN_NULL};
+  int values[] = {true, false, type::PELOTON_VALUE_BOOLEAN_NULL};
 
   CmpBool result;
   type::Value val0;
@@ -61,7 +61,7 @@ TEST_F(BooleanValueTests, ComparisonTest) {
       bool expected_null = false;
 
       // VALUE #0
-      if (values[i] == type::PELOTON_BOOLEAN_NULL) {
+      if (values[i] == type::PELOTON_VALUE_BOOLEAN_NULL) {
         val0 = type::ValueFactory::GetNullValueByType(type::TypeId::BOOLEAN);
         expected_null = true;
       } else {
@@ -70,7 +70,7 @@ TEST_F(BooleanValueTests, ComparisonTest) {
       }
 
       // VALUE #1
-      if (values[j] == type::PELOTON_BOOLEAN_NULL) {
+      if (values[j] == type::PELOTON_VALUE_BOOLEAN_NULL) {
         val1 = type::ValueFactory::GetNullValueByType(type::TypeId::BOOLEAN);
         expected_null = true;
       } else {
@@ -145,20 +145,20 @@ TEST_F(BooleanValueTests, ToStringTest) {
 }
 
 TEST_F(BooleanValueTests, HashTest) {
-  int values[] = {true, false, type::PELOTON_BOOLEAN_NULL};
+  int values[] = {true, false, type::PELOTON_VALUE_BOOLEAN_NULL};
 
   CmpBool result;
   type::Value val0;
   type::Value val1;
 
   for (int i = 0; i < 2; i++) {
-    if (values[i] == type::PELOTON_BOOLEAN_NULL) {
+    if (values[i] == type::PELOTON_VALUE_BOOLEAN_NULL) {
       val0 = type::ValueFactory::GetNullValueByType(type::TypeId::BOOLEAN);
     } else {
       val0 = type::ValueFactory::GetBooleanValue(static_cast<bool>(values[i]));
     }
     for (int j = 0; j < 2; j++) {
-      if (values[j] == type::PELOTON_BOOLEAN_NULL) {
+      if (values[j] == type::PELOTON_VALUE_BOOLEAN_NULL) {
         val1 = type::ValueFactory::GetNullValueByType(type::TypeId::BOOLEAN);
       } else {
         val1 =

--- a/test/type/date_value_test.cpp
+++ b/test/type/date_value_test.cpp
@@ -32,7 +32,7 @@ TEST_F(DateValueTests, ComparisonTest) {
       ExpressionType::COMPARE_GREATERTHAN,
       ExpressionType::COMPARE_GREATERTHANOREQUALTO};
 
-  int32_t values[] = {1000000000, 2000000000, type::PELOTON_DATE_NULL};
+  int32_t values[] = {1000000000, 2000000000, type::PELOTON_VALUE_DATE_NULL};
 
   CmpBool result;
   type::Value val0;
@@ -43,7 +43,7 @@ TEST_F(DateValueTests, ComparisonTest) {
       bool expected_null = false;
 
       // VALUE #0
-      if (values[i] == type::PELOTON_DATE_NULL) {
+      if (values[i] == type::PELOTON_VALUE_DATE_NULL) {
         val0 = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
         expected_null = true;
       } else {
@@ -52,7 +52,7 @@ TEST_F(DateValueTests, ComparisonTest) {
       }
 
       // VALUE #1
-      if (values[j] == type::PELOTON_DATE_NULL) {
+      if (values[j] == type::PELOTON_VALUE_DATE_NULL) {
         val1 = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
         expected_null = true;
       } else {
@@ -119,21 +119,21 @@ TEST_F(DateValueTests, NullToStringTest) {
 }
 
 TEST_F(DateValueTests, HashTest) {
-  int32_t values[] = {1000000000, 2000000000, type::PELOTON_DATE_NULL};
+  int32_t values[] = {1000000000, 2000000000, type::PELOTON_VALUE_DATE_NULL};
 
   type::Value result;
   type::Value val0;
   type::Value val1;
 
   for (int i = 0; i < 2; i++) {
-    if (values[i] == type::PELOTON_DATE_NULL) {
+    if (values[i] == type::PELOTON_VALUE_DATE_NULL) {
       val0 = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
     } else {
       val0 = type::ValueFactory::GetDateValue(
           static_cast<int32_t>(values[i]));
     }
     for (int j = 0; j < 2; j++) {
-      if (values[j] == type::PELOTON_DATE_NULL) {
+      if (values[j] == type::PELOTON_VALUE_DATE_NULL) {
         val1 = type::ValueFactory::GetNullValueByType(type::TypeId::DATE);
       } else {
         val1 = type::ValueFactory::GetDateValue(

--- a/test/type/numeric_value_test.cpp
+++ b/test/type/numeric_value_test.cpp
@@ -40,7 +40,7 @@ int16_t RANDOM16() {
 
 int32_t RANDOM32() {
   int32_t ret = (((size_t)(rand()) << 1) | ((size_t)(rand()) & 0x1));
-  if (ret != type::PELOTON_INT32_NULL)
+  if (ret != type::PELOTON_VALUE_INT32_NULL)
     return ret;
   return 1;
 }
@@ -48,7 +48,7 @@ int32_t RANDOM32() {
 int64_t RANDOM64() {
   int64_t ret = (((size_t)(rand()) << 33) | ((size_t)(rand()) << 2) |
                  ((size_t)(rand()) & 0x3));
-  if (ret != type::PELOTON_INT64_NULL)
+  if (ret != type::PELOTON_VALUE_INT64_NULL)
     return ret;
   return 1;
 }
@@ -585,7 +585,7 @@ TEST_F(NumericValueTests, CastAsTest) {
       type::TypeId::VARCHAR,
   };
 
-  for (int i = type::PELOTON_INT8_MIN; i <= type::PELOTON_INT8_MAX; i++) {
+  for (int i = type::PELOTON_VALUE_INT8_MIN; i <= type::PELOTON_VALUE_INT8_MAX; i++) {
     for (auto t1 : types) {
       type::Value v1;
 
@@ -666,28 +666,28 @@ TEST_F(NumericValueTests, NullValueTest) {
 
   // Compare null
   bool_result[0] = type::ValueFactory::GetIntegerValue(rand()).CompareEquals(
-    type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL));
+    type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL));
   bool_result[1] = type::ValueFactory::GetIntegerValue(rand()).CompareEquals(
-    type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL));
+    type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL));
   bool_result[2] = type::ValueFactory::GetIntegerValue(rand()).CompareEquals(
-    type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL));
+    type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL));
   bool_result[3] = type::ValueFactory::GetIntegerValue(rand()).CompareEquals(
-    type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL));
+    type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL));
   bool_result[4] = type::ValueFactory::GetIntegerValue(rand()).CompareEquals(
-    type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL));
+    type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL));
   for (int i = 0; i < 5; i++) {
     EXPECT_TRUE(bool_result[i] == CmpBool::NULL_);
   }
 
-  bool_result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL).CompareEquals(
+  bool_result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL).CompareEquals(
     type::ValueFactory::GetIntegerValue(rand()));
-  bool_result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL).CompareEquals(
+  bool_result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL).CompareEquals(
     type::ValueFactory::GetIntegerValue(rand()));
-  bool_result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL).CompareEquals(
+  bool_result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL).CompareEquals(
     type::ValueFactory::GetIntegerValue(rand()));
-  bool_result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL).CompareEquals(
+  bool_result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL).CompareEquals(
     type::ValueFactory::GetIntegerValue(rand()));
-  bool_result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL).CompareEquals(
+  bool_result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL).CompareEquals(
     type::ValueFactory::GetIntegerValue(rand()));
   for (int i = 0; i < 5; i++) {
     EXPECT_TRUE(bool_result[i] == CmpBool::NULL_);
@@ -698,29 +698,29 @@ TEST_F(NumericValueTests, NullValueTest) {
 
   // Operate null
   result[0] = type::ValueFactory::GetIntegerValue(rand()).Add(
-    type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL));
+    type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL));
   result[1] = type::ValueFactory::GetIntegerValue(rand()).Add(
-    type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL));
+    type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL));
   result[2] = type::ValueFactory::GetIntegerValue(rand()).Add(
-    type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL));
+    type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL));
   result[3] = type::ValueFactory::GetIntegerValue(rand()).Add(
-    type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL));
+    type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL));
   result[4] = type::ValueFactory::GetIntegerValue(rand()).Add(
-    type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL));
+    type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL));
   for (int i = 0; i < 5; i++) {
     EXPECT_TRUE(result[i].IsNull());
   }
 
   result[0] = type::ValueFactory::GetIntegerValue(rand()).Subtract(
-    type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL));
+    type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL));
   result[1] = type::ValueFactory::GetIntegerValue(rand()).Subtract(
-    type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL));
+    type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL));
   result[2] = type::ValueFactory::GetIntegerValue(rand()).Subtract(
-    type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL));
+    type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL));
   result[3] = type::ValueFactory::GetIntegerValue(rand()).Subtract(
-    type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL));
+    type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL));
   result[4] = type::ValueFactory::GetIntegerValue(rand()).Subtract(
-    type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL));
+    type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL));
   for (int i = 0; i < 5; i++) {
     EXPECT_TRUE(result[i].IsNull());
   }
@@ -728,123 +728,123 @@ TEST_F(NumericValueTests, NullValueTest) {
 
 
   result[0] = type::ValueFactory::GetIntegerValue(rand()).Multiply(
-    type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL));
+    type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL));
   result[1] = type::ValueFactory::GetIntegerValue(rand()).Multiply(
-    type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL));
+    type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL));
   result[2] = type::ValueFactory::GetIntegerValue(rand()).Multiply(
-    type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL));
+    type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL));
   result[3] = type::ValueFactory::GetIntegerValue(rand()).Multiply(
-    type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL));
+    type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL));
   result[4] = type::ValueFactory::GetIntegerValue(rand()).Multiply(
-    type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL));
+    type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL));
   for (int i = 0; i < 5; i++) {
     EXPECT_TRUE(result[i].IsNull());
   }
 
   result[0] = type::ValueFactory::GetIntegerValue(rand()).Divide(
-    type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL));
+    type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL));
   result[1] = type::ValueFactory::GetIntegerValue(rand()).Divide(
-    type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL));
+    type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL));
   result[2] = type::ValueFactory::GetIntegerValue(rand()).Divide(
-    type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL));
+    type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL));
   result[3] = type::ValueFactory::GetIntegerValue(rand()).Divide(
-    type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL));
+    type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL));
   result[4] = type::ValueFactory::GetIntegerValue(rand()).Divide(
-    type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL));
+    type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL));
   for (int i = 0; i < 5; i++) {
     EXPECT_TRUE(result[i].IsNull());
   }
 
   result[0] = type::ValueFactory::GetIntegerValue(rand()).Modulo(
-    type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL));
+    type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL));
   result[1] = type::ValueFactory::GetIntegerValue(rand()).Modulo(
-    type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL));
+    type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL));
   result[2] = type::ValueFactory::GetIntegerValue(rand()).Modulo(
-    type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL));
+    type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL));
   result[3] = type::ValueFactory::GetIntegerValue(rand()).Modulo(
-    type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL));
+    type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL));
   result[4] = type::ValueFactory::GetIntegerValue(rand()).Modulo(
-    type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL));
+    type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL));
   for (int i = 0; i < 5; i++) {
     EXPECT_TRUE(result[i].IsNull());
   }
 
-  result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL).Add(
+  result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL).Add(
     type::ValueFactory::GetIntegerValue(rand()));
-  result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL).Add(
+  result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL).Add(
     type::ValueFactory::GetIntegerValue(rand()));
-  result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL).Add(
+  result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL).Add(
     type::ValueFactory::GetIntegerValue(rand()));
-  result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL).Add(
+  result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL).Add(
     type::ValueFactory::GetIntegerValue(rand()));
-  result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL).Add(
-    type::ValueFactory::GetIntegerValue(rand()));
-  for (int i = 0; i < 5; i++) {
-    EXPECT_TRUE(result[i].IsNull());
-  }
-
-  result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL).Subtract(
-    type::ValueFactory::GetIntegerValue(rand()));
-  result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL).Subtract(
-    type::ValueFactory::GetIntegerValue(rand()));
-  result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL).Subtract(
-    type::ValueFactory::GetIntegerValue(rand()));
-  result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL).Subtract(
-    type::ValueFactory::GetIntegerValue(rand()));
-  result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL).Subtract(
+  result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL).Add(
     type::ValueFactory::GetIntegerValue(rand()));
   for (int i = 0; i < 5; i++) {
     EXPECT_TRUE(result[i].IsNull());
   }
 
-  result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL).Multiply(
+  result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL).Subtract(
     type::ValueFactory::GetIntegerValue(rand()));
-  result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL).Multiply(
+  result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL).Subtract(
     type::ValueFactory::GetIntegerValue(rand()));
-  result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL).Multiply(
+  result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL).Subtract(
     type::ValueFactory::GetIntegerValue(rand()));
-  result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL).Multiply(
+  result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL).Subtract(
     type::ValueFactory::GetIntegerValue(rand()));
-  result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL).Multiply(
-    type::ValueFactory::GetIntegerValue(rand()));
-  for (int i = 0; i < 5; i++) {
-    EXPECT_TRUE(result[i].IsNull());
-  }
-
-  result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL).Divide(
-    type::ValueFactory::GetIntegerValue(rand()));
-  result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL).Divide(
-    type::ValueFactory::GetIntegerValue(rand()));
-  result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL).Divide(
-    type::ValueFactory::GetIntegerValue(rand()));
-  result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL).Divide(
-    type::ValueFactory::GetIntegerValue(rand()));
-  result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL).Divide(
+  result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL).Subtract(
     type::ValueFactory::GetIntegerValue(rand()));
   for (int i = 0; i < 5; i++) {
     EXPECT_TRUE(result[i].IsNull());
   }
 
-  result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL).Modulo(
+  result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL).Multiply(
     type::ValueFactory::GetIntegerValue(rand()));
-  result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL).Modulo(
+  result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL).Multiply(
     type::ValueFactory::GetIntegerValue(rand()));
-  result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL).Modulo(
+  result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL).Multiply(
     type::ValueFactory::GetIntegerValue(rand()));
-  result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL).Modulo(
+  result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL).Multiply(
     type::ValueFactory::GetIntegerValue(rand()));
-  result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL).Modulo(
+  result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL).Multiply(
+    type::ValueFactory::GetIntegerValue(rand()));
+  for (int i = 0; i < 5; i++) {
+    EXPECT_TRUE(result[i].IsNull());
+  }
+
+  result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL).Divide(
+    type::ValueFactory::GetIntegerValue(rand()));
+  result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL).Divide(
+    type::ValueFactory::GetIntegerValue(rand()));
+  result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL).Divide(
+    type::ValueFactory::GetIntegerValue(rand()));
+  result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL).Divide(
+    type::ValueFactory::GetIntegerValue(rand()));
+  result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL).Divide(
+    type::ValueFactory::GetIntegerValue(rand()));
+  for (int i = 0; i < 5; i++) {
+    EXPECT_TRUE(result[i].IsNull());
+  }
+
+  result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL).Modulo(
+    type::ValueFactory::GetIntegerValue(rand()));
+  result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL).Modulo(
+    type::ValueFactory::GetIntegerValue(rand()));
+  result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL).Modulo(
+    type::ValueFactory::GetIntegerValue(rand()));
+  result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL).Modulo(
+    type::ValueFactory::GetIntegerValue(rand()));
+  result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL).Modulo(
     type::ValueFactory::GetIntegerValue(rand()));
   for (int i = 0; i < 5; i++) {
     EXPECT_TRUE(result[i].IsNull());
   }
 
 
-  result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_INT8_NULL).Sqrt();
-  result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_INT16_NULL).Sqrt();
-  result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_INT32_NULL).Sqrt();
-  result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_INT64_NULL).Sqrt();
-  result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_DECIMAL_NULL).Sqrt();
+  result[0] = type::ValueFactory::GetTinyIntValue((int8_t)type::PELOTON_VALUE_INT8_NULL).Sqrt();
+  result[1] = type::ValueFactory::GetSmallIntValue((int16_t)type::PELOTON_VALUE_INT16_NULL).Sqrt();
+  result[2] = type::ValueFactory::GetIntegerValue((int32_t)type::PELOTON_VALUE_INT32_NULL).Sqrt();
+  result[3] = type::ValueFactory::GetBigIntValue((int64_t)type::PELOTON_VALUE_INT64_NULL).Sqrt();
+  result[4] = type::ValueFactory::GetDecimalValue((double)type::PELOTON_VALUE_DECIMAL_NULL).Sqrt();
   for (int i = 0; i < 5; i++) {
     EXPECT_TRUE(result[i].IsNull());
   }

--- a/test/type/timestamp_value_test.cpp
+++ b/test/type/timestamp_value_test.cpp
@@ -32,7 +32,7 @@ TEST_F(TimestampValueTests, ComparisonTest) {
       ExpressionType::COMPARE_GREATERTHAN,
       ExpressionType::COMPARE_GREATERTHANOREQUALTO};
 
-  uint64_t values[] = {1000000000, 2000000000, type::PELOTON_TIMESTAMP_NULL};
+  uint64_t values[] = {1000000000, 2000000000, type::PELOTON_VALUE_TIMESTAMP_NULL};
 
   CmpBool result;
   type::Value val0;
@@ -43,7 +43,7 @@ TEST_F(TimestampValueTests, ComparisonTest) {
       bool expected_null = false;
 
       // VALUE #0
-      if (values[i] == type::PELOTON_TIMESTAMP_NULL) {
+      if (values[i] == type::PELOTON_VALUE_TIMESTAMP_NULL) {
         val0 = type::ValueFactory::GetNullValueByType(type::TypeId::TIMESTAMP);
         expected_null = true;
       } else {
@@ -52,7 +52,7 @@ TEST_F(TimestampValueTests, ComparisonTest) {
       }
 
       // VALUE #1
-      if (values[j] == type::PELOTON_TIMESTAMP_NULL) {
+      if (values[j] == type::PELOTON_VALUE_TIMESTAMP_NULL) {
         val1 = type::ValueFactory::GetNullValueByType(type::TypeId::TIMESTAMP);
         expected_null = true;
       } else {
@@ -117,21 +117,21 @@ TEST_F(TimestampValueTests, NullToStringTest) {
 }
 
 TEST_F(TimestampValueTests, HashTest) {
-  uint64_t values[] = {1000000000, 2000000000, type::PELOTON_TIMESTAMP_NULL};
+  uint64_t values[] = {1000000000, 2000000000, type::PELOTON_VALUE_TIMESTAMP_NULL};
 
   type::Value result;
   type::Value val0;
   type::Value val1;
 
   for (int i = 0; i < 2; i++) {
-    if (values[i] == type::PELOTON_TIMESTAMP_NULL) {
+    if (values[i] == type::PELOTON_VALUE_TIMESTAMP_NULL) {
       val0 = type::ValueFactory::GetNullValueByType(type::TypeId::TIMESTAMP);
     } else {
       val0 = type::ValueFactory::GetTimestampValue(
           static_cast<uint64_t>(values[i]));
     }
     for (int j = 0; j < 2; j++) {
-      if (values[j] == type::PELOTON_TIMESTAMP_NULL) {
+      if (values[j] == type::PELOTON_VALUE_TIMESTAMP_NULL) {
         val1 = type::ValueFactory::GetNullValueByType(type::TypeId::TIMESTAMP);
       } else {
         val1 = type::ValueFactory::GetTimestampValue(

--- a/test/type/value_factory_test.cpp
+++ b/test/type/value_factory_test.cpp
@@ -49,7 +49,7 @@ int16_t RANDOM16() {
 
 int32_t RANDOM32() {
   int32_t ret = (((size_t)(rand()) << 1) | ((size_t)(rand()) & 0x1));
-  if (ret != type::PELOTON_INT32_NULL)
+  if (ret != type::PELOTON_VALUE_INT32_NULL)
     return ret;
   return 1;
 }
@@ -57,7 +57,7 @@ int32_t RANDOM32() {
 int64_t RANDOM64() {
   int64_t ret = (((size_t)(rand()) << 33) | ((size_t)(rand()) << 2) |
                  ((size_t)(rand()) & 0x3));
-  if (ret != type::PELOTON_INT64_NULL)
+  if (ret != type::PELOTON_VALUE_INT64_NULL)
     return ret;
   return 1;
 }
@@ -70,16 +70,16 @@ TEST_F(ValueFactoryTests, ZeroValueTest) {
 }
 
 TEST_F(ValueFactoryTests, PeekValueTest) {
-  type::Value v1(type::TypeId::TINYINT, (int8_t)type::PELOTON_INT8_MAX);
-  EXPECT_EQ(type::ValuePeeker::PeekTinyInt(v1), type::PELOTON_INT8_MAX);
-  type::Value v2(type::TypeId::SMALLINT, (int16_t)type::PELOTON_INT16_MAX);
-  EXPECT_EQ(type::ValuePeeker::PeekSmallInt(v2), type::PELOTON_INT16_MAX);
-  type::Value v3(type::TypeId::INTEGER, (int32_t)type::PELOTON_INT32_MAX);
-  EXPECT_EQ(type::ValuePeeker::PeekInteger(v3), type::PELOTON_INT32_MAX);
-  type::Value v4(type::TypeId::BIGINT, (int64_t)type::PELOTON_INT64_MAX);
-  EXPECT_EQ(type::ValuePeeker::PeekBigInt(v4), type::PELOTON_INT64_MAX);
-  type::Value v5(type::TypeId::DECIMAL, (double)type::PELOTON_DECIMAL_MAX);
-  EXPECT_EQ(type::ValuePeeker::PeekDouble(v5), type::PELOTON_DECIMAL_MAX);
+  type::Value v1(type::TypeId::TINYINT, (int8_t)type::PELOTON_VALUE_INT8_MAX);
+  EXPECT_EQ(type::ValuePeeker::PeekTinyInt(v1), type::PELOTON_VALUE_INT8_MAX);
+  type::Value v2(type::TypeId::SMALLINT, (int16_t)type::PELOTON_VALUE_INT16_MAX);
+  EXPECT_EQ(type::ValuePeeker::PeekSmallInt(v2), type::PELOTON_VALUE_INT16_MAX);
+  type::Value v3(type::TypeId::INTEGER, (int32_t)type::PELOTON_VALUE_INT32_MAX);
+  EXPECT_EQ(type::ValuePeeker::PeekInteger(v3), type::PELOTON_VALUE_INT32_MAX);
+  type::Value v4(type::TypeId::BIGINT, (int64_t)type::PELOTON_VALUE_INT64_MAX);
+  EXPECT_EQ(type::ValuePeeker::PeekBigInt(v4), type::PELOTON_VALUE_INT64_MAX);
+  type::Value v5(type::TypeId::DECIMAL, (double)type::PELOTON_VALUE_DECIMAL_MAX);
+  EXPECT_EQ(type::ValuePeeker::PeekDouble(v5), type::PELOTON_VALUE_DECIMAL_MAX);
   type::Value v6(type::TypeId::BOOLEAN, true);
   EXPECT_EQ(type::ValuePeeker::PeekBoolean(v6), true);
   std::string str = "hello";
@@ -91,18 +91,18 @@ TEST_F(ValueFactoryTests, PeekValueTest) {
 
 TEST_F(ValueFactoryTests, CastTest) {
   type::Value v1(type::ValueFactory::CastAsBigInt(
-    type::Value(type::TypeId::INTEGER, (int32_t)type::PELOTON_INT32_MAX)));
+    type::Value(type::TypeId::INTEGER, (int32_t)type::PELOTON_VALUE_INT32_MAX)));
   EXPECT_EQ(v1.GetTypeId(), type::TypeId::BIGINT);
-  EXPECT_EQ(v1.GetAs<int64_t>(), type::PELOTON_INT32_MAX);
+  EXPECT_EQ(v1.GetAs<int64_t>(), type::PELOTON_VALUE_INT32_MAX);
 
   type::Value v2(type::ValueFactory::CastAsBigInt(
-    type::Value(type::TypeId::SMALLINT, (int16_t)type::PELOTON_INT16_MAX)));
+    type::Value(type::TypeId::SMALLINT, (int16_t)type::PELOTON_VALUE_INT16_MAX)));
   EXPECT_EQ(v2.GetTypeId(), type::TypeId::BIGINT);
 
   EXPECT_THROW(type::ValueFactory::CastAsBigInt(type::Value(type::TypeId::BOOLEAN, 0)), peloton::Exception);
-  EXPECT_THROW(type::ValueFactory::CastAsSmallInt(type::Value(type::TypeId::INTEGER, type::PELOTON_INT32_MAX)),
+  EXPECT_THROW(type::ValueFactory::CastAsSmallInt(type::Value(type::TypeId::INTEGER, type::PELOTON_VALUE_INT32_MAX)),
                                             peloton::Exception);
-  EXPECT_THROW(type::ValueFactory::CastAsTinyInt(type::Value(type::TypeId::INTEGER,type::PELOTON_INT32_MAX)),
+  EXPECT_THROW(type::ValueFactory::CastAsTinyInt(type::Value(type::TypeId::INTEGER,type::PELOTON_VALUE_INT32_MAX)),
                                            peloton::Exception);
 
   type::Value v3(type::ValueFactory::CastAsVarchar(type::ValueFactory::GetVarcharValue("hello")));
@@ -111,9 +111,9 @@ TEST_F(ValueFactoryTests, CastTest) {
   type::Value v4(type::ValueFactory::Clone(v3));
   EXPECT_TRUE(v3.CompareEquals(v4) == CmpBool::TRUE);
 
-  type::Value v5(type::ValueFactory::CastAsVarchar(type::Value(type::TypeId::TINYINT, (int8_t)type::PELOTON_INT8_MAX)));
+  type::Value v5(type::ValueFactory::CastAsVarchar(type::Value(type::TypeId::TINYINT, (int8_t)type::PELOTON_VALUE_INT8_MAX)));
   EXPECT_EQ(v5.ToString(), "127");
-  type::Value v6(type::ValueFactory::CastAsVarchar(type::Value(type::TypeId::BIGINT, (int64_t)type::PELOTON_INT64_MAX)));
+  type::Value v6(type::ValueFactory::CastAsVarchar(type::Value(type::TypeId::BIGINT, (int64_t)type::PELOTON_VALUE_INT64_MAX)));
   EXPECT_EQ(v6.ToString(), "9223372036854775807");
 
   std::string str1("9999-12-31 23:59:59.999999+14");


### PR DESCRIPTION
Standardize Peloton's macro names mentioned in #1019 
Also, I removed one line which caused my test failure. (cost_test.cpp:45:11: error: unused variable 'N_ROW' [-Werror,-Wunused-const-variable], MacOS).
https://github.com/cmu-db/peloton/blob/aaaa62151fc2023e570998d2df00d4ba11d85081/test/optimizer/cost_test.cpp#L45

