### PR TITLE
Fix duplicated headers

### DIFF
--- a/src/network/peloton_server.cpp
+++ b/src/network/peloton_server.cpp
@@ -6,21 +6,10 @@
 //
 // Identification: src/network/peloton_server.cpp
 //
-// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
-//===----------------------------------------------------------------------===//
-//
-//                         Peloton
-//
-// peloton_server.cpp
-//
-// Identification: src/network/peloton_server.cpp
-//
-// Copyright (c) 2015-17, Carnegie Mellon University Database Group
-//
-//===----------------------------------------------------------------------===//
 #include "event2/thread.h"
 #include <fstream>
 

--- a/src/network/postgres_protocol_handler.cpp
+++ b/src/network/postgres_protocol_handler.cpp
@@ -6,19 +6,7 @@
 //
 // Identification: src/network/postgres_protocol_handler.cpp
 //
-// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
-//
-//===----------------------------------------------------------------------===//
-
-//===----------------------------------------------------------------------===//
-//
-//                         Peloton
-//
-// postgres_protocol_handler.cpp
-//
-// Identification: src/network/postgres_protocol_handler.cpp
-//
-// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 

--- a/src/network/protocol_handler.cpp
+++ b/src/network/protocol_handler.cpp
@@ -6,21 +6,10 @@
 //
 // Identification: src/network/protocol_handler.cpp
 //
-// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
-//===----------------------------------------------------------------------===//
-//
-//                         Peloton
-//
-// protocol_handler.h
-//
-// Identification: src/include/network/protocol_handler.h
-//
-// Copyright (c) 2015-17, Carnegie Mellon University Database Group
-//
-//===----------------------------------------------------------------------===//
 #include "network/protocol_handler.h"
 
 #include <boost/algorithm/string.hpp>

--- a/src/network/service/network_address.cpp
+++ b/src/network/service/network_address.cpp
@@ -6,21 +6,10 @@
 //
 // Identification: src/network/service/network_address.cpp
 //
-// Copyright (c) 2015-2017, Carnegie Mellon University Database Group
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
 //
 //===----------------------------------------------------------------------===//
 
-//===----------------------------------------------------------------------===//
-//
-//                         Peloton
-//
-// tcp_address.cpp
-//
-// Identification: src/network/tcp_address.cpp
-//
-// Copyright (c) 2015-16, Carnegie Mellon University Database Group
-//
-//===----------------------------------------------------------------------===//
 #include "network/service/network_address.h"
 
 #include <netdb.h>


### PR DESCRIPTION
The formatter script accidentally added duplicated headers in 4 files in 60f4f97fc4fde86926878d9e7f8f7e15a5e42c13, because an empty line was missing after the existing header. 

This PR simply removes one of them. 