### PR TITLE
Fix memory leak in query history logging

### DIFF
--- a/src/brain/query_logger.cpp
+++ b/src/brain/query_logger.cpp
@@ -11,22 +11,40 @@
 //===----------------------------------------------------------------------===//
 
 #include "brain/query_logger.h"
+
 #include "catalog/query_history_catalog.h"
 #include "concurrency/transaction_context.h"
 #include "concurrency/transaction_manager_factory.h"
-#include "parser/pg_query.h"
 
 namespace peloton {
 namespace brain {
 
+QueryLogger::Fingerprint::Fingerprint(const std::string &query)
+    : query_(query),
+      fingerprint_(""),
+      fingerprint_result_(pg_query_fingerprint(query.c_str())) {
+  if (fingerprint_result_.hexdigest != nullptr) {
+    fingerprint_ = fingerprint_result_.hexdigest;
+  }
+}
+
+QueryLogger::Fingerprint::~Fingerprint() {
+  pg_query_free_fingerprint_result(fingerprint_result_);
+}
+
 void QueryLogger::LogQuery(std::string query_string, uint64_t timestamp) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-  auto txn = txn_manager.BeginTransaction();
-  std::string fingerprint = pg_query_fingerprint(query_string.c_str()).hexdigest;
+  auto *txn = txn_manager.BeginTransaction();
 
-  catalog::QueryHistoryCatalog::GetInstance()->InsertQueryHistory(
-      query_string, fingerprint, timestamp, nullptr, txn);
+  // Perform fingerprint
+  Fingerprint fingerprint{query_string};
 
+  // Log query + fingerprint
+  auto &query_history_catalog = catalog::QueryHistoryCatalog::GetInstance();
+  query_history_catalog.InsertQueryHistory(
+      query_string, fingerprint.GetFingerprint(), timestamp, nullptr, txn);
+
+  // We're done
   txn_manager.CommitTransaction(txn);
 }
 

--- a/src/include/brain/query_logger.h
+++ b/src/include/brain/query_logger.h
@@ -12,7 +12,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
+
+#include "parser/pg_query.h"
 
 namespace peloton {
 namespace brain {
@@ -25,8 +28,28 @@ class QueryLogger {
  public:
   QueryLogger() = default;
 
-  /*
+  class Fingerprint {
+   public:
+    /// Constructor
+    explicit Fingerprint(const std::string &query);
+
+    /// Destructor
+    ~Fingerprint();
+
+    /// Get original string
+    const std::string &GetQueryString() { return query_; }
+    const std::string &GetFingerprint() { return fingerprint_; }
+
+   private:
+    // Accessors
+    std::string query_;
+    std::string fingerprint_;
+    PgQueryFingerprintResult fingerprint_result_;
+  };
+
+  /**
    * @brief This function logs the query into query_history_catalog
+   *
    * @param the sql string corresponding to the query
    * @param timestamp of the transaction that executed the query
    */

--- a/src/include/catalog/query_history_catalog.h
+++ b/src/include/catalog/query_history_catalog.h
@@ -6,7 +6,7 @@
 //
 // Identification: src/include/catalog/query_history_catalog.h
 //
-// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 

--- a/src/include/catalog/query_history_catalog.h
+++ b/src/include/catalog/query_history_catalog.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "catalog/abstract_catalog.h"
+#include "type/ephemeral_pool.h"
 
 #define QUERY_HISTORY_CATALOG_NAME "pg_query_history"
 
@@ -34,14 +35,14 @@ class QueryHistoryCatalog : public AbstractCatalog {
   ~QueryHistoryCatalog();
 
   // Global Singleton
-  static QueryHistoryCatalog *GetInstance(
+  static QueryHistoryCatalog &GetInstance(
       concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
   //===--------------------------------------------------------------------===//
   bool InsertQueryHistory(const std::string &query_string,
-                          std::string &fingerprint, uint64_t timestamp,
+                          const std::string &fingerprint, uint64_t timestamp,
                           type::AbstractPool *pool,
                           concurrency::TransactionContext *txn);
 
@@ -54,6 +55,8 @@ class QueryHistoryCatalog : public AbstractCatalog {
  private:
   QueryHistoryCatalog(concurrency::TransactionContext *txn);
 
+  // Pool to use for variable length strings
+  type::EphemeralPool pool_;
 };
 
 }  // namespace catalog

--- a/test/brain/query_logger_test.cpp
+++ b/test/brain/query_logger_test.cpp
@@ -6,7 +6,7 @@
 //
 // Identification: test/brain/query_logger_test.cpp
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/brain/query_logger_test.cpp
+++ b/test/brain/query_logger_test.cpp
@@ -11,38 +11,40 @@
 //===----------------------------------------------------------------------===//
 
 #include "common/harness.h"
+
+#include "brain/query_logger.h"
 #include "sql/testing_sql_util.h"
 #include "settings/settings_manager.h"
-#include "parser/pg_query.h"
-
-using std::vector;
-using std::string;
 
 namespace peloton {
 namespace test {
 
 class QueryLoggerTests : public PelotonTest {
  protected:
-  virtual void SetUp() override {
+  void SetUp() override {
     settings::SettingsManager::SetBool(settings::SettingId::brain, true);
     PelotonInit::Initialize();
 
     // query to check that logging is done
     select_query_ =
         "SELECT query_string, fingerprint FROM pg_catalog.pg_query_history;";
-    select_query_fingerprint_ =
-        pg_query_fingerprint(select_query_.c_str()).hexdigest;
+
+    brain::QueryLogger::Fingerprint fingerprint{select_query_};
+    select_query_fingerprint_ = fingerprint.GetFingerprint();
+
     wait_time_ = 2;
   }
 
-  virtual void TearDown() override { PelotonInit::Shutdown(); }
+  void TearDown() override { PelotonInit::Shutdown(); }
 
   // Executes the given query and then checks if the queries that are executed
   // till now are actually logged
-  void TestSimpleUtil(string const &test_query,
-                      vector<std::string> &expected_result) {
-    string test_query_fingerprint =
-        pg_query_fingerprint(test_query.c_str()).hexdigest;
+  void TestSimpleUtil(std::string const &test_query,
+                      std::vector<std::string> &expected_result) {
+    brain::QueryLogger::Fingerprint fingerprint{test_query};
+
+    std::string test_query_fingerprint = fingerprint.GetFingerprint();
+
     expected_result.push_back(test_query + "|" + test_query_fingerprint);
     TestingSQLUtil::ExecuteSQLQuery(test_query.c_str());
 
@@ -57,14 +59,16 @@ class QueryLoggerTests : public PelotonTest {
   }
 
   // Executes the given query and then checks if the queries that are executed
-  // till now are actually logged only when the transaction commits. Otherwise
+  // until now are actually logged only when the transaction commits. Otherwise
   // stores to queries for checking this later when commit happens.
-  void TestTransactionUtil(string const &test_query,
-                           vector<std::string> &expected_result,
+  void TestTransactionUtil(std::string const &test_query,
+                           std::vector<std::string> &expected_result,
                            bool committed) {
-    static vector<std::string> temporary_expected_result;
-    string test_query_fingerprint =
-        pg_query_fingerprint(test_query.c_str()).hexdigest;
+    static std::vector<std::string> temporary_expected_result;
+
+    brain::QueryLogger::Fingerprint fingerprint{test_query};
+    std::string test_query_fingerprint = fingerprint.GetFingerprint();
+
     temporary_expected_result.push_back(test_query + "|" +
                                         test_query_fingerprint);
     TestingSQLUtil::ExecuteSQLQuery(test_query.c_str());
@@ -100,15 +104,20 @@ class QueryLoggerTests : public PelotonTest {
   }
 
  protected:
-  string select_query_;  // fixed query to check the queries logged in the table
-  string select_query_fingerprint_;  // fingerprint for the fixed query
-  int wait_time_;  // time to wait in seconds for the query to log into the
-                   // table
+  // fixed query to check the queries logged in the table
+  std::string select_query_;
+
+  // fingerprint for the fixed query
+  std::string select_query_fingerprint_;
+
+  // time to wait in seconds for the query to log into the table
+  int wait_time_;
 };
 
 // Testing the functionality of query logging
 TEST_F(QueryLoggerTests, QueriesTest) {
-  vector<std::string> expected_result;  // used to store the expected result
+  // used to store the expected result
+  std::vector<std::string> expected_result;
 
   // create the table and do some inserts and check
   TestSimpleUtil("CREATE TABLE test(a INT);", expected_result);


### PR DESCRIPTION
Tonight, I rebased against master and ran into two tests failing because of memory leaks:
1. `query_logger_test`
2. `ssl_test`

As to how these changes made it into master without failing Travis is a separate issue. But, this PR fixes the first issue. 

`pg_query_fingerprint()` mallocs memory that must be freed by the caller through a companion call to `pg_query_free_fingerprint_result()`. This wasn't being done. I added a wrapper class that leverages RAII to make the appropriate call to safely free up allocated memory. 