### PR TITLE
Fix index tests

### DIFF
--- a/test/index/testing_index_util.cpp
+++ b/test/index/testing_index_util.cpp
@@ -104,7 +104,7 @@ void TestingIndexUtil::UniqueKeyInsertTest(const IndexType index_type) {
 
   // INDEX
   std::unique_ptr<index::Index, void (*)(index::Index *)> index(
-      TestingIndexUtil::BuildIndex(index_type, false), DestroyIndex);
+      TestingIndexUtil::BuildIndex(index_type, true), DestroyIndex);
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Single threaded test
@@ -151,10 +151,10 @@ void TestingIndexUtil::UniqueKeyDeleteTest(const IndexType index_type) {
 
   key0->SetValue(0, type::ValueFactory::GetIntegerValue(100), pool);
   key0->SetValue(1, type::ValueFactory::GetVarcharValue("a"), pool);
-  key2->SetValue(0, type::ValueFactory::GetIntegerValue(100), pool);
-  key2->SetValue(1, type::ValueFactory::GetVarcharValue("b"), pool);
   key1->SetValue(0, type::ValueFactory::GetIntegerValue(100), pool);
-  key1->SetValue(1, type::ValueFactory::GetVarcharValue("c"), pool);
+  key1->SetValue(1, type::ValueFactory::GetVarcharValue("b"), pool);
+  key2->SetValue(0, type::ValueFactory::GetIntegerValue(100), pool);
+  key2->SetValue(1, type::ValueFactory::GetVarcharValue("c"), pool);
 
   LOG_DEBUG("INDEX CONTENTS:\n%s",
            index::IndexUtil::Debug(index.get()).c_str());
@@ -278,7 +278,7 @@ void TestingIndexUtil::UniqueKeyMultiThreadedTest(const IndexType index_type) {
 
   // INDEX
   std::unique_ptr<index::Index, void (*)(index::Index *)> index(
-      TestingIndexUtil::BuildIndex(index_type, false), DestroyIndex);
+      TestingIndexUtil::BuildIndex(index_type, true), DestroyIndex);
   const catalog::Schema *key_schema = index->GetKeySchema();
 
   // Parallel Test


### PR DESCRIPTION
Some of the index tests were not correctly creating unique-key indexes. UniqueKeyDeleteTest was also checking the wrong keys. This is for 15-721 project 2.