### PR TITLE
Modify StatsStorage::GetTableStats() to take a txn as a parameter instead creating a new one

### DIFF
--- a/src/binder/binder_context.cpp
+++ b/src/binder/binder_context.cpp
@@ -37,10 +37,8 @@ void BinderContext::AddRegularTable(const std::string db_name,
                                     const std::string table_alias,
                                     concurrency::TransactionContext *txn) {
   // using catalog object to retrieve meta-data
-  // PL_ASSERT(txn->catalog_cache.GetDatabaseObject(db_name) != nullptr);
   auto table_object =
     catalog::Catalog::GetInstance()->GetTableObject(db_name, table_name, txn);
-    // txn->catalog_cache.GetDatabaseObject(db_name)->GetTableObject(table_name, true);
 
   if (regular_table_alias_map_.find(table_alias) !=
           regular_table_alias_map_.end() ||

--- a/src/include/optimizer/cost_calculator.h
+++ b/src/include/optimizer/cost_calculator.h
@@ -21,7 +21,8 @@ class Memo;
 // Derive cost for a physical group expressionh
 class CostCalculator : public OperatorVisitor {
  public:
-  double CalculateCost(GroupExpression *gexpr, Memo *memo);
+  double CalculateCost(GroupExpression *gexpr, Memo *memo,
+                       concurrency::TransactionContext *txn);
 
   void Visit(const DummyScan *) override;
   void Visit(const PhysicalSeqScan *) override;
@@ -53,6 +54,7 @@ class CostCalculator : public OperatorVisitor {
 
   GroupExpression *gexpr_;
   Memo *memo_;
+  concurrency::TransactionContext *txn_;
   double output_cost_ = 0;
 };
 

--- a/src/include/optimizer/optimizer_metadata.h
+++ b/src/include/optimizer/optimizer_metadata.h
@@ -29,7 +29,7 @@ class OptimizerMetadata {
   Memo memo;
   RuleSet rule_set;
   OptimizerTaskPool *task_pool;
-  catalog::CatalogCache* catalog_cache;
+  concurrency::TransactionContext* txn;
 
   void SetTaskPool(OptimizerTaskPool *task_pool) {
     this->task_pool = task_pool;

--- a/src/include/optimizer/stats/stats_storage.h
+++ b/src/include/optimizer/stats/stats_storage.h
@@ -62,17 +62,21 @@ class StatsStorage {
                                                   oid_t table_id,
                                                   oid_t column_id);
 
-  std::shared_ptr<TableStats> GetTableStats(oid_t database_id, oid_t table_id);
+  std::shared_ptr<TableStats> GetTableStats(
+      oid_t database_id, oid_t table_id, concurrency::TransactionContext *txn);
 
-  std::shared_ptr<TableStats> GetTableStats(oid_t database_id, oid_t table_id,
-                                            std::vector<oid_t> column_ids);
+  std::shared_ptr<TableStats> GetTableStats(
+      oid_t database_id, oid_t table_id, std::vector<oid_t> column_ids,
+      concurrency::TransactionContext *txn);
 
   /* Functions for triggerring stats collection */
 
-  ResultType AnalyzeStatsForAllTables(concurrency::TransactionContext *txn = nullptr);
+  ResultType AnalyzeStatsForAllTables(
+      concurrency::TransactionContext *txn = nullptr);
 
-  ResultType AnalyzeStatsForTable(storage::DataTable *table,
-                                  concurrency::TransactionContext *txn = nullptr);
+  ResultType AnalyzeStatsForTable(
+      storage::DataTable *table,
+      concurrency::TransactionContext *txn = nullptr);
 
   ResultType AnalayzeStatsForColumns(storage::DataTable *table,
                                      std::vector<std::string> column_names);

--- a/src/include/optimizer/stats_calculator.h
+++ b/src/include/optimizer/stats_calculator.h
@@ -27,7 +27,7 @@ class TableStats;
 class StatsCalculator : public OperatorVisitor {
  public:
   void CalculateStats(GroupExpression *gexpr, ExprSet required_cols,
-                      Memo *memo);
+                      Memo *memo, concurrency::TransactionContext* txn);
 
   void Visit(const LogicalGet *) override;
   void Visit(const LogicalQueryDerivedGet *) override;
@@ -75,6 +75,7 @@ class StatsCalculator : public OperatorVisitor {
   GroupExpression *gexpr_;
   ExprSet required_cols_;
   Memo *memo_;
+  concurrency::TransactionContext* txn_;
 };
 
 }  // namespace optimizer

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -110,7 +110,6 @@ shared_ptr<planner::AbstractPlan> Optimizer::BuildPelotonPlanTree(
       make_shared<binder::BindNodeVisitor>(txn, default_database_name);
   bind_node_visitor->BindNameToNode(parse_tree);
 
-  metadata_.catalog_cache = &txn->catalog_cache;
   // Handle ddl statement
   bool is_ddl_stmt;
   auto ddl_plan = HandleDDLStatement(parse_tree, is_ddl_stmt, txn);
@@ -118,6 +117,7 @@ shared_ptr<planner::AbstractPlan> Optimizer::BuildPelotonPlanTree(
     return move(ddl_plan);
   }
 
+  metadata_.txn = txn;
   // Generate initial operator tree from query tree
   shared_ptr<GroupExpression> gexpr = InsertQueryTree(parse_tree, txn);
   GroupID root_id = gexpr->GetGroupID();

--- a/src/optimizer/optimizer_task.cpp
+++ b/src/optimizer/optimizer_task.cpp
@@ -249,7 +249,8 @@ void DeriveStats::execute() {
   }
 
   StatsCalculator calculator;
-  calculator.CalculateStats(gexpr_, required_cols_, &context_->metadata->memo);
+  calculator.CalculateStats(gexpr_, required_cols_, &context_->metadata->memo,
+                            context_->metadata->txn);
   gexpr_->SetDerivedStats();
 }
 //===--------------------------------------------------------------------===//
@@ -291,8 +292,8 @@ void OptimizeInputs::execute() {
       // 1. Collect stats needed and cache them in the group
       // 2. Calculate cost based on children's stats
       CostCalculator cost_calculator;
-      cur_total_cost_ +=
-          cost_calculator.CalculateCost(group_expr_, &context_->metadata->memo);
+      cur_total_cost_ += cost_calculator.CalculateCost(
+          group_expr_, &context_->metadata->memo, context_->metadata->txn);
     }
 
     for (; cur_child_idx_ < (int)group_expr_->GetChildrenGroupsSize();
@@ -367,7 +368,8 @@ void OptimizeInputs::execute() {
               std::make_shared<PropertySet>(extended_output_properties);
           CostCalculator cost_calculator;
           cur_total_cost_ += cost_calculator.CalculateCost(
-              memo_enforced_expr, &context_->metadata->memo);
+              memo_enforced_expr, &context_->metadata->memo,
+              context_->metadata->txn);
 
           // Update hash tables for group and group expression
           memo_enforced_expr->SetLocalHashTable(

--- a/src/optimizer/stats_calculator.cpp
+++ b/src/optimizer/stats_calculator.cpp
@@ -27,10 +27,12 @@ namespace peloton {
 namespace optimizer {
 
 void StatsCalculator::CalculateStats(GroupExpression *gexpr,
-                                     ExprSet required_cols, Memo *memo) {
+                                     ExprSet required_cols, Memo *memo,
+                                     concurrency::TransactionContext *txn) {
   gexpr_ = gexpr;
   memo_ = memo;
   required_cols_ = required_cols;
+  txn_ = txn;
   gexpr->Op().Accept(this);
 }
 
@@ -41,7 +43,7 @@ void StatsCalculator::Visit(const LogicalGet *op) {
   }
   auto table_stats = std::dynamic_pointer_cast<TableStats>(
       StatsStorage::GetInstance()->GetTableStats(op->table->GetDatabaseOid(),
-                                                 op->table->GetTableOid()));
+                                                 op->table->GetTableOid(), txn_));
   // First, get the required stats of the base table
   std::unordered_map<std::string, std::shared_ptr<ColumnStats>> required_stats;
   for (auto &col : required_cols_) {

--- a/test/optimizer/selectivity_test.cpp
+++ b/test/optimizer/selectivity_test.cpp
@@ -80,7 +80,9 @@ TEST_F(SelectivityTests, RangeSelectivityTest) {
   oid_t table_id = table->GetOid();
   std::string column_name = "test.id";  // first column
   auto stats_storage = StatsStorage::GetInstance();
-  auto table_stats = stats_storage->GetTableStats(db_id, table_id);
+  txn = txn_manager.BeginTransaction();
+  auto table_stats = stats_storage->GetTableStats(db_id, table_id, txn);
+  txn_manager.CommitTransaction(txn);
   type::Value value1 = type::ValueFactory::GetIntegerValue(nrow / 4);
   ValueCondition condition{column_name, ExpressionType::COMPARE_LESSTHAN,
                            value1};
@@ -93,7 +95,9 @@ TEST_F(SelectivityTests, RangeSelectivityTest) {
   TestingSQLUtil::ExecuteSQLQuery("ANALYZE test");
 
   // Get updated table stats and check new selectivity
-  table_stats = stats_storage->GetTableStats(db_id, table_id);
+  txn = txn_manager.BeginTransaction();
+  table_stats = stats_storage->GetTableStats(db_id, table_id, txn);
+  txn_manager.CommitTransaction(txn);
   double less_than_sel =
       Selectivity::ComputeSelectivity(table_stats, condition);
   ExpectSelectivityEqual(less_than_sel, 0.25);
@@ -136,8 +140,11 @@ TEST_F(SelectivityTests, LikeSelectivityTest) {
   oid_t table_id = data_table->GetOid();
 
   auto stats_storage = StatsStorage::GetInstance();
-  auto table_stats = stats_storage->GetTableStats(db_id, table_id);
-  table_stats->SetTupleSampler(std::make_shared<TupleSampler>(data_table.get()));
+  txn = txn_manager.BeginTransaction();
+  auto table_stats = stats_storage->GetTableStats(db_id, table_id, txn);
+  txn_manager.CommitTransaction(txn);
+  table_stats->SetTupleSampler(
+      std::make_shared<TupleSampler>(data_table.get()));
 
   type::Value value = type::ValueFactory::GetVarcharValue("%3");
   ValueCondition condition1{"test_table.COL_D", ExpressionType::COMPARE_LIKE,
@@ -181,7 +188,9 @@ TEST_F(SelectivityTests, EqualSelectivityTest) {
   oid_t table_id = table->GetOid();
   std::string column_name1 = "test.b";
   auto stats_storage = StatsStorage::GetInstance();
-  auto table_stats = stats_storage->GetTableStats(db_id, table_id);
+  txn = txn_manager.BeginTransaction();
+  auto table_stats = stats_storage->GetTableStats(db_id, table_id, txn);
+  txn_manager.CommitTransaction(txn);
 
   type::Value value1 = type::ValueFactory::GetDecimalValue(1.0);
 
@@ -193,7 +202,9 @@ TEST_F(SelectivityTests, EqualSelectivityTest) {
 
   // Run analyze
   TestingSQLUtil::ExecuteSQLQuery("ANALYZE test");
-  table_stats = stats_storage->GetTableStats(db_id, table_id);
+  txn = txn_manager.BeginTransaction();
+  table_stats = stats_storage->GetTableStats(db_id, table_id, txn);
+  txn_manager.CommitTransaction(txn);
 
   // Check selectivity
   // equal, in mcv
@@ -224,7 +235,9 @@ TEST_F(SelectivityTests, EqualSelectivityTest) {
 
   // Run analyze
   TestingSQLUtil::ExecuteSQLQuery("ANALYZE test");
-  table_stats = stats_storage->GetTableStats(db_id, table_id);
+  txn = txn_manager.BeginTransaction();
+  table_stats = stats_storage->GetTableStats(db_id, table_id, txn);
+  txn_manager.CommitTransaction(txn);
 
   // Check selectivity
   // equal, not in mcv

--- a/test/optimizer/stats_storage_test.cpp
+++ b/test/optimizer/stats_storage_test.cpp
@@ -248,8 +248,10 @@ TEST_F(StatsStorageTests, GetTableStatsTest) {
   stats_storage->AnalyzeStatsForAllTables(txn);
   txn_manager.CommitTransaction(txn);
 
+  txn = txn_manager.BeginTransaction();
   std::shared_ptr<TableStats> table_stats = stats_storage->GetTableStats(
-      data_table->GetDatabaseOid(), data_table->GetOid());
+      data_table->GetDatabaseOid(), data_table->GetOid(), txn);
+  txn_manager.CommitTransaction(txn);
   EXPECT_EQ(table_stats->num_rows, tuple_count);
 }
 


### PR DESCRIPTION
As @poojanilangekar and @yingjunwu mentioned in previous emails, when visiting `ColumnStatsCatalog`, the stats storage use a `concurrency::TransactionContext*`  passed in as a parameter instead of creating a new one. This is a quick fix for that.