### PR TITLE
Lockfreearray

### DIFF
--- a/src/common/container/lock_free_array.cpp
+++ b/src/common/container/lock_free_array.cpp
@@ -31,7 +31,6 @@ class IndirectionArray;
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 LOCK_FREE_ARRAY_TYPE::LockFreeArray() {
-  PL_ASSERT(lock_free_array.size() == 0);
   lock_free_array.reserve(LOCK_FREE_ARRAR_INIT_SIZE);
 }
 
@@ -64,6 +63,7 @@ bool LOCK_FREE_ARRAY_TYPE::Erase(const std::size_t &offset,
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 ValueType LOCK_FREE_ARRAY_TYPE::Find(const std::size_t &offset) const {
   LOG_TRACE("Find at %lu", offset);
+  PL_ASSERT(lock_free_array.size() > offset);
   auto value = lock_free_array.at(offset);
   return value;
 }

--- a/src/common/container/lock_free_array.cpp
+++ b/src/common/container/lock_free_array.cpp
@@ -31,7 +31,7 @@ class IndirectionArray;
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 LOCK_FREE_ARRAY_TYPE::LockFreeArray() {
-  lock_free_array.reserve(LOCK_FREE_ARRAR_INIT_SIZE);
+  lock_free_array.reserve(kLockfreeArrayInitSize);
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
@@ -99,13 +99,9 @@ LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 bool LOCK_FREE_ARRAY_TYPE::IsEmpty() const { return lock_free_array.empty(); }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
-void LOCK_FREE_ARRAY_TYPE::Clear(const ValueType &invalid_value) {
+void LOCK_FREE_ARRAY_TYPE::Clear() {
   // Set invalid value for all elements
-
-  for (std::size_t array_itr = 0; array_itr < lock_free_array.size();
-       array_itr++) {
-    lock_free_array.at(array_itr) = invalid_value;
-  }
+  lock_free_array.clear();
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS

--- a/src/common/container/lock_free_array.cpp
+++ b/src/common/container/lock_free_array.cpp
@@ -100,7 +100,6 @@ bool LOCK_FREE_ARRAY_TYPE::IsEmpty() const { return lock_free_array.empty(); }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 void LOCK_FREE_ARRAY_TYPE::Clear() {
-  // Set invalid value for all elements
   lock_free_array.clear();
 }
 

--- a/src/common/container/lock_free_array.cpp
+++ b/src/common/container/lock_free_array.cpp
@@ -19,72 +19,68 @@
 
 namespace peloton {
 
-namespace index{
+namespace index {
 class Index;
 }
 
-namespace storage{
+namespace storage {
 class TileGroup;
 class Database;
 class IndirectionArray;
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
-LOCK_FREE_ARRAY_TYPE::LockFreeArray(){
-  lock_free_array.reset(new lock_free_array_t());
+LOCK_FREE_ARRAY_TYPE::LockFreeArray() {
+  PL_ASSERT(lock_free_array.size() == 0);
+  lock_free_array.reserve(LOCK_FREE_ARRAR_INIT_SIZE);
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
-LOCK_FREE_ARRAY_TYPE::~LockFreeArray(){
-}
+LOCK_FREE_ARRAY_TYPE::~LockFreeArray() { lock_free_array.clear(); }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
-bool LOCK_FREE_ARRAY_TYPE::Update(const std::size_t &offset, ValueType value){
-  PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
-  LOG_TRACE("Update at %lu", lock_free_array_offset.load());
-  lock_free_array->at(offset) =  value;
+bool LOCK_FREE_ARRAY_TYPE::Update(const std::size_t &offset, ValueType value) {
+  LOG_TRACE("Update at %lu", offset);
+  PL_ASSERT(lock_free_array.size() >= offset + 1);
+  lock_free_array.at(offset) = value;
   return true;
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
-bool LOCK_FREE_ARRAY_TYPE::Append(ValueType value){
-  LOG_TRACE("Appended at %lu", lock_free_array_offset.load());
-  lock_free_array->at(lock_free_array_offset++) = value;
+bool LOCK_FREE_ARRAY_TYPE::Append(ValueType value) {
+  LOG_TRACE("Appended value.");
+  lock_free_array.push_back(value);
   return true;
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
-bool LOCK_FREE_ARRAY_TYPE::Erase(const std::size_t &offset, const ValueType& invalid_value){
-  PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
+bool LOCK_FREE_ARRAY_TYPE::Erase(const std::size_t &offset,
+                                 const ValueType &invalid_value) {
   LOG_TRACE("Erase at %lu", offset);
-  lock_free_array->at(offset) =  invalid_value;
+  lock_free_array.at(offset) = invalid_value;
   return true;
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
-ValueType LOCK_FREE_ARRAY_TYPE::Find(const std::size_t &offset) const{
-  PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
+ValueType LOCK_FREE_ARRAY_TYPE::Find(const std::size_t &offset) const {
   LOG_TRACE("Find at %lu", offset);
-  auto value = lock_free_array->at(offset);
+  auto value = lock_free_array.at(offset);
   return value;
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
-ValueType LOCK_FREE_ARRAY_TYPE::FindValid(const std::size_t &offset,
-                                          const ValueType& invalid_value) const {
-  PL_ASSERT(offset <= LOCK_FREE_ARRAY_MAX_SIZE);
+ValueType LOCK_FREE_ARRAY_TYPE::FindValid(
+    const std::size_t &offset, const ValueType &invalid_value) const {
   LOG_TRACE("Find Valid at %lu", offset);
 
   std::size_t valid_array_itr = 0;
   std::size_t array_itr;
-
-  for(array_itr = 0;
-      array_itr < lock_free_array_offset;
-      array_itr++){
-    auto value = lock_free_array->at(array_itr);
+  auto lock_free_array_offset = lock_free_array.size();
+  for (array_itr = 0; array_itr < lock_free_array_offset; array_itr++) {
+    auto value = lock_free_array.at(array_itr);
     if (value != invalid_value) {
       // Check offset
-      if(valid_array_itr == offset) {
+      if (valid_array_itr == offset) {
         return value;
       }
 
@@ -97,41 +93,30 @@ ValueType LOCK_FREE_ARRAY_TYPE::FindValid(const std::size_t &offset,
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
-size_t LOCK_FREE_ARRAY_TYPE::GetSize() const{
-  return lock_free_array_offset;
-}
+size_t LOCK_FREE_ARRAY_TYPE::GetSize() const { return lock_free_array.size(); }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
-bool LOCK_FREE_ARRAY_TYPE::IsEmpty() const{
-  return lock_free_array->empty();
-}
+bool LOCK_FREE_ARRAY_TYPE::IsEmpty() const { return lock_free_array.empty(); }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
-void LOCK_FREE_ARRAY_TYPE::Clear(const ValueType& invalid_value) {
+void LOCK_FREE_ARRAY_TYPE::Clear(const ValueType &invalid_value) {
+  // Set invalid value for all elements
 
-  // Set invalid value for all elements and reset lock_free_array_offset
-  for(std::size_t array_itr = 0;
-      array_itr < lock_free_array_offset;
-      array_itr++){
-    lock_free_array->at(array_itr) = invalid_value;
+  for (std::size_t array_itr = 0; array_itr < lock_free_array.size();
+       array_itr++) {
+    lock_free_array.at(array_itr) = invalid_value;
   }
-
-  // Reset sentinel
-  lock_free_array_offset = 0;
-
 }
 
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
-bool LOCK_FREE_ARRAY_TYPE::Contains(const ValueType& value) {
-
+bool LOCK_FREE_ARRAY_TYPE::Contains(const ValueType &value) {
   bool exists = false;
 
-  for(std::size_t array_itr = 0;
-      array_itr < lock_free_array_offset;
-      array_itr++){
-    auto array_value = lock_free_array->at(array_itr);
+  for (std::size_t array_itr = 0; array_itr < lock_free_array.size();
+       array_itr++) {
+    auto array_value = lock_free_array.at(array_itr);
     // Check array value
-    if(array_value == value) {
+    if (array_value == value) {
       exists = true;
       break;
     }

--- a/src/include/catalog/manager.h
+++ b/src/include/catalog/manager.h
@@ -18,11 +18,12 @@
 #include <vector>
 #include <unordered_map>
 #include <memory>
+#include <include/common/internal_types.h>
 
 #include "common/macros.h"
 #include "common/internal_types.h"
 #include "common/container/lock_free_array.h"
-
+#include "tbb/concurrent_unordered_map.h"
 namespace peloton {
 
 namespace storage {
@@ -64,7 +65,6 @@ class Manager {
 
   void ClearTileGroup(void);
 
-
   //===--------------------------------------------------------------------===//
   // INDIRECTION ARRAY ALLOCATION
   //===--------------------------------------------------------------------===//
@@ -94,18 +94,17 @@ class Manager {
   //===--------------------------------------------------------------------===//
   std::atomic<oid_t> tile_group_oid_ = ATOMIC_VAR_INIT(START_OID);
 
-  LockFreeArray<std::shared_ptr<storage::TileGroup>> tile_group_locator_;
-
-  static std::shared_ptr<storage::TileGroup> empty_tile_group_;
+  tbb::concurrent_unordered_map<oid_t, std::shared_ptr<storage::TileGroup>>
+      tile_group_locator_;
 
   //===--------------------------------------------------------------------===//
   // Data members for indirection array allocation
   //===--------------------------------------------------------------------===//
   std::atomic<oid_t> indirection_array_oid_ = ATOMIC_VAR_INIT(START_OID);
 
-  LockFreeArray<std::shared_ptr<storage::IndirectionArray>> indirection_array_locator_;
-
-  static std::shared_ptr<storage::IndirectionArray> empty_indirection_array_;
+  tbb::concurrent_unordered_map<oid_t,
+                                std::shared_ptr<storage::IndirectionArray>>
+      indirection_array_locator_;
 };
 
 }  // namespace catalog

--- a/src/include/catalog/manager.h
+++ b/src/include/catalog/manager.h
@@ -18,7 +18,7 @@
 #include <vector>
 #include <unordered_map>
 #include <memory>
-#include <include/common/internal_types.h>
+#include "include/common/internal_types.h"
 
 #include "common/macros.h"
 #include "common/internal_types.h"

--- a/src/include/catalog/manager.h
+++ b/src/include/catalog/manager.h
@@ -96,6 +96,7 @@ class Manager {
 
   tbb::concurrent_unordered_map<oid_t, std::shared_ptr<storage::TileGroup>>
       tile_group_locator_;
+  static std::shared_ptr<storage::TileGroup> empty_tile_group_;
 
   //===--------------------------------------------------------------------===//
   // Data members for indirection array allocation
@@ -105,6 +106,7 @@ class Manager {
   tbb::concurrent_unordered_map<oid_t,
                                 std::shared_ptr<storage::IndirectionArray>>
       indirection_array_locator_;
+  static std::shared_ptr<storage::IndirectionArray> empty_indirection_array_;
 };
 
 }  // namespace catalog

--- a/src/include/common/container/lock_free_array.h
+++ b/src/include/common/container/lock_free_array.h
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
-
+#include "tbb/concurrent_vector.h"
+#include "tbb/tbb_allocator.h"
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
@@ -22,7 +22,7 @@
 
 namespace peloton {
 
-#define LOCK_FREE_ARRAY_MAX_SIZE 1024 * 1024
+#define LOCK_FREE_ARRAR_INIT_SIZE (256)
 
 // LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 #define LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS template <typename ValueType>
@@ -33,7 +33,6 @@ namespace peloton {
 LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 class LockFreeArray {
  public:
-
   LockFreeArray();
   ~LockFreeArray();
 
@@ -47,10 +46,11 @@ class LockFreeArray {
   ValueType Find(const std::size_t &offset) const;
 
   // Get a valid item
-  ValueType FindValid(const std::size_t &offset, const ValueType& invalid_value) const;
+  ValueType FindValid(const std::size_t &offset,
+                      const ValueType &invalid_value) const;
 
   // Delete key from the lock_free_array
-  bool Erase(const std::size_t &offset, const ValueType& invalid_value);
+  bool Erase(const std::size_t &offset, const ValueType &invalid_value);
 
   // Returns item count in the lock_free_array
   size_t GetSize() const;
@@ -59,20 +59,15 @@ class LockFreeArray {
   bool IsEmpty() const;
 
   // Clear all elements and reset them to default value
-  void Clear(const ValueType& invalid_value);
+  void Clear(const ValueType &invalid_value);
 
   // Exists ?
-  bool Contains(const ValueType& value);
+  bool Contains(const ValueType &value);
 
  private:
-
-  // lock free array type
-  typedef std::array<ValueType, LOCK_FREE_ARRAY_MAX_SIZE> lock_free_array_t;
-
-  std::atomic<std::size_t> lock_free_array_offset {0};
-
   // lock free array
-  std::unique_ptr<lock_free_array_t> lock_free_array;
+  tbb::concurrent_vector<ValueType, tbb::zero_allocator<ValueType>>
+      lock_free_array;
 };
 
 }  // namespace peloton

--- a/src/include/common/container/lock_free_array.h
+++ b/src/include/common/container/lock_free_array.h
@@ -22,7 +22,7 @@
 
 namespace peloton {
 
-#define LOCK_FREE_ARRAR_INIT_SIZE (256)
+static const size_t kLockfreeArrayInitSize = 256;
 
 // LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS
 #define LOCK_FREE_ARRAY_TEMPLATE_ARGUMENTS template <typename ValueType>
@@ -59,7 +59,7 @@ class LockFreeArray {
   bool IsEmpty() const;
 
   // Clear all elements and reset them to default value
-  void Clear(const ValueType &invalid_value);
+  void Clear();
 
   // Exists ?
   bool Contains(const ValueType &value);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1029,7 +1029,7 @@ void DataTable::DropTileGroups() {
   }
 
   // Clear array
-  tile_groups_.Clear(invalid_tile_group_id);
+  tile_groups_.Clear();
 
   tile_group_count_ = 0;
 }
@@ -1100,7 +1100,7 @@ void DataTable::DropIndexWithOid(const oid_t &index_oid) {
 void DataTable::DropIndexes() {
   // TODO: iterate over all indexes, and actually drop them
 
-  indexes_.Clear(nullptr);
+  indexes_.Clear();
 
   indexes_columns_.clear();
 }


### PR DESCRIPTION
#1168 #973 
Use tbb::concurrent_vector to implement the LockFreeArray.
Use tbb::concurrent_unorded_map to replace the old lockfree array.
