### PR TITLE
Add statistics counter to record memory usage

### DIFF
--- a/src/include/index/bwtree.h
+++ b/src/include/index/bwtree.h
@@ -2089,6 +2089,10 @@ class BwTree : public BwTreeBase {
                    AllocationMeta::CHUNK_SIZE()];
       PL_ASSERT(alloc_base != nullptr);
 
+      // Also add to statistics counter
+      AddToMemAllocStatistics(sizeof(ElasticNode) + size * sizeof(ElementType) +
+                              AllocationMeta::CHUNK_SIZE())
+
       // Initialize the AllocationMeta - tail points to the first byte inside
       // class ElasticNode; limit points to the first byte after class
       // AllocationMeta

--- a/src/include/index/bwtree.h
+++ b/src/include/index/bwtree.h
@@ -7412,6 +7412,15 @@ class BwTree : public BwTreeBase {
   }
 
   /*
+   * AddToMemAllocStatistics() - This function adds an amount onto the statistics counter
+   *                             that tracks the total bytes we have allocated
+   */
+  inline void AddToMemAllocStatistics(size_t amount) {
+    mem_alloc.fetch_add(amount);
+    return;
+  }
+
+  /*
    * class EpochManager - Maintains a linked list of deleted nodes
    *                      for threads to access until all threads
    *                      entering epochs before the deletion of

--- a/src/include/index/bwtree.h
+++ b/src/include/index/bwtree.h
@@ -1803,6 +1803,8 @@ class BwTree : public BwTreeBase {
       }
 
       char *new_chunk = new char[CHUNK_SIZE()];
+      // Adding to statistics
+      AddToMemAllocStatistics(CHUNK_SIZE());
       AllocationMeta *expected = nullptr;
 
       // Prepare the new chunk's metadata field
@@ -6517,6 +6519,8 @@ class BwTree : public BwTreeBase {
     *parent_node_id_p = parent_node_id;
 
     InnerAbortNode *abort_node_p = new InnerAbortNode{parent_node_p};
+    // Adding to statistics counter
+    AddToMemAllocStatistics(sizeof(InnerAbortNode));
 
     bool ret =
         InstallNodeToReplace(parent_node_id, abort_node_p, parent_node_p);

--- a/src/include/index/bwtree.h
+++ b/src/include/index/bwtree.h
@@ -7388,11 +7388,18 @@ class BwTree : public BwTreeBase {
   std::atomic<uint64_t> update_op_count;
   std::atomic<uint64_t> update_abort_count;
 
+  // This value records the aggregated number of bytes allodated by BwTree node
+  // allocation function
+  std::atomic<size_t> mem_alloc;
+
   // InteractiveDebugger idb;
 
   EpochManager epoch_manager;
 
  public:
+
+  
+
   /*
    * class EpochManager - Maintains a linked list of deleted nodes
    *                      for threads to access until all threads

--- a/src/include/index/bwtree.h
+++ b/src/include/index/bwtree.h
@@ -2986,8 +2986,7 @@ class BwTree : public BwTreeBase {
    * If both are nullptr then we just traverse and do not do anything
    */
   const KeyValuePair *Traverse(Context *context_p, const ValueType *value_p,
-                               std::pair<int, bool> *index_pair_p,
-                               bool unique_key=false) {
+                               std::pair<int, bool> *index_pair_p) {
     // For value collection it always returns nullptr
     const KeyValuePair *found_pair_p = nullptr;
 
@@ -3073,7 +3072,7 @@ class BwTree : public BwTreeBase {
     } else {
       // If a value is given then use this value to Traverse down leaf
       // page to find whether the value exists or not
-      found_pair_p = NavigateLeafNode(context_p, *value_p, index_pair_p, unique_key);
+      found_pair_p = NavigateLeafNode(context_p, *value_p, index_pair_p);
     }
 
     if (context_p->abort_flag == true) {
@@ -4173,8 +4172,7 @@ class BwTree : public BwTreeBase {
    */
   const KeyValuePair *NavigateLeafNode(Context *context_p,
                                        const ValueType &search_value,
-                                       std::pair<int, bool> *index_pair_p,
-                                       bool unique_key=false) {
+                                       std::pair<int, bool> *index_pair_p) {
     // This will go to the right sibling until we have seen
     // a node whose range match the search key
     NavigateSiblingChain(context_p);
@@ -4219,7 +4217,7 @@ class BwTree : public BwTreeBase {
             // We do not need to check any delete set here, since if the
             // value has been deleted earlier then this function would
             // already have returned
-            if (unique_key == true || ValueCmpEqual(scan_start_it->second, search_value)) {
+            if (ValueCmpEqual(scan_start_it->second, search_value)) {
               // Since only Delete() will use this piece of information
               // we set exist flag to false to indicate that the value
               // has been invalidated
@@ -4247,7 +4245,7 @@ class BwTree : public BwTreeBase {
               static_cast<const LeafInsertNode *>(node_p);
 
           if (KeyCmpEqual(search_key, insert_node_p->item.first)) {
-            if (unique_key == true || ValueCmpEqual(insert_node_p->item.second, search_value)) {
+            if (ValueCmpEqual(insert_node_p->item.second, search_value)) {
               // Only Delete() will use this
               // We just simply inherit from the first node
               *index_pair_p = insert_node_p->GetIndexPair();
@@ -4266,7 +4264,7 @@ class BwTree : public BwTreeBase {
 
           // If the value was deleted then return false
           if (KeyCmpEqual(search_key, delete_node_p->item.first)) {
-            if (unique_key == true || ValueCmpEqual(delete_node_p->item.second, search_value)) {
+            if (ValueCmpEqual(delete_node_p->item.second, search_value)) {
               // Only Insert() will use this
               // We just simply inherit from the first node
               *index_pair_p = delete_node_p->GetIndexPair();
@@ -6995,12 +6993,8 @@ class BwTree : public BwTreeBase {
    *
    * This function returns false if value already exists
    * If CAS fails this function retries until it succeeds
-   * 
-   * Note that this function also takes a unique_key argument, to indicate whether
-   * we allow the same key with different values. For a primary key index this
-   * should be set true. By default we allow non-unique key
    */
-  bool Insert(const KeyType &key, const ValueType &value, bool unique_key=false) {
+  bool Insert(const KeyType &key, const ValueType &value) {
     LOG_TRACE("Insert called");
 
 #ifdef BWTREE_DEBUG
@@ -7017,7 +7011,7 @@ class BwTree : public BwTreeBase {
       // Also if the key previously exists in the delta chain
       // then return the position of the node using next_key_p
       // if there is none then return nullptr
-      const KeyValuePair *item_p = Traverse(&context, &value, &index_pair, unique_key);
+      const KeyValuePair *item_p = Traverse(&context, &value, &index_pair);
 
       // If the key-value pair already exists then return false
       if (item_p != nullptr) {

--- a/src/include/index/bwtree.h
+++ b/src/include/index/bwtree.h
@@ -7398,7 +7398,18 @@ class BwTree : public BwTreeBase {
 
  public:
 
-  
+  /*
+   * GetTotalMemAlloc() - This function returns the total number of bytes
+   *                      allocated by the BwTree
+   * 
+   * 1. The returned value is aggregated value since the bwtree is instanciated
+   *    If you want to get accurate memory allocation in a time interval, call
+   *    this function before and after the interval, and use the difference
+   * 2. Releasing memory does not change this counter. This counter increases monotonically
+   */
+  inline size_t GetTotalMemAlloc() {
+    return mem_alloc.load();
+  }
 
   /*
    * class EpochManager - Maintains a linked list of deleted nodes

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -53,15 +53,20 @@ bool BWTREE_INDEX_TYPE::InsertEntry(const storage::Tuple *key,
   KeyType index_key;
   index_key.SetFromKey(key);
 
-  bool ret = container.Insert(index_key, value);
+  bool ret;
+  if(HasUniqueKeys() == true) {
+    ret = container.Insert(index_key, value, true);
+  } else {
+    ret = container.Insert(index_key, value, false);
+  }
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
-          settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexInserts(metadata);
   }
 
-  LOG_TRACE("InsertEntry(key=%s, val=%s) [%s]",
-            index_key.GetInfo().c_str(),
+  // NOTE: If I use index_key.GetInfo() here, I always get an empty key?
+  LOG_DEBUG("InsertEntry(key=%s, val=%s) [%s]",
+            key->GetInfo().c_str(),
             IndexUtil::GetInfo(value).c_str(),
             (ret ? "SUCCESS" : "FAIL"));
 
@@ -85,14 +90,13 @@ bool BWTREE_INDEX_TYPE::DeleteEntry(const storage::Tuple *key,
   // it is unnecessary for us to allocate memory
   bool ret = container.Delete(index_key, value);
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
-          settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexDeletes(
         delete_count, metadata);
   }
 
-  LOG_TRACE("DeleteEntry(key=%s, val=%s) [%s]",
-            index_key.GetInfo().c_str(),
+  LOG_DEBUG("DeleteEntry(key=%s, val=%s) [%s]",
+            key->GetInfo().c_str(),
             IndexUtil::GetInfo(value).c_str(),
             (ret ? "SUCCESS" : "FAIL"));
 
@@ -122,8 +126,7 @@ bool BWTREE_INDEX_TYPE::CondInsertEntry(
     assert(ret == false);
   }
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
-          settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexInserts(metadata);
   }
 
@@ -197,8 +200,7 @@ void BWTREE_INDEX_TYPE::Scan(
     }
   }  // if is full scan
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
-          settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
         result.size(), metadata);
   }
@@ -222,6 +224,7 @@ void BWTREE_INDEX_TYPE::ScanLimit(
     const std::vector<ExpressionType> &expr_list,
     ScanDirectionType scan_direction, std::vector<ValueType> &result,
     const ConjunctionScanPredicate *csp_p, uint64_t limit, uint64_t offset) {
+
   // Only work with limit == 1 and offset == 0
   // Because that gets translated to "min"
   // But still since we could not access tuples in the table
@@ -243,6 +246,7 @@ void BWTREE_INDEX_TYPE::ScanLimit(
     auto scan_itr = container.Begin(index_low_key);
     if ((scan_itr.IsEnd() == false) &&
         (container.KeyCmpLessEqual(scan_itr->first, index_high_key))) {
+
       result.push_back(scan_itr->second);
     }
   } else {
@@ -263,8 +267,7 @@ void BWTREE_INDEX_TYPE::ScanAllKeys(std::vector<ValueType> &result) {
     it++;
   }
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
-          settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
         result.size(), metadata);
   }
@@ -280,8 +283,7 @@ void BWTREE_INDEX_TYPE::ScanKey(const storage::Tuple *key,
   // This function in BwTree fills a given vector
   container.GetValue(index_key, result);
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
-          settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
         result.size(), metadata);
   }

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -53,20 +53,15 @@ bool BWTREE_INDEX_TYPE::InsertEntry(const storage::Tuple *key,
   KeyType index_key;
   index_key.SetFromKey(key);
 
-  bool ret;
-  if(HasUniqueKeys() == true) {
-    ret = container.Insert(index_key, value, true);
-  } else {
-    ret = container.Insert(index_key, value, false);
-  }
+  bool ret = container.Insert(index_key, value);
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexInserts(metadata);
   }
 
-  // NOTE: If I use index_key.GetInfo() here, I always get an empty key?
-  LOG_DEBUG("InsertEntry(key=%s, val=%s) [%s]",
-            key->GetInfo().c_str(),
+  LOG_TRACE("InsertEntry(key=%s, val=%s) [%s]",
+            index_key.GetInfo().c_str(),
             IndexUtil::GetInfo(value).c_str(),
             (ret ? "SUCCESS" : "FAIL"));
 
@@ -90,13 +85,14 @@ bool BWTREE_INDEX_TYPE::DeleteEntry(const storage::Tuple *key,
   // it is unnecessary for us to allocate memory
   bool ret = container.Delete(index_key, value);
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexDeletes(
         delete_count, metadata);
   }
 
-  LOG_DEBUG("DeleteEntry(key=%s, val=%s) [%s]",
-            key->GetInfo().c_str(),
+  LOG_TRACE("DeleteEntry(key=%s, val=%s) [%s]",
+            index_key.GetInfo().c_str(),
             IndexUtil::GetInfo(value).c_str(),
             (ret ? "SUCCESS" : "FAIL"));
 
@@ -126,7 +122,8 @@ bool BWTREE_INDEX_TYPE::CondInsertEntry(
     assert(ret == false);
   }
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexInserts(metadata);
   }
 
@@ -200,7 +197,8 @@ void BWTREE_INDEX_TYPE::Scan(
     }
   }  // if is full scan
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
         result.size(), metadata);
   }
@@ -224,7 +222,6 @@ void BWTREE_INDEX_TYPE::ScanLimit(
     const std::vector<ExpressionType> &expr_list,
     ScanDirectionType scan_direction, std::vector<ValueType> &result,
     const ConjunctionScanPredicate *csp_p, uint64_t limit, uint64_t offset) {
-
   // Only work with limit == 1 and offset == 0
   // Because that gets translated to "min"
   // But still since we could not access tuples in the table
@@ -246,7 +243,6 @@ void BWTREE_INDEX_TYPE::ScanLimit(
     auto scan_itr = container.Begin(index_low_key);
     if ((scan_itr.IsEnd() == false) &&
         (container.KeyCmpLessEqual(scan_itr->first, index_high_key))) {
-
       result.push_back(scan_itr->second);
     }
   } else {
@@ -267,7 +263,8 @@ void BWTREE_INDEX_TYPE::ScanAllKeys(std::vector<ValueType> &result) {
     it++;
   }
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
         result.size(), metadata);
   }
@@ -283,7 +280,8 @@ void BWTREE_INDEX_TYPE::ScanKey(const storage::Tuple *key,
   // This function in BwTree fills a given vector
   container.GetValue(index_key, result);
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
         result.size(), metadata);
   }


### PR DESCRIPTION
Currently the counter is a shared member variable. Use GetMemAlloc() to obtain aggregated number of bytes allocated for Inner, Leaf and Delta nodes.