### PR TITLE
Read the parameters of thread pool correctly from settings

### DIFF
--- a/src/include/threadpool/mono_queue_pool.h
+++ b/src/include/threadpool/mono_queue_pool.h
@@ -24,9 +24,7 @@ namespace threadpool {
  */
 class MonoQueuePool {
  public:
-  MonoQueuePool() = delete;
-
-  MonoQueuePool(int task_queue_size, int worker_pool_size)
+  MonoQueuePool(uint32_t task_queue_size, uint32_t worker_pool_size)
       : task_queue_(task_queue_size),
         worker_pool_(worker_pool_size, &task_queue_),
         is_running_(false) {}
@@ -55,18 +53,18 @@ class MonoQueuePool {
   }
 
   static MonoQueuePool &GetInstance() {
-    int task_queue_size = settings::SettingsManager::GetInt(
+    uint32_t task_queue_size = settings::SettingsManager::GetInt(
         settings::SettingId::monoqueue_task_queue_size);
-    int worker_pool_size = settings::SettingsManager::GetInt(
+    uint32_t worker_pool_size = settings::SettingsManager::GetInt(
         settings::SettingId::monoqueue_worker_pool_size);
     static MonoQueuePool mono_queue_pool(task_queue_size, worker_pool_size);
     return mono_queue_pool;
   }
 
   static MonoQueuePool &GetBrainInstance() {
-    int task_queue_size = settings::SettingsManager::GetInt(
+    uint32_t task_queue_size = settings::SettingsManager::GetInt(
         settings::SettingId::brain_task_queue_size);
-    int worker_pool_size = settings::SettingsManager::GetInt(
+    uint32_t worker_pool_size = settings::SettingsManager::GetInt(
         settings::SettingId::brain_worker_pool_size);
     static MonoQueuePool brain_queue_pool(task_queue_size, worker_pool_size);
     return brain_queue_pool;

--- a/src/include/threadpool/mono_queue_pool.h
+++ b/src/include/threadpool/mono_queue_pool.h
@@ -24,7 +24,9 @@ namespace threadpool {
  */
 class MonoQueuePool {
  public:
-  MonoQueuePool(int task_queue_size = 32, int worker_pool_size = 4)
+  MonoQueuePool() = delete;
+
+  MonoQueuePool(int task_queue_size, int worker_pool_size)
       : task_queue_(task_queue_size),
         worker_pool_(worker_pool_size, &task_queue_),
         is_running_(false) {}
@@ -53,19 +55,18 @@ class MonoQueuePool {
   }
 
   static MonoQueuePool &GetInstance() {
-    int task_queue_size = settings::SettingsManager::GetBool(
+    int task_queue_size = settings::SettingsManager::GetInt(
         settings::SettingId::monoqueue_task_queue_size);
-    int worker_pool_size = settings::SettingsManager::GetBool(
+    int worker_pool_size = settings::SettingsManager::GetInt(
         settings::SettingId::monoqueue_worker_pool_size);
-
     static MonoQueuePool mono_queue_pool(task_queue_size, worker_pool_size);
     return mono_queue_pool;
   }
 
   static MonoQueuePool &GetBrainInstance() {
-    int task_queue_size = settings::SettingsManager::GetBool(
+    int task_queue_size = settings::SettingsManager::GetInt(
         settings::SettingId::brain_task_queue_size);
-    int worker_pool_size = settings::SettingsManager::GetBool(
+    int worker_pool_size = settings::SettingsManager::GetInt(
         settings::SettingId::brain_worker_pool_size);
     static MonoQueuePool brain_queue_pool(task_queue_size, worker_pool_size);
     return brain_queue_pool;

--- a/test/optimizer/cost_test.cpp
+++ b/test/optimizer/cost_test.cpp
@@ -42,7 +42,7 @@ namespace test {
 
 using namespace optimizer;
 
-const int N_ROW = 100;
+// const int N_ROW = 100;
 
 class CostTests : public PelotonTest {};
 


### PR DESCRIPTION
Minor fix to read the correct parameters for the worker and brain thread pool. This fixes the broken release build issue.