### PR TITLE
Making the ReadWriteSet ThreadSafe

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -21,6 +21,13 @@ include("cmake/External/gflags.cmake")
 include_directories(SYSTEM ${GFLAGS_INCLUDE_DIRS})
 list(APPEND Peloton_LINKER_LIBS ${GFLAGS_LIBRARIES})
 
+# ---[ intel tbb
+find_package(TBB REQUIRED)
+include_directories(SYSTEM ${TBB_INCLUDE_DIRS})
+list(APPEND Peloton_LINKER_LIBS ${TBB_LIBRARIES})
+
+#add_executable(TBB_Sample TBB_Sample.cpp)
+
 # ---[ Cap'nProto
 include("cmake/External/capnproto.cmake")
 include_directories(SYSTEM ${CAPNP_INCLUDE_DIRS})

--- a/cmake/Modules/FindTBB.cmake
+++ b/cmake/Modules/FindTBB.cmake
@@ -1,0 +1,359 @@
+# - Find ThreadingBuildingBlocks include dirs and libraries
+# Use this module by invoking find_package with the form:
+#  find_package(TBB
+#    [REQUIRED]             # Fail with error if TBB is not found
+#    )                      #
+# Once done, this will define
+#
+#  TBB_FOUND - system has TBB
+#  TBB_INCLUDE_DIRS - the TBB include directories
+#  TBB_LIBRARIES - TBB libraries to be lined, doesn't include malloc or
+#                  malloc proxy
+#
+#  TBB_VERSION_MAJOR - Major Product Version Number
+#  TBB_VERSION_MINOR - Minor Product Version Number
+#  TBB_INTERFACE_VERSION - Engineering Focused Version Number
+#  TBB_COMPATIBLE_INTERFACE_VERSION - The oldest major interface version
+#                                     still supported. This uses the engineering
+#                                     focused interface version numbers.
+#
+#  TBB_MALLOC_FOUND - system has TBB malloc library
+#  TBB_MALLOC_INCLUDE_DIRS - the TBB malloc include directories
+#  TBB_MALLOC_LIBRARIES - The TBB malloc libraries to be lined
+#
+#  TBB_MALLOC_PROXY_FOUND - system has TBB malloc proxy library
+#  TBB_MALLOC_PROXY_INCLUDE_DIRS = the TBB malloc proxy include directories
+#  TBB_MALLOC_PROXY_LIBRARIES - The TBB malloc proxy libraries to be lined
+#
+#
+# This module reads hints about search locations from variables:
+#  ENV TBB_ARCH_PLATFORM - for eg. set it to "mic" for Xeon Phi builds
+#  ENV TBB_ROOT or just TBB_ROOT - root directory of tbb installation
+#  ENV TBB_BUILD_PREFIX - specifies the build prefix for user built tbb
+#                         libraries. Should be specified with ENV TBB_ROOT
+#                         and optionally...
+#  ENV TBB_BUILD_DIR - if build directory is different than ${TBB_ROOT}/build
+#
+#
+# Modified by Robert Maynard from the original OGRE source
+#
+#-------------------------------------------------------------------
+# This file is part of the CMake build system for OGRE
+#     (Object-oriented Graphics Rendering Engine)
+# For the latest info, see http://www.ogre3d.org/
+#
+# The contents of this file are placed in the public domain. Feel
+# free to make use of it in any way you like.
+#-------------------------------------------------------------------
+#
+#=============================================================================
+# Copyright 2010-2012 Kitware, Inc.
+# Copyright 2012      Rolf Eike Beer <eike@sf-mail.de>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+
+#=============================================================================
+#  FindTBB helper functions and macros
+#
+
+#===============================================
+# Do the final processing for the package find.
+#===============================================
+macro(findpkg_finish PREFIX)
+    # skip if already processed during this run
+    if (NOT ${PREFIX}_FOUND)
+        if (${PREFIX}_INCLUDE_DIR AND ${PREFIX}_LIBRARY)
+            set(${PREFIX}_FOUND TRUE)
+            set (${PREFIX}_INCLUDE_DIRS ${${PREFIX}_INCLUDE_DIR})
+            set (${PREFIX}_LIBRARIES ${${PREFIX}_LIBRARY})
+        else ()
+            if (${PREFIX}_FIND_REQUIRED AND NOT ${PREFIX}_FIND_QUIETLY)
+                message(FATAL_ERROR "Required library ${PREFIX} not found.")
+            endif ()
+        endif ()
+
+        #mark the following variables as internal variables
+        mark_as_advanced(${PREFIX}_INCLUDE_DIR
+                ${PREFIX}_LIBRARY
+                ${PREFIX}_LIBRARY_DEBUG
+                ${PREFIX}_LIBRARY_RELEASE)
+    endif ()
+endmacro()
+
+#===============================================
+# Generate debug names from given release names
+#===============================================
+macro(get_debug_names PREFIX)
+    foreach(i ${${PREFIX}})
+        set(${PREFIX}_DEBUG ${${PREFIX}_DEBUG} ${i}d ${i}D ${i}_d ${i}_D ${i}_debug ${i})
+    endforeach()
+endmacro()
+
+#===============================================
+# See if we have env vars to help us find tbb
+#===============================================
+macro(getenv_path VAR)
+    set(ENV_${VAR} $ENV{${VAR}})
+    # replace won't work if var is blank
+    if (ENV_${VAR})
+        string( REGEX REPLACE "\\\\" "/" ENV_${VAR} ${ENV_${VAR}} )
+    endif ()
+endmacro()
+
+#===============================================
+# Couple a set of release AND debug libraries
+#===============================================
+macro(make_library_set PREFIX)
+    if (${PREFIX}_RELEASE AND ${PREFIX}_DEBUG)
+        set(${PREFIX} optimized ${${PREFIX}_RELEASE} debug ${${PREFIX}_DEBUG})
+    elseif (${PREFIX}_RELEASE)
+        set(${PREFIX} ${${PREFIX}_RELEASE})
+    elseif (${PREFIX}_DEBUG)
+        set(${PREFIX} ${${PREFIX}_DEBUG})
+    endif ()
+endmacro()
+
+
+#=============================================================================
+#  Now to actually find TBB
+#
+
+# Get path, convert backslashes as ${ENV_${var}}
+getenv_path(TBB_ROOT)
+
+# initialize search paths
+set(TBB_PREFIX_PATH ${TBB_ROOT} ${ENV_TBB_ROOT})
+set(TBB_INC_SEARCH_PATH "")
+set(TBB_LIB_SEARCH_PATH "")
+
+
+# If user built from sources
+set(TBB_BUILD_PREFIX $ENV{TBB_BUILD_PREFIX})
+if (TBB_BUILD_PREFIX AND ENV_TBB_ROOT)
+    getenv_path(TBB_BUILD_DIR)
+    if (NOT ENV_TBB_BUILD_DIR)
+        set(ENV_TBB_BUILD_DIR ${ENV_TBB_ROOT}/build)
+    endif ()
+
+    # include directory under ${ENV_TBB_ROOT}/include
+    list(APPEND TBB_LIB_SEARCH_PATH
+            ${ENV_TBB_BUILD_DIR}/${TBB_BUILD_PREFIX}_release
+            ${ENV_TBB_BUILD_DIR}/${TBB_BUILD_PREFIX}_debug)
+endif ()
+
+
+# For Windows, let's assume that the user might be using the precompiled
+# TBB packages from the main website. These use a rather awkward directory
+# structure (at least for automatically finding the right files) depending
+# on platform and compiler, but we'll do our best to accommodate it.
+# Not adding the same effort for the precompiled linux builds, though. Those
+# have different versions for CC compiler versions and linux kernels which
+# will never adequately match the user's setup, so there is no feasible way
+# to detect the "best" version to use. The user will have to manually
+# select the right files. (Chances are the distributions are shipping their
+# custom version of tbb, anyway, so the problem is probably nonexistent.)
+if (WIN32 AND MSVC)
+    set(COMPILER_PREFIX "vc7.1")
+    if (MSVC_VERSION EQUAL 1400)
+        set(COMPILER_PREFIX "vc8")
+    elseif(MSVC_VERSION EQUAL 1500)
+        set(COMPILER_PREFIX "vc9")
+    elseif(MSVC_VERSION EQUAL 1600)
+        set(COMPILER_PREFIX "vc10")
+    elseif(MSVC_VERSION EQUAL 1700)
+        set(COMPILER_PREFIX "vc11")
+    elseif(MSVC_VERSION EQUAL 1800)
+        set(COMPILER_PREFIX "vc12")
+    elseif(MSVC_VERSION EQUAL 1900)
+        set(COMPILER_PREFIX "vc14")
+    endif ()
+
+    # for each prefix path, add ia32/64\${COMPILER_PREFIX}\lib to the lib search path
+    foreach (dir IN LISTS TBB_PREFIX_PATH)
+        if (CMAKE_CL_64)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia64/${COMPILER_PREFIX}/lib)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia64/${COMPILER_PREFIX})
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/intel64/${COMPILER_PREFIX}/lib)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/intel64/${COMPILER_PREFIX})
+        else ()
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia32/${COMPILER_PREFIX}/lib)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia32/${COMPILER_PREFIX})
+        endif ()
+    endforeach ()
+endif ()
+
+# For OS X binary distribution, choose libc++ based libraries for Mavericks (10.9)
+# and above and AppleClang
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND
+        NOT CMAKE_SYSTEM_VERSION VERSION_LESS 13.0)
+    set (USE_LIBCXX OFF)
+    cmake_policy(GET CMP0025 POLICY_VAR)
+
+    if (POLICY_VAR STREQUAL "NEW")
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+            set (USE_LIBCXX ON)
+        endif ()
+    else ()
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+            set (USE_LIBCXX ON)
+        endif ()
+    endif ()
+
+    if (USE_LIBCXX)
+        foreach (dir IN LISTS TBB_PREFIX_PATH)
+            list (APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/libc++ ${dir}/libc++/lib)
+        endforeach ()
+    endif ()
+endif ()
+
+# check compiler ABI
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(COMPILER_PREFIX)
+    if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.7)
+        list(APPEND COMPILER_PREFIX "gcc4.7")
+    endif()
+    if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)
+        list(APPEND COMPILER_PREFIX "gcc4.4")
+    endif()
+    list(APPEND COMPILER_PREFIX "gcc4.1")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(COMPILER_PREFIX)
+    if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6)
+        list(APPEND COMPILER_PREFIX "gcc4.7")
+    endif()
+    list(APPEND COMPILER_PREFIX "gcc4.4")
+else() # Assume compatibility with 4.4 for other compilers
+    list(APPEND COMPILER_PREFIX "gcc4.4")
+endif ()
+
+# if platform architecture is explicitly specified
+set(TBB_ARCH_PLATFORM $ENV{TBB_ARCH_PLATFORM})
+if (TBB_ARCH_PLATFORM)
+    foreach (dir IN LISTS TBB_PREFIX_PATH)
+        list(APPEND TBB_LIB_SEARCH_PATH ${dir}/${TBB_ARCH_PLATFORM}/lib)
+        list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/${TBB_ARCH_PLATFORM})
+    endforeach ()
+endif ()
+
+foreach (dir IN LISTS TBB_PREFIX_PATH)
+    foreach (prefix IN LISTS COMPILER_PREFIX)
+        if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/intel64)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/intel64/${prefix})
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/intel64/lib)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/intel64/${prefix}/lib)
+        else ()
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia32)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia32/${prefix})
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia32/lib)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia32/${prefix}/lib)
+        endif ()
+    endforeach()
+endforeach ()
+
+# add general search paths
+foreach (dir IN LISTS TBB_PREFIX_PATH)
+    list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib ${dir}/Lib ${dir}/lib/tbb
+            ${dir}/Libs)
+    list(APPEND TBB_INC_SEARCH_PATH ${dir}/include ${dir}/Include
+            ${dir}/include/tbb)
+endforeach ()
+
+set(TBB_LIBRARY_NAMES tbb)
+get_debug_names(TBB_LIBRARY_NAMES)
+
+
+find_path(TBB_INCLUDE_DIR
+        NAMES tbb/tbb.h
+        PATHS ${TBB_INC_SEARCH_PATH})
+
+find_library(TBB_LIBRARY_RELEASE
+        NAMES ${TBB_LIBRARY_NAMES}
+        PATHS ${TBB_LIB_SEARCH_PATH})
+find_library(TBB_LIBRARY_DEBUG
+        NAMES ${TBB_LIBRARY_NAMES_DEBUG}
+        PATHS ${TBB_LIB_SEARCH_PATH})
+make_library_set(TBB_LIBRARY)
+
+findpkg_finish(TBB)
+
+#if we haven't found TBB no point on going any further
+if (NOT TBB_FOUND)
+    return()
+endif ()
+
+#=============================================================================
+# Look for TBB's malloc package
+set(TBB_MALLOC_LIBRARY_NAMES tbbmalloc)
+get_debug_names(TBB_MALLOC_LIBRARY_NAMES)
+
+find_path(TBB_MALLOC_INCLUDE_DIR
+        NAMES tbb/tbb.h
+        PATHS ${TBB_INC_SEARCH_PATH})
+
+find_library(TBB_MALLOC_LIBRARY_RELEASE
+        NAMES ${TBB_MALLOC_LIBRARY_NAMES}
+        PATHS ${TBB_LIB_SEARCH_PATH})
+find_library(TBB_MALLOC_LIBRARY_DEBUG
+        NAMES ${TBB_MALLOC_LIBRARY_NAMES_DEBUG}
+        PATHS ${TBB_LIB_SEARCH_PATH})
+make_library_set(TBB_MALLOC_LIBRARY)
+
+findpkg_finish(TBB_MALLOC)
+
+#=============================================================================
+# Look for TBB's malloc proxy package
+set(TBB_MALLOC_PROXY_LIBRARY_NAMES tbbmalloc_proxy)
+get_debug_names(TBB_MALLOC_PROXY_LIBRARY_NAMES)
+
+find_path(TBB_MALLOC_PROXY_INCLUDE_DIR
+        NAMES tbb/tbbmalloc_proxy.h
+        PATHS ${TBB_INC_SEARCH_PATH})
+
+find_library(TBB_MALLOC_PROXY_LIBRARY_RELEASE
+        NAMES ${TBB_MALLOC_PROXY_LIBRARY_NAMES}
+        PATHS ${TBB_LIB_SEARCH_PATH})
+find_library(TBB_MALLOC_PROXY_LIBRARY_DEBUG
+        NAMES ${TBB_MALLOC_PROXY_LIBRARY_NAMES_DEBUG}
+        PATHS ${TBB_LIB_SEARCH_PATH})
+make_library_set(TBB_MALLOC_PROXY_LIBRARY)
+
+findpkg_finish(TBB_MALLOC_PROXY)
+
+
+#=============================================================================
+#parse all the version numbers from tbb
+if(NOT TBB_VERSION)
+
+    #only read the start of the file
+    file(READ
+            "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h"
+            TBB_VERSION_CONTENTS
+            LIMIT 2048)
+
+    string(REGEX REPLACE
+            ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
+            TBB_VERSION_MAJOR "${TBB_VERSION_CONTENTS}")
+
+    string(REGEX REPLACE
+            ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"
+            TBB_VERSION_MINOR "${TBB_VERSION_CONTENTS}")
+
+    string(REGEX REPLACE
+            ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1"
+            TBB_INTERFACE_VERSION "${TBB_VERSION_CONTENTS}")
+
+    string(REGEX REPLACE
+            ".*#define TBB_COMPATIBLE_INTERFACE_VERSION ([0-9]+).*" "\\1"
+            TBB_COMPATIBLE_INTERFACE_VERSION "${TBB_VERSION_CONTENTS}")
+
+endif()

--- a/script/installation/packages.sh
+++ b/script/installation/packages.sh
@@ -103,7 +103,8 @@ if [ "$DISTRO" = "UBUNTU" ]; then
         libpqxx-dev \
         libedit-dev \
         libssl-dev \
-        postgresql-client
+        postgresql-client \
+        libtbb-dev
 
 ## ------------------------------------------------
 ## DEBIAN
@@ -130,7 +131,8 @@ elif [ "$DISTRO" = "DEBIAN OS" ]; then
         libpqxx-dev \
         llvm-dev \
         libedit-dev \
-        postgresql-client
+        postgresql-client \
+        libtbb-dev
 
 ## ------------------------------------------------
 ## FEDORA
@@ -163,7 +165,8 @@ elif [[ "$DISTRO" == *"FEDORA"* ]]; then
         ${LLVM}-static \
         libedit-devel \
         postgresql \
-        libatomic
+        libatomic \
+        libtbb-dev
 
 ## ------------------------------------------------
 ## REDHAT
@@ -226,7 +229,8 @@ elif [[ "$DISTRO" == *"REDHAT"* ]] && [[ "${DISTRO_VER%.*}" == "7" ]]; then
         llvm3.9 \
         llvm3.9-static \
         llvm3.9-devel \
-        postgresql
+        postgresql \
+        libtbb-dev
 
     # Manually download some packages to guarantee
     # version compatibility
@@ -257,6 +261,7 @@ elif [ "$DISTRO" = "DARWIN" ]; then
     brew install libedit
     brew install llvm@3.7
     brew install postgresql
+    brew install tbb
 
 ## ------------------------------------------------
 ## UNKNOWN

--- a/src/common/container/lock_free_array.cpp
+++ b/src/common/container/lock_free_array.cpp
@@ -32,7 +32,6 @@ class IndirectionArray;
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 LOCK_FREE_ARRAY_TYPE::LockFreeArray(){
   new_lock_free_array.clear();
-  lock_free_array.reset(new lock_free_array_t());
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
@@ -44,7 +43,6 @@ LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 bool LOCK_FREE_ARRAY_TYPE::Update(const std::size_t &offset, ValueType value){
   PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
   LOG_TRACE("Update at %lu", lock_free_array_offset.load());
-  lock_free_array->at(offset) =  value;
   if (new_lock_free_array.size() < offset + 1) {
     new_lock_free_array.resize(LOCK_FREE_ARRAY_MAX_SIZE);
   }
@@ -55,7 +53,6 @@ bool LOCK_FREE_ARRAY_TYPE::Update(const std::size_t &offset, ValueType value){
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 bool LOCK_FREE_ARRAY_TYPE::Append(ValueType value){
   LOG_TRACE("Appended at %lu", lock_free_array_offset.load());
-  lock_free_array->at(lock_free_array_offset++) = value;
   new_lock_free_array.push_back(value);
   return true;
 }
@@ -64,7 +61,6 @@ LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 bool LOCK_FREE_ARRAY_TYPE::Erase(const std::size_t &offset, const ValueType& invalid_value){
   PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
   LOG_TRACE("Erase at %lu", offset);
-  lock_free_array->at(offset) =  invalid_value;
   new_lock_free_array.at(offset) = invalid_value;
   return true;
 }

--- a/src/common/container/lock_free_array.cpp
+++ b/src/common/container/lock_free_array.cpp
@@ -31,29 +31,26 @@ class IndirectionArray;
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 LOCK_FREE_ARRAY_TYPE::LockFreeArray(){
-  new_lock_free_array.clear();
+  lock_free_array.reset(new lock_free_array_t());
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 LOCK_FREE_ARRAY_TYPE::~LockFreeArray(){
-  new_lock_free_array.clear();
+  lock_free_array.release();
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 bool LOCK_FREE_ARRAY_TYPE::Update(const std::size_t &offset, ValueType value){
   PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
   LOG_TRACE("Update at %lu", lock_free_array_offset.load());
-  if (new_lock_free_array.size() < offset + 1) {
-    new_lock_free_array.resize(LOCK_FREE_ARRAY_MAX_SIZE);
-  }
-  new_lock_free_array.at(offset) = value;
+  lock_free_array->at(offset) =  value;
   return true;
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 bool LOCK_FREE_ARRAY_TYPE::Append(ValueType value){
   LOG_TRACE("Appended at %lu", lock_free_array_offset.load());
-  new_lock_free_array.push_back(value);
+  lock_free_array->at(lock_free_array_offset++) = value;
   return true;
 }
 
@@ -61,7 +58,7 @@ LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 bool LOCK_FREE_ARRAY_TYPE::Erase(const std::size_t &offset, const ValueType& invalid_value){
   PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
   LOG_TRACE("Erase at %lu", offset);
-  new_lock_free_array.at(offset) = invalid_value;
+  lock_free_array->at(offset) =  invalid_value;
   return true;
 }
 
@@ -69,8 +66,7 @@ LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 ValueType LOCK_FREE_ARRAY_TYPE::Find(const std::size_t &offset) const{
   PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
   LOG_TRACE("Find at %lu", offset);
-//  auto value = lock_free_array->at(offset);
-  auto value = new_lock_free_array.at(offset);
+  auto value = lock_free_array->at(offset);
   return value;
 }
 
@@ -82,11 +78,11 @@ ValueType LOCK_FREE_ARRAY_TYPE::FindValid(const std::size_t &offset,
 
   std::size_t valid_array_itr = 0;
   std::size_t array_itr;
-  auto new_lock_free_array_offset = new_lock_free_array.size();
+
   for(array_itr = 0;
-      array_itr < new_lock_free_array_offset;
+      array_itr < lock_free_array_offset;
       array_itr++){
-    auto value = new_lock_free_array.at(array_itr);
+    auto value = lock_free_array->at(array_itr);
     if (value != invalid_value) {
       // Check offset
       if(valid_array_itr == offset) {
@@ -103,14 +99,12 @@ ValueType LOCK_FREE_ARRAY_TYPE::FindValid(const std::size_t &offset,
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 size_t LOCK_FREE_ARRAY_TYPE::GetSize() const{
-  return new_lock_free_array.size();
-//  return lock_free_array_offset;
+  return lock_free_array_offset;
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 bool LOCK_FREE_ARRAY_TYPE::IsEmpty() const{
-  return new_lock_free_array.empty();
-//  return lock_free_array->empty();
+  return lock_free_array->empty();
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
@@ -119,10 +113,9 @@ void LOCK_FREE_ARRAY_TYPE::Clear(const ValueType& invalid_value) {
   // Set invalid value for all elements and reset lock_free_array_offset
 
   for(std::size_t array_itr = 0;
-      array_itr < new_lock_free_array.size();
+      array_itr < lock_free_array_offset;
       array_itr++){
-//    lock_free_array->at(array_itr) = invalid_value;
-    new_lock_free_array.at(array_itr) = invalid_value;
+    lock_free_array->at(array_itr) = invalid_value;
   }
 
   // Reset sentinel
@@ -136,9 +129,9 @@ bool LOCK_FREE_ARRAY_TYPE::Contains(const ValueType& value) {
   bool exists = false;
 
   for(std::size_t array_itr = 0;
-      array_itr < new_lock_free_array.size();
+      array_itr < lock_free_array_offset;
       array_itr++){
-    auto array_value = new_lock_free_array.at(array_itr);
+    auto array_value = lock_free_array->at(array_itr);
     // Check array value
     if(array_value == value) {
       exists = true;

--- a/src/executor/aggregator.cpp
+++ b/src/executor/aggregator.cpp
@@ -283,7 +283,7 @@ bool SortedAggregator::Advance(AbstractTuple *next_tuple) {
       type::Value rval =
           (delegate_tuple_.GetValue(node->GetGroupbyColIds()[grpColOffset]));
 
-      if (lval.CompareNotEquals(rval) == CmpBool::TRUE) {
+      if (lval.CompareNotEquals(rval) == CmpBool::CmpTrue) {
         LOG_TRACE("Group-by columns changed.");
 
         // Call helper to output the current group result

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -712,7 +712,7 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
     // To make the procedure more uniform, we interpret IN as EQUAL
     // and NOT IN as NOT EQUAL, and react based on expression type below
     // accordingly
-    if (lhs.CompareEquals(rhs) == CmpBool::TRUE) {
+    if (lhs.CompareEquals(rhs) == CmpBool::CmpTrue) {
       switch (expr_type) {
         case ExpressionType::COMPARE_EQUAL:
         case ExpressionType::COMPARE_LESSTHANOREQUALTO:
@@ -730,7 +730,7 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
                                ExpressionTypeToString(expr_type));
       }
     } else {
-      if (lhs.CompareLessThan(rhs) == CmpBool::TRUE) {
+      if (lhs.CompareLessThan(rhs) == CmpBool::CmpTrue) {
         switch (expr_type) {
           case ExpressionType::COMPARE_NOTEQUAL:
           case ExpressionType::COMPARE_LESSTHAN:
@@ -748,7 +748,7 @@ bool IndexScanExecutor::CheckKeyConditions(const ItemPointer &tuple_location) {
                                  ExpressionTypeToString(expr_type));
         }
       } else {
-        if (lhs.CompareGreaterThan(rhs) == CmpBool::TRUE) {
+        if (lhs.CompareGreaterThan(rhs) == CmpBool::CmpTrue) {
           switch (expr_type) {
             case ExpressionType::COMPARE_NOTEQUAL:
             case ExpressionType::COMPARE_GREATERTHAN:

--- a/src/executor/merge_join_executor.cpp
+++ b/src/executor/merge_join_executor.cpp
@@ -146,7 +146,7 @@ bool MergeJoinExecutor::DExecute() {
           clause.right_->Evaluate(&left_tuple, &right_tuple, nullptr);
 
       // Left key < Right key, advance left
-      if (left_value.CompareLessThan(right_value) == CmpBool::TRUE) {
+      if (left_value.CompareLessThan(right_value) == CmpBool::CmpTrue) {
         LOG_TRACE("left < right, advance left ");
         left_start_row = left_end_row;
         left_end_row = Advance(left_tile, left_start_row, true);
@@ -154,7 +154,7 @@ bool MergeJoinExecutor::DExecute() {
         break;
       }
       // Left key > Right key, advance right
-      else if (left_value.CompareGreaterThan(right_value) == CmpBool::TRUE) {
+      else if (left_value.CompareGreaterThan(right_value) == CmpBool::CmpTrue) {
         LOG_TRACE("left > right, advance right ");
         right_start_row = right_end_row;
         right_end_row = Advance(right_tile, right_start_row, false);
@@ -260,7 +260,7 @@ size_t MergeJoinExecutor::Advance(LogicalTile *tile, size_t start_row,
       auto next_value =
           expr->Evaluate(&next_tuple, &next_tuple, executor_context_);
 
-      if (!(this_value.CompareEquals(next_value) == CmpBool::TRUE)) {
+      if (!(this_value.CompareEquals(next_value) == CmpBool::CmpTrue)) {
         diff = true;
         break;
       }

--- a/src/executor/order_by_executor.cpp
+++ b/src/executor/order_by_executor.cpp
@@ -201,16 +201,16 @@ bool OrderByExecutor::DoSort() {
         type::Value va = (ta->GetValue(id));
         type::Value vb = (tb->GetValue(id));
         if (!descend_flags[id]) {
-          if (va.CompareLessThan(vb) == CmpBool::TRUE)
+          if (va.CompareLessThan(vb) == CmpBool::CmpTrue)
             return true;
           else {
-            if (va.CompareGreaterThan(vb) == CmpBool::TRUE) return false;
+            if (va.CompareGreaterThan(vb) == CmpBool::CmpTrue) return false;
           }
         } else {
-          if (vb.CompareLessThan(va) == CmpBool::TRUE)
+          if (vb.CompareLessThan(va) == CmpBool::CmpTrue)
             return true;
           else {
-            if (vb.CompareGreaterThan(va) == CmpBool::TRUE) return false;
+            if (vb.CompareGreaterThan(va) == CmpBool::CmpTrue) return false;
           }
         }
       }

--- a/src/include/common/container/lock_free_array.h
+++ b/src/include/common/container/lock_free_array.h
@@ -12,13 +12,16 @@
 
 
 #pragma once
-
+#include "tbb/concurrent_vector.h"
+#include "tbb/tbb_allocator.h"
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
 #include <array>
 #include <atomic>
 #include <memory>
+
+
 
 namespace peloton {
 
@@ -73,6 +76,9 @@ class LockFreeArray {
 
   // lock free array
   std::unique_ptr<lock_free_array_t> lock_free_array;
+  typedef tbb::concurrent_vector<ValueType, tbb::zero_allocator<ValueType>> TBBLockFreeArray;
+  TBBLockFreeArray new_lock_free_array;
+
 };
 
 }  // namespace peloton

--- a/src/include/common/container/lock_free_array.h
+++ b/src/include/common/container/lock_free_array.h
@@ -75,7 +75,7 @@ class LockFreeArray {
   std::atomic<std::size_t> lock_free_array_offset {0};
 
   // lock free array
-  std::unique_ptr<lock_free_array_t> lock_free_array;
+//  std::unique_ptr<lock_free_array_t> lock_free_array;
   typedef tbb::concurrent_vector<ValueType, tbb::zero_allocator<ValueType>> TBBLockFreeArray;
   TBBLockFreeArray new_lock_free_array;
 

--- a/src/include/common/container/lock_free_array.h
+++ b/src/include/common/container/lock_free_array.h
@@ -12,8 +12,7 @@
 
 
 #pragma once
-#include "tbb/concurrent_vector.h"
-#include "tbb/tbb_allocator.h"
+
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
@@ -75,10 +74,7 @@ class LockFreeArray {
   std::atomic<std::size_t> lock_free_array_offset {0};
 
   // lock free array
-//  std::unique_ptr<lock_free_array_t> lock_free_array;
-  typedef tbb::concurrent_vector<ValueType, tbb::zero_allocator<ValueType>> TBBLockFreeArray;
-  TBBLockFreeArray new_lock_free_array;
-
+  std::unique_ptr<lock_free_array_t> lock_free_array;
 };
 
 }  // namespace peloton

--- a/src/include/common/container_tuple.h
+++ b/src/include/common/container_tuple.h
@@ -100,7 +100,7 @@ class ContainerTuple : public AbstractTuple {
       for (size_t idx = 0; idx < column_ids_->size(); idx++) {
         type::Value lhs = (GetValue(column_ids_->at(idx)));
         type::Value rhs = (other.GetValue(other.column_ids_->at(idx)));
-        if (lhs.CompareNotEquals(rhs) == CmpBool::TRUE) {
+        if (lhs.CompareNotEquals(rhs) == CmpBool::CmpTrue) {
           return false;
         }
       }
@@ -109,7 +109,7 @@ class ContainerTuple : public AbstractTuple {
       for (size_t column_itr = 0; column_itr < column_count; column_itr++) {
         type::Value lhs = (GetValue(column_itr));
         type::Value rhs = (other.GetValue(column_itr));
-        if (lhs.CompareNotEquals(rhs) == CmpBool::TRUE) return false;
+        if (lhs.CompareNotEquals(rhs) == CmpBool::CmpTrue) return false;
       }
     }
     return true;
@@ -219,7 +219,7 @@ class ContainerTuple<std::vector<type::Value>> : public AbstractTuple {
     for (size_t column_itr = 0; column_itr < container_->size(); column_itr++) {
       type::Value lhs = GetValue(column_itr);
       type::Value rhs = other.GetValue(column_itr);
-      if (lhs.CompareNotEquals(rhs) == CmpBool::TRUE) return false;
+      if (lhs.CompareNotEquals(rhs) == CmpBool::CmpTrue) return false;
     }
     return true;
   }

--- a/src/include/common/internal_types.h
+++ b/src/include/common/internal_types.h
@@ -68,8 +68,8 @@ extern int TEST_TUPLES_PER_TILEGROUP;
 // This is used when comparing values with each other
 //===--------------------------------------------------------------------===//
 enum class CmpBool {
-  FALSE = 0,
-  TRUE = 1,
+  CmpFalse = 0,
+  CmpTrue = 1,
   NULL_ = 2 // Note the underscore suffix
 };
 

--- a/src/include/common/internal_types.h
+++ b/src/include/common/internal_types.h
@@ -24,6 +24,8 @@
 #include <vector>
 #include <unistd.h>
 
+#include "tbb/concurrent_unordered_map.h"
+
 #include "parser/pg_trigger.h"
 #include "type/type_id.h"
 #include "common/logger.h"
@@ -1196,9 +1198,12 @@ std::string RWTypeToString(RWType type);
 RWType StringToRWType(const std::string &str);
 std::ostream &operator<<(std::ostream &os, const RWType &type);
 
-// block -> offset -> type
-typedef std::unordered_map<oid_t, std::unordered_map<oid_t, RWType>>
-    ReadWriteSet;
+// offset -> type
+typedef tbb::concurrent_unordered_map<oid_t, RWType> BlockReadWriteSet;
+
+// block -> <offset -> type>
+typedef tbb::concurrent_unordered_map<oid_t, BlockReadWriteSet > ReadWriteSet;
+
 
 // this enum is to identify why the version should be GC'd.
 enum class GCVersionType {

--- a/src/include/executor/aggregator.h
+++ b/src/include/executor/aggregator.h
@@ -305,7 +305,7 @@ class HashAggregator : public AbstractAggregator {
     bool operator()(const std::vector<type::Value> &lhs,
                     const std::vector<type::Value> &rhs) const {
       for (size_t i = 0; i < lhs.size() && i < rhs.size(); i++) {
-        if (lhs[i].CompareNotEquals(rhs[i]) == CmpBool::TRUE) return false;
+        if (lhs[i].CompareNotEquals(rhs[i]) == CmpBool::CmpTrue) return false;
       }
       if (lhs.size() == rhs.size()) return true;
       return false;

--- a/src/include/expression/constant_value_expression.h
+++ b/src/include/expression/constant_value_expression.h
@@ -102,7 +102,7 @@ inline bool ConstantValueExpression::ExactlyEquals(
     const AbstractExpression &other) const {
   if (exp_type_ != other.GetExpressionType()) return false;
   auto &const_expr = static_cast<const ConstantValueExpression &>(other);
-  return value_.CompareEquals(const_expr.value_) == CmpBool::TRUE;
+  return value_.CompareEquals(const_expr.value_) == CmpBool::CmpTrue;
 }
 
 inline hash_t ConstantValueExpression::HashForExactMatch() const {

--- a/src/include/index/generic_key.h
+++ b/src/include/index/generic_key.h
@@ -95,9 +95,9 @@ class GenericComparator {
       const type::Value lhs_value = (lhs.ToValue(schema, col_itr));
       const type::Value rhs_value = (rhs.ToValue(schema, col_itr));
 
-      if (lhs_value.CompareLessThan(rhs_value) == CmpBool::TRUE) return true;
+      if (lhs_value.CompareLessThan(rhs_value) == CmpBool::CmpTrue) return true;
 
-      if (lhs_value.CompareGreaterThan(rhs_value) == CmpBool::TRUE)
+      if (lhs_value.CompareGreaterThan(rhs_value) == CmpBool::CmpTrue)
         return false;
     }
 
@@ -128,10 +128,10 @@ class FastGenericComparator {
       bool inlined = schema->IsInlined(col_itr);
 
       if (type::TypeUtil::CompareLessThanRaw(type, lhs_data, rhs_data,
-                                             inlined) == CmpBool::TRUE)
+                                             inlined) == CmpBool::CmpTrue)
         return true;
       else if (type::TypeUtil::CompareGreaterThanRaw(type, lhs_data, rhs_data,
-                                                     inlined) == CmpBool::TRUE)
+                                                     inlined) == CmpBool::CmpTrue)
         return false;
     }
 
@@ -157,10 +157,10 @@ class GenericComparatorRaw {
       const type::Value lhs_value = (lhs.ToValue(schema, column_itr));
       const type::Value rhs_value = (rhs.ToValue(schema, column_itr));
 
-      if (lhs_value.CompareLessThan(rhs_value) == CmpBool::TRUE)
+      if (lhs_value.CompareLessThan(rhs_value) == CmpBool::CmpTrue)
         return VALUE_COMPARE_LESSTHAN;
 
-      if (lhs_value.CompareGreaterThan(rhs_value) == CmpBool::TRUE)
+      if (lhs_value.CompareGreaterThan(rhs_value) == CmpBool::CmpTrue)
         return VALUE_COMPARE_GREATERTHAN;
     }
 

--- a/src/include/index/tuple_key.h
+++ b/src/include/index/tuple_key.h
@@ -191,12 +191,12 @@ class TupleKeyComparator {
         rhTuple.GetValue(rhs.ColumnForIndexColumn(col_itr));
 
       // If there is a field in LHS < RHS then return true;
-      if (lhValue.CompareLessThan(rhValue) == CmpBool::TRUE) {
+      if (lhValue.CompareLessThan(rhValue) == CmpBool::CmpTrue) {
         return true;
       }
       
       // If there is a field in LHS > RHS then return false
-      if (lhValue.CompareGreaterThan(rhValue) == CmpBool::TRUE) {
+      if (lhValue.CompareGreaterThan(rhValue) == CmpBool::CmpTrue) {
         return false;
       }
     }
@@ -248,11 +248,11 @@ class TupleKeyComparatorRaw {
       type::Value rhValue = \
           rhTuple.GetValue(rhs.ColumnForIndexColumn(col_itr));
 
-      if (lhValue.CompareLessThan(rhValue) == CmpBool::TRUE) {
+      if (lhValue.CompareLessThan(rhValue) == CmpBool::CmpTrue) {
         return VALUE_COMPARE_LESSTHAN;
       }
 
-      if (lhValue.CompareGreaterThan(rhValue) == CmpBool::TRUE) {
+      if (lhValue.CompareGreaterThan(rhValue) == CmpBool::CmpTrue) {
         return VALUE_COMPARE_GREATERTHAN;
       }
     }
@@ -306,7 +306,7 @@ class TupleKeyEqualityChecker {
 
       // If any of these two columns differ then just return false
       // because we know they could not be equal 
-      if (lhValue.CompareNotEquals(rhValue) == CmpBool::TRUE) {
+      if (lhValue.CompareNotEquals(rhValue) == CmpBool::CmpTrue) {
         return false;
       }
     }

--- a/src/include/storage/zone_map_manager.h
+++ b/src/include/storage/zone_map_manager.h
@@ -84,25 +84,25 @@ class ZoneMapManager {
       std::unique_ptr<std::vector<type::Value>> &result_vector);
 
   bool checkEqual(type::Value predicateVal, ColumnStatistics *stats) {
-    return ((stats->min).CompareLessThanEquals(predicateVal)) == CmpBool::TRUE &&
-           ((stats->max).CompareGreaterThanEquals(predicateVal) == CmpBool::TRUE);
+    return ((stats->min).CompareLessThanEquals(predicateVal)) == CmpBool::CmpTrue &&
+           ((stats->max).CompareGreaterThanEquals(predicateVal) == CmpBool::CmpTrue);
   }
 
   bool checkLessThan(type::Value predicateVal, ColumnStatistics *stats) {
-    return (predicateVal.CompareGreaterThan(stats->min) == CmpBool::TRUE);
+    return (predicateVal.CompareGreaterThan(stats->min) == CmpBool::CmpTrue);
   }
 
   bool checkLessThanEquals(type::Value predicateVal, ColumnStatistics *stats) {
-    return (predicateVal.CompareGreaterThanEquals(stats->min) == CmpBool::TRUE);
+    return (predicateVal.CompareGreaterThanEquals(stats->min) == CmpBool::CmpTrue);
   }
 
   bool checkGreaterThan(type::Value predicateVal, ColumnStatistics *stats) {
-    return (predicateVal.CompareLessThan(stats->max) == CmpBool::TRUE);
+    return (predicateVal.CompareLessThan(stats->max) == CmpBool::CmpTrue);
   }
 
   bool checkGreaterThanEquals(type::Value predicateVal,
                               ColumnStatistics *stats) {
-    return (predicateVal.CompareLessThanEquals(stats->max) == CmpBool::TRUE);
+    return (predicateVal.CompareLessThanEquals(stats->max) == CmpBool::CmpTrue);
   }
 
   //===--------------------------------------------------------------------===//

--- a/src/include/type/type_util.h
+++ b/src/include/type/type_util.h
@@ -61,44 +61,44 @@ class TypeUtil {
       case TypeId::TINYINT: {
         result = (*reinterpret_cast<const int8_t*>(left) ==
                           *reinterpret_cast<const int8_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::SMALLINT: {
         result = (*reinterpret_cast<const int16_t*>(left) ==
                           *reinterpret_cast<const int16_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::INTEGER: {
         result = (*reinterpret_cast<const int32_t*>(left) ==
                           *reinterpret_cast<const int32_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::BIGINT: {
         result = (*reinterpret_cast<const int64_t*>(left) ==
                           *reinterpret_cast<const int64_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::DECIMAL: {
         result = (*reinterpret_cast<const double*>(left) ==
                           *reinterpret_cast<const double*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::TIMESTAMP:
       case TypeId::DATE: {
         result = (*reinterpret_cast<const uint64_t*>(left) ==
                           *reinterpret_cast<const uint64_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::VARCHAR:
@@ -110,7 +110,7 @@ class TypeUtil {
           rightPtr = *reinterpret_cast<const char* const*>(right);
         }
         if (leftPtr == nullptr || rightPtr == nullptr) {
-          result = CmpBool::FALSE;
+          result = CmpBool::CmpFalse;
           break;
         }
         uint32_t leftLen = *reinterpret_cast<const uint32_t*>(leftPtr);
@@ -140,44 +140,44 @@ class TypeUtil {
       case TypeId::TINYINT: {
         result = (*reinterpret_cast<const int8_t*>(left) <
                           *reinterpret_cast<const int8_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::SMALLINT: {
         result = (*reinterpret_cast<const int16_t*>(left) <
                           *reinterpret_cast<const int16_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::INTEGER: {
         result = (*reinterpret_cast<const int32_t*>(left) <
                           *reinterpret_cast<const int32_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::BIGINT: {
         result = (*reinterpret_cast<const int64_t*>(left) <
                           *reinterpret_cast<const int64_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::DECIMAL: {
         result = (*reinterpret_cast<const double*>(left) <
                           *reinterpret_cast<const double*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::TIMESTAMP:
       case TypeId::DATE: {
         result = (*reinterpret_cast<const uint64_t*>(left) <
                           *reinterpret_cast<const uint64_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::VARCHAR:
@@ -189,7 +189,7 @@ class TypeUtil {
           rightPtr = *reinterpret_cast<const char* const*>(right);
         }
         if (leftPtr == nullptr || rightPtr == nullptr) {
-          result = CmpBool::FALSE;
+          result = CmpBool::CmpFalse;
           break;
         }
         uint32_t leftLen = *reinterpret_cast<const uint32_t*>(leftPtr);
@@ -219,44 +219,44 @@ class TypeUtil {
       case TypeId::TINYINT: {
         result = (*reinterpret_cast<const int8_t*>(left) >
                           *reinterpret_cast<const int8_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::SMALLINT: {
         result = (*reinterpret_cast<const int16_t*>(left) >
                           *reinterpret_cast<const int16_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::INTEGER: {
         result = (*reinterpret_cast<const int32_t*>(left) >
                           *reinterpret_cast<const int32_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::BIGINT: {
         result = (*reinterpret_cast<const int64_t*>(left) >
                           *reinterpret_cast<const int64_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::DECIMAL: {
         result = (*reinterpret_cast<const double*>(left) >
                           *reinterpret_cast<const double*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::TIMESTAMP:
       case TypeId::DATE: {
         result = (*reinterpret_cast<const uint64_t*>(left) >
                           *reinterpret_cast<const uint64_t*>(right)
-                      ? CmpBool::TRUE
-                      : CmpBool::FALSE);
+                      ? CmpBool::CmpTrue
+                      : CmpBool::CmpFalse);
         break;
       }
       case TypeId::VARCHAR:
@@ -268,7 +268,7 @@ class TypeUtil {
           rightPtr = *reinterpret_cast<const char* const*>(right);
         }
         if (leftPtr == nullptr || rightPtr == nullptr) {
-          result = CmpBool::FALSE;
+          result = CmpBool::CmpFalse;
           break;
         }
         uint32_t leftLen = *reinterpret_cast<const uint32_t*>(leftPtr);

--- a/src/include/type/value.h
+++ b/src/include/type/value.h
@@ -31,7 +31,7 @@ namespace type {
 class Type;
 
 inline CmpBool GetCmpBool(bool boolean) {
-  return boolean ? CmpBool::TRUE : CmpBool::FALSE;
+  return boolean ? CmpBool::CmpTrue : CmpBool::CmpFalse;
 }
 
 // A value is an abstract class that represents a view over SQL data stored in
@@ -278,7 +278,7 @@ class Value : public Printable {
   // For unordered_map
   struct equal_to {
     inline bool operator()(const Value &x, const Value &y) const {
-      return Type::GetInstance(x.type_id_)->CompareEquals(x, y) == CmpBool::TRUE;
+      return Type::GetInstance(x.type_id_)->CompareEquals(x, y) == CmpBool::CmpTrue;
     }
   };
 

--- a/src/index/index.cpp
+++ b/src/index/index.cpp
@@ -253,7 +253,7 @@ bool Index::Compare(const AbstractTuple &index_key,
     }
 
     LOG_TRACE("Difference : %d ", diff);*/
-    if (lhs.CompareEquals(rhs) == CmpBool::TRUE) {
+    if (lhs.CompareEquals(rhs) == CmpBool::CmpTrue) {
       switch (expr_type) {
         case ExpressionType::COMPARE_EQUAL:
         case ExpressionType::COMPARE_LESSTHANOREQUALTO:
@@ -271,7 +271,7 @@ bool Index::Compare(const AbstractTuple &index_key,
                                ExpressionTypeToString(expr_type));
       }
     } else {
-      if (lhs.CompareLessThan(rhs) == CmpBool::TRUE) {
+      if (lhs.CompareLessThan(rhs) == CmpBool::CmpTrue) {
         switch (expr_type) {
           case ExpressionType::COMPARE_NOTEQUAL:
           case ExpressionType::COMPARE_LESSTHAN:
@@ -289,7 +289,7 @@ bool Index::Compare(const AbstractTuple &index_key,
                                  ExpressionTypeToString(expr_type));
         }
       } else {
-        if (lhs.CompareGreaterThan(rhs) == CmpBool::TRUE) {
+        if (lhs.CompareGreaterThan(rhs) == CmpBool::CmpTrue) {
           switch (expr_type) {
             case ExpressionType::COMPARE_NOTEQUAL:
             case ExpressionType::COMPARE_GREATERTHAN:

--- a/src/index/index_util.cpp
+++ b/src/index/index_util.cpp
@@ -191,12 +191,12 @@ bool IndexUtil::ValuePairComparator(const std::pair<type::Value, int> &i,
                                     const std::pair<type::Value, int> &j) {
 
   // If first elements are equal then compare the second element
-  if (i.first.CompareEquals(j.first) == CmpBool::TRUE) {
+  if (i.first.CompareEquals(j.first) == CmpBool::CmpTrue) {
     return i.second < j.second;
   }
   
   // Otherwise compare the first element for "<" or ">"
-  return i.first.CompareLessThan(j.first) == CmpBool::TRUE;
+  return i.first.CompareLessThan(j.first) == CmpBool::CmpTrue;
 }
 
 void IndexUtil::ConstructIntervals(oid_t leading_column_id,
@@ -312,7 +312,7 @@ void IndexUtil::FindMaxMinInColumns(oid_t leading_column_id,
                 values[i].GetInfo().c_str());
       if (non_leading_columns[column_id].first.IsNull() ||
           non_leading_columns[column_id].first
-            .CompareGreaterThan(values[i]) == CmpBool::TRUE) {
+            .CompareGreaterThan(values[i]) == CmpBool::CmpTrue) {
         LOG_TRACE("Update min\n");
         non_leading_columns[column_id].first = values[i].Copy();
       }
@@ -325,7 +325,7 @@ void IndexUtil::FindMaxMinInColumns(oid_t leading_column_id,
                 values[i].GetInfo().c_str());
       if (non_leading_columns[column_id].first.IsNull() ||
           non_leading_columns[column_id].second.
-            CompareLessThan(values[i]) == CmpBool::TRUE) {
+            CompareLessThan(values[i]) == CmpBool::CmpTrue) {
         LOG_TRACE("Update max\n");
         non_leading_columns[column_id].second = values[i].Copy();
       }

--- a/src/optimizer/stats/cost.cpp
+++ b/src/optimizer/stats/cost.cpp
@@ -182,7 +182,7 @@ namespace optimizer {
 //     return DEFAULT_COST;
 //   }
 //   std::string column = columns[0];
-//   bool order = orders[0];  // TRUE is ASC, FALSE is DESC
+//   bool order = orders[0];  // CmpTrue is ASC, CmpFalse is DESC
 //   double cost = DEFAULT_COST;
 //   // Special case when first column has index.
 //   if (input_stats->HasPrimaryIndex(column)) {

--- a/src/storage/tuple.cpp
+++ b/src/storage/tuple.cpp
@@ -312,7 +312,7 @@ bool Tuple::EqualsNoSchemaCheck(const AbstractTuple &other) const {
   for (int column_itr = 0; column_itr < column_count; column_itr++) {
     type::Value lhs = (GetValue(column_itr));
     type::Value rhs = (other.GetValue(column_itr));
-    if (lhs.CompareNotEquals(rhs) == CmpBool::TRUE) {
+    if (lhs.CompareNotEquals(rhs) == CmpBool::CmpTrue) {
       return false;
     }
   }
@@ -325,7 +325,7 @@ bool Tuple::EqualsNoSchemaCheck(const AbstractTuple &other,
   for (auto column_itr : columns) {
     type::Value lhs = (GetValue(column_itr));
     type::Value rhs = (other.GetValue(column_itr));
-    if (lhs.CompareNotEquals(rhs) == CmpBool::TRUE) {
+    if (lhs.CompareNotEquals(rhs) == CmpBool::CmpTrue) {
       return false;
     }
   }
@@ -363,10 +363,10 @@ int Tuple::Compare(const Tuple &other) const {
   for (int column_itr = 0; column_itr < column_count; column_itr++) {
     type::Value lhs = (GetValue(column_itr));
     type::Value rhs = (other.GetValue(column_itr));
-    if (lhs.CompareGreaterThan(rhs) == CmpBool::TRUE) {
+    if (lhs.CompareGreaterThan(rhs) == CmpBool::CmpTrue) {
       return 1;
     }
-    if (lhs.CompareLessThan(rhs) == CmpBool::TRUE) {
+    if (lhs.CompareLessThan(rhs) == CmpBool::CmpTrue) {
       return -1;
     }
   }
@@ -379,10 +379,10 @@ int Tuple::Compare(const Tuple &other,
   for (auto column_itr : columns) {
     type::Value lhs = (GetValue(column_itr));
     type::Value rhs = (other.GetValue(column_itr));
-    if (lhs.CompareGreaterThan(rhs) == CmpBool::TRUE) {
+    if (lhs.CompareGreaterThan(rhs) == CmpBool::CmpTrue) {
       return 1;
     }
-    if (lhs.CompareLessThan(rhs) == CmpBool::TRUE) {
+    if (lhs.CompareLessThan(rhs) == CmpBool::CmpTrue) {
       return -1;
     }
   }

--- a/src/storage/zone_map_manager.cpp
+++ b/src/storage/zone_map_manager.cpp
@@ -96,10 +96,10 @@ void ZoneMapManager::CreateOrUpdateZoneMapForTileGroup(
     oid_t num_tuple_slots = tile_group->GetAllocatedTupleCount();
     for (oid_t tuple_itr = 0; tuple_itr < num_tuple_slots; tuple_itr++) {
       type::Value current_val = tile_group->GetValue(tuple_itr, col_itr);
-      if (current_val.CompareGreaterThan(max) == CmpBool::TRUE) {
+      if (current_val.CompareGreaterThan(max) == CmpBool::CmpTrue) {
         max = current_val;
       }
-      if (current_val.CompareLessThan(min) == CmpBool::TRUE) {
+      if (current_val.CompareLessThan(min) == CmpBool::CmpTrue) {
         min = current_val;
       }
     }

--- a/src/type/array_type.cpp
+++ b/src/type/array_type.cpp
@@ -80,7 +80,7 @@ Value ArrayType::InList(const Value &list, const Value &object) const {
       std::vector<bool>::iterator it;
       for (it = vec.begin(); it != vec.end(); it++) {
         Value res = ValueFactory::GetBooleanValue(ValueFactory::GetBooleanValue(*it).CompareEquals(object));
-        if (ValueFactory::GetBooleanValue(*it).CompareEquals(object) == CmpBool::TRUE) return res;
+        if (ValueFactory::GetBooleanValue(*it).CompareEquals(object) == CmpBool::CmpTrue) return res;
       }
       return ValueFactory::GetBooleanValue(false);
     }

--- a/src/type/boolean_type.cpp
+++ b/src/type/boolean_type.cpp
@@ -76,14 +76,14 @@ CmpBool BooleanType::CompareGreaterThanEquals(const Value& left,
 Value BooleanType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::CmpTrue) return left.Copy();
   return right.Copy();
 }
 
 Value BooleanType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
+  if (left.CompareGreaterThanEquals(right) == CmpBool::CmpTrue) return left.Copy();
   return right.Copy();
 }
 

--- a/src/type/date_type.cpp
+++ b/src/type/date_type.cpp
@@ -62,14 +62,14 @@ CmpBool DateType::CompareGreaterThanEquals(const Value& left,
 Value DateType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::CmpTrue) return left.Copy();
   return right.Copy();
 }
 
 Value DateType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareGreaterThan(right) == CmpBool::TRUE) return left.Copy();
+  if (left.CompareGreaterThan(right) == CmpBool::CmpTrue) return left.Copy();
   return right.Copy();
 }
 

--- a/src/type/decimal_type.cpp
+++ b/src/type/decimal_type.cpp
@@ -163,7 +163,7 @@ Value DecimalType::Min(const Value& left, const Value &right) const {
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
-  if (left.CompareLessThanEquals(right) == CmpBool::TRUE)
+  if (left.CompareLessThanEquals(right) == CmpBool::CmpTrue)
     return left.Copy();
   return right.Copy();
 }
@@ -174,7 +174,7 @@ Value DecimalType::Max(const Value& left, const Value &right) const {
   if (left.IsNull() || right.IsNull())
     return left.OperateNull(right);
 
-  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE)
+  if (left.CompareGreaterThanEquals(right) == CmpBool::CmpTrue)
     return left.Copy();
   return right.Copy();
 }

--- a/src/type/integer_parent_type.cpp
+++ b/src/type/integer_parent_type.cpp
@@ -28,7 +28,7 @@ Value IntegerParentType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
 
-  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::CmpTrue) return left.Copy();
   return right.Copy();
 }
 
@@ -37,7 +37,7 @@ Value IntegerParentType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
 
-  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
+  if (left.CompareGreaterThanEquals(right) == CmpBool::CmpTrue) return left.Copy();
   return right.Copy();
 }
 

--- a/src/type/timestamp_type.cpp
+++ b/src/type/timestamp_type.cpp
@@ -68,14 +68,14 @@ CmpBool TimestampType::CompareGreaterThanEquals(const Value& left, const Value &
 Value TimestampType::Min(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::CmpTrue) return left.Copy();
   return right.Copy();
 }
 
 Value TimestampType::Max(const Value& left, const Value& right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
+  if (left.CompareGreaterThanEquals(right) == CmpBool::CmpTrue) return left.Copy();
   return right.Copy();
 }
 

--- a/src/type/varlen_type.cpp
+++ b/src/type/varlen_type.cpp
@@ -129,14 +129,14 @@ CmpBool VarlenType::CompareGreaterThanEquals(const Value &left,
 Value VarlenType::Min(const Value &left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareLessThan(right) == CmpBool::TRUE) return left.Copy();
+  if (left.CompareLessThan(right) == CmpBool::CmpTrue) return left.Copy();
   return right.Copy();
 }
 
 Value VarlenType::Max(const Value &left, const Value &right) const {
   PL_ASSERT(left.CheckComparable(right));
   if (left.IsNull() || right.IsNull()) return left.OperateNull(right);
-  if (left.CompareGreaterThanEquals(right) == CmpBool::TRUE) return left.Copy();
+  if (left.CompareGreaterThanEquals(right) == CmpBool::CmpTrue) return left.Copy();
   return right.Copy();
 }
 

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -388,7 +388,7 @@ TEST_F(BinderCorrectnessTest, FunctionExpressionTest) {
       dynamic_cast<parser::SelectStatement *>(stmt)->select_list[0].get());
   EXPECT_TRUE(funct_expr->Evaluate(nullptr, nullptr, nullptr)
                   .CompareEquals(type::ValueFactory::GetVarcharValue("est")) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
 
   txn_manager.CommitTransaction(txn);
 }

--- a/test/codegen/block_nested_loop_join_translator_test.cpp
+++ b/test/codegen/block_nested_loop_join_translator_test.cpp
@@ -129,7 +129,7 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, SingleColumnEqualityJoin) {
     for (const auto &t : results) {
       auto a1 = GetCol(t, JoinOutputColPos::Table1_ColA);
       auto a2 = GetCol(t, JoinOutputColPos::Table1_ColA);
-      EXPECT_TRUE(a1.CompareEquals(a2) == CmpBool::TRUE);
+      EXPECT_TRUE(a1.CompareEquals(a2) == CmpBool::CmpTrue);
     }
   }
 
@@ -204,7 +204,7 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, NonEqualityJoin) {
     for (const auto &t : results) {
       auto a = GetCol(t, JoinOutputColPos::Table1_ColA);
       auto b = GetCol(t, JoinOutputColPos::Table2_ColB);
-      EXPECT_TRUE(a.CompareGreaterThan(b) == CmpBool::TRUE);
+      EXPECT_TRUE(a.CompareGreaterThan(b) == CmpBool::CmpTrue);
     }
   }
 
@@ -233,7 +233,7 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, NonEqualityJoin) {
     for (const auto &t : results) {
       auto a = GetCol(t, JoinOutputColPos::Table1_ColA);
       auto b = GetCol(t, JoinOutputColPos::Table2_ColB);
-      EXPECT_TRUE(a.CompareLessThanEquals(b) == CmpBool::TRUE);
+      EXPECT_TRUE(a.CompareLessThanEquals(b) == CmpBool::CmpTrue);
     }
   }
 
@@ -263,7 +263,7 @@ TEST_F(BlockNestedLoopJoinTranslatorTest, NonEqualityJoin) {
       auto a1_pl_b1 = a1.Add(b1);
 
       auto a2 = GetCol(t, JoinOutputColPos::Table2_ColA);
-      EXPECT_TRUE(a1_pl_b1.CompareGreaterThan(a2) == CmpBool::TRUE);
+      EXPECT_TRUE(a1_pl_b1.CompareGreaterThan(a2) == CmpBool::CmpTrue);
     }
   }
 }

--- a/test/codegen/case_translator_test.cpp
+++ b/test/codegen/case_translator_test.cpp
@@ -90,21 +90,21 @@ TEST_F(CaseTranslatorTest, SimpleCase) {
   EXPECT_EQ(NumRowsInTestTable(), results.size());
   EXPECT_TRUE(results[0].GetValue(0).CompareEquals(
                   type::ValueFactory::GetBigIntValue(0)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
   EXPECT_TRUE(results[0].GetValue(1).CompareEquals(
                   type::ValueFactory::GetBigIntValue(0)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
   EXPECT_TRUE(results[1].GetValue(0).CompareEquals(
                   type::ValueFactory::GetBigIntValue(10)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
   EXPECT_TRUE(results[1].GetValue(1).CompareEquals(
                   type::ValueFactory::GetBigIntValue(1)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
 
   for (uint32_t i = 2; i < NumRowsInTestTable(); i++) {
     EXPECT_TRUE(results[i].GetValue(1).CompareEquals(
                     type::ValueFactory::GetBigIntValue(0)) ==
-                CmpBool::TRUE);
+                CmpBool::CmpTrue);
   }
 }
 
@@ -160,22 +160,22 @@ TEST_F(CaseTranslatorTest, SimpleCaseMoreWhen) {
   EXPECT_EQ(NumRowsInTestTable(), results.size());
   EXPECT_TRUE(results[0].GetValue(0).CompareEquals(
                   type::ValueFactory::GetBigIntValue(0)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
   EXPECT_TRUE(results[0].GetValue(1).CompareEquals(
                   type::ValueFactory::GetBigIntValue(0)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
   EXPECT_TRUE(results[1].GetValue(0).CompareEquals(
                   type::ValueFactory::GetBigIntValue(10)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
   EXPECT_TRUE(results[1].GetValue(1).CompareEquals(
                   type::ValueFactory::GetBigIntValue(1)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
   EXPECT_TRUE(results[2].GetValue(0).CompareEquals(
                   type::ValueFactory::GetBigIntValue(20)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
   EXPECT_TRUE(results[2].GetValue(1).CompareEquals(
                   type::ValueFactory::GetBigIntValue(2)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
 }
 
 }  // namespace test

--- a/test/codegen/group_by_translator_test.cpp
+++ b/test/codegen/group_by_translator_test.cpp
@@ -91,7 +91,7 @@ TEST_F(GroupByTranslatorTest, SingleColumnGrouping) {
   type::Value const_one = type::ValueFactory::GetIntegerValue(1);
   for (const auto &tuple : results) {
     EXPECT_TRUE(tuple.GetValue(1).CompareEquals(const_one) ==
-                CmpBool::TRUE);
+                CmpBool::CmpTrue);
   }
 }
 
@@ -152,7 +152,7 @@ TEST_F(GroupByTranslatorTest, MultiColumnGrouping) {
   type::Value const_one = type::ValueFactory::GetIntegerValue(1);
   for (const auto &tuple : results) {
     type::Value group_count = tuple.GetValue(2);
-    EXPECT_TRUE(group_count.CompareEquals(const_one) == CmpBool::TRUE);
+    EXPECT_TRUE(group_count.CompareEquals(const_one) == CmpBool::CmpTrue);
   }
 }
 
@@ -381,7 +381,7 @@ TEST_F(GroupByTranslatorTest, SingleCountStar) {
   EXPECT_EQ(1, results.size());
   EXPECT_TRUE(results[0].GetValue(0).CompareEquals(
                   type::ValueFactory::GetBigIntValue(10)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
 }
 
 TEST_F(GroupByTranslatorTest, MinAndMax) {
@@ -446,13 +446,13 @@ TEST_F(GroupByTranslatorTest, MinAndMax) {
   // MAX(a) = (# inserted - 1) * 10 = (10 - 1) * 10 = 9 * 10 = 90
   EXPECT_TRUE(results[0].GetValue(0).CompareEquals(
                   type::ValueFactory::GetBigIntValue(90)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
 
   // The values of 'b' are equal to the (zero-indexed) row ID * 10 + 1. The
   // minimum row ID is 0. Therefore: MIN(b) = 0 * 10 + 1 = 1
   EXPECT_TRUE(results[0].GetValue(1).CompareEquals(
                   type::ValueFactory::GetBigIntValue(1)) ==
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
 }
 
 }  // namespace test

--- a/test/codegen/hash_join_translator_test.cpp
+++ b/test/codegen/hash_join_translator_test.cpp
@@ -122,7 +122,7 @@ TEST_F(HashJoinTranslatorTest, SingleHashJoinColumnTest) {
               tuple.GetInfo().c_str());
 
     // Check that the joins keys are actually equal
-    EXPECT_EQ(CmpBool::TRUE,
+    EXPECT_EQ(CmpBool::CmpTrue,
               tuple.GetValue(0).CompareEquals(tuple.GetValue(1)));
   }
 }

--- a/test/codegen/insert_translator_test.cpp
+++ b/test/codegen/insert_translator_test.cpp
@@ -88,13 +88,13 @@ TEST_F(InsertTranslatorTest, InsertOneTuple) {
   // Check that we got all the results
   auto &results_table1 = buffer_table1.GetOutputTuples();
 
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetDecimalValue(2)));
-  EXPECT_EQ(CmpBool::TRUE,
+  EXPECT_EQ(CmpBool::CmpTrue,
             results_table1[0].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("Tuple1")));
 }
@@ -147,21 +147,21 @@ TEST_F(InsertTranslatorTest, InsertScanTranslator) {
   // Check that we got all the results
   auto &results_table1 = buffer_table1.GetOutputTuples();
 
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(3).CompareEquals(
                                      type::ValueFactory::GetVarcharValue("3")));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[9].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[9].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(90)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[9].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[9].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(91)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[9].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[9].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(92)));
-  EXPECT_EQ(CmpBool::TRUE,
+  EXPECT_EQ(CmpBool::CmpTrue,
             results_table1[9].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("93")));
 }
@@ -215,19 +215,19 @@ TEST_F(InsertTranslatorTest, InsertScanTranslatorWithNull) {
   // Check that we got all the results
   auto &results_table1 = buffer_table1.GetOutputTuples();
 
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(0)));
   EXPECT_TRUE(results_table1[0].GetValue(1).IsNull());
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(3).CompareEquals(
                                      type::ValueFactory::GetVarcharValue("3")));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[9].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[9].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(90)));
   EXPECT_TRUE(results_table1[9].GetValue(1).IsNull());
-  EXPECT_EQ(CmpBool::TRUE, results_table1[9].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[9].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(92)));
-  EXPECT_EQ(CmpBool::TRUE,
+  EXPECT_EQ(CmpBool::CmpTrue,
             results_table1[9].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("93")));
 }
@@ -280,21 +280,21 @@ TEST_F(InsertTranslatorTest, InsertScanColumnTranslator) {
   // Check that we got all the results
   auto &results_table1 = buffer_table1.GetOutputTuples();
 
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[0].GetValue(3).CompareEquals(
                                      type::ValueFactory::GetVarcharValue("3")));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[9].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[9].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(91)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[9].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[9].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(90)));
-  EXPECT_EQ(CmpBool::TRUE, results_table1[9].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_table1[9].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(92)));
-  EXPECT_EQ(CmpBool::TRUE,
+  EXPECT_EQ(CmpBool::CmpTrue,
             results_table1[9].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("93")));
 }

--- a/test/codegen/order_by_translator_test.cpp
+++ b/test/codegen/order_by_translator_test.cpp
@@ -60,7 +60,7 @@ TEST_F(OrderByTranslatorTest, SingleIntColAscTest) {
       results.begin(), results.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
         auto is_lte = t1.GetValue(0).CompareLessThanEquals(t2.GetValue(0));
-        return is_lte == CmpBool::TRUE;
+        return is_lte == CmpBool::CmpTrue;
       }));
 }
 
@@ -97,7 +97,7 @@ TEST_F(OrderByTranslatorTest, SingleIntColDescTest) {
       results.begin(), results.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
         auto is_gte = t1.GetValue(0).CompareGreaterThanEquals(t2.GetValue(0));
-        return is_gte == CmpBool::TRUE;
+        return is_gte == CmpBool::CmpTrue;
       }));
 }
 
@@ -135,14 +135,14 @@ TEST_F(OrderByTranslatorTest, MultiIntColAscTest) {
       results.begin(), results.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
         if (t1.GetValue(1).CompareEquals(t2.GetValue(0)) ==
-            CmpBool::TRUE) {
+            CmpBool::CmpTrue) {
           // t1.b == t2.b => t1.a <= t2.a
           return t1.GetValue(0).CompareLessThanEquals(t2.GetValue(0)) ==
-                 CmpBool::TRUE;
+                 CmpBool::CmpTrue;
         } else {
           // t1.b != t2.b => t1.b < t2.b
           return t1.GetValue(1).CompareLessThan(t2.GetValue(1)) ==
-                 CmpBool::TRUE;
+                 CmpBool::CmpTrue;
         }
       }));
 }
@@ -181,14 +181,14 @@ TEST_F(OrderByTranslatorTest, MultiIntColMixedTest) {
       results.begin(), results.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
         if (t1.GetValue(1).CompareEquals(t2.GetValue(1)) ==
-            CmpBool::TRUE) {
+            CmpBool::CmpTrue) {
           // t1.b == t2.b => t1.a <= t2.a
           return t1.GetValue(0).CompareLessThanEquals(t2.GetValue(0)) ==
-                 CmpBool::TRUE;
+                 CmpBool::CmpTrue;
         } else {
           // t1.b != t2.b => t1.b > t2.b
           return t1.GetValue(1).CompareGreaterThan(t2.GetValue(1)) ==
-                 CmpBool::TRUE;
+                 CmpBool::CmpTrue;
         }
       }));
 }

--- a/test/codegen/parameterization_test.cpp
+++ b/test/codegen/parameterization_test.cpp
@@ -201,11 +201,11 @@ TEST_F(ParameterizationTest, ConstParameterWithConjunction) {
 
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(1, results.size());
-  EXPECT_EQ(CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(21)));
-  EXPECT_EQ(CmpBool::TRUE, results[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetDecimalValue(22)));
 
   // SELECT a, b, c FROM table where a >= 30 and b = 31;
@@ -238,11 +238,11 @@ TEST_F(ParameterizationTest, ConstParameterWithConjunction) {
 
   const auto &results_2 = buffer_2.GetOutputTuples();
   ASSERT_EQ(1, results_2.size());
-  EXPECT_EQ(CmpBool::TRUE, results_2[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_2[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(30)));
-  EXPECT_EQ(CmpBool::TRUE, results_2[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_2[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(31)));
-  EXPECT_EQ(CmpBool::TRUE, results_2[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_2[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetDecimalValue(32)));
   EXPECT_TRUE(cached);
 
@@ -316,9 +316,9 @@ TEST_F(ParameterizationTest, ParamParameterWithConjunction) {
 
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(NumRowsInTestTable() - 2, results.size());
-  EXPECT_EQ(CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(CmpBool::FALSE, results[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpFalse, results[0].GetValue(3).CompareEquals(
                                       type::ValueFactory::GetVarcharValue("")));
   EXPECT_FALSE(cached);
 
@@ -354,9 +354,9 @@ TEST_F(ParameterizationTest, ParamParameterWithConjunction) {
 
   const auto &results_2 = buffer_2.GetOutputTuples();
   ASSERT_EQ(NumRowsInTestTable() - 3, results_2.size());
-  EXPECT_EQ(CmpBool::TRUE, results_2[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_2[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(30)));
-  EXPECT_EQ(CmpBool::FALSE,
+  EXPECT_EQ(CmpBool::CmpFalse,
             results_2[0].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("empty")));
   EXPECT_TRUE(cached);
@@ -393,9 +393,9 @@ TEST_F(ParameterizationTest, ParamParameterWithConjunction) {
 
   const auto &results_3 = buffer_3.GetOutputTuples();
   ASSERT_EQ(NumRowsInTestTable() - 3, results_3.size());
-  EXPECT_EQ(CmpBool::TRUE, results_3[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_3[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(30)));
-  EXPECT_EQ(CmpBool::FALSE,
+  EXPECT_EQ(CmpBool::CmpFalse,
             results_3[0].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("empty")));
   EXPECT_TRUE(cached);
@@ -432,9 +432,9 @@ TEST_F(ParameterizationTest, ParamParameterWithConjunction) {
 
   const auto &results_4 = buffer_4.GetOutputTuples();
   ASSERT_EQ(NumRowsInTestTable() - 3, results_3.size());
-  EXPECT_EQ(CmpBool::TRUE, results_4[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_4[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(30)));
-  EXPECT_EQ(CmpBool::FALSE,
+  EXPECT_EQ(CmpBool::CmpFalse,
             results_4[0].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("empty")));
   EXPECT_TRUE(cached);

--- a/test/codegen/query_cache_test.cpp
+++ b/test/codegen/query_cache_test.cpp
@@ -276,9 +276,9 @@ TEST_F(QueryCacheTest, CacheSeqScanPlan) {
   // Check that we got all the results
   const auto &results_1 = buffer_1.GetOutputTuples();
   EXPECT_EQ(1, results_1.size());
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(21)));
   EXPECT_FALSE(cached);
 
@@ -287,9 +287,9 @@ TEST_F(QueryCacheTest, CacheSeqScanPlan) {
 
   const auto &results_2 = buffer_2.GetOutputTuples();
   EXPECT_EQ(1, results_2.size());
-  EXPECT_EQ(CmpBool::TRUE, results_2[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_2[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(CmpBool::TRUE, results_2[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_2[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(21)));
   EXPECT_TRUE(cached);
   EXPECT_EQ(1, codegen::QueryCache::Instance().GetCount());
@@ -332,7 +332,7 @@ TEST_F(QueryCacheTest, CacheHashJoinPlan) {
 
     // Check that the joins keys are actually equal
     EXPECT_EQ(tuple.GetValue(0).CompareEquals(tuple.GetValue(1)),
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
   }
 
   // We collect the results of the query into an in-memory buffer
@@ -348,7 +348,7 @@ TEST_F(QueryCacheTest, CacheHashJoinPlan) {
 
     // Check that the joins keys are actually equal
     EXPECT_EQ(tuple.GetValue(0).CompareEquals(tuple.GetValue(1)),
-              CmpBool::TRUE);
+              CmpBool::CmpTrue);
   }
   EXPECT_EQ(1, codegen::QueryCache::Instance().GetCount());
 
@@ -410,7 +410,7 @@ TEST_F(QueryCacheTest, CacheOrderByPlan) {
       results_1.begin(), results_1.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
         auto is_gte = t1.GetValue(0).CompareGreaterThanEquals(t2.GetValue(0));
-        return is_gte == CmpBool::TRUE;
+        return is_gte == CmpBool::CmpTrue;
       }));
 
   CompileAndExecuteCache(order_by_plan_2, buffer_2, cached);
@@ -421,7 +421,7 @@ TEST_F(QueryCacheTest, CacheOrderByPlan) {
       results_2.begin(), results_2.end(),
       [](const codegen::WrappedTuple &t1, const codegen::WrappedTuple &t2) {
         auto is_gte = t1.GetValue(0).CompareGreaterThanEquals(t2.GetValue(0));
-        return is_gte == CmpBool::TRUE;
+        return is_gte == CmpBool::CmpTrue;
       }));
 
   auto found = (codegen::QueryCache::Instance().Find(

--- a/test/codegen/table_scan_translator_test.cpp
+++ b/test/codegen/table_scan_translator_test.cpp
@@ -216,15 +216,15 @@ TEST_F(TableScanTranslatorTest, SimplePredicateWithNull) {
   EXPECT_EQ(2, results.size());
 
   // First tuple should be (0, 1)
-  EXPECT_EQ(CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(1)));
 
   // Second tuple should be (10, 11)
-  EXPECT_EQ(CmpBool::TRUE, results[1].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[1].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_EQ(CmpBool::TRUE, results[1].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[1].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(11)));
 }
 
@@ -291,9 +291,9 @@ TEST_F(TableScanTranslatorTest, ScanWithConjunctionPredicate) {
   // Check output results
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(1, results.size());
-  EXPECT_EQ(CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(21)));
 }
 
@@ -579,9 +579,9 @@ TEST_F(TableScanTranslatorTest, ScanWithModuloPredicate) {
   // Check output results
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(1, results.size());
-  EXPECT_EQ(CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_EQ(CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(1)));
 }
 

--- a/test/codegen/update_translator_test.cpp
+++ b/test/codegen/update_translator_test.cpp
@@ -113,21 +113,21 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstant) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(3).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(3).CompareEquals(
                                      type::ValueFactory::GetVarcharValue("3")));
-  EXPECT_EQ(CmpBool::TRUE, results_1[9].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[9].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[9].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[9].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(91)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[9].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[9].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(92)));
-  EXPECT_EQ(CmpBool::TRUE,
+  EXPECT_EQ(CmpBool::CmpTrue,
             results_1[9].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("93")));
 }
@@ -206,13 +206,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantAndPredicate) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(40)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(49)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(42)));
-  EXPECT_EQ(CmpBool::TRUE,
+  EXPECT_EQ(CmpBool::CmpTrue,
             results_1[0].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("43")));
 }
@@ -298,13 +298,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAnOperatorExpression) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(40)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(49)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(42)));
-  EXPECT_EQ(CmpBool::TRUE,
+  EXPECT_EQ(CmpBool::CmpTrue,
             results_1[0].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("43")));
 }
@@ -400,13 +400,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAnOperatorExpressionComplex) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(41)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(81)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(42)));
-  EXPECT_EQ(CmpBool::TRUE,
+  EXPECT_EQ(CmpBool::CmpTrue,
             results_1[0].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("43")));
 }
@@ -485,13 +485,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithAConstantPrimary) {
   // Check that we got all the results
   auto &results_5 = buffer_5.GetOutputTuples();
 
-  EXPECT_EQ(CmpBool::TRUE, results_5[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_5[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(CmpBool::TRUE, results_5[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_5[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(11)));
-  EXPECT_EQ(CmpBool::TRUE, results_5[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_5[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(12)));
-  EXPECT_EQ(CmpBool::TRUE,
+  EXPECT_EQ(CmpBool::CmpTrue,
             results_5[0].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("13")));
 }
@@ -569,13 +569,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithCast) {
   // Check that we got all the results
   auto &results_1 = buffer_1.GetOutputTuples();
 
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(11)));
-  EXPECT_EQ(CmpBool::TRUE, results_1[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_1[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(2)));
-  EXPECT_EQ(CmpBool::TRUE,
+  EXPECT_EQ(CmpBool::CmpTrue,
             results_1[0].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("13")));
 
@@ -640,13 +640,13 @@ TEST_F(UpdateTranslatorTest, UpdateColumnsWithCast) {
   // Check that we got all the results
   auto &results_3 = buffer_3.GetOutputTuples();
 
-  EXPECT_EQ(CmpBool::TRUE, results_3[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_3[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_EQ(CmpBool::TRUE, results_3[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_3[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(11)));
-  EXPECT_EQ(CmpBool::TRUE, results_3[0].GetValue(2).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results_3[0].GetValue(2).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(3)));
-  EXPECT_EQ(CmpBool::TRUE,
+  EXPECT_EQ(CmpBool::CmpTrue,
             results_3[0].GetValue(3).CompareEquals(
                 type::ValueFactory::GetVarcharValue("13")));
 }

--- a/test/codegen/zone_map_scan_test.cpp
+++ b/test/codegen/zone_map_scan_test.cpp
@@ -145,9 +145,9 @@ TEST_F(ZoneMapScanTest, ScanwithConjunctionPredicate) {
   // Check output results
   const auto &results = buffer.GetOutputTuples();
   ASSERT_EQ(1, results.size());
-  EXPECT_EQ(CmpBool::TRUE, results[0].GetValue(0).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[0].GetValue(0).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(20)));
-  EXPECT_EQ(CmpBool::TRUE, results[0].GetValue(1).CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, results[0].GetValue(1).CompareEquals(
                                      type::ValueFactory::GetIntegerValue(21)));
 }
 }

--- a/test/common/container_tuple_test.cpp
+++ b/test/common/container_tuple_test.cpp
@@ -37,7 +37,7 @@ TEST_F(ContainerTupleTests, VectorValue) {
 
   for (size_t i = 0; i < values.size(); i++) {
     LOG_INFO("%s", ctuple.GetValue(i).GetInfo().c_str());
-    EXPECT_TRUE(values[i].CompareEquals(ctuple.GetValue(i)) == CmpBool::TRUE);
+    EXPECT_TRUE(values[i].CompareEquals(ctuple.GetValue(i)) == CmpBool::CmpTrue);
   }
 }
 

--- a/test/common/lock_free_array_test.cpp
+++ b/test/common/lock_free_array_test.cpp
@@ -44,8 +44,8 @@ TEST_F(LockFreeArrayTests, BasicTest) {
 
 }
 
-// Test shared pointers
-TEST_F(LockFreeArrayTests, SharedPointerTest) {
+//// Test shared pointers
+TEST_F(LockFreeArrayTests, SharedPointerTest1) {
 
   typedef std::shared_ptr<oid_t> value_type;
 
@@ -63,6 +63,40 @@ TEST_F(LockFreeArrayTests, SharedPointerTest) {
     EXPECT_EQ(array_size, element_count);
   }
 
+}
+
+TEST_F(LockFreeArrayTests, SharedPointerTest2) {
+
+  typedef std::shared_ptr<oid_t> value_type;
+
+  {
+    LockFreeArray<value_type> array;
+
+
+    std::thread t0([&] {
+      size_t const element_count = 10000;
+      for (size_t element = 0; element < element_count; ++element ) {
+        std::shared_ptr<oid_t> entry(new oid_t);
+        auto status = array.Append(entry);
+        EXPECT_TRUE(status);
+      }
+    });
+
+
+    size_t const element_count = 10000;
+    for (size_t element = 0; element < element_count; ++element ) {
+      std::shared_ptr<oid_t> entry(new oid_t);
+      auto status = array.Append(entry);
+      EXPECT_TRUE(status);
+    }
+    t0.join();
+
+    auto array_size = array.GetSize();
+    EXPECT_EQ(array_size, element_count*2);
+
+
+
+  }
 }
 
 }  // namespace test

--- a/test/executor/aggregate_test.cpp
+++ b/test/executor/aggregate_test.cpp
@@ -126,16 +126,16 @@ TEST_F(AggregateTests, SortedDistinctTest) {
   type::Value val = (result_tile->GetValue(0, 2));
   CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(0, 3));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(2)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(5, 2));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(51)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(5, 3));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(52)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
 }
 
 TEST_F(AggregateTests, SortedSumGroupByTest) {
@@ -227,16 +227,16 @@ TEST_F(AggregateTests, SortedSumGroupByTest) {
   type::Value val = (result_tile->GetValue(0, 0));
   CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(105)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(1, 0));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(1, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(355)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
 }
 
 TEST_F(AggregateTests, SortedSumMaxGroupByTest) {
@@ -333,16 +333,16 @@ TEST_F(AggregateTests, SortedSumMaxGroupByTest) {
   type::Value val = (result_tile->GetValue(0, 0));
   CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(0)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(105)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(0, 2));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(42)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(1, 0));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
 }
 
 TEST_F(AggregateTests, MinMaxTest) {
@@ -454,16 +454,16 @@ TEST_F(AggregateTests, MinMaxTest) {
   type::Value val = (result_tile->GetValue(0, 0));
   CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(91)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(0, 2));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(2)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(0, 3));
   cmp = (val.CompareEquals(type::ValueFactory::GetDecimalValue(92)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
 }
 
 TEST_F(AggregateTests, HashDistinctTest) {
@@ -741,15 +741,15 @@ TEST_F(AggregateTests, HashCountDistinctGroupByTest) {
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(0)));
   CmpBool cmp1 =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE || cmp1 == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue || cmp1 == CmpBool::CmpTrue);
 
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(5)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
 
   val = (result_tile->GetValue(0, 2));
   cmp = (val.CompareLessThanEquals(type::ValueFactory::GetIntegerValue(3)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
 }
 
 TEST_F(AggregateTests, PlainSumCountDistinctTest) {
@@ -854,13 +854,13 @@ TEST_F(AggregateTests, PlainSumCountDistinctTest) {
   type::Value val = (result_tile->GetValue(0, 0));
   CmpBool cmp =
       (val.CompareEquals(type::ValueFactory::GetIntegerValue(50)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(0, 1));
   cmp = (val.CompareEquals(type::ValueFactory::GetIntegerValue(10)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   val = (result_tile->GetValue(0, 2));
   cmp = (val.CompareLessThanEquals(type::ValueFactory::GetIntegerValue(3)));
-  EXPECT_TRUE(cmp == CmpBool::TRUE);
+  EXPECT_TRUE(cmp == CmpBool::CmpTrue);
 }
 
 }  // namespace test

--- a/test/executor/materialization_test.cpp
+++ b/test/executor/materialization_test.cpp
@@ -81,18 +81,18 @@ TEST_F(MaterializationTests, SingleBaseTileTest) {
     type::Value val1 = (result_base_tile->GetValue(i, 1));
     CmpBool cmp = (val0.CompareEquals(
       type::ValueFactory::GetIntegerValue(TestingExecutorUtil::PopulatedValue(i, 0))));
-    EXPECT_TRUE(cmp == CmpBool::TRUE);
+    EXPECT_TRUE(cmp == CmpBool::CmpTrue);
     cmp = val1.CompareEquals(type::ValueFactory::GetIntegerValue(
         TestingExecutorUtil::PopulatedValue(i, 1)));
-    EXPECT_TRUE(cmp == CmpBool::TRUE);
+    EXPECT_TRUE(cmp == CmpBool::CmpTrue);
 
     // Double check that logical tile is functioning.
     type::Value logic_val0 = (result_logical_tile->GetValue(i, 0));
     type::Value logic_val1 = (result_logical_tile->GetValue(i, 1));
     cmp = (logic_val0.CompareEquals(val0));
-    EXPECT_TRUE(cmp == CmpBool::TRUE);
+    EXPECT_TRUE(cmp == CmpBool::CmpTrue);
     cmp = (logic_val1.CompareEquals(val1));
-    EXPECT_TRUE(cmp == CmpBool::TRUE);
+    EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   }
 }
 
@@ -154,28 +154,28 @@ TEST_F(MaterializationTests, TwoBaseTilesWithReorderTest) {
     // Output column 2.
     CmpBool cmp(val2.CompareEquals(
       type::ValueFactory::GetIntegerValue(TestingExecutorUtil::PopulatedValue(i, 0))));
-    EXPECT_TRUE(cmp == CmpBool::TRUE);
+    EXPECT_TRUE(cmp == CmpBool::CmpTrue);
 
     // Output column 1.
     cmp = (val1.CompareEquals(type::ValueFactory::GetIntegerValue(
         TestingExecutorUtil::PopulatedValue(i, 1))));
-    EXPECT_TRUE(cmp == CmpBool::TRUE);
+    EXPECT_TRUE(cmp == CmpBool::CmpTrue);
 
     // Output column 0.
     cmp = (val0.CompareEquals(type::ValueFactory::GetVarcharValue(
         std::to_string(TestingExecutorUtil::PopulatedValue(i, 3)))));
-    EXPECT_TRUE(cmp == CmpBool::TRUE);
+    EXPECT_TRUE(cmp == CmpBool::CmpTrue);
 
     // Double check that logical tile is functioning.
     type::Value logic_val0 = (result_logical_tile->GetValue(i, 0));
     type::Value logic_val1 = (result_logical_tile->GetValue(i, 1));
     type::Value logic_val2 = (result_logical_tile->GetValue(i, 2));
     cmp = (logic_val0.CompareEquals(val0));
-    EXPECT_TRUE(cmp == CmpBool::TRUE);
+    EXPECT_TRUE(cmp == CmpBool::CmpTrue);
     cmp = (logic_val1.CompareEquals(val1));
-    EXPECT_TRUE(cmp == CmpBool::TRUE);
+    EXPECT_TRUE(cmp == CmpBool::CmpTrue);
     cmp = (logic_val2.CompareEquals(val2));
-    EXPECT_TRUE(cmp == CmpBool::TRUE);
+    EXPECT_TRUE(cmp == CmpBool::CmpTrue);
   }
 }
 

--- a/test/executor/seq_scan_test.cpp
+++ b/test/executor/seq_scan_test.cpp
@@ -238,7 +238,7 @@ void RunTest(executor::SeqScanExecutor &executor, int expected_num_tiles,
           (type::ValueFactory::GetVarcharValue(std::to_string(val2)));
       type::Value val =
           (result_tiles[i]->GetValue(new_tuple_id, expected_num_cols - 1));
-      EXPECT_TRUE(val.CompareEquals(string_value) == CmpBool::TRUE);
+      EXPECT_TRUE(val.CompareEquals(string_value) == CmpBool::CmpTrue);
     }
     EXPECT_EQ(0, expected_tuples_left.size());
   }

--- a/test/expression/expression_test.cpp
+++ b/test/expression/expression_test.cpp
@@ -213,7 +213,7 @@ TEST_F(ExpressionTests, ExtractDateTests) {
   //    type::Value expected = type::ValueFactory::GetDecimalValue(x.second);
   //    type::Value result = extract_expr->Evaluate(nullptr, nullptr, nullptr);
   //    EXPECT_FALSE(result.IsNull());
-  //    EXPECT_EQ(CmpBool::TRUE, expected.CompareEquals(result));
+  //    EXPECT_EQ(CmpBool::CmpTrue, expected.CompareEquals(result));
   //  }
 }
 
@@ -264,14 +264,14 @@ TEST_F(ExpressionTests, SimpleCase) {
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   type::Value result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   type::Value expected = type::ValueFactory::GetIntegerValue(2);
-  EXPECT_EQ(CmpBool::TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(CmpBool::CmpTrue, expected.CompareEquals(result));
 
   // Test with A = 2, should get 3
   tuple->SetValue(0, type::ValueFactory::GetIntegerValue(2), nullptr);
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   expected = type::ValueFactory::GetIntegerValue(3);
-  EXPECT_EQ(CmpBool::TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(CmpBool::CmpTrue, expected.CompareEquals(result));
 }
 
 TEST_F(ExpressionTests, SimpleCaseCopyTest) {
@@ -323,14 +323,14 @@ TEST_F(ExpressionTests, SimpleCaseCopyTest) {
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   type::Value result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   type::Value expected = type::ValueFactory::GetIntegerValue(2);
-  EXPECT_EQ(CmpBool::TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(CmpBool::CmpTrue, expected.CompareEquals(result));
 
   // Test with A = 2, should get 3
   tuple->SetValue(0, type::ValueFactory::GetIntegerValue(2), nullptr);
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   expected = type::ValueFactory::GetIntegerValue(3);
-  EXPECT_EQ(CmpBool::TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(CmpBool::CmpTrue, expected.CompareEquals(result));
 }
 
 TEST_F(ExpressionTests, SimpleCaseWithDefault) {
@@ -377,14 +377,14 @@ TEST_F(ExpressionTests, SimpleCaseWithDefault) {
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   type::Value result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   type::Value expected = type::ValueFactory::GetIntegerValue(2);
-  EXPECT_EQ(CmpBool::TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(CmpBool::CmpTrue, expected.CompareEquals(result));
 
   // Test with A = 2, should get 3
   tuple->SetValue(0, type::ValueFactory::GetIntegerValue(2), nullptr);
   tuple->SetValue(1, type::ValueFactory::GetIntegerValue(1), nullptr);
   result = case_expression->Evaluate(tuple.get(), nullptr, nullptr);
   expected = type::ValueFactory::GetIntegerValue(3);
-  EXPECT_EQ(CmpBool::TRUE, expected.CompareEquals(result));
+  EXPECT_EQ(CmpBool::CmpTrue, expected.CompareEquals(result));
 }
 
 }  // namespace test

--- a/test/logging/recovery_test.cpp
+++ b/test/logging/recovery_test.cpp
@@ -311,16 +311,16 @@
 
 //   type::Value rval0 = (recovery_table->GetTileGroupById(100)->GetValue(5, 0));
 //   CmpBool cmp0 = (val0.CompareEquals(rval0));
-//   EXPECT_TRUE(cmp0 == CmpBool::TRUE);
+//   EXPECT_TRUE(cmp0 == CmpBool::CmpTrue);
 //   type::Value rval1 = (recovery_table->GetTileGroupById(100)->GetValue(5, 1));
 //   CmpBool cmp1 = (val1.CompareEquals(rval1));
-//   EXPECT_TRUE(cmp1 == CmpBool::TRUE);
+//   EXPECT_TRUE(cmp1 == CmpBool::CmpTrue);
 //   type::Value rval2 = (recovery_table->GetTileGroupById(100)->GetValue(5, 2));
 //   CmpBool cmp2 = (val2.CompareEquals(rval2));
-//   EXPECT_TRUE(cmp2 == CmpBool::TRUE);
+//   EXPECT_TRUE(cmp2 == CmpBool::CmpTrue);
 //   type::Value rval3 = (recovery_table->GetTileGroupById(100)->GetValue(5, 3));
 //   CmpBool cmp3 = (val3.CompareEquals(rval3));
-//   EXPECT_TRUE(cmp3 == CmpBool::TRUE);
+//   EXPECT_TRUE(cmp3 == CmpBool::CmpTrue);
 
 //   EXPECT_EQ(recovery_table->GetTupleCount(), 1);
 //   EXPECT_EQ(recovery_table->GetTileGroupCount(), 2);
@@ -365,16 +365,16 @@
 
 //   type::Value rval0 = (recovery_table->GetTileGroupById(100)->GetValue(5, 0));
 //   CmpBool cmp0 = (val0.CompareEquals(rval0));
-//   EXPECT_TRUE(cmp0 == CmpBool::TRUE);
+//   EXPECT_TRUE(cmp0 == CmpBool::CmpTrue);
 //   type::Value rval1 = (recovery_table->GetTileGroupById(100)->GetValue(5, 1));
 //   CmpBool cmp1 = (val1.CompareEquals(rval1));
-//   EXPECT_TRUE(cmp1 == CmpBool::TRUE);
+//   EXPECT_TRUE(cmp1 == CmpBool::CmpTrue);
 //   type::Value rval2 = (recovery_table->GetTileGroupById(100)->GetValue(5, 2));
 //   CmpBool cmp2 = (val2.CompareEquals(rval2));
-//   EXPECT_TRUE(cmp2 == CmpBool::TRUE);
+//   EXPECT_TRUE(cmp2 == CmpBool::CmpTrue);
 //   type::Value rval3 = (recovery_table->GetTileGroupById(100)->GetValue(5, 3));
 //   CmpBool cmp3 = (val3.CompareEquals(rval3));
-//   EXPECT_TRUE(cmp3 == CmpBool::TRUE);
+//   EXPECT_TRUE(cmp3 == CmpBool::CmpTrue);
 
 //   EXPECT_EQ(recovery_table->GetTupleCount(), 0);
 //   EXPECT_EQ(recovery_table->GetTileGroupCount(), 2);

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -393,7 +393,7 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   auto constant =
       (expression::ConstantValueExpression *)update_stmt->updates.at(0)
           ->value.get();
-  EXPECT_EQ(CmpBool::TRUE, constant->GetValue().CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, constant->GetValue().CompareEquals(
                                type::ValueFactory::GetDecimalValue(48)));
 
   // Test Second Set Condition
@@ -403,7 +403,7 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   auto child1 = (expression::TupleValueExpression *)op_expr->GetChild(0);
   EXPECT_EQ(child1->GetColumnName(), "s_ytd");
   auto child2 = (expression::ConstantValueExpression *)op_expr->GetChild(1);
-  EXPECT_EQ(CmpBool::TRUE, child2->GetValue().CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, child2->GetValue().CompareEquals(
                                type::ValueFactory::GetIntegerValue(1)));
 
   // Test Where clause
@@ -414,14 +414,14 @@ TEST_F(PostgresParserTests, ExpressionUpdateTest) {
   auto column = (expression::TupleValueExpression *)cond1->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_i_id");
   constant = (expression::ConstantValueExpression *)cond1->GetChild(1);
-  EXPECT_EQ(CmpBool::TRUE, constant->GetValue().CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, constant->GetValue().CompareEquals(
                                type::ValueFactory::GetIntegerValue(68999)));
   auto cond2 = (expression::OperatorExpression *)where->GetChild(1);
   EXPECT_EQ(cond2->GetExpressionType(), ExpressionType::COMPARE_EQUAL);
   column = (expression::TupleValueExpression *)cond2->GetChild(0);
   EXPECT_EQ(column->GetColumnName(), "s_w_id");
   constant = (expression::ConstantValueExpression *)cond2->GetChild(1);
-  EXPECT_EQ(CmpBool::TRUE, constant->GetValue().CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, constant->GetValue().CompareEquals(
                                type::ValueFactory::GetIntegerValue(4)));
 }
 
@@ -590,7 +590,7 @@ TEST_F(PostgresParserTests, InsertTest) {
              .at(1)
              .get())
             ->GetValue());
-    EXPECT_EQ(CmpBool::TRUE, res);
+    EXPECT_EQ(CmpBool::CmpTrue, res);
 
     // LOG_TRACE("%d : %s", ++ii, stmt_list->GetInfo().c_str());
     LOG_INFO("%d : %s", ++ii, stmt_list->GetInfo().c_str());
@@ -856,9 +856,9 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   auto child2 =
       (expression::ConstantValueExpression *)default_expr->GetChild(1);
   EXPECT_TRUE(child2 != nullptr);
-  EXPECT_EQ(CmpBool::TRUE, child1->GetValue().CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, child1->GetValue().CompareEquals(
                                type::ValueFactory::GetIntegerValue(1)));
-  EXPECT_EQ(CmpBool::TRUE, child2->GetValue().CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, child2->GetValue().CompareEquals(
                                type::ValueFactory::GetIntegerValue(2)));
 
   // Check Second column
@@ -906,13 +906,13 @@ TEST_F(PostgresParserTests, ConstraintTest) {
   auto plus_child2 =
       (expression::ConstantValueExpression *)check_child1->GetChild(1);
   EXPECT_TRUE(plus_child2 != nullptr);
-  EXPECT_EQ(CmpBool::TRUE, plus_child2->GetValue().CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, plus_child2->GetValue().CompareEquals(
                                type::ValueFactory::GetIntegerValue(1)));
   auto check_child2 =
       (expression::ConstantValueExpression *)column->check_expression->GetChild(
           1);
   EXPECT_TRUE(check_child2 != nullptr);
-  EXPECT_EQ(CmpBool::TRUE, check_child2->GetValue().CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, check_child2->GetValue().CompareEquals(
                                type::ValueFactory::GetIntegerValue(0)));
 
   // Check the last foreign key
@@ -1089,7 +1089,7 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   auto const_expr =
       (expression::ConstantValueExpression *)fun_expr->GetChild(0);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_EQ(CmpBool::TRUE, const_expr->GetValue().CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, const_expr->GetValue().CompareEquals(
                                type::ValueFactory::GetIntegerValue(1)));
   auto tv_expr = (expression::TupleValueExpression *)fun_expr->GetChild(1);
   EXPECT_TRUE(tv_expr != nullptr);
@@ -1103,7 +1103,7 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ(1, fun_expr->GetChildrenSize());
   const_expr = (expression::ConstantValueExpression *)fun_expr->GetChild(0);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_EQ(CmpBool::TRUE, const_expr->GetValue().CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, const_expr->GetValue().CompareEquals(
                                type::ValueFactory::GetIntegerValue(99)));
 
   // Check FUN(b) > 2
@@ -1119,7 +1119,7 @@ TEST_F(PostgresParserTests, FuncCallTest) {
   EXPECT_EQ("b", tv_expr->GetColumnName());
   const_expr = (expression::ConstantValueExpression *)op_expr->GetChild(1);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_EQ(CmpBool::TRUE, const_expr->GetValue().CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, const_expr->GetValue().CompareEquals(
                                type::ValueFactory::GetIntegerValue(2)));
 }
 
@@ -1142,7 +1142,7 @@ TEST_F(PostgresParserTests, UDFFuncCallTest) {
   auto const_expr =
       (expression::ConstantValueExpression *)fun_expr->GetChild(0);
   EXPECT_TRUE(const_expr != nullptr);
-  EXPECT_EQ(CmpBool::TRUE, const_expr->GetValue().CompareEquals(
+  EXPECT_EQ(CmpBool::CmpTrue, const_expr->GetValue().CompareEquals(
                                type::ValueFactory::GetIntegerValue(1)));
 
   auto tv_expr = (expression::TupleValueExpression *)fun_expr->GetChild(1);

--- a/test/storage/masked_tuple_test.cpp
+++ b/test/storage/masked_tuple_test.cpp
@@ -41,7 +41,7 @@ void MaskedTupleTestHelper(storage::MaskedTuple *masked_tuple,
         v.CompareEquals(type::ValueFactory::GetIntegerValue(expected));
     LOG_TRACE("mask[%d]->%d ==> (Expected=%d / Result=%s)", i, mask[i],
               expected, v.GetInfo().c_str());
-    EXPECT_EQ(CmpBool::TRUE, result);
+    EXPECT_EQ(CmpBool::CmpTrue, result);
   }
 }
 
@@ -80,7 +80,7 @@ TEST_F(MaskedTupleTests, BasicTest) {
     int expected = values[i];
     auto result =
         v.CompareEquals(type::ValueFactory::GetIntegerValue(expected));
-    EXPECT_EQ(CmpBool::TRUE, result);
+    EXPECT_EQ(CmpBool::CmpTrue, result);
   }
 
   // CREATE MASKED TUPLE

--- a/test/storage/temp_table_test.cpp
+++ b/test/storage/temp_table_test.cpp
@@ -90,7 +90,7 @@ TEST_F(TempTableTests, InsertTest) {
         // I have to do this because we can't put type::Value into a std::set
         bool found = false;
         for (auto val : values) {
-          found = val.CompareEquals(tupleVal) == CmpBool::TRUE;
+          found = val.CompareEquals(tupleVal) == CmpBool::CmpTrue;
           if (found) break;
         }  // FOR
         EXPECT_TRUE(found);

--- a/test/type/array_value_test.cpp
+++ b/test/type/array_value_test.cpp
@@ -274,49 +274,49 @@ TEST_F(ArrayValueTests, InListTest) {
 void CheckEqual(type::Value v1, type::Value v2) {
   CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE(result[0] == CmpBool::TRUE);
+  EXPECT_TRUE(result[0] == CmpBool::CmpTrue);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE(result[1] == CmpBool::FALSE);
+  EXPECT_TRUE(result[1] == CmpBool::CmpFalse);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE(result[2] == CmpBool::FALSE);
+  EXPECT_TRUE(result[2] == CmpBool::CmpFalse);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE(result[3] == CmpBool::TRUE);
+  EXPECT_TRUE(result[3] == CmpBool::CmpTrue);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE(result[4] == CmpBool::FALSE);
+  EXPECT_TRUE(result[4] == CmpBool::CmpFalse);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE(result[5] == CmpBool::TRUE);
+  EXPECT_TRUE(result[5] == CmpBool::CmpTrue);
 }
 
 void CheckLessThan(type::Value v1, type::Value v2) {
   CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE(result[0] == CmpBool::FALSE);
+  EXPECT_TRUE(result[0] == CmpBool::CmpFalse);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE(result[1] == CmpBool::TRUE);
+  EXPECT_TRUE(result[1] == CmpBool::CmpTrue);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE(result[2] == CmpBool::TRUE);
+  EXPECT_TRUE(result[2] == CmpBool::CmpTrue);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE(result[3] == CmpBool::TRUE);
+  EXPECT_TRUE(result[3] == CmpBool::CmpTrue);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE(result[4] == CmpBool::FALSE);
+  EXPECT_TRUE(result[4] == CmpBool::CmpFalse);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE(result[5] == CmpBool::FALSE);
+  EXPECT_TRUE(result[5] == CmpBool::CmpFalse);
 }
 
 void CheckGreaterThan(type::Value v1, type::Value v2) {
   CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_TRUE(result[0] == CmpBool::FALSE);
+  EXPECT_TRUE(result[0] == CmpBool::CmpFalse);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_TRUE(result[1] == CmpBool::TRUE);
+  EXPECT_TRUE(result[1] == CmpBool::CmpTrue);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_TRUE(result[2] == CmpBool::FALSE);
+  EXPECT_TRUE(result[2] == CmpBool::CmpFalse);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_TRUE(result[3] == CmpBool::FALSE);
+  EXPECT_TRUE(result[3] == CmpBool::CmpFalse);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_TRUE(result[4] == CmpBool::TRUE);
+  EXPECT_TRUE(result[4] == CmpBool::CmpTrue);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_TRUE(result[5] == CmpBool::TRUE);
+  EXPECT_TRUE(result[5] == CmpBool::CmpTrue);
 }
 
 TEST_F(ArrayValueTests, CompareTest) {

--- a/test/type/boolean_value_test.cpp
+++ b/test/type/boolean_value_test.cpp
@@ -117,8 +117,8 @@ TEST_F(BooleanValueTests, ComparisonTest) {
 
         if (expected_null) expected = false;
 
-        EXPECT_EQ(expected, result == CmpBool::TRUE);
-        EXPECT_EQ(!expected, result == CmpBool::FALSE);
+        EXPECT_EQ(expected, result == CmpBool::CmpTrue);
+        EXPECT_EQ(!expected, result == CmpBool::CmpFalse);
         EXPECT_EQ(expected_null, result == CmpBool::NULL_);
       }
     }
@@ -169,7 +169,7 @@ TEST_F(BooleanValueTests, HashTest) {
       auto hash0 = val0.Hash();
       auto hash1 = val1.Hash();
 
-      if (result == CmpBool::TRUE) {
+      if (result == CmpBool::CmpTrue) {
         EXPECT_EQ(hash0, hash1);
       } else {
         EXPECT_NE(hash0, hash1);

--- a/test/type/date_value_test.cpp
+++ b/test/type/date_value_test.cpp
@@ -104,8 +104,8 @@ TEST_F(DateValueTests, ComparisonTest) {
         if (expected_null) {
           EXPECT_EQ(expected_null, result == CmpBool::NULL_);
         } else {
-          EXPECT_EQ(expected, result == CmpBool::TRUE);
-          EXPECT_EQ(!expected, result == CmpBool::FALSE);
+          EXPECT_EQ(expected, result == CmpBool::CmpTrue);
+          EXPECT_EQ(!expected, result == CmpBool::CmpFalse);
         }
       }
     }
@@ -157,7 +157,7 @@ TEST_F(DateValueTests, CopyTest) {
   type::Value val0 =
       type::ValueFactory::GetDateValue(static_cast<int32_t>(1000000));
   type::Value val1 = val0.Copy();
-  EXPECT_EQ(CmpBool::TRUE, val0.CompareEquals(val1));
+  EXPECT_EQ(CmpBool::CmpTrue, val0.CompareEquals(val1));
 }
 
 TEST_F(DateValueTests, CastTest) {

--- a/test/type/numeric_value_test.cpp
+++ b/test/type/numeric_value_test.cpp
@@ -56,49 +56,49 @@ int64_t RANDOM64() {
 void CheckEqual(type::Value &v1, type::Value &v2) {
   CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_EQ(CmpBool::TRUE, result[0]);
+  EXPECT_EQ(CmpBool::CmpTrue, result[0]);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_EQ(CmpBool::FALSE, result[1]);
+  EXPECT_EQ(CmpBool::CmpFalse, result[1]);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_EQ(CmpBool::FALSE, result[2]);
+  EXPECT_EQ(CmpBool::CmpFalse, result[2]);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_EQ(CmpBool::TRUE, result[3]);
+  EXPECT_EQ(CmpBool::CmpTrue, result[3]);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_EQ(CmpBool::FALSE, result[4]);
+  EXPECT_EQ(CmpBool::CmpFalse, result[4]);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_EQ(CmpBool::TRUE, result[5]);
+  EXPECT_EQ(CmpBool::CmpTrue, result[5]);
 }
 
 void CheckLessThan(type::Value &v1, type::Value &v2) {
   CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_EQ(CmpBool::FALSE, result[0]);
+  EXPECT_EQ(CmpBool::CmpFalse, result[0]);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_EQ(CmpBool::TRUE, result[1]);
+  EXPECT_EQ(CmpBool::CmpTrue, result[1]);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_EQ(CmpBool::TRUE, result[2]);
+  EXPECT_EQ(CmpBool::CmpTrue, result[2]);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_EQ(CmpBool::TRUE, result[3]);
+  EXPECT_EQ(CmpBool::CmpTrue, result[3]);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_EQ(CmpBool::FALSE, result[4]);
+  EXPECT_EQ(CmpBool::CmpFalse, result[4]);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_EQ(CmpBool::FALSE, result[5]);
+  EXPECT_EQ(CmpBool::CmpFalse, result[5]);
 }
 
 void CheckGreaterThan(type::Value &v1, type::Value &v2) {
   CmpBool result[6];
   result[0] = v1.CompareEquals(v2);
-  EXPECT_EQ(CmpBool::FALSE, result[0]);
+  EXPECT_EQ(CmpBool::CmpFalse, result[0]);
   result[1] = v1.CompareNotEquals(v2);
-  EXPECT_EQ(CmpBool::TRUE, result[1]);
+  EXPECT_EQ(CmpBool::CmpTrue, result[1]);
   result[2] = v1.CompareLessThan(v2);
-  EXPECT_EQ(CmpBool::FALSE, result[2]);
+  EXPECT_EQ(CmpBool::CmpFalse, result[2]);
   result[3] = v1.CompareLessThanEquals(v2);
-  EXPECT_EQ(CmpBool::FALSE, result[3]);
+  EXPECT_EQ(CmpBool::CmpFalse, result[3]);
   result[4] = v1.CompareGreaterThan(v2);
-  EXPECT_EQ(CmpBool::TRUE, result[4]);
+  EXPECT_EQ(CmpBool::CmpTrue, result[4]);
   result[5] = v1.CompareGreaterThanEquals(v2);
-  EXPECT_EQ(CmpBool::TRUE, result[5]);
+  EXPECT_EQ(CmpBool::CmpTrue, result[5]);
 }
 
 // Compare two integers

--- a/test/type/timestamp_value_test.cpp
+++ b/test/type/timestamp_value_test.cpp
@@ -102,8 +102,8 @@ TEST_F(TimestampValueTests, ComparisonTest) {
         if (expected_null) {
           EXPECT_EQ(expected_null, result == CmpBool::NULL_);
         } else {
-          EXPECT_EQ(expected, result == CmpBool::TRUE);
-          EXPECT_EQ(!expected, result == CmpBool::FALSE);
+          EXPECT_EQ(expected, result == CmpBool::CmpTrue);
+          EXPECT_EQ(!expected, result == CmpBool::CmpFalse);
         }
       }
     }
@@ -155,7 +155,7 @@ TEST_F(TimestampValueTests, CopyTest) {
   type::Value val0 =
       type::ValueFactory::GetTimestampValue(static_cast<uint64_t>(1000000));
   type::Value val1 = val0.Copy();
-  EXPECT_EQ(CmpBool::TRUE, val0.CompareEquals(val1));
+  EXPECT_EQ(CmpBool::CmpTrue, val0.CompareEquals(val1));
 }
 
 TEST_F(TimestampValueTests, CastTest) {

--- a/test/type/type_util_test.cpp
+++ b/test/type/type_util_test.cpp
@@ -129,8 +129,8 @@ TEST_F(TypeUtilTests, CompareEqualsRawTest) {
   const int num_cols = (int)schema->GetColumnCount();
   for (int tuple_idx = 1; tuple_idx < 3; tuple_idx++) {
     CmpBool expected = (tuple_idx == 2 ?
-                                CmpBool::TRUE :
-                                CmpBool::FALSE);
+                                CmpBool::CmpTrue :
+                                CmpBool::CmpFalse);
 
     for (int i = 0; i < num_cols; i++) {
       const char* val0 = tuples[0]->GetDataPtr(i);
@@ -229,10 +229,10 @@ TEST_F(TypeUtilTests, CompareStringsTest) {
           CmpBool result = type::GetCmpBool(
               type::TypeUtil::CompareStrings(str1.c_str(), i,
                                              str2.c_str(), j) < 0);
-          if (result != CmpBool::TRUE) {
+          if (result != CmpBool::CmpTrue) {
             LOG_ERROR("INVALID '%s' < '%s'", str1.c_str(), str2.c_str());
           }
-          EXPECT_EQ(CmpBool::TRUE, result);
+          EXPECT_EQ(CmpBool::CmpTrue, result);
         } // FOR (upper2)
       } // FOR (str2)
     } // FOR (upper1)

--- a/test/type/value_factory_test.cpp
+++ b/test/type/value_factory_test.cpp
@@ -109,7 +109,7 @@ TEST_F(ValueFactoryTests, CastTest) {
   EXPECT_EQ(v3.GetTypeId(), type::TypeId::VARCHAR);
 
   type::Value v4(type::ValueFactory::Clone(v3));
-  EXPECT_TRUE(v3.CompareEquals(v4) == CmpBool::TRUE);
+  EXPECT_TRUE(v3.CompareEquals(v4) == CmpBool::CmpTrue);
 
   type::Value v5(type::ValueFactory::CastAsVarchar(type::Value(type::TypeId::TINYINT, (int8_t)type::PELOTON_INT8_MAX)));
   EXPECT_EQ(v5.ToString(), "127");
@@ -161,7 +161,7 @@ TEST_F(ValueFactoryTests, SerializationTest) {
       type::Value expected = (expect_min ?
                                 type::Type::GetMinValue(col_type) :
                                 type::Type::GetMaxValue(col_type));
-      EXPECT_EQ(CmpBool::TRUE, v.CompareEquals(expected));
+      EXPECT_EQ(CmpBool::CmpTrue, v.CompareEquals(expected));
     }
   }
 }

--- a/test/type/value_test.cpp
+++ b/test/type/value_test.cpp
@@ -45,7 +45,7 @@ TEST_F(ValueTests, HashTest) {
               max_val.ToString().c_str(), min_val.ToString().c_str());
 
     // They should not be equal
-    EXPECT_EQ(CmpBool::FALSE, max_val.CompareEquals(min_val));
+    EXPECT_EQ(CmpBool::CmpFalse, max_val.CompareEquals(min_val));
 
     // Nor should their hash values be equal
     auto max_hash = max_val.Hash();
@@ -55,7 +55,7 @@ TEST_F(ValueTests, HashTest) {
     // But if I copy the first value then the hashes should be the same
     auto copyVal = max_val.Copy();
     auto copyHash = copyVal.Hash();
-    EXPECT_EQ(CmpBool::TRUE, max_val.CompareEquals(copyVal));
+    EXPECT_EQ(CmpBool::CmpTrue, max_val.CompareEquals(copyVal));
     EXPECT_EQ(max_hash, copyHash);
   }  // FOR
 }
@@ -69,8 +69,8 @@ TEST_F(ValueTests, MinMaxTest) {
     if (col_type == type::TypeId::VARCHAR) {
       max_val = type::ValueFactory::GetVarcharValue(std::string("AAA"), nullptr);
       min_val = type::ValueFactory::GetVarcharValue(std::string("ZZZ"), nullptr);
-      EXPECT_EQ(CmpBool::FALSE, min_val.CompareLessThan(max_val));
-      EXPECT_EQ(CmpBool::FALSE, max_val.CompareGreaterThan(min_val));
+      EXPECT_EQ(CmpBool::CmpFalse, min_val.CompareLessThan(max_val));
+      EXPECT_EQ(CmpBool::CmpFalse, max_val.CompareGreaterThan(min_val));
     }
 
     // FIXME: Broken types!!!
@@ -78,14 +78,14 @@ TEST_F(ValueTests, MinMaxTest) {
     LOG_DEBUG("MinMax: %s", TypeIdToString(col_type).c_str());
 
     // Check that we always get the correct MIN value
-    EXPECT_EQ(CmpBool::TRUE, min_val.Min(min_val).CompareEquals(min_val));
-    EXPECT_EQ(CmpBool::TRUE, min_val.Min(max_val).CompareEquals(min_val));
-    EXPECT_EQ(CmpBool::TRUE, min_val.Min(min_val).CompareEquals(min_val));
+    EXPECT_EQ(CmpBool::CmpTrue, min_val.Min(min_val).CompareEquals(min_val));
+    EXPECT_EQ(CmpBool::CmpTrue, min_val.Min(max_val).CompareEquals(min_val));
+    EXPECT_EQ(CmpBool::CmpTrue, min_val.Min(min_val).CompareEquals(min_val));
 
     // Check that we always get the correct MAX value
-    EXPECT_EQ(CmpBool::TRUE, max_val.Max(min_val).CompareEquals(max_val));
-    EXPECT_EQ(CmpBool::TRUE, min_val.Max(max_val).CompareEquals(max_val));
-    EXPECT_EQ(CmpBool::TRUE, max_val.Max(min_val).CompareEquals(max_val));
+    EXPECT_EQ(CmpBool::CmpTrue, max_val.Max(min_val).CompareEquals(max_val));
+    EXPECT_EQ(CmpBool::CmpTrue, min_val.Max(max_val).CompareEquals(max_val));
+    EXPECT_EQ(CmpBool::CmpTrue, max_val.Max(min_val).CompareEquals(max_val));
   } // FOR
 }
 
@@ -106,7 +106,7 @@ TEST_F(ValueTests, VarcharCopyTest) {
 
     // But their underlying data should be equal
     auto result = val1.CompareEquals(val2);
-    EXPECT_EQ(CmpBool::TRUE, result);
+    EXPECT_EQ(CmpBool::CmpTrue, result);
   }  // FOR
 }
 }


### PR DESCRIPTION
First step of changing the ReadWriteSet. Currently the unordered_map is changed to tbb::concurrent_unordered_map. If this passes the Jenkins build, the next step would be to modify the ReadWriteSet type to tbb::concurrent_unordered_map<ItemPointer, RWType>. 