### PR TITLE
Fix travis build to check status of tests and benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,14 @@ matrix:
               # COVERALLS: we run coveralls only for one compiler
               - COVERALLS=On
           # only run tests if the build itself succeeded
-          after_success:
+          script:
+              # create build directory
+              - mkdir build
+              - cd build
+              # run cmake. NOTE: the PATH is made explicit to avoid automatic selection of the preinstalled llvm version in the Travis trusty image
+              - PATH=/usr/lib/llvm-3.7/bin:/usr/bin:$PATH cmake -DCOVERALLS=$COVERALLS -DCMAKE_PREFIX_PATH=`llvm-config-3.7 --prefix` -DCMAKE_BUILD_TYPE=$PELOTON_BUILD_TYPE -DUSE_SANITIZER=Address ..
+              # build
+              - make -j4
               # run tests
               - if [[ $TRAVIS_OS_NAME != 'osx' ]]; then make check -j4; fi
               - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then ASAN_OPTIONS=detect_container_overflow=0 make check -j4; fi
@@ -68,7 +75,14 @@ matrix:
               - PELOTON_BUILD_TYPE=Release
               - COVERALLS=Off
           # only run tests if the build itself succeeded
-          after_success:
+          script:
+              # create build directory
+              - mkdir build
+              - cd build
+              # run cmake. NOTE: the PATH is made explicit to avoid automatic selection of the preinstalled llvm version in the Travis trusty image
+              - PATH=/usr/lib/llvm-3.7/bin:/usr/bin:$PATH cmake -DCOVERALLS=$COVERALLS -DCMAKE_PREFIX_PATH=`llvm-config-3.7 --prefix` -DCMAKE_BUILD_TYPE=$PELOTON_BUILD_TYPE -DUSE_SANITIZER=Address ..
+              # build
+              - make -j4
               # run tests
               - if [[ $TRAVIS_OS_NAME != 'osx' ]]; then make check -j4; fi
               - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then ASAN_OPTIONS=detect_container_overflow=0 make check -j4; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
               - PELOTON_BUILD_TYPE=Debug
               # COVERALLS: we run coveralls only for one compiler
               - COVERALLS=On
-          # only run tests if the build itself succeeded
+          # override script value to run also tests and benchmarks
           script:
               # create build directory
               - mkdir build
@@ -74,7 +74,7 @@ matrix:
               - CC=gcc-4.8
               - PELOTON_BUILD_TYPE=Release
               - COVERALLS=Off
-          # only run tests if the build itself succeeded
+          # override script value to run also tests and benchmarks
           script:
               # create build directory
               - mkdir build
@@ -143,6 +143,7 @@ before_script:
     # first, run source_validator
     - python ./script/validators/source_validator.py
 
+# build peloton (override this value to execute tests)
 script:
     # create build directory
     - mkdir build

--- a/script/testing/jdbc/src/PelotonErrorTest.java
+++ b/script/testing/jdbc/src/PelotonErrorTest.java
@@ -23,7 +23,7 @@ public class PelotonErrorTest {
     private static final String DDL = "CREATE TABLE foo(id integer PRIMARY KEY, year integer);";
 
     private static Connection makeConnection(String host, int port, String username, String pass) throws SQLException {
-        String url = String.format("jdbc:postgresql://%s:%d/pavlo", host, port);
+        String url = String.format("jdbc:postgresql://%s:%d/default_database", host, port);
         Connection conn = DriverManager.getConnection(url, username, pass);
         return conn;
     }

--- a/script/testing/jdbc/src/PelotonTypeTest.java
+++ b/script/testing/jdbc/src/PelotonTypeTest.java
@@ -34,7 +34,7 @@ public class PelotonTypeTest {
     
 
     private static Connection makeConnection(String host, int port, String username, String pass) throws SQLException {
-        String url = String.format("jdbc:postgresql://%s:%d/pavlo", host, port);
+        String url = String.format("jdbc:postgresql://%s:%d/default_database", host, port);
         Connection conn = DriverManager.getConnection(url, username, pass);
         return conn;
     }


### PR DESCRIPTION
I made a terrible mistake in #989, that allows travis builds to succeed, even if the tests and benchmarks fail. 
The section `after_success` ignores the exit code of the executed scripts. [1] I changed those scripts to be executed in the section `script`. 

Thanks to @pervazea for finding this and sorry to everyone for making this dump mistake :(

[1] https://docs.travis-ci.com/user/customizing-the-build/#Breaking-the-Build