### PR TITLE
Fix order-by in codegen

### DIFF
--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -39,20 +39,20 @@ llvm::Constant *CodeGen::ConstBool(bool val) const {
   }
 }
 
-llvm::Constant *CodeGen::Const8(uint8_t val) const {
-  return llvm::ConstantInt::get(Int8Type(), val, false);
+llvm::Constant *CodeGen::Const8(int8_t val) const {
+  return llvm::ConstantInt::get(Int8Type(), val, true);
 }
 
-llvm::Constant *CodeGen::Const16(uint16_t val) const {
-  return llvm::ConstantInt::get(Int16Type(), val, false);
+llvm::Constant *CodeGen::Const16(int16_t val) const {
+  return llvm::ConstantInt::get(Int16Type(), val, true);
 }
 
-llvm::Constant *CodeGen::Const32(uint32_t val) const {
-  return llvm::ConstantInt::get(Int32Type(), val, false);
+llvm::Constant *CodeGen::Const32(int32_t val) const {
+  return llvm::ConstantInt::get(Int32Type(), val, true);
 }
 
-llvm::Constant *CodeGen::Const64(uint64_t val) const {
-  return llvm::ConstantInt::get(Int64Type(), val, false);
+llvm::Constant *CodeGen::Const64(int64_t val) const {
+  return llvm::ConstantInt::get(Int64Type(), val, true);
 }
 
 llvm::Constant *CodeGen::ConstDouble(double val) const {

--- a/src/codegen/type/bigint_type.cpp
+++ b/src/codegen/type/bigint_type.cpp
@@ -168,7 +168,7 @@ struct CompareBigInt : public TypeSystem::SimpleComparisonHandleNull {
     // result to a 32-bit value
     llvm::Value *diff = codegen->CreateSub(left.GetValue(), right.GetValue());
     return Value{Integer::Instance(),
-                 codegen->CreateSExt(diff, codegen.Int32Type()), nullptr,
+                 codegen->CreateTrunc(diff, codegen.Int32Type()), nullptr,
                  nullptr};
   }
 };

--- a/src/codegen/type/decimal_type.cpp
+++ b/src/codegen/type/decimal_type.cpp
@@ -141,7 +141,7 @@ struct CompareDecimal : public TypeSystem::SimpleComparisonHandleNull {
                            const Value &right) const override {
     // For integer comparisons, just subtract left from right and cast the
     // result to a 32-bit value
-    llvm::Value *diff = codegen->CreateSub(left.GetValue(), right.GetValue());
+    llvm::Value *diff = codegen->CreateFSub(left.GetValue(), right.GetValue());
     return Value{Integer::Instance(),
                  codegen->CreateFPToSI(diff, codegen.Int32Type()), nullptr,
                  nullptr};

--- a/src/codegen/type/type_system.cpp
+++ b/src/codegen/type/type_system.cpp
@@ -141,12 +141,53 @@ Value TypeSystem::SimpleComparisonHandleNull::EvalCompareGte(
   GEN_COMPARE(CompareGteImpl(codegen, left, right));
 }
 
+#undef GEN_COMPARE
+
 Value TypeSystem::SimpleComparisonHandleNull::EvalCompareForSort(
     CodeGen &codegen, const Value &left, const Value &right) const {
-  GEN_COMPARE(CompareForSortImpl(codegen, left, right));
-}
+  // Do null-safe comparison
+  auto real_cmp = CompareForSortImpl(codegen, left, right);
 
-#undef GEN_COMPARE
+  // If neither input is NULLable, we're done
+  if (!left.IsNullable() && !right.IsNullable()) {
+    return real_cmp;
+  }
+
+  /// What we're doing is a simplification of the NULL-handling logic Postgres
+  /// uses when sorting heap tuples. We essentially implement a shortcut version
+  /// of the following logic:
+  ///
+  /// @code
+  ///  if (left.IsNull()) {
+  ///    if (right.IsNull()) {
+  ///       return 0;
+  ///    } else {
+  ///       return 1;
+  ///    }
+  ///  } else if (right.IsNull()) {
+  ///    if (left.IsNull()) {
+  ///      return 0;
+  ///    } else {
+  ///      return -1;
+  ///    }
+  ///  } else {
+  ///    return Impl();
+  ///  }
+  /// @endcode
+
+  llvm::Value *left_null = left.IsNull(codegen);
+  llvm::Value *right_null = right.IsNull(codegen);
+  llvm::Value *either_null = codegen->CreateOr(left_null, right_null);
+
+  llvm::Value *null_cmp =
+      codegen->CreateSub(codegen->CreateZExt(left_null, codegen.Int32Type()),
+                         codegen->CreateZExt(right_null, codegen.Int32Type()));
+
+  llvm::Value *final =
+      codegen->CreateSelect(either_null, null_cmp, real_cmp.GetValue());
+
+  return Value{Integer::Instance(), final, nullptr, nullptr};
+}
 
 //===----------------------------------------------------------------------===//
 //
@@ -210,11 +251,34 @@ Value TypeSystem::ExpensiveComparisonHandleNull::EvalCompareGte(
 
 Value TypeSystem::ExpensiveComparisonHandleNull::EvalCompareForSort(
     CodeGen &codegen, const Value &left, const Value &right) const {
-  auto impl = [this](CodeGen &codegen, const Value &left, const Value &right) {
+  // If neither input is NULLable, we're done
+  if (!left.IsNullable() && !right.IsNullable()) {
     return CompareForSortImpl(codegen, left, right);
-  };
-  const auto &result_type = Integer::Instance();
-  return GenerateBinaryHandleNull(codegen, result_type, left, right, impl);
+  }
+
+  /// The logic here is very similar to
+  /// SimpleComparisonHandleNull::EvalCompareForSort() except we **generate**
+  /// an if-clause becuase the non-null check is unsafe.
+
+  auto *left_null = left.IsNull(codegen);
+  auto *right_null = right.IsNull(codegen);
+
+  Value null_ret, ret_val;
+  lang::If is_null{codegen, codegen->CreateOr(left_null, right_null)};
+  {
+    // One of the inputs is null
+    auto *null_cmp = codegen->CreateSub(
+        codegen->CreateZExt(left_null, codegen.Int32Type()),
+        codegen->CreateZExt(right_null, codegen.Int32Type()));
+    null_ret = Value{Integer::Instance(), null_cmp};
+  }
+  is_null.ElseBlock();
+  {
+    // If both values are not null, perform the non-null-aware operation
+    ret_val = CompareForSortImpl(codegen, left, right);
+  }
+  is_null.EndIf();
+  return is_null.BuildPHI(null_ret, ret_val);
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/include/codegen/codegen.h
+++ b/src/include/codegen/codegen.h
@@ -70,10 +70,10 @@ class CodeGen {
 
   /// Constant wrappers for bool, int8, int16, int32, int64, strings, and null
   llvm::Constant *ConstBool(bool val) const;
-  llvm::Constant *Const8(uint8_t val) const;
-  llvm::Constant *Const16(uint16_t val) const;
-  llvm::Constant *Const32(uint32_t val) const;
-  llvm::Constant *Const64(uint64_t val) const;
+  llvm::Constant *Const8(int8_t val) const;
+  llvm::Constant *Const16(int16_t val) const;
+  llvm::Constant *Const32(int32_t val) const;
+  llvm::Constant *Const64(int64_t val) const;
   llvm::Constant *ConstDouble(double val) const;
   llvm::Constant *ConstString(const std::string &s) const;
   llvm::Constant *Null(llvm::Type *type) const;


### PR DESCRIPTION
This PR fixes a few issues related to sorting in codegen.

1. Fix sorting logic in the presence of NULLs.
2. Fix sorting of BigInt types, which was broken before due issuing a wrong sign-extension instruction.
3. Fix sorting of Decimal types, which was broken due to issuing wrong `sub` instruction.
4. Simplify the generated sort function.
5. Add sorting tests that include NULL data for both integers and strings.