### PR TITLE
Initial Junit JDBC tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 *~
 # Merge files created by git.
 *.orig
+# Java bytecode
+*.class
 # Byte compiled python modules.
 *.pyc
 # vim swap files

--- a/script/testing/junit/InsertPSTest.java
+++ b/script/testing/junit/InsertPSTest.java
@@ -1,0 +1,465 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// InsertPSTest.java
+//
+// Identification: script/testing/junit/InsertPSTest.java
+//
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+
+/**
+ * 1 and 2 tuple, prepared insert statement tests.
+ */
+
+import java.sql.*;
+import org.junit.*;
+import static org.junit.Assert.assertEquals;
+
+public class InsertPSTest extends PLTestBase {
+    private Connection conn;
+    private ResultSet rs;
+    private String s_sql = "SELECT * FROM tbl;";    
+
+    private static final String SQL_DROP_TABLE =
+            "DROP TABLE IF EXISTS tbl;";
+
+    private static final String SQL_CREATE_TABLE =
+            "CREATE TABLE tbl (" +
+                    "c1 int NOT NULL PRIMARY KEY, " +
+                    "c2 int," +
+                    "c3 int);";
+
+    /**
+     * Initialize the database and table for testing
+     */
+    private void InitDatabase() throws SQLException {
+        Statement stmt = conn.createStatement();
+        stmt.execute(SQL_DROP_TABLE);
+        stmt.execute(SQL_CREATE_TABLE);
+    }
+
+    /**
+     * Get columns, for follow on value checking, using a
+     * prepared statement
+     */
+    private void getResultsPS() throws SQLException {
+        rs = conn.prepareStatement(s_sql).executeQuery();
+    }
+	
+    @Before
+    public void Setup() throws SQLException {
+	conn = makeDefaultConnection();
+	conn.setAutoCommit(true);
+	InitDatabase();
+    }
+
+    @After
+    public void Teardown() throws SQLException {
+        Statement stmt = conn.createStatement();
+        stmt.execute(SQL_DROP_TABLE);
+    }
+
+    /**
+     * Set column values.
+     *
+     * @param pstmt   prepared statement to receive values
+     * @param values  array of values
+     */
+    public void setValues(PreparedStatement pstmt,
+			  int [] values) throws SQLException {
+	int col = 1;
+	for (int i=0; i<values.length; i++) {
+	    pstmt.setInt(col++, (int) values[i]);
+	}
+    }
+
+    /**
+     * Check a single row of queried values against expected values
+     *
+     * @param rs              resultset, with cursor at the desired row
+     * @param columns         column names
+     * @param expected_values expected values of columns
+     */
+
+    public void checkRow(ResultSet rs,
+			 String [] columns,
+			 int [] expected_values) throws SQLException {
+        assertEquals(columns.length, expected_values.length);
+	for (int i=0; i<columns.length; i++) {
+	    assertEquals(rs.getInt(columns[i]), expected_values[i]);
+	}
+    }
+    
+    /**
+     * Prepared statement, 1 tuple insert, with no column specification.
+     */
+    @Test
+    public void testPS_1Tuple_NCS() throws SQLException {
+	
+        String sql = "INSERT INTO tbl VALUES (?, ?, ?);";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+	setValues(pstmt, new int [] {1, 2, 3});
+        pstmt.addBatch();
+        pstmt.executeBatch();
+
+        String s_sql = "SELECT * FROM tbl;";
+        PreparedStatement p_s_stmt = conn.prepareStatement(s_sql);
+        ResultSet rs = p_s_stmt.executeQuery();
+
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {1, 2, 3});
+        assertNoMoreRows(rs);
+    }
+
+    /**
+     * Prepared statement, 1 tuple insert, with columns inserted
+     * in schema order.
+     */
+    @Test
+    public void testPS_1Tuple_CS_1() throws SQLException {
+	
+        String sql = "INSERT INTO tbl (c1, c2, c3) VALUES (?, ?, ?);";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+	
+	setValues(pstmt, new int [] {1, 2, 3});	
+        pstmt.addBatch();
+        pstmt.executeBatch();
+
+	getResultsPS();
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {1, 2, 3});
+        assertNoMoreRows(rs);
+    }
+
+    /**
+     * Prepared statement, 1 tuple insert, with columns inserted
+     * in different order from schema.
+     */
+
+    // Currently fails. See #1197
+    //@Test
+    public void testPS_1Tuple_CS_2() throws SQLException {
+	
+        String sql = "INSERT INTO tbl (c3, c1, c2) VALUES (?, ?, ?);";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+	
+	setValues(pstmt, new int [] {3, 1, 2});		
+        pstmt.addBatch();
+        pstmt.executeBatch();
+
+	getResultsPS();
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {1, 2, 3});
+        assertNoMoreRows(rs);
+    }
+
+    /**
+     * Prepared statement, 1 tuple insert, with columns inserted
+     * in different order from schema, with one constant column.
+     */
+
+    // Currently fails. See #1197
+    // @Test
+    public void testPS_1Tuple_CS_3() throws SQLException {
+
+        String sql = "INSERT INTO tbl (c3, c1, c2) VALUES (?, 1, ?);";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+	setValues(pstmt, new int [] {3, 2});			
+
+        pstmt.addBatch();
+        pstmt.executeBatch();
+
+	getResultsPS();
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {1, 2, 3});
+        assertNoMoreRows(rs);
+    }
+
+    /**
+     * Prepared statement, 1 tuple insert, with columns inserted
+     * in schema order, with 2nd column missing.
+     */
+    @Test
+    public void testPS_1Tuple_CS_4() throws SQLException {
+
+        String sql = "INSERT INTO tbl (c1, c3) VALUES (?, ?);";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+	setValues(pstmt, new int [] {1, 3});	
+
+        pstmt.addBatch();
+        pstmt.executeBatch();
+
+	getResultsPS();
+	// shouldn't the default be null?
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {1, 0, 3});
+        assertNoMoreRows(rs);
+    }
+    
+    /* --------------------------------------------
+     * 2 tuple insertions
+    * ---------------------------------------------
+    */
+
+    /**
+     * Prepared statement, 2 tuple insert, with no column specification.
+     */
+    @Test
+    public void testPS_2Tuple_NCS() throws SQLException {
+	
+        String sql = "INSERT INTO tbl VALUES (?, ?, ?);";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+	setValues(pstmt, new int [] {1, 2, 3});	
+        pstmt.addBatch();
+	
+	setValues(pstmt, new int [] {11, 12, 13});		
+        pstmt.addBatch();	
+        pstmt.executeBatch();
+
+	getResultsPS();
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {1, 2, 3});
+	
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {11, 12, 13});
+        assertNoMoreRows(rs);
+    }
+
+    /**
+     * Prepared statement, 2 tuple insert, with column inserted
+     * in schema order
+     * 
+     */
+    @Test
+    public void testPS_2Tuple_CS_1() throws SQLException {
+	
+        String sql = "INSERT INTO tbl (c1, c2, c3) VALUES (?, ?, ?);";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+	setValues(pstmt, new int [] {1, 2, 3});	
+        pstmt.addBatch();
+	
+	setValues(pstmt, new int [] {11, 12, 13});		
+        pstmt.addBatch();	
+        pstmt.executeBatch();
+
+	getResultsPS();
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {1, 2, 3});
+	
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {11, 12, 13});
+        assertNoMoreRows(rs);
+    }
+
+    /**
+     * Prepared statement, 2 tuple insert, with columns inserted
+     * in different order from schema.
+     */
+    // Currently fails. See #1197
+    //@Test
+    public void testPS_2Tuple_CS_2() throws SQLException {
+	
+        String sql = "INSERT INTO tbl (c3, c1, c2) VALUES (?, ?, ?);";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+	
+	setValues(pstmt, new int [] {3, 2, 1});
+        pstmt.addBatch();
+	
+	setValues(pstmt, new int [] {13, 11, 12});
+        pstmt.addBatch();
+        pstmt.executeBatch();
+
+	getResultsPS();
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {1, 2, 3});
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {11, 12, 13});
+        assertNoMoreRows(rs);
+    }
+
+    /**
+     * Prepared statement, 2 tuple insert, with columns inserted
+     * in different order from schema, with one constant column.
+     */
+    // Currently fails. See #1197
+    //@Test
+    public void testPS_2Tuple_CS_3() throws SQLException {
+
+        String sql = "INSERT INTO tbl (c3, c1, c2) VALUES (?, 1, ?);";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+	setValues(pstmt, new int [] {3, 2});
+        pstmt.addBatch();
+	
+	setValues(pstmt, new int [] {13, 12});
+        pstmt.addBatch();	
+        pstmt.executeBatch();
+
+	getResultsPS();
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {1, 2, 3});
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {1, 12, 13});
+        assertNoMoreRows(rs);
+    }
+    
+    /**
+     * Prepared statement, 2 tuple insert, with columns inserted
+     * in schema order, with 2nd column missing.
+     */
+    // Currently failing. See comments in #1197
+    // @Test
+    public void testPS_2Tuple_CS_4() throws SQLException {
+
+        String sql = "INSERT INTO tbl (c1, c3) VALUES (?, ?);";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+	setValues(pstmt, new int [] {1, 3});
+        pstmt.addBatch();
+	
+	setValues(pstmt, new int [] {11, 13});	
+        pstmt.addBatch();
+        pstmt.executeBatch();
+
+	getResultsPS();
+	// shouldn't the default be null?
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {1, 0, 3});
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {11, 0, 13});
+        assertNoMoreRows(rs);
+    }
+    
+
+    /* --------------------------------------------
+     * simple (non-prepared) insert statement tests
+    * ---------------------------------------------
+    */
+    
+    /**
+     * 1 tuple insert, with no column specification.
+     */
+    //@Test
+    public void test_1Tuple_NCS() throws SQLException {
+	
+        String sql = "INSERT INTO tbl VALUES (1, 2, 3);";
+        Statement stmt = conn.createStatement();
+        stmt.execute(sql);
+
+        String s_sql = "SELECT * FROM tbl;";
+        Statement s_stmt = conn.createStatement();
+        ResultSet rs = s_stmt.executeQuery(s_sql);
+	
+        rs.next();
+        assertEquals(rs.getInt("c1"), 1);
+        assertEquals(rs.getInt("c2"), 2);
+        assertEquals(rs.getInt("c3"), 3);
+        assertNoMoreRows(rs);
+    }
+
+    /**
+     * 1 tuple insert, with columns inserted in schema order.
+     */
+    //@Test
+    public void test_1Tuple_CS_1() throws SQLException {
+	
+        String sql = "INSERT INTO tbl (c1, c2, c3) VALUES (1, 2, 3);";
+        Statement stmt = conn.createStatement();
+        stmt.execute(sql);
+
+        String s_sql = "SELECT * FROM tbl;";
+        Statement s_stmt = conn.createStatement();
+        ResultSet rs = s_stmt.executeQuery(s_sql);
+
+        rs.next();
+        assertEquals(rs.getInt("c1"), 1);
+        assertEquals(rs.getInt("c2"), 2);
+        assertEquals(rs.getInt("c3"), 3);
+        assertNoMoreRows(rs);
+    }
+
+    /**
+     * 1 tuple insert, with columns inserted in different order from schema.
+     */
+    //@Test
+    public void test_1Tuple_CS_2() throws SQLException {
+	
+        String sql = "INSERT INTO tbl (c3, c1, c2) VALUES (3, 1, 2);";
+        Statement stmt = conn.createStatement();
+        stmt.execute(sql);
+
+        String s_sql = "SELECT * FROM tbl;";
+        Statement s_stmt = conn.createStatement();
+        ResultSet rs = s_stmt.executeQuery(s_sql);
+
+        rs.next();
+        assertEquals(rs.getInt("c1"), 1);
+        assertEquals(rs.getInt("c2"), 2);
+        assertEquals(rs.getInt("c3"), 3);
+        assertNoMoreRows(rs);
+    }
+
+
+    /* 2 tuple inserts */
+    
+    /**
+     * 2 tuple insert, with no column specification.
+     */
+    //@Test
+    public void test_2Tuple_NCS() throws SQLException {
+	
+        String sql = "INSERT INTO tbl VALUES (1, 2, 3), (11, 12, 13);";
+        Statement stmt = conn.createStatement();
+        stmt.execute(sql);
+
+        String s_sql = "SELECT * FROM tbl;";
+        Statement s_stmt = conn.createStatement();
+        ResultSet rs = s_stmt.executeQuery(s_sql);
+
+        rs.next();
+        assertEquals(rs.getInt("c1"), 1);
+        assertEquals(rs.getInt("c2"), 2);
+        assertEquals(rs.getInt("c3"), 3);
+
+        rs.next();
+        assertEquals(rs.getInt("c1"), 11);
+        assertEquals(rs.getInt("c2"), 12);
+        assertEquals(rs.getInt("c3"), 13);
+	
+        assertNoMoreRows(rs);
+    }
+
+    
+}

--- a/script/testing/junit/InsertPSTest.java
+++ b/script/testing/junit/InsertPSTest.java
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 /**
  * 1 and 2 tuple, prepared insert statement tests.
  */
@@ -209,7 +208,31 @@ public class InsertPSTest extends PLTestBase {
 		 new int [] {1, 0, 3});
         assertNoMoreRows(rs);
     }
-    
+
+    /**
+     * Prepared statement, 1 tuple insert, with columns inserted
+     * in schema order, one constant column
+     */
+    // Works, due to use of insert rather than push back
+
+    @Test
+    public void testPS_1Tuple_CS_5() throws SQLException {
+	
+        String sql = "INSERT INTO tbl (c1, c2, c3) VALUES (?, 2, ?);";
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+	
+	setValues(pstmt, new int [] {1, 3});	
+        pstmt.addBatch();
+        pstmt.executeBatch();
+
+	getResultsPS();
+        rs.next();
+	checkRow(rs,
+		 new String [] {"c1", "c2", "c3"},
+		 new int [] {1, 2, 3});
+        assertNoMoreRows(rs);
+    }
+
     /* --------------------------------------------
      * 2 tuple insertions
     * ---------------------------------------------
@@ -431,8 +454,7 @@ public class InsertPSTest extends PLTestBase {
         assertNoMoreRows(rs);
     }
 
-
-    /* 2 tuple inserts */
+    /* 2 tuple (non-prepared statement) inserts */
     
     /**
      * 2 tuple insert, with no column specification.
@@ -460,6 +482,4 @@ public class InsertPSTest extends PLTestBase {
 	
         assertNoMoreRows(rs);
     }
-
-    
 }

--- a/script/testing/junit/InsertTPCCTest.java
+++ b/script/testing/junit/InsertTPCCTest.java
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// InsertTPCCTest.java
+//
+// Identification: script/testing/junit/InsertTPCCTest.java
+//
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+import java.sql.*;
+    
+import org.junit.*;
+import static org.junit.Assert.assertEquals;
+
+
+public class InsertTPCCTest extends PLTestBase {
+    private Connection conn;
+
+    private static final String SQL_DROP_TABLE =
+	"DROP TABLE IF EXISTS oorder;";
+
+    private static final String SQL_CREATE_TABLE =
+	"CREATE TABLE oorder (" +
+	"o_w_id int NOT NULL PRIMARY KEY, " +
+	"o_d_id int NOT NULL PRIMARY KEY, " +
+	"o_id int NOT NULL PRIMARY KEY," +
+	"o_c_id int NOT NULL," +
+	"o_carrier_id int," +
+	"o_ol_cnt decimal NOT NULL," +
+	"o_all_local decimal NOT NULL," +
+	"o_entry_d timestamp NOT NULL);";
+
+    private void InitDatabase() throws SQLException {
+	Statement stmt = conn.createStatement();
+	stmt.execute(SQL_DROP_TABLE);
+	stmt.execute(SQL_CREATE_TABLE);
+    }
+
+    @Before
+    public void Setup() {
+	try {
+	    conn = makeDefaultConnection();
+	    conn.setAutoCommit(true);
+	    InitDatabase();
+        } catch (SQLException ex) {
+	    DumpSQLException(ex);
+	    // throw ex;
+	}
+    }
+
+    @After
+    public void Teardown() throws SQLException {
+	Statement stmt = conn.createStatement();
+	stmt.execute(SQL_DROP_TABLE);
+    }
+
+    
+    @Test
+    public void testPstmtCVInsert() throws SQLException {
+	int col;
+	Timestamp ts = new org.postgresql.util.PGTimestamp((long) 100);
+	
+        String sql = "INSERT INTO oorder " +
+	    "(O_ID, O_D_ID, O_W_ID, O_C_ID, O_ENTRY_D, O_OL_CNT, O_ALL_LOCAL)"+
+	    " VALUES (?, ?, ?, ?, ?, ?, ?)";
+	
+        PreparedStatement pstmt = conn.prepareStatement(sql);
+	col = 1;
+	
+	pstmt.setInt(col++, (int) 1);  //o_id
+	pstmt.setInt(col++, (int) 2);  //o_d_id
+	pstmt.setInt(col++, (int) 3);  //o_w_id
+	pstmt.setInt(col++, (int) 4);  //o_c_id
+	pstmt.setTimestamp(col++, ts); //o_entry_d
+	pstmt.setInt(col++, (int) 6);  //o_ol_count
+	pstmt.setInt(col++, (int) 7);  //o_all_local
+	
+	pstmt.addBatch();
+	pstmt.executeBatch();
+
+	String s_sql = "SELECT * FROM oorder;";
+	PreparedStatement p_s_stmt = conn.prepareStatement(s_sql);
+	ResultSet rs = p_s_stmt.executeQuery();
+
+	rs.next();
+	assertEquals(rs.getInt("o_id"), 1);
+	assertEquals(rs.getInt("o_d_id"), 2);
+	assertEquals(rs.getInt("o_w_id"), 3);
+	assertEquals(rs.getInt("o_c_id"), 4);
+	// skip o_entry_d timestamp
+	assertEquals(rs.getInt("o_ol_cnt"), 6);
+	assertEquals(rs.getInt("o_all_local"), 7);
+	
+	assertNoMoreRows(rs);
+    }
+}

--- a/script/testing/junit/PLTestBase.java
+++ b/script/testing/junit/PLTestBase.java
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// PLTestBase.java
+//
+// Identification: script/testing/junit/PLTestBase.java
+//
+// Copyright (c) 2015-2018, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * Base class (helper functions) for prepared statement tests 
+ */
+
+import java.sql.*;
+import org.junit.*;
+import static org.junit.Assert.assertEquals;
+    
+public class PLTestBase {
+    
+    public static Connection makeDefaultConnection() throws SQLException {
+	return makeConnection("localhost", 15721, "postgres", "postgres");
+    }
+    
+    public static Connection makeConnection(String host,
+					    int port,
+					    String username,
+					    String pass) throws SQLException {
+	String url = String.format("jdbc:postgresql://%s:%d/default_database",
+				   host, port);
+	Connection conn = DriverManager.getConnection(url, username, pass);
+	return conn;
+    }
+
+    public static void assertNoMoreRows(ResultSet rs) throws SQLException {
+	int extra_rows = 0;
+	while(rs.next()) {
+	    extra_rows++;
+	}
+	assertEquals(extra_rows, 0);
+    }
+    
+    public static void DumpSQLException(SQLException ex) {
+	System.err.println("Failed to execute test. Got " +
+			   ex.getClass().getSimpleName());
+	System.err.println(" + Message:    " + ex.getMessage());
+	System.err.println(" + Error Code: " + ex.getErrorCode());
+	System.err.println(" + SQL State:  " + ex.getSQLState());
+    }
+    
+}

--- a/script/testing/junit/Readme.txt
+++ b/script/testing/junit/Readme.txt
@@ -1,0 +1,38 @@
+
+
+This directory contains tests using Junit4 and JDBC and prepared statements.
+
+To compile:
+make
+
+To run, using the Junit console:
+1. Start up the database server, manually, e.g.
+   ./peloton
+
+2. Run the tests, (from this directory):
+   make test
+
+
+If the JUnit console output style is not to your taste,
+they can be run more directly using the Junit runner. Copy the following
+code into a file, and invoke it from this directory, e.g.
+   bash run_tests.sh
+
+# construct the class path
+CP=".:lib/hamcrest-core-1.3.jar:lib/postgresql-9.4.1209.jre6.jar:lib/junit-4.12.jar"
+
+# execute the InsertPSTest class. More than one test class may be
+# supplied on the command line
+java -cp $CP org.junit.runner.JUnitCore InsertPSTest
+
+
+Test notes
+----------
+
+1. The InsertTPCCTest uses a table schema and insert statment from the
+   TPPC benchmark.
+   Peloton fails this test. It will be enabled once fixed.
+
+2. InsertPSTest contains a set of prepared statement tests. The tests that
+   currently do not pass on Peloton are disabled.
+   	     


### PR DESCRIPTION
Partially satisfying #1075.

This initial version focuses on prepared statement tests. A number of the tests fail due to issues documented in #1197. Those tests are currently disabled and will be enabled after the insert plan code is fixed.

