### PR TITLE
Minimal fix for "make check", #1196

### DIFF
--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -37,6 +37,11 @@ namespace concurrency {
 class TransactionContext;
 }
 
+namespace test {
+  class OptimizerRuleTests_SimpleAssociativeRuleTest_Test;
+  class OptimizerRuleTests_SimpleAssociativeRuleTest2_Test;
+} 
+
 namespace optimizer {
 
 struct QueryInfo {
@@ -54,6 +59,9 @@ struct QueryInfo {
 class Optimizer : public AbstractOptimizer {
   friend class BindingIterator;
   friend class GroupBindingIterator;
+
+  friend class ::peloton::test::OptimizerRuleTests_SimpleAssociativeRuleTest_Test;
+  friend class ::peloton::test::OptimizerRuleTests_SimpleAssociativeRuleTest2_Test; 
 
  public:
   Optimizer(const Optimizer &) = delete;

--- a/test/optimizer/optimizer_rule_test.cpp
+++ b/test/optimizer/optimizer_rule_test.cpp
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define private public
-
 #include "binder/bind_node_visitor.h"
 #include "catalog/catalog.h"
 #include "common/harness.h"


### PR DESCRIPTION
This allows "make check" to work. 
A follow up issue has been created, to fix the optimizer tests to use accessor functions.

