### PR TITLE
Sequential Scan + Halloween Problem Fix 

### DIFF
--- a/src/codegen/updater.cpp
+++ b/src/codegen/updater.cpp
@@ -53,6 +53,11 @@ char *Updater::GetDataPtr(uint32_t tile_group_id, uint32_t tuple_offset) {
 
 char *Updater::Prepare(uint32_t tile_group_id, uint32_t tuple_offset) {
   PELOTON_ASSERT(table_ != nullptr && executor_context_ != nullptr);
+
+  if (IsInStatementWriteSet(ItemPointer(tile_group_id, tuple_offset))) {
+    return nullptr;
+  }
+  
   auto *txn = executor_context_->GetTransaction();
   auto tile_group = table_->GetTileGroupById(tile_group_id).get();
   auto *tile_group_header = tile_group->GetHeader();
@@ -79,7 +84,7 @@ char *Updater::PreparePK(uint32_t tile_group_id, uint32_t tuple_offset) {
 
   PELOTON_ASSERT(table_ != nullptr && executor_context_ != nullptr);
 
-  if (statement_write_set_->find(ItemPointer(tile_group_id, tuple_offset)) != statement_write_set_->end()) {
+  if (IsInStatementWriteSet(ItemPointer(tile_group_id, tuple_offset))) {
     return nullptr;
   }
 
@@ -130,7 +135,6 @@ void Updater::Update() {
   auto tile_group = table_->GetTileGroupById(old_location_.block).get();
   auto *tile_group_header = tile_group->GetHeader();
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-
   // Either update in-place
   if (is_owner_ == true) {
     txn_manager.PerformUpdate(txn, old_location_);
@@ -151,6 +155,7 @@ void Updater::Update() {
     return;
   }
   txn_manager.PerformUpdate(txn, old_location_, new_location_);
+  AddToStatementWriteSet(new_location_);
   executor_context_->num_processed++;
 }
 
@@ -174,7 +179,7 @@ void Updater::UpdatePK() {
     return;
   }
   txn_manager.PerformInsert(txn, new_location_, index_entry_ptr);
-  statement_write_set_->insert(new_location_);
+  AddToStatementWriteSet(new_location_);
   executor_context_->num_processed++;
 }
 

--- a/src/codegen/updater.cpp
+++ b/src/codegen/updater.cpp
@@ -38,7 +38,7 @@ void Updater::Init(storage::DataTable *table,
   target_list_ =
       new TargetList(target_vector, target_vector + target_vector_size);
 
-  statement_write_set_ = new ReadWriteSet();
+  statement_write_set_ = new WriteSet();
 }
 
 char *Updater::GetDataPtr(uint32_t tile_group_id, uint32_t tuple_offset) {
@@ -78,7 +78,8 @@ char *Updater::Prepare(uint32_t tile_group_id, uint32_t tuple_offset) {
 char *Updater::PreparePK(uint32_t tile_group_id, uint32_t tuple_offset) {
 
   PELOTON_ASSERT(table_ != nullptr && executor_context_ != nullptr);
-  if (statement_write_set_->Contains(ItemPointer(tile_group_id, tuple_offset))) {
+
+  if (statement_write_set_->find(ItemPointer(tile_group_id, tuple_offset)) != statement_write_set_->end()) {
     return nullptr;
   }
 
@@ -173,7 +174,7 @@ void Updater::UpdatePK() {
     return;
   }
   txn_manager.PerformInsert(txn, new_location_, index_entry_ptr);
-  statement_write_set_->Insert(new_location_, RWType::INSERT);
+  statement_write_set_->insert(new_location_);
   executor_context_->num_processed++;
 }
 

--- a/src/executor/update_executor.cpp
+++ b/src/executor/update_executor.cpp
@@ -53,6 +53,8 @@ bool UpdateExecutor::DInit() {
   PELOTON_ASSERT(target_table_);
   PELOTON_ASSERT(project_info_);
 
+  statement_write_set_.Clear();
+
   return true;
 }
 
@@ -60,6 +62,11 @@ bool UpdateExecutor::PerformUpdatePrimaryKey(
     bool is_owner, storage::TileGroup *tile_group,
     storage::TileGroupHeader *tile_group_header, oid_t physical_tuple_id,
     ItemPointer &old_location) {
+  
+  if (statement_write_set_.Contains(old_location)) {
+    return true;
+  }
+
   auto &transaction_manager =
       concurrency::TransactionManagerFactory::GetInstance();
 
@@ -136,6 +143,7 @@ bool UpdateExecutor::PerformUpdatePrimaryKey(
   }
 
   transaction_manager.PerformInsert(current_txn, location, index_entry_ptr);
+  statement_write_set_.Insert(location, RWType::INSERT);
 
   return true;
 }

--- a/src/executor/update_executor.cpp
+++ b/src/executor/update_executor.cpp
@@ -53,7 +53,7 @@ bool UpdateExecutor::DInit() {
   PELOTON_ASSERT(target_table_);
   PELOTON_ASSERT(project_info_);
 
-  statement_write_set_.Clear();
+  statement_write_set_.clear();
 
   return true;
 }
@@ -63,7 +63,7 @@ bool UpdateExecutor::PerformUpdatePrimaryKey(
     storage::TileGroupHeader *tile_group_header, oid_t physical_tuple_id,
     ItemPointer &old_location) {
   
-  if (statement_write_set_.Contains(old_location)) {
+  if (statement_write_set_.find(old_location) != statement_write_set_.end()) {
     return true;
   }
 
@@ -143,8 +143,7 @@ bool UpdateExecutor::PerformUpdatePrimaryKey(
   }
 
   transaction_manager.PerformInsert(current_txn, location, index_entry_ptr);
-  statement_write_set_.Insert(location, RWType::INSERT);
-
+  statement_write_set_.insert(location);
   return true;
 }
 

--- a/src/executor/update_executor.cpp
+++ b/src/executor/update_executor.cpp
@@ -62,10 +62,10 @@ bool UpdateExecutor::PerformUpdatePrimaryKey(
     bool is_owner, storage::TileGroup *tile_group,
     storage::TileGroupHeader *tile_group_header, oid_t physical_tuple_id,
     ItemPointer &old_location) {
-  
-  if (statement_write_set_.find(old_location) != statement_write_set_.end()) {
+
+  /* if (statement_write_set_.find(old_location) != statement_write_set_.end()) {
     return true;
-  }
+  } */
 
   auto &transaction_manager =
       concurrency::TransactionManagerFactory::GetInstance();
@@ -195,6 +195,9 @@ bool UpdateExecutor::DExecute() {
     oid_t physical_tuple_id = pos_lists[0][visible_tuple_id];
 
     ItemPointer old_location(tile_group->GetTileGroupId(), physical_tuple_id);
+    if (IsInStatementWriteSet(old_location)) {
+      continue;
+    }
 
     LOG_TRACE("Visible Tuple id : %u, Physical Tuple id : %u ",
               visible_tuple_id, physical_tuple_id);
@@ -269,6 +272,7 @@ bool UpdateExecutor::DExecute() {
                                 executor_context_);
 
         transaction_manager.PerformUpdate(current_txn, old_location);
+        statement_write_set_.insert(old_location);
       }
     }
     // if we have already obtained the ownership
@@ -366,6 +370,7 @@ bool UpdateExecutor::DExecute() {
                     new_location.offset);
           transaction_manager.PerformUpdate(current_txn, old_location,
                                             new_location);
+          statement_write_set_.insert(new_location);
 
           // TODO: Why don't we also do this in the if branch above?
           executor_context_->num_processed += 1;  // updated one

--- a/src/executor/update_executor.cpp
+++ b/src/executor/update_executor.cpp
@@ -63,10 +63,6 @@ bool UpdateExecutor::PerformUpdatePrimaryKey(
     storage::TileGroupHeader *tile_group_header, oid_t physical_tuple_id,
     ItemPointer &old_location) {
 
-  /* if (statement_write_set_.find(old_location) != statement_write_set_.end()) {
-    return true;
-  } */
-
   auto &transaction_manager =
       concurrency::TransactionManagerFactory::GetInstance();
 

--- a/src/include/codegen/updater.h
+++ b/src/include/codegen/updater.h
@@ -67,6 +67,17 @@ class Updater {
 
   char *GetDataPtr(uint32_t tile_group_id, uint32_t tuple_offset);
 
+  // Check if the tuple is in the statement write set
+  inline bool IsInStatementWriteSet(ItemPointer location) {
+    return statement_write_set_->find(location) !=
+           statement_write_set_->end();
+  }
+
+  // Add the updated location to the statement write set
+  inline void AddToStatementWriteSet(ItemPointer& location) {
+    statement_write_set_->insert(location);
+  }
+
  private:
   // Table and executor context from the update translator
   storage::DataTable *table_;

--- a/src/include/codegen/updater.h
+++ b/src/include/codegen/updater.h
@@ -75,6 +75,9 @@ class Updater {
   // Target list and direct map list pointer from the update translator
   TargetList *target_list_;
 
+  // Write set for tracking newly created tuples inserted by the same statement
+  ReadWriteSet *statement_write_set_;
+
   // Ownership information
   bool is_owner_;
   bool acquired_ownership_;

--- a/src/include/codegen/updater.h
+++ b/src/include/codegen/updater.h
@@ -76,6 +76,12 @@ class Updater {
   TargetList *target_list_;
 
   // Write set for tracking newly created tuples inserted by the same statement
+  // This statement-level write set is essential for avoiding the Halloween Problem,
+  // which refers to the phenomenon that an update operation causes a change to
+  // a tuple, potentially allowing this tuple to be visited more than once during
+  // the same operation.
+  // By maintaining the statement-level write set, an update operation will check 
+  // whether the to-be-updated tuple is created by the same operation.
   ReadWriteSet *statement_write_set_;
 
   // Ownership information

--- a/src/include/codegen/updater.h
+++ b/src/include/codegen/updater.h
@@ -82,7 +82,7 @@ class Updater {
   // the same operation.
   // By maintaining the statement-level write set, an update operation will check 
   // whether the to-be-updated tuple is created by the same operation.
-  ReadWriteSet *statement_write_set_;
+  WriteSet *statement_write_set_;
 
   // Ownership information
   bool is_owner_;

--- a/src/include/common/internal_types.h
+++ b/src/include/common/internal_types.h
@@ -24,6 +24,7 @@
 #include <unistd.h>
 
 #include "tbb/concurrent_vector.h"
+#include "tbb/concurrent_unordered_set.h"
 
 #include "parser/pg_trigger.h"
 #include "type/type_id.h"
@@ -1208,6 +1209,8 @@ std::ostream &operator<<(std::ostream &os, const RWType &type);
 // ItemPointer -> type
 typedef CuckooMap<ItemPointer, RWType, ItemPointerHasher, ItemPointerComparator>
     ReadWriteSet;
+
+typedef tbb::concurrent_unordered_multiset<ItemPointer, ItemPointerHasher, ItemPointerComparator> WriteSet;
 
 // this enum is to identify why the version should be GC'd.
 enum class GCVersionType {

--- a/src/include/common/internal_types.h
+++ b/src/include/common/internal_types.h
@@ -1210,7 +1210,7 @@ std::ostream &operator<<(std::ostream &os, const RWType &type);
 typedef CuckooMap<ItemPointer, RWType, ItemPointerHasher, ItemPointerComparator>
     ReadWriteSet;
 
-typedef tbb::concurrent_unordered_multiset<ItemPointer, ItemPointerHasher, ItemPointerComparator> WriteSet;
+typedef tbb::concurrent_unordered_set<ItemPointer, ItemPointerHasher, ItemPointerComparator> WriteSet;
 
 // this enum is to identify why the version should be GC'd.
 enum class GCVersionType {

--- a/src/include/common/item_pointer.h
+++ b/src/include/common/item_pointer.h
@@ -44,6 +44,10 @@ class ItemPointer {
     }
   }
 
+  bool operator==(const ItemPointer &rhs) const {
+    return (block == rhs.block && offset == rhs.offset);
+  }
+
 } __attribute__((__aligned__(8))) __attribute__((__packed__));
 
 extern ItemPointer INVALID_ITEMPOINTER;

--- a/src/include/executor/update_executor.h
+++ b/src/include/executor/update_executor.h
@@ -60,7 +60,7 @@ class UpdateExecutor : public AbstractExecutor {
   // the same operation.
   // By maintaining the statement-level write set, an update operation will check 
   // whether the to-be-updated tuple is created by the same operation.
-  ReadWriteSet statement_write_set_;
+  WriteSet statement_write_set_;
 };
 
 }  // namespace executor

--- a/src/include/executor/update_executor.h
+++ b/src/include/executor/update_executor.h
@@ -49,6 +49,10 @@ class UpdateExecutor : public AbstractExecutor {
 
   bool DExecute();
 
+  inline bool IsInStatementWriteSet(ItemPointer &location) {
+    return (statement_write_set_.find(location) != statement_write_set_.end());
+  }
+
  private:
   storage::DataTable *target_table_ = nullptr;
   const planner::ProjectInfo *project_info_ = nullptr;

--- a/src/include/executor/update_executor.h
+++ b/src/include/executor/update_executor.h
@@ -52,6 +52,9 @@ class UpdateExecutor : public AbstractExecutor {
  private:
   storage::DataTable *target_table_ = nullptr;
   const planner::ProjectInfo *project_info_ = nullptr;
+
+  // Write set for tracking newly created tuples inserted by the same statement
+  ReadWriteSet statement_write_set_;
 };
 
 }  // namespace executor

--- a/src/include/executor/update_executor.h
+++ b/src/include/executor/update_executor.h
@@ -54,6 +54,12 @@ class UpdateExecutor : public AbstractExecutor {
   const planner::ProjectInfo *project_info_ = nullptr;
 
   // Write set for tracking newly created tuples inserted by the same statement
+  // This statement-level write set is essential for avoiding the Halloween Problem,
+  // which refers to the phenomenon that an update operation causes a change to
+  // a tuple, potentially allowing this tuple to be visited more than once during
+  // the same operation.
+  // By maintaining the statement-level write set, an update operation will check 
+  // whether the to-be-updated tuple is created by the same operation.
   ReadWriteSet statement_write_set_;
 };
 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -286,8 +286,16 @@ class DataTable : public AbstractTable {
                        concurrency::TransactionContext *transaction,
                        ItemPointer **index_entry_ptr);
 
+  inline static size_t GetActiveTileGroupCount() {
+    return default_active_tilegroup_count_;
+  }
+
   static void SetActiveTileGroupCount(const size_t active_tile_group_count) {
     default_active_tilegroup_count_ = active_tile_group_count;
+  }
+
+  inline static size_t GetActiveIndirectionArrayCount() {
+    return default_active_indirection_array_count_;
   }
 
   static void SetActiveIndirectionArrayCount(
@@ -345,9 +353,8 @@ class DataTable : public AbstractTable {
   bool CheckForeignKeyConstraints(const AbstractTuple *tuple,
                                   concurrency::TransactionContext *transaction);
 
- public:
+ private:
   static size_t default_active_tilegroup_count_;
-
   static size_t default_active_indirection_array_count_;
 
  private:

--- a/test/executor/loader_test.cpp
+++ b/test/executor/loader_test.cpp
@@ -132,22 +132,32 @@ TEST_F(LoaderTests, LoadingTest) {
   auto expected_tile_group_count = 0;
 
   int total_tuple_count = loader_threads_count * tilegroup_count_per_loader * TEST_TUPLES_PER_TILEGROUP;
-  int max_cached_tuple_count = TEST_TUPLES_PER_TILEGROUP * storage::DataTable::default_active_tilegroup_count_;
-  int max_unfill_cached_tuple_count = (TEST_TUPLES_PER_TILEGROUP - 1) * storage::DataTable::default_active_tilegroup_count_;
+  int max_cached_tuple_count =
+      TEST_TUPLES_PER_TILEGROUP * storage::DataTable::GetActiveTileGroupCount();
+  int max_unfill_cached_tuple_count =
+      (TEST_TUPLES_PER_TILEGROUP - 1) *
+      storage::DataTable::GetActiveTileGroupCount();
 
   if (total_tuple_count - max_cached_tuple_count <= 0) {
     if (total_tuple_count <= max_unfill_cached_tuple_count) {
-      expected_tile_group_count = storage::DataTable::default_active_tilegroup_count_;
+      expected_tile_group_count = storage::DataTable::GetActiveTileGroupCount();
     } else {
-      expected_tile_group_count = storage::DataTable::default_active_tilegroup_count_ + total_tuple_count - max_unfill_cached_tuple_count; 
+      expected_tile_group_count =
+          storage::DataTable::GetActiveTileGroupCount() + total_tuple_count -
+          max_unfill_cached_tuple_count;
     }
   } else {
-    int filled_tile_group_count = total_tuple_count / max_cached_tuple_count * storage::DataTable::default_active_tilegroup_count_;
+    int filled_tile_group_count = total_tuple_count / max_cached_tuple_count * storage::DataTable::GetActiveTileGroupCount();
     
     if (total_tuple_count - filled_tile_group_count * TEST_TUPLES_PER_TILEGROUP - max_unfill_cached_tuple_count <= 0) {
-      expected_tile_group_count = filled_tile_group_count + storage::DataTable::default_active_tilegroup_count_;
+      expected_tile_group_count = filled_tile_group_count +
+                                  storage::DataTable::GetActiveTileGroupCount();
     } else {
-      expected_tile_group_count = filled_tile_group_count + storage::DataTable::default_active_tilegroup_count_ + (total_tuple_count - filled_tile_group_count - max_unfill_cached_tuple_count); 
+      expected_tile_group_count =
+          filled_tile_group_count +
+          storage::DataTable::GetActiveTileGroupCount() +
+          (total_tuple_count - filled_tile_group_count -
+           max_unfill_cached_tuple_count);
     }
   }
 

--- a/test/performance/insert_performance_test.cpp
+++ b/test/performance/insert_performance_test.cpp
@@ -119,22 +119,33 @@ TEST_F(InsertPerformanceTests, LoadingTest) {
   auto expected_tile_group_count = 0;
 
   int total_tuple_count = loader_threads_count * tilegroup_count_per_loader * TEST_TUPLES_PER_TILEGROUP;
-  int max_cached_tuple_count = TEST_TUPLES_PER_TILEGROUP * storage::DataTable::default_active_tilegroup_count_;
-  int max_unfill_cached_tuple_count = (TEST_TUPLES_PER_TILEGROUP - 1) * storage::DataTable::default_active_tilegroup_count_;
+  int max_cached_tuple_count =
+      TEST_TUPLES_PER_TILEGROUP * storage::DataTable::GetActiveTileGroupCount();
+  int max_unfill_cached_tuple_count =
+      (TEST_TUPLES_PER_TILEGROUP - 1) *
+      storage::DataTable::GetActiveTileGroupCount();
 
   if (total_tuple_count - max_cached_tuple_count <= 0) {
     if (total_tuple_count <= max_unfill_cached_tuple_count) {
-      expected_tile_group_count = storage::DataTable::default_active_tilegroup_count_;
+      expected_tile_group_count = storage::DataTable::GetActiveTileGroupCount();
     } else {
-      expected_tile_group_count = storage::DataTable::default_active_tilegroup_count_ + total_tuple_count - max_unfill_cached_tuple_count; 
+      expected_tile_group_count =
+          storage::DataTable::GetActiveTileGroupCount() + total_tuple_count -
+          max_unfill_cached_tuple_count;
     }
   } else {
-    int filled_tile_group_count = total_tuple_count / max_cached_tuple_count * storage::DataTable::default_active_tilegroup_count_;
-    
+    int filled_tile_group_count = total_tuple_count / max_cached_tuple_count *
+                                  storage::DataTable::GetActiveTileGroupCount();
+
     if (total_tuple_count - filled_tile_group_count * TEST_TUPLES_PER_TILEGROUP - max_unfill_cached_tuple_count <= 0) {
-      expected_tile_group_count = filled_tile_group_count + storage::DataTable::default_active_tilegroup_count_;
+      expected_tile_group_count = filled_tile_group_count +
+                                  storage::DataTable::GetActiveTileGroupCount();
     } else {
-      expected_tile_group_count = filled_tile_group_count + storage::DataTable::default_active_tilegroup_count_ + (total_tuple_count - filled_tile_group_count - max_unfill_cached_tuple_count); 
+      expected_tile_group_count =
+          filled_tile_group_count +
+          storage::DataTable::GetActiveTileGroupCount() +
+          (total_tuple_count - filled_tile_group_count -
+           max_unfill_cached_tuple_count);
     }
   }
 

--- a/test/sql/update_sql_test.cpp
+++ b/test/sql/update_sql_test.cpp
@@ -278,7 +278,10 @@ TEST_F(UpdateSQLTests, UpdateSQLCastTest) {
   txn_manager.CommitTransaction(txn);
 }
 
-TEST_F(UpdateSQLTests, HalloweenTest) {
+TEST_F(UpdateSQLTests, HalloweenProblemTest) {
+  // This SQL Test verifies that executor does not cause the Halloween Problem
+  // This test checks for tables without Primary Keys
+
   LOG_DEBUG("Bootstrapping...");
 
   auto catalog = catalog::Catalog::GetInstance();
@@ -288,6 +291,12 @@ TEST_F(UpdateSQLTests, HalloweenTest) {
   txn_manager.CommitTransaction(txn);
 
   LOG_DEBUG("Bootstrapping completed!");
+
+  // Setting ActiveTileGroupCount to 3 in order to trigger the case where
+  // the executor scans TileGroup 0, inserts an empty version in TileGroup 1.
+  // It then inserts the updated version of the tuple in TileGroup 2.
+  // When it scans TileGroup 2, without the statement level WriteSet,
+  // it would have caused a second update on an already updated Tuple.
 
   size_t active_tilegroup_count = 3;
   storage::DataTable::SetActiveTileGroupCount(active_tilegroup_count);
@@ -310,9 +319,7 @@ TEST_F(UpdateSQLTests, HalloweenTest) {
   TestingSQLUtil::ExecuteSQLQuery("INSERT INTO test VALUES (10, 1000);");
   LOG_DEBUG("Tuple inserted!");
 
-  txn_manager.CommitTransaction(txn);
-
-  // Update a tuple into table
+  // Update a tuple in the table
   LOG_DEBUG("Updating a tuple...");
   LOG_DEBUG("Query: UPDATE test SET a = a/2");
 
@@ -321,7 +328,6 @@ TEST_F(UpdateSQLTests, HalloweenTest) {
   std::string error_message;
   int rows_affected;
 
-  txn = txn_manager.BeginTransaction();
   TestingSQLUtil::ExecuteSQLQuery("UPDATE test SET a = a/2;", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
@@ -333,7 +339,7 @@ TEST_F(UpdateSQLTests, HalloweenTest) {
 
   LOG_DEBUG("Selecting updated value.");
   txn = txn_manager.BeginTransaction();
-  // Check value of column salary after updating
+  // Check value of column a after updating
   TestingSQLUtil::ExecuteSQLQuery("SELECT a from test", result,
                                   tuple_descriptor, rows_affected,
                                   error_message);
@@ -342,6 +348,107 @@ TEST_F(UpdateSQLTests, HalloweenTest) {
 
   EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 0), "5");
   LOG_DEBUG("Successfully updated tuple.");
+
+  // free the database just created
+  txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+TEST_F(UpdateSQLTests, HalloweenProblemTestWithPK) {
+  // This SQL Test verifies that executor does not cause the Halloween Problem
+  // This test checks for tables with Primary Keys
+  // It checks for updates on both Non-Primary Key column & Primary Key column
+
+  LOG_DEBUG("Bootstrapping...");
+
+  auto catalog = catalog::Catalog::GetInstance();
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog->CreateDatabase(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+
+  LOG_DEBUG("Bootstrapping completed!");
+
+  // active_tilegroup_count set to 3, [Reason: Refer to HalloweenProblemTest]
+  size_t active_tilegroup_count = 3;
+  storage::DataTable::SetActiveTileGroupCount(active_tilegroup_count);
+
+  LOG_DEBUG("Active tile group count = %zu",
+            storage::DataTable::GetActiveTileGroupCount());
+  // Create a table first
+  LOG_DEBUG("Creating a table...");
+  LOG_DEBUG("Query: CREATE TABLE test(a INT PRIMARY KEY, b INT)");
+
+  TestingSQLUtil::ExecuteSQLQuery("CREATE TABLE test(a INT PRIMARY KEY, b INT);");
+
+  LOG_DEBUG("Table created!");
+
+  txn = txn_manager.BeginTransaction();
+  // Insert a tuple into table
+  LOG_DEBUG("Inserting a tuple...");
+
+  LOG_DEBUG("Query: INSERT INTO test VALUES (10, 100)");
+  TestingSQLUtil::ExecuteSQLQuery("INSERT INTO test VALUES (10, 1000);");
+  LOG_DEBUG("Tuple inserted!");
+
+  // Update a tuple in table
+  LOG_DEBUG("Updating a tuple...");
+  LOG_DEBUG("Query: UPDATE test SET a = a/2");
+
+  std::vector<ResultValue> result;
+  std::vector<FieldInfo> tuple_descriptor;
+  std::string error_message;
+  int rows_affected;
+
+  TestingSQLUtil::ExecuteSQLQuery("UPDATE test SET a = a/2;", result,
+                                  tuple_descriptor, rows_affected,
+                                  error_message);
+
+  // Check the return value
+  EXPECT_EQ(1, rows_affected);
+  LOG_DEBUG("Tuple Primary Key column Updated!");
+  txn_manager.CommitTransaction(txn);
+
+  LOG_DEBUG("Selecting updated value.");
+  txn = txn_manager.BeginTransaction();
+  // Check value of column a after updating
+  TestingSQLUtil::ExecuteSQLQuery("SELECT a from test", result,
+                                  tuple_descriptor, rows_affected,
+                                  error_message);
+  // Check the return value
+  txn_manager.CommitTransaction(txn);
+
+  EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 0), "5");
+  LOG_DEBUG("Successfully updated tuple.");
+
+  txn = txn_manager.BeginTransaction();
+
+  LOG_DEBUG("Updating a tuple...");
+  LOG_DEBUG("Query: UPDATE test SET b = b/2");
+
+  TestingSQLUtil::ExecuteSQLQuery("UPDATE test SET b = b/2;", result,
+                                  tuple_descriptor, rows_affected,
+                                  error_message);
+
+  EXPECT_EQ(1, rows_affected);
+  LOG_DEBUG("Tuple Non-Primary Key column Updated!");
+  txn_manager.CommitTransaction(txn);
+
+  LOG_DEBUG("Selecting updated value.");
+  txn = txn_manager.BeginTransaction();
+  // Check value of column b after updating
+  TestingSQLUtil::ExecuteSQLQuery("SELECT b from test", result,
+                                  tuple_descriptor, rows_affected,
+                                  error_message);
+  // Check the return value
+  txn_manager.CommitTransaction(txn);
+
+  EXPECT_EQ(TestingSQLUtil::GetResultValueAsString(result, 0), "500");
+  LOG_DEBUG("Successfully updated tuple.");
+
+
+
 
   // free the database just created
   txn = txn_manager.BeginTransaction();
@@ -360,6 +467,7 @@ TEST_F(UpdateSQLTests, MultiTileGroupUpdateSQLTest) {
 
   LOG_DEBUG("Bootstrapping completed!");
 
+  // active_tilegroup_count set to 3, [Reason: Refer to HalloweenProblemTest]
   size_t active_tilegroup_count = 3;
   storage::DataTable::SetActiveTileGroupCount(active_tilegroup_count);
 
@@ -382,7 +490,7 @@ TEST_F(UpdateSQLTests, MultiTileGroupUpdateSQLTest) {
 
   LOG_DEBUG("Tuple inserted!");
 
-  // Update a tuple into table
+  // Update a tuple in the table
   LOG_DEBUG("Updating a tuple...");
   LOG_DEBUG("Query: UPDATE test SET a = 10 WHERE b = 100");
 
@@ -398,15 +506,20 @@ TEST_F(UpdateSQLTests, MultiTileGroupUpdateSQLTest) {
   LOG_DEBUG("Query: UPDATE test SET a = 1 WHERE b = 100");
   // Check the return value
   EXPECT_EQ(1, rows_affected);
-  LOG_DEBUG("Tuple Updated!");
+  LOG_DEBUG("Tuple Update successful!");
 
   TestingSQLUtil::ExecuteSQLQuery("UPDATE test SET a = 1 WHERE b = 100;",
                                   result, tuple_descriptor, rows_affected,
                                   error_message);
 
   // Check the return value
+  // Updating the tuple the second time casued the assertion failure
+  // on line 641 of timestamp_ordering_transaction_manager.cpp
+  // This was because it tried to update an already updated version
+  // of the tuple. This was fixed by the statement level WriteSet.
   EXPECT_EQ(1, rows_affected);
-  LOG_DEBUG("Tuple Updated!");
+  LOG_DEBUG("Tuple Update successful, again!");
+
 
   // free the database just created
   txn = txn_manager.BeginTransaction();


### PR DESCRIPTION
This PR fixes the Halloween Problem along with the sequential scan problem.

It builds on #1240 and checks for an entry in each WriteSet for each tuple (irrespective of whether or not it updates the Primary Key). 

I have tested this with varying tile_group_count. I have also tested the fix with and without codegen. It appears to have solved the Halloween problem for both the engines. 