### PR TITLE
Fix the capnproto variable setting and linking issue.

### DIFF
--- a/cmake/External/capnproto.cmake
+++ b/cmake/External/capnproto.cmake
@@ -44,12 +44,24 @@ if (NOT __CAPNP_INCLUDED) # guard against multiple includes
       LOG_INSTALL 1
       )
 
+    # This will set several system default installaion dirs which capnproto is using.
+    # It's important especially for LIBDIR which varies from platform to platform.
+    include(GNUInstallDirs)
+
     set(CAPNP_FOUND TRUE)
-    set(CAPNP_EXECUTABLE ${capnp_INSTALL}/bin/capnp)
-    set(CAPNPC_CXX_EXECUTABLE ${capnp_INSTALL}/bin/capnpc-c++)
-    set(CAPNP_INCLUDE_DIRS ${capnp_INSTALL}/include)
-    set(CAPNP_INCLUDE_DIRECTORY ${capnp_INSTALL}/include)
+    set(CAPNP_EXECUTABLE ${capnp_INSTALL}/${CMAKE_INSTALL_BINDIR}/capnp)
+    set(CAPNPC_CXX_EXECUTABLE ${capnp_INSTALL}/${CMAKE_INSTALL_BINDIR}/capnpc-c++)
+    set(CAPNP_INCLUDE_DIRS ${capnp_INSTALL}/${CMAKE_INSTALL_INCLUDEDIR})
+    set(CAPNP_INCLUDE_DIRECTORY ${capnp_INSTALL}/${CMAKE_INSTALL_INCLUDEDIR})
     set(CAPNP_EXTERNAL TRUE)
+    set(CAPNP_LIBRARIES
+      ${capnp_INSTALL}/${CMAKE_INSTALL_LIBDIR}/libcapnp-rpc.a
+      ${capnp_INSTALL}/${CMAKE_INSTALL_LIBDIR}/libcapnp.a
+      ${capnp_INSTALL}/${CMAKE_INSTALL_LIBDIR}/libkj-async.a
+      ${capnp_INSTALL}/${CMAKE_INSTALL_LIBDIR}/libkj.a
+      ${CMAKE_THREAD_LIBS_INIT}
+    )
+    set(CAPNP_LIBRARY_DIRS ${capnp_INSTALL}/${CMAKE_INSTALL_LIBDIR})
 
     list(APPEND external_project_dependencies capnp)
 


### PR DESCRIPTION
It turned out that capnproto won't set any installation variables if we include it as an external project. However as #1083 described, we cannot manually hard-code the paths, nor can we directly remove those variable settings either.

This PR solves that issue by setting those variables with the default system installation directories provided by CMAKE.