### PR TITLE
Adapt Readme: Remove Support for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ Check out the [installation instructions](https://github.com/cmu-db/peloton/wiki
 
 Peloton has been tested to work on the following platforms:
 
-* Ubuntu Linux 14.04+ (64-bit) [gcc4, gcc5]
-* Fedora Linux 24+ (64-bit) [gcc4, gcc5]
+* Ubuntu Linux 14.04+ (64-bit) [gcc4.8, gcc5]
 * Mac OS X 10.9+ (64-bit) [XCode v8 Only]
 
- Please note that it will not compile on 32-bit systems.
+Support for Fedora was dropped because of missing official support for Tensorflow. Please note that it will not compile on 32-bit systems.
 
 ## Development / Contributing
 


### PR DESCRIPTION
Remove Fedora as a "known to work platform" because of missing support for Tensorflow. 