### PR TITLE
Peloton Brain Recommended Indexes

### DIFF
--- a/src/include/planner/abstract_scan_plan.h
+++ b/src/include/planner/abstract_scan_plan.h
@@ -43,6 +43,10 @@ class AbstractScan : public AbstractPlan {
     return predicate_.get();
   }
 
+  expression::AbstractExpression *GetPredicateUnsafe() const {
+    return predicate_.get();
+  }
+
   const std::vector<oid_t> &GetColumnIds() const { return column_ids_; }
 
   void GetOutputColumns(std::vector<oid_t> &columns) const override {

--- a/src/include/planner/plan_util.h
+++ b/src/include/planner/plan_util.h
@@ -14,6 +14,7 @@
 
 #include <set>
 #include <string>
+#include <tuple>
 
 #include "planner/abstract_plan.h"
 #include "planner/abstract_scan_plan.h"
@@ -35,6 +36,7 @@ class SQLStatement;
 }  // namespace parser
 
 namespace planner {
+typedef std::tuple<oid_t, oid_t, oid_t> col_triplet;
 
 class PlanUtil {
  public:
@@ -70,7 +72,7 @@ class PlanUtil {
   * @param DBName
   * @return set of affected column ids
   */
-  static const std::set<oid_t> GetAffectedColumns(
+  static const std::set<col_triplet> GetAffectedColumns(
       catalog::CatalogCache &catalog_cache,
       std::unique_ptr<parser::SQLStatementList> sql_stmt_list,
       const std::string &db_name);

--- a/src/include/planner/plan_util.h
+++ b/src/include/planner/plan_util.h
@@ -70,9 +70,9 @@ class PlanUtil {
   * @param CatalogCache
   * @param SQLStatementList
   * @param DBName
-  * @return set of affected column ids
+  * @return vector of affected column ids with triplet format
   */
-  static const std::set<col_triplet> GetAffectedColumns(
+  static const std::vector<col_triplet> GetAffectedColumns(
       catalog::CatalogCache &catalog_cache,
       std::unique_ptr<parser::SQLStatementList> sql_stmt_list,
       const std::string &db_name);

--- a/src/include/planner/plan_util.h
+++ b/src/include/planner/plan_util.h
@@ -63,6 +63,16 @@ class PlanUtil {
       catalog::CatalogCache &catalog_cache,
       const parser::SQLStatement &sql_stmt);
 
+  /**
+  * @brief Get the columns affected by a given query
+  * @param CatalogCache
+  * @param SQLStatement
+  * @return set of affected column ids
+  */
+  static const std::set<oid_t> GetAffectedColumns(
+      catalog::CatalogCache &catalog_cache,
+      const parser::SQLStatement &sql_stmt);
+
  private:
   ///
   /// Helpers for GetInfo() and GetTablesReferenced()

--- a/src/include/planner/plan_util.h
+++ b/src/include/planner/plan_util.h
@@ -66,12 +66,14 @@ class PlanUtil {
   /**
   * @brief Get the columns affected by a given query
   * @param CatalogCache
-  * @param SQLStatement
+  * @param SQLStatementList
+  * @param DBName
   * @return set of affected column ids
   */
   static const std::set<oid_t> GetAffectedColumns(
       catalog::CatalogCache &catalog_cache,
-      const parser::SQLStatement &sql_stmt);
+      std::unique_ptr<parser::SQLStatementList> sql_stmt_list,
+      const std::string &db_name);
 
  private:
   ///

--- a/test/planner/plan_util_test.cpp
+++ b/test/planner/plan_util_test.cpp
@@ -264,13 +264,15 @@ TEST_F(PlanUtilTests, GetAffectedColumnsTest) {
   EXPECT_EQ(expected_oids, affected_cols);
 
   // ========= SELECT statement check ==
-  query_string = "SELECT * FROM test_table;";
+  query_string = "SELECT id FROM test_table WHERE first_name = last_name;";
   stmt.reset(new Statement("SELECT", query_string));
   sql_stmt_list = peloton_parser.BuildParseTree(query_string);
   affected_cols = planner::PlanUtil::GetAffectedColumns(
       txn->catalog_cache, std::move(sql_stmt_list), TEST_DB_COLUMNS);
 
   EXPECT_EQ(3, static_cast<int>(affected_cols.size()));
+  expected_oids = std::set<oid_t>({id_col_oid, fname_col_oid, lname_col_oid});
+  EXPECT_EQ(expected_oids, affected_cols);
   txn_manager.CommitTransaction(txn);
 }
 

--- a/test/planner/plan_util_test.cpp
+++ b/test/planner/plan_util_test.cpp
@@ -28,6 +28,7 @@ namespace peloton {
 namespace test {
 
 #define TEST_DB_NAME "test_db"
+#define TEST_DB_COLUMNS "test_db_columns"
 
 class PlanUtilTests : public PelotonTest {};
 
@@ -163,7 +164,128 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
 
   // no indexes are affected
   EXPECT_EQ(0, static_cast<int>(affected_indexes.size()));
-  txn_manager.CommitTransaction(txn);  
+  txn_manager.CommitTransaction(txn);
+}
+
+TEST_F(PlanUtilTests, GetAffectedColumnsTest) {
+  auto catalog = catalog::Catalog::GetInstance();
+  catalog->Bootstrap();
+
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+
+  catalog->CreateDatabase(TEST_DB_COLUMNS, txn);
+  auto db = catalog->GetDatabaseWithName(TEST_DB_COLUMNS, txn);
+  // Insert a table first
+  auto id_column = catalog::Column(
+      type::TypeId::INTEGER, type::Type::GetTypeSize(type::TypeId::INTEGER),
+      "id", true);
+  auto fname_column =
+      catalog::Column(type::TypeId::VARCHAR, 32, "first_name", false);
+  auto lname_column =
+      catalog::Column(type::TypeId::VARCHAR, 32, "last_name", false);
+
+  std::unique_ptr<catalog::Schema> table_schema(
+      new catalog::Schema({id_column, fname_column, lname_column}));
+  txn_manager.CommitTransaction(txn);
+
+  txn = txn_manager.BeginTransaction();
+  catalog->CreateTable(TEST_DB_COLUMNS, "test_table", std::move(table_schema),
+                       txn);
+  txn_manager.CommitTransaction(txn);
+
+  txn = txn_manager.BeginTransaction();
+  auto source_table = db->GetTableWithName("test_table");
+  oid_t id_col_oid =
+      source_table->GetSchema()->GetColumnID(id_column.column_name);
+  oid_t fname_col_oid =
+      source_table->GetSchema()->GetColumnID(fname_column.column_name);
+  oid_t lname_col_oid =
+      source_table->GetSchema()->GetColumnID(lname_column.column_name);
+  txn_manager.CommitTransaction(txn);
+
+  // dummy txn to get the catalog_cache object
+  txn = txn_manager.BeginTransaction();
+
+  // This is also required so that database objects are cached
+  auto db_object = catalog->GetDatabaseObject(TEST_DB_COLUMNS, txn);
+  EXPECT_EQ(1, static_cast<int>(db_object->GetTableObjects().size()));
+
+  // Till now, we have a table : id, first_name, last_name
+  auto table_object = db_object->GetTableObject("test_table");
+
+  // An update query affecting both indexes
+  std::string query_string = "UPDATE test_table SET id = 0, first_name = '';";
+  std::unique_ptr<Statement> stmt(new Statement("UPDATE", query_string));
+  auto &peloton_parser = parser::PostgresParser::GetInstance();
+  auto sql_stmt_list = peloton_parser.BuildParseTree(query_string);
+  auto sql_stmt = sql_stmt_list->GetStatement(0);
+  static_cast<parser::UpdateStatement *>(sql_stmt)->table->TryBindDatabaseName(
+      TEST_DB_COLUMNS);
+  std::set<oid_t> affected_cols =
+      planner::PlanUtil::GetAffectedColumns(txn->catalog_cache, *sql_stmt);
+
+  // id and first_name are affected
+  EXPECT_EQ(2, static_cast<int>(affected_cols.size()));
+  std::set<oid_t> expected_oids{id_col_oid, fname_col_oid};
+  EXPECT_EQ(expected_oids, affected_cols);
+
+  // first_name is affected
+  query_string = "UPDATE test_table SET first_name = '';";
+  stmt.reset(new Statement("UPDATE", query_string));
+  sql_stmt_list = peloton_parser.BuildParseTree(query_string);
+  sql_stmt = sql_stmt_list->GetStatement(0);
+  static_cast<parser::UpdateStatement *>(sql_stmt)->table->TryBindDatabaseName(
+      TEST_DB_COLUMNS);
+  affected_cols =
+      planner::PlanUtil::GetAffectedColumns(txn->catalog_cache, *sql_stmt);
+
+  // only first_name is affected
+  EXPECT_EQ(1, static_cast<int>(affected_cols.size()));
+  expected_oids = std::set<oid_t>({fname_col_oid});
+  EXPECT_EQ(expected_oids, affected_cols);
+
+  // ====== DELETE statements check ===
+  query_string = "DELETE FROM test_table;";
+  stmt.reset(new Statement("DELETE", query_string));
+  sql_stmt_list = peloton_parser.BuildParseTree(query_string);
+  sql_stmt = sql_stmt_list->GetStatement(0);
+  static_cast<parser::DeleteStatement *>(sql_stmt)->TryBindDatabaseName(
+      TEST_DB_COLUMNS);
+  affected_cols =
+      planner::PlanUtil::GetAffectedColumns(txn->catalog_cache, *sql_stmt);
+
+  // all columns are affected
+  EXPECT_EQ(3, static_cast<int>(affected_cols.size()));
+  expected_oids = std::set<oid_t>({id_col_oid, fname_col_oid, lname_col_oid});
+  EXPECT_EQ(expected_oids, affected_cols);
+
+  // ========= INSERT statements check ==
+  query_string = "INSERT INTO test_table VALUES (1, 'pel', 'ton');";
+  stmt.reset(new Statement("INSERT", query_string));
+  sql_stmt_list = peloton_parser.BuildParseTree(query_string);
+  sql_stmt = sql_stmt_list->GetStatement(0);
+  static_cast<parser::InsertStatement *>(sql_stmt)->TryBindDatabaseName(
+      TEST_DB_COLUMNS);
+  affected_cols =
+      planner::PlanUtil::GetAffectedColumns(txn->catalog_cache, *sql_stmt);
+
+  // all indexes are affected
+  EXPECT_EQ(3, static_cast<int>(affected_cols.size()));
+  expected_oids = std::set<oid_t>({id_col_oid, fname_col_oid, lname_col_oid});
+  EXPECT_EQ(expected_oids, affected_cols);
+
+  //  // ========= SELECT statement check ==
+  //  query_string = "SELECT * FROM test_table;";
+  //  stmt.reset(new Statement("SELECT", query_string));
+  //  sql_stmt_list = peloton_parser.BuildParseTree(query_string);
+  //  sql_stmt = sql_stmt_list->GetStatement(0);
+  //  affected_indexes =
+  //      planner::PlanUtil::GetAffectedIndexes(txn->catalog_cache, *sql_stmt);
+  //
+  //  // no indexes are affected
+  //  EXPECT_EQ(0, static_cast<int>(affected_indexes.size()));
+  txn_manager.CommitTransaction(txn);
 }
 
 }  // namespace test

--- a/test/planner/plan_util_test.cpp
+++ b/test/planner/plan_util_test.cpp
@@ -221,9 +221,11 @@ TEST_F(PlanUtilTests, GetAffectedColumnsTest) {
   std::unique_ptr<Statement> stmt(new Statement("UPDATE", query_string));
   auto &peloton_parser = parser::PostgresParser::GetInstance();
   auto sql_stmt_list = peloton_parser.BuildParseTree(query_string);
-  std::set<planner::col_triplet> affected_cols =
+  std::vector<planner::col_triplet> affected_cols_vector =
       planner::PlanUtil::GetAffectedColumns(
           txn->catalog_cache, std::move(sql_stmt_list), TEST_DB_COLUMNS);
+  std::set<planner::col_triplet> affected_cols(affected_cols_vector.begin(),
+                                               affected_cols_vector.end());
 
   // id and first_name are affected
   EXPECT_EQ(2, static_cast<int>(affected_cols.size()));
@@ -236,8 +238,10 @@ TEST_F(PlanUtilTests, GetAffectedColumnsTest) {
   query_string = "UPDATE test_table SET first_name = '';";
   stmt.reset(new Statement("UPDATE", query_string));
   sql_stmt_list = peloton_parser.BuildParseTree(query_string);
-  affected_cols = planner::PlanUtil::GetAffectedColumns(
+  affected_cols_vector = planner::PlanUtil::GetAffectedColumns(
       txn->catalog_cache, std::move(sql_stmt_list), TEST_DB_COLUMNS);
+  affected_cols = std::set<planner::col_triplet>(affected_cols_vector.begin(),
+                                                 affected_cols_vector.end());
 
   // only first_name is affected
   EXPECT_EQ(1, static_cast<int>(affected_cols.size()));
@@ -249,8 +253,10 @@ TEST_F(PlanUtilTests, GetAffectedColumnsTest) {
   query_string = "DELETE FROM test_table;";
   stmt.reset(new Statement("DELETE", query_string));
   sql_stmt_list = peloton_parser.BuildParseTree(query_string);
-  affected_cols = planner::PlanUtil::GetAffectedColumns(
+  affected_cols_vector = planner::PlanUtil::GetAffectedColumns(
       txn->catalog_cache, std::move(sql_stmt_list), TEST_DB_COLUMNS);
+  affected_cols = std::set<planner::col_triplet>(affected_cols_vector.begin(),
+                                                 affected_cols_vector.end());
 
   // all columns are affected
   EXPECT_EQ(3, static_cast<int>(affected_cols.size()));
@@ -264,8 +270,10 @@ TEST_F(PlanUtilTests, GetAffectedColumnsTest) {
   query_string = "INSERT INTO test_table VALUES (1, 'pel', 'ton');";
   stmt.reset(new Statement("INSERT", query_string));
   sql_stmt_list = peloton_parser.BuildParseTree(query_string);
-  affected_cols = planner::PlanUtil::GetAffectedColumns(
+  affected_cols_vector = planner::PlanUtil::GetAffectedColumns(
       txn->catalog_cache, std::move(sql_stmt_list), TEST_DB_COLUMNS);
+  affected_cols = std::set<planner::col_triplet>(affected_cols_vector.begin(),
+                                                 affected_cols_vector.end());
 
   // all columns are affected
   EXPECT_EQ(3, static_cast<int>(affected_cols.size()));
@@ -279,8 +287,10 @@ TEST_F(PlanUtilTests, GetAffectedColumnsTest) {
   query_string = "SELECT id FROM test_table WHERE first_name = last_name;";
   stmt.reset(new Statement("SELECT", query_string));
   sql_stmt_list = peloton_parser.BuildParseTree(query_string);
-  affected_cols = planner::PlanUtil::GetAffectedColumns(
+  affected_cols_vector = planner::PlanUtil::GetAffectedColumns(
       txn->catalog_cache, std::move(sql_stmt_list), TEST_DB_COLUMNS);
+  affected_cols = std::set<planner::col_triplet>(affected_cols_vector.begin(),
+                                                 affected_cols_vector.end());
 
   EXPECT_EQ(3, static_cast<int>(affected_cols.size()));
   expected_oids.clear();

--- a/test/planner/plan_util_test.cpp
+++ b/test/planner/plan_util_test.cpp
@@ -270,7 +270,7 @@ TEST_F(PlanUtilTests, GetAffectedColumnsTest) {
   affected_cols = planner::PlanUtil::GetAffectedColumns(
       txn->catalog_cache, std::move(sql_stmt_list), TEST_DB_COLUMNS);
 
-  EXPECT_EQ(0, static_cast<int>(affected_cols.size()));
+  EXPECT_EQ(3, static_cast<int>(affected_cols.size()));
   txn_manager.CommitTransaction(txn);
 }
 


### PR DESCRIPTION
This is the PR for Peloton Brain Recommended Indexes task. The primary function is `PlanUtil::GetAffectedColumns()`, and I used #1105 as reference. 

The purpose of this function: given a `SQLStatement` (a query), return all the affected columns in a vector.

I completed the code for `UPDATE`/`INSERT`/`DELETE`/`SELECT`:

* `INSERT`/`DELETE`: all columns are affected
* `UPDATE`: columns in `UpdateClause` are affected
* `SELECT`: all scanned columns are affected (in or not in predicates)

The returned vector is actually a vector of triplets: each element of the vector is a tuple containing three values, representing database oid, table oid and column oid, respectively.

For `SELECT` queries, the elements of the returned vector are "sorted" in such a way that columns in predicates (having higher priority) are put in the front of the vector, and output columns (having lower priority) are put in the end of the vector.

This is the initial version of the code, still need suggestions on improvement/test cases.