### PR TITLE
Fix memory leak in the insert_sql_test [Partial fix for #1212]

### DIFF
--- a/test/sql/insert_sql_test.cpp
+++ b/test/sql/insert_sql_test.cpp
@@ -598,6 +598,7 @@ TEST_F(InsertSQLTests, BadTypes) {
   query = "INSERT INTO foo(id5) VALUES('h');";
   EXPECT_THROW(TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query, txn),
                peloton::Exception);
+  txn_manager.CommitTransaction(txn);
 
   // free the database just created
   txn = txn_manager.BeginTransaction();
@@ -618,6 +619,7 @@ TEST_F(InsertSQLTests, NonExistentTable) {
   txn = txn_manager.BeginTransaction();
   EXPECT_THROW(TestingSQLUtil::GeneratePlanWithOptimizer(optimizer, query, txn),
                peloton::CatalogException);
+  txn_manager.CommitTransaction(txn);
 }
 
 }  // namespace test


### PR DESCRIPTION
I have checked all tests which expect exceptions. This was the only test where the transaction was not explicitly committed. We could abort these transactions but I noticed that most other tests try to commit the transactions which throw exceptions.
 