### PR TITLE
Clean up of the index utility code

### DIFF
--- a/src/include/index/bwtree.h
+++ b/src/include/index/bwtree.h
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-//                         PelotonDB
+//                         Peloton
 //
 // bwtree.h
 //
-// Identification: src/index/bwtree.h
+// Identification: src/include/index/bwtree.h
 //
-// Copyright (c) 2015, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 //

--- a/src/include/index/bwtree_index.h
+++ b/src/include/index/bwtree_index.h
@@ -4,9 +4,9 @@
 //
 // bwtree_index.h
 //
-// Identification: src/backend/index/bwtree_index.h
+// Identification: src/include/index/bwtree_index.h
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -67,20 +67,20 @@ class BWTreeIndex : public Index {
 
   ~BWTreeIndex();
 
-  bool InsertEntry(const storage::Tuple *key, ItemPointer *value);
+  bool InsertEntry(const storage::Tuple *key, ItemPointer *value) override;
 
-  bool DeleteEntry(const storage::Tuple *key, ItemPointer *value);
+  bool DeleteEntry(const storage::Tuple *key, ItemPointer *value) override;
 
   bool CondInsertEntry(const storage::Tuple *key,
                        ItemPointer *value,
-                       std::function<bool(const void *)> predicate);
+                       std::function<bool(const void *)> predicate) override;
 
   void Scan(const std::vector<type::Value> &values,
             const std::vector<oid_t> &key_column_ids,
             const std::vector<ExpressionType> &expr_types,
             ScanDirectionType scan_direction,
             std::vector<ValueType> &result,
-            const ConjunctionScanPredicate *csp_p);
+            const ConjunctionScanPredicate *csp_p) override;
             
   void ScanLimit(const std::vector<type::Value> &values,
                  const std::vector<oid_t> &key_column_ids,
@@ -89,23 +89,24 @@ class BWTreeIndex : public Index {
                  std::vector<ValueType> &result,
                  const ConjunctionScanPredicate *csp_p,
                  uint64_t limit,
-                 uint64_t offset);
+                 uint64_t offset) override;
 
-  void ScanAllKeys(std::vector<ValueType> &result);
+  void ScanAllKeys(std::vector<ValueType> &result) override;
 
   void ScanKey(const storage::Tuple *key,
-               std::vector<ValueType> &result);
+               std::vector<ValueType> &result) override;
 
-  std::string GetTypeName() const;
+  std::string GetTypeName() const override;
 
   // TODO: Implement this
-  size_t GetMemoryFootprint() { return 0; }
+  size_t GetMemoryFootprint() override { return 0; }
   
-  bool NeedGC() {
+  bool NeedGC() override {
     return container.NeedGarbageCollection();
   }
 
-  void PerformGC() {
+  void PerformGC() override {
+    LOG_INFO("Bw-Tree Garbage Collection!");
     container.PerformGarbageCollection();
     
     return;

--- a/src/include/index/compact_ints_key.h
+++ b/src/include/index/compact_ints_key.h
@@ -6,7 +6,7 @@
 //
 // Identification: src/include/index/compact_ints_key.h
 //
-// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -320,16 +320,23 @@ class CompactIntsKey {
   }
 
  public:
-  /*
-   * GetInfo() - Prints the content of this key
+
+  /**
+   * Prints the content of this key.
+   *
+   * IMPORTANT: This class should <b>not</b> override Printable
+   * because that adds an extra 8 bytes and it makes all the math
+   * above for doing fast comparisons fail.
+   *
+   * @return
    */
-  std::string GetInfo() const {
+  const std::string GetInfo() const {
     std::ostringstream os;
     os << "CompactIntsKey<" << KeySize << "> - " << key_size_byte << " bytes"
        << std::endl;
 
     // This is the current offset we are on printing the key
-    int offset = 0;
+    size_t offset = 0;
     while (offset < key_size_byte) {
       constexpr int byte_per_line = 16;
       os << StringUtil::Format("0x%.8X    ", offset);

--- a/src/include/index/generic_key.h
+++ b/src/include/index/generic_key.h
@@ -6,11 +6,13 @@
 //
 // Identification: src/include/index/generic_key.h
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
 #pragma once
+
+#include <sstream>
 
 #include "type/type_util.h"
 
@@ -51,6 +53,24 @@ class GenericKey {
     const char *data_ptr = &data[schema->GetOffset(column_id)];
     return (data_ptr);
   }
+
+  /**
+   * Generate a human-readable version of this GenericKey.
+   * This method is slow (lots of memory copying) so you
+   * don't want to execute this on the critical path of
+   * anything real in the system.
+   *
+   * IMPORTANT: The output is based on the original tuple
+   * schema and not the key schema. So you may end up seeing
+   * attributes values that are not actually used in the index.
+   *
+   * @return
+   */
+  const std::string GetInfo() const {
+    storage::Tuple tuple(schema, data);
+    return (tuple.GetInfo());
+  }
+
 
   // actual location of data, extends past the end.
   char data[KeySize];

--- a/src/include/index/index.h
+++ b/src/include/index/index.h
@@ -6,7 +6,7 @@
 //
 // Identification: src/include/index/index.h
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -255,6 +255,20 @@ class Index : public Printable {
   // Index Scan
   ///////////////////////////////////////////////////////////////////
 
+  /**
+   * Scans a range inside the index and returns all elements
+   * in the result vector. The type of scan to perform is
+   * specified by the given scan predicate (csp_p).
+   * Whether to perform a forward or backward scan is
+   * determined by the given scan_direction.
+   *
+   * @param value_list
+   * @param tuple_column_id_list
+   * @param expr_list
+   * @param scan_direction
+   * @param result
+   * @param csp_p
+   */
   virtual void Scan(const std::vector<type::Value> &value_list,
                     const std::vector<oid_t> &tuple_column_id_list,
                     const std::vector<ExpressionType> &expr_list,
@@ -262,6 +276,20 @@ class Index : public Printable {
                     std::vector<ItemPointer *> &result,
                     const ConjunctionScanPredicate *csp_p) = 0;
 
+  /**
+   * The ScanLimit function has the same behavior as the Scan function
+   * except that the scan stops after it reads offset + limit elements.
+   * Therefore, maximum of limit elements are returned in the result vector.
+   *
+   * @param value_list
+   * @param tuple_column_id_list
+   * @param expr_list
+   * @param scan_direction
+   * @param result
+   * @param csp_p
+   * @param limit
+   * @param offset
+   */
   virtual void ScanLimit(const std::vector<type::Value> &value_list,
                          const std::vector<oid_t> &tuple_column_id_list,
                          const std::vector<ExpressionType> &expr_list,
@@ -270,17 +298,41 @@ class Index : public Printable {
                          const ConjunctionScanPredicate *csp_p, uint64_t limit,
                          uint64_t offset) = 0;
 
-  // This is the version used to test scan
-  // Since it does scan planning everytime, it is slow, and should
-  // only be used for correctness testing
+  /**
+   * This is the version used to test the basic scan operation.
+   * Since it does a scan planning every time it is invoked, it will
+   * be slower than the regular scan.
+   * This should <b>only</b> be used for correctness testing.
+   *
+   * @param value_list
+   * @param tuple_column_id_list
+   * @param expr_list
+   * @param scan_direction
+   * @param result
+   */
   virtual void ScanTest(const std::vector<type::Value> &value_list,
                         const std::vector<oid_t> &tuple_column_id_list,
                         const std::vector<ExpressionType> &expr_list,
                         const ScanDirectionType &scan_direction,
                         std::vector<ItemPointer *> &result);
 
+  /**
+   * Scan all of the keys in the index and store their values
+   * in the result vector.
+   *
+   * @param result
+   */
   virtual void ScanAllKeys(std::vector<ItemPointer *> &result) = 0;
 
+  /**
+   * Finds all of the values in the index for the given key and
+   * return them in the result vector.
+   * If the index is not configured to store duplicate keys,
+   * then at most one value will be returned.
+   *
+   * @param key
+   * @param result
+   */
   virtual void ScanKey(const storage::Tuple *key,
                        std::vector<ItemPointer *> &result) = 0;
 
@@ -340,8 +392,6 @@ class Index : public Printable {
   const catalog::Schema *GetKeySchema() const {
     return metadata->GetKeySchema();
   }
-
-  IndexType GetIndexMethodType() { return metadata->GetIndexType(); }
 
   IndexConstraintType GetIndexType() const {
     return metadata->GetIndexConstraintType();

--- a/src/include/index/index_util.h
+++ b/src/include/index/index_util.h
@@ -6,10 +6,9 @@
 //
 // Identification: src/include/index/index_util.h
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
-
 
 #pragma once
 
@@ -76,11 +75,21 @@ class IndexUtil {
                       std::vector<std::pair<oid_t, oid_t>> &value_index_list);
 
   /**
-   *
+   * Generate a string with a list of the values in the index.
+   * Note that this is will not print out the keys!.
    * @param index
    * @return
    */
   static std::string Debug(Index *index);
+
+  /**
+   * Return a string representation of an ItemPointer.
+   * This is here because we don't want to add extra methods
+   * to our ItemPointer since that takes up memory.
+   * @param ptr
+   * @return
+   */
+  static const std::string GetInfo(const ItemPointer *ptr);
 
 };
 

--- a/src/include/index/tuple_key.h
+++ b/src/include/index/tuple_key.h
@@ -1,4 +1,3 @@
-
 //===----------------------------------------------------------------------===//
 //
 //                         Peloton
@@ -7,7 +6,7 @@
 //
 // Identification: src/include/index/tuple_key.h
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -114,6 +113,20 @@ class TupleKey {
       return indexColumn;
     else
       return column_indices[indexColumn];
+  }
+
+  /**
+ * Prints the content of this key.
+ *
+ * IMPORTANT: This class should <b>not</b> override Printable
+ * because that adds an extra 8 bytes and it makes all the math
+ * above for doing fast comparisons fail.
+ *
+ * @return
+ */
+  const std::string GetInfo() const {
+    storage::Tuple tuple(key_tuple_schema, key_tuple);
+    return (tuple.GetInfo());
   }
 };
 

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -4,18 +4,17 @@
 //
 // bwtree_index.cpp
 //
-// Identification: src/backend/index/bwtree_index.cpp
+// Identification: src/index/bwtree_index.cpp
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
+
 #include "index/bwtree_index.h"
 
-#include "common/logger.h"
 #include "index/index_key.h"
 #include "index/scan_optimizer.h"
 #include "statistics/stats_aggregator.h"
-#include "storage/tuple.h"
 #include "settings/settings_manager.h"
 
 namespace peloton {
@@ -60,6 +59,11 @@ bool BWTREE_INDEX_TYPE::InsertEntry(const storage::Tuple *key,
     stats::BackendStatsContext::GetInstance()->IncrementIndexInserts(metadata);
   }
 
+  LOG_TRACE("InsertEntry(key=%s, val=%s) [%s]",
+            index_key.GetInfo().c_str(),
+            IndexUtil::GetInfo(value).c_str(),
+            (ret ? "SUCCESS" : "FAIL"));
+
   return ret;
 }
 
@@ -73,6 +77,7 @@ bool BWTREE_INDEX_TYPE::DeleteEntry(const storage::Tuple *key,
                                     ItemPointer *value) {
   KeyType index_key;
   index_key.SetFromKey(key);
+
   size_t delete_count = 0;
 
   // In Delete() since we just use the value for comparison (i.e. read-only)
@@ -83,6 +88,12 @@ bool BWTREE_INDEX_TYPE::DeleteEntry(const storage::Tuple *key,
     stats::BackendStatsContext::GetInstance()->IncrementIndexDeletes(
         delete_count, metadata);
   }
+
+  LOG_TRACE("DeleteEntry(key=%s, val=%s) [%s]",
+            index_key.GetInfo().c_str(),
+            IndexUtil::GetInfo(value).c_str(),
+            (ret ? "SUCCESS" : "FAIL"));
+
   return ret;
 }
 

--- a/src/index/index_util.cpp
+++ b/src/index/index_util.cpp
@@ -6,7 +6,7 @@
 //
 // Identification: src/index/index_util.cpp
 //
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
@@ -352,10 +352,16 @@ std::string IndexUtil::Debug(Index *index) {
   std::ostringstream os;
   int i = 0;
   for (auto ptr : location_ptrs) {
-    os << StringUtil::Format("%03d: {%d, %d}\n", i, ptr->block, ptr->offset);
+    if (i > 0) os << std::endl;
+    os << StringUtil::Format("%03d: %s",
+                             i, IndexUtil::GetInfo(ptr).c_str());
     i += 1;
   }
   return (os.str());
+}
+
+const std::string IndexUtil::GetInfo(const ItemPointer *ptr) {
+  return StringUtil::Format("{%d, %d}", ptr->block, ptr->offset);
 }
 
 }  // namespace index


### PR DESCRIPTION
This is to help make it easier for the students to debug their project in the class. I am going to merge this unless anybody complains.

1. Added GetInfo methods for TupleKey and GenericKey.
2. Added IndexUtil::GetInfo(ItemPointer)
3. Added examples of debug output in BwTreeIndex::InsertEntry + DeleteEntry

https://www.youtube.com/watch?v=_QXRQRoO4IE