### PR TITLE
Suppress Postgres parser mem leaks

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,8 +95,13 @@ foreach(test_src ${test_srcs} )
 	
 	# add test
   add_test(${test_name} ${CMAKE_BINARY_DIR}/test/${test_name} --gtest_color=yes
-           --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${test_name}.xml)
-	
+    --gtest_output=xml:${CMAKE_BINARY_DIR}/test/${test_name}.xml)
+  
+  # leak suppression / whitelist
+  set_property(TEST ${test_name}
+	PROPERTY ENVIRONMENT
+	"LSAN_OPTIONS=suppressions=${PROJECT_SOURCE_DIR}/test/leak_suppr.txt")
+	 
 endforeach(test_src ${test_srcs})
 
 ##################################################################################

--- a/test/leak_suppr.txt
+++ b/test/leak_suppr.txt
@@ -1,0 +1,5 @@
+
+# suppress the leak in the pg_query parser memory management
+# see #1194
+# 
+leak:src_backend_utils_mmgr_mcxt.c


### PR DESCRIPTION
Add a leak suppression file and pass it to make check. On other than sanitizer builds, it will be a no-op.

