### PR TITLE
[15721] TileGroup Freeing

### DIFF
--- a/src/catalog/manager.cpp
+++ b/src/catalog/manager.cpp
@@ -37,12 +37,14 @@ Manager &Manager::GetInstance() {
 void Manager::AddTileGroup(const oid_t oid,
                            std::shared_ptr<storage::TileGroup> location) {
   // add/update the catalog reference to the tile group
+  num_live_tile_groups_.fetch_add(1);
   tile_group_locator_[oid] = location;
 }
 
 void Manager::DropTileGroup(const oid_t oid) {
   // drop the catalog reference to the tile group
   tile_group_locator_[oid] = empty_tile_group_;
+  num_live_tile_groups_.fetch_sub(1);
 }
 
 std::shared_ptr<storage::TileGroup> Manager::GetTileGroup(const oid_t oid) {

--- a/src/catalog/manager.cpp
+++ b/src/catalog/manager.cpp
@@ -42,6 +42,7 @@ void Manager::AddTileGroup(const oid_t oid,
 }
 
 void Manager::DropTileGroup(const oid_t oid) {
+  
   // drop the catalog reference to the tile group
   tile_group_locator_[oid] = empty_tile_group_;
   num_live_tile_groups_.fetch_sub(1);

--- a/src/common/container/cuckoo_map.cpp
+++ b/src/common/container/cuckoo_map.cpp
@@ -19,6 +19,7 @@
 #include "common/logger.h"
 #include "common/macros.h"
 #include "common/container/lock_free_queue.h"
+#include "storage/data_table.h"
 
 namespace peloton {
 
@@ -130,5 +131,7 @@ template class CuckooMap<oid_t, std::shared_ptr<
 template class CuckooMap<oid_t, std::shared_ptr<
     CuckooMap<oid_t, std::shared_ptr<
         LockFreeQueue<ItemPointer>>>>>;
+
+template class CuckooMap<oid_t, storage::DataTable *>;
 
 }  // namespace peloton

--- a/src/common/container/cuckoo_map.cpp
+++ b/src/common/container/cuckoo_map.cpp
@@ -18,6 +18,7 @@
 #include "common/item_pointer.h"
 #include "common/logger.h"
 #include "common/macros.h"
+#include "common/container/lock_free_queue.h"
 
 namespace peloton {
 
@@ -121,5 +122,13 @@ template class CuckooMap<StatementCache *, StatementCache *>;
 // Used in InternalTypes
 template class CuckooMap<ItemPointer, RWType, ItemPointerHasher,
                          ItemPointerComparator>;
+
+// Used in TransactionLevelGCManager
+template class CuckooMap<oid_t, std::shared_ptr<
+    peloton::LockFreeQueue<ItemPointer>>>;
+
+template class CuckooMap<oid_t, std::shared_ptr<
+    CuckooMap<oid_t, std::shared_ptr<
+        LockFreeQueue<ItemPointer>>>>>;
 
 }  // namespace peloton

--- a/src/common/container/cuckoo_map.cpp
+++ b/src/common/container/cuckoo_map.cpp
@@ -128,10 +128,6 @@ template class CuckooMap<ItemPointer, RWType, ItemPointerHasher,
 template class CuckooMap<oid_t, std::shared_ptr<
     peloton::LockFreeQueue<ItemPointer>>>;
 
-template class CuckooMap<oid_t, std::shared_ptr<
-    CuckooMap<oid_t, std::shared_ptr<
-        LockFreeQueue<ItemPointer>>>>>;
-
 template class CuckooMap<oid_t, storage::DataTable *>;
 
 }  // namespace peloton

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -49,7 +49,7 @@ void PelotonInit::Initialize() {
   }
 
   int parallelism = (CONNECTION_THREAD_COUNT + 3) / 4;
-  storage::DataTable::SetActiveTileGroupCount(parallelism);
+  storage::DataTable::SetDefaultActiveTileGroupCount(parallelism);
   storage::DataTable::SetActiveIndirectionArrayCount(parallelism);
 
   // start epoch.

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -841,6 +841,9 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
       gc_set->operator[](tile_group_id)[tuple_slot] =
           GCVersionType::COMMIT_DELETE;
 
+      gc_set->operator[](new_version.block)[new_version.offset] =
+          GCVersionType::COMMIT_DELETE;
+
       log_manager.LogDelete(ItemPointer(tile_group_id, tuple_slot));
 
     } else if (tuple_entry.second == RWType::INSERT) {

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -841,8 +841,10 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
       gc_set->operator[](tile_group_id)[tuple_slot] =
           GCVersionType::COMMIT_DELETE;
 
-      gc_set->operator[](new_version.block)[new_version.offset] =
-          GCVersionType::COMMIT_DELETE;
+      // TODO: Add the new, empty version to the garbage of this txn
+      // The line below is one possible implementation
+//      gc_set->operator[](new_version.block)[new_version.offset] = GCVersionType::TOMBSTONE;
+      //
 
       log_manager.LogDelete(ItemPointer(tile_group_id, tuple_slot));
 

--- a/src/executor/seq_scan_executor.cpp
+++ b/src/executor/seq_scan_executor.cpp
@@ -154,6 +154,12 @@ bool SeqScanExecutor::DExecute() {
     while (current_tile_group_offset_ < table_tile_group_count_) {
       auto tile_group =
           target_table_->GetTileGroup(current_tile_group_offset_++);
+
+      if (tile_group == nullptr) {
+        // tile group was freed so, continue to next tile group
+        continue;
+      }
+
       auto tile_group_header = tile_group->GetHeader();
 
       oid_t active_tuple_count = tile_group->GetNextTupleSlot();

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -253,6 +253,7 @@ void TransactionLevelGCManager::AddToRecycleMap(
       // if immutable is false and the entry for table_id exists.
       if ((!immutable) && table_recycle_queues != nullptr) {
         auto recycle_queue = GetTileGroupRecycleQueue(table_recycle_queues, tile_group_id);
+        PELOTON_ASSERT(recycle_queue != nullptr);
         recycle_queue->Enqueue(location);
       }
     }
@@ -294,7 +295,7 @@ ItemPointer TransactionLevelGCManager::ReturnFreeSlot(const oid_t &table_id) {
   std::shared_ptr<peloton::CuckooMap<oid_t, std::shared_ptr<
       peloton::LockFreeQueue<ItemPointer>>>> table_recycle_queues;
 
-  if (!recycle_queues_.Find(table_id, table_recycle_queues)) {
+  if (!recycle_queues_->Find(table_id, table_recycle_queues)) {
     return INVALID_ITEMPOINTER;
   }
 

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -263,7 +263,7 @@ void TransactionLevelGCManager::AddToRecycleMap(
 
         // Attempt to free the TileGroup
         if ((!immutable) && recycle_queue->SizeApprox() == table->GetTuplesPerTileGroup() &&
-            table->IsActiveTileGroup(tile_group_id == false)) {
+            table->IsActiveTileGroup(tile_group_id) == false) {
             // TileGroup should be freed
             table->DropTileGroup(tile_group_id);
           }

--- a/src/include/catalog/manager.h
+++ b/src/include/catalog/manager.h
@@ -54,6 +54,8 @@ class Manager {
 
   oid_t GetCurrentTileGroupId() { return tile_group_oid_; }
 
+  oid_t GetNumLiveTileGroups() const { return num_live_tile_groups_; }
+
   void SetNextTileGroupId(oid_t next_oid) { tile_group_oid_ = next_oid; }
 
   void AddTileGroup(const oid_t oid,
@@ -96,6 +98,8 @@ class Manager {
 
   tbb::concurrent_unordered_map<oid_t, std::shared_ptr<storage::TileGroup>>
       tile_group_locator_;
+  std::atomic<oid_t> num_live_tile_groups_ = ATOMIC_VAR_INIT(0);
+
   static std::shared_ptr<storage::TileGroup> empty_tile_group_;
 
   //===--------------------------------------------------------------------===//

--- a/src/include/catalog/manager.h
+++ b/src/include/catalog/manager.h
@@ -54,7 +54,7 @@ class Manager {
 
   oid_t GetCurrentTileGroupId() { return tile_group_oid_; }
 
-  oid_t GetNumLiveTileGroups() const { return num_live_tile_groups_; }
+  oid_t GetNumLiveTileGroups() const { return num_live_tile_groups_.load(); }
 
   void SetNextTileGroupId(oid_t next_oid) { tile_group_oid_ = next_oid; }
 

--- a/src/include/common/container/lock_free_queue.h
+++ b/src/include/common/container/lock_free_queue.h
@@ -38,6 +38,8 @@ class LockFreeQueue {
 
   bool IsEmpty() { return queue_.size_approx() == 0; }
 
+  size_t SizeApprox() const { return queue_.size_approx(); }
+
  private:
   // Underlying moodycamel's concurrent queue
   moodycamel::ConcurrentQueue<T> queue_;

--- a/src/include/common/internal_types.h
+++ b/src/include/common/internal_types.h
@@ -1221,7 +1221,7 @@ enum class GCVersionType {
   ABORT_UPDATE,    // a version that is updated during txn abort.
   ABORT_DELETE,    // a version that is deleted during txn abort.
   ABORT_INSERT,    // a version that is inserted during txn abort.
-  ABORT_INS_DEL,   // a version that is inserted and deleted during txn commit.
+  ABORT_INS_DEL,   // a version that is inserted and deleted during txn abort.
 };
 std::string GCVersionTypeToString(GCVersionType type);
 GCVersionType StringToGCVersionType(const std::string &str);

--- a/src/include/gc/gc_manager.h
+++ b/src/include/gc/gc_manager.h
@@ -69,7 +69,7 @@ class GCManager {
     return INVALID_ITEMPOINTER;
   }
 
-  virtual void RegisterTable(const oid_t &table_id UNUSED_ATTRIBUTE, const oid_t &tuples_per_tile_group UNUSED_ATTRIBUTE) {}
+  virtual void RegisterTable(oid_t table_id UNUSED_ATTRIBUTE, oid_t tuples_per_tile_group UNUSED_ATTRIBUTE) {}
 
   virtual void DeregisterTable(const oid_t &table_id UNUSED_ATTRIBUTE) {}
 

--- a/src/include/gc/gc_manager.h
+++ b/src/include/gc/gc_manager.h
@@ -73,6 +73,10 @@ class GCManager {
 
   virtual void DeregisterTable(const oid_t &table_id UNUSED_ATTRIBUTE) {}
 
+  virtual void RegisterTileGroup(const oid_t &table_id UNUSED_ATTRIBUTE, const oid_t &tile_group_id UNUSED_ATTRIBUTE) {}
+
+  virtual void DeregisterTileGroup(const oid_t &table_id UNUSED_ATTRIBUTE, const oid_t &tile_group_id UNUSED_ATTRIBUTE) {}
+
   virtual size_t GetTableCount() { return 0; }
 
   virtual void RecycleTransaction(

--- a/src/include/gc/gc_manager.h
+++ b/src/include/gc/gc_manager.h
@@ -20,6 +20,7 @@
 #include "common/logger.h"
 #include "common/macros.h"
 #include "common/internal_types.h"
+#include "storage/data_table.h"
 
 namespace peloton {
 
@@ -69,7 +70,7 @@ class GCManager {
     return INVALID_ITEMPOINTER;
   }
 
-  virtual void RegisterTable(oid_t table_id UNUSED_ATTRIBUTE, oid_t tuples_per_tile_group UNUSED_ATTRIBUTE) {}
+  virtual void RegisterTable(oid_t table_id UNUSED_ATTRIBUTE, storage::DataTable *table UNUSED_ATTRIBUTE) {}
 
   virtual void DeregisterTable(const oid_t &table_id UNUSED_ATTRIBUTE) {}
 

--- a/src/include/gc/gc_manager.h
+++ b/src/include/gc/gc_manager.h
@@ -69,7 +69,7 @@ class GCManager {
     return INVALID_ITEMPOINTER;
   }
 
-  virtual void RegisterTable(const oid_t &table_id UNUSED_ATTRIBUTE) {}
+  virtual void RegisterTable(const oid_t &table_id UNUSED_ATTRIBUTE, const oid_t &tuples_per_tile_group UNUSED_ATTRIBUTE) {}
 
   virtual void DeregisterTable(const oid_t &table_id UNUSED_ATTRIBUTE) {}
 

--- a/src/include/gc/gc_manager.h
+++ b/src/include/gc/gc_manager.h
@@ -74,10 +74,6 @@ class GCManager {
 
   virtual void DeregisterTable(const oid_t &table_id UNUSED_ATTRIBUTE) {}
 
-  virtual void RegisterTileGroup(const oid_t &table_id UNUSED_ATTRIBUTE, const oid_t &tile_group_id UNUSED_ATTRIBUTE) {}
-
-  virtual void DeregisterTileGroup(const oid_t &table_id UNUSED_ATTRIBUTE, const oid_t &tile_group_id UNUSED_ATTRIBUTE) {}
-
   virtual size_t GetTableCount() { return 0; }
 
   virtual void RecycleTransaction(

--- a/src/include/gc/transaction_level_gc_manager.h
+++ b/src/include/gc/transaction_level_gc_manager.h
@@ -113,7 +113,7 @@ class TransactionLevelGCManager : public GCManager {
 
   virtual ItemPointer ReturnFreeSlot(const oid_t &table_id) override;
 
-  virtual void RegisterTable(const oid_t &table_id, const oid_t &tuples_per_tile_group) override {
+  virtual void RegisterTable(oid_t table_id, oid_t tuples_per_tile_group) override {
     // Insert a new entry for the table
 
     if (recycle_queues_->Contains(table_id)) {

--- a/src/include/gc/transaction_level_gc_manager.h
+++ b/src/include/gc/transaction_level_gc_manager.h
@@ -150,7 +150,10 @@ class TransactionLevelGCManager : public GCManager {
 
   virtual void RegisterTileGroup(const oid_t &table_id, const oid_t &tile_group_id) override {
     auto table_recycle_queues = GetTableRecycleQueues(table_id);
-    PELOTON_ASSERT(table_recycle_queues != nullptr);
+    if (table_recycle_queues == nullptr) {
+      // Expect this condition to be true if registering catalog TileGroups
+      return;
+    }
     auto recycle_queue = std::make_shared<LockFreeQueue<ItemPointer>>(1000);
     //TODO: read tile group size from settings
     table_recycle_queues->Insert(tile_group_id, recycle_queue);

--- a/src/include/gc/transaction_level_gc_manager.h
+++ b/src/include/gc/transaction_level_gc_manager.h
@@ -128,7 +128,8 @@ class TransactionLevelGCManager : public GCManager {
   }
 
   std::shared_ptr<peloton::CuckooMap<oid_t, std::shared_ptr<
-      peloton::LockFreeQueue<ItemPointer>>>> GetTableRecycleQueues(const oid_t &table_id) const {
+      peloton::LockFreeQueue<ItemPointer>>>>
+  GetTableRecycleQueues(const oid_t &table_id) const {
     std::shared_ptr<peloton::CuckooMap<oid_t, std::shared_ptr<
         peloton::LockFreeQueue<ItemPointer>>>> table_recycle_queues;
     if (recycle_queues_->Find(table_id, table_recycle_queues)) {
@@ -138,7 +139,8 @@ class TransactionLevelGCManager : public GCManager {
     }
   }
 
-  std::shared_ptr<peloton::LockFreeQueue<ItemPointer>> GetTileGroupRecycleQueue(std::shared_ptr<peloton::CuckooMap<oid_t, std::shared_ptr<
+  std::shared_ptr<peloton::LockFreeQueue<ItemPoigcnter>>
+  GetTileGroupRecycleQueue(std::shared_ptr<peloton::CuckooMap<oid_t, std::shared_ptr<
       peloton::LockFreeQueue<ItemPointer>>>> table_recycle_queues, const oid_t &tile_group_id) const {
     std::shared_ptr<peloton::LockFreeQueue<ItemPointer>> recycle_queue;
     if (table_recycle_queues != nullptr && table_recycle_queues->Find(tile_group_id, recycle_queue)) {

--- a/src/include/gc/transaction_level_gc_manager.h
+++ b/src/include/gc/transaction_level_gc_manager.h
@@ -112,6 +112,10 @@ class TransactionLevelGCManager : public GCManager {
 
   virtual ItemPointer ReturnFreeSlot(const oid_t &table_id) override;
 
+//  void TransactionLevelGCManager::RemoveInvalidSlotsFromRecycleQueue(
+//      std::shared_ptr<peloton::LockFreeQueue<ItemPointer>>recycle_queue,
+//      oid_t tile_group_id);
+
   virtual void RegisterTable(oid_t table_id, storage::DataTable *table) override {
     // Insert a new entry for the table
 
@@ -170,6 +174,8 @@ class TransactionLevelGCManager : public GCManager {
 
   int Reclaim(const int &thread_id, const eid_t &expired_eid);
 
+  void ClearGarbage(int thread_id);
+
  private:
   inline unsigned int HashToThread(const size_t &thread_id) {
     return (unsigned int)thread_id % gc_thread_count_;
@@ -181,7 +187,6 @@ class TransactionLevelGCManager : public GCManager {
    *
    * @return No return value.
    */
-  void ClearGarbage(int thread_id);
 
   void Running(const int &thread_id);
 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -298,7 +298,7 @@ class DataTable : public AbstractTable {
 
   inline size_t GetActiveTileGroupCount() const { return active_tilegroup_count_; }
 
-  inline size_t GetNumTuplesPerTileGroup() const { return tuples_per_tilegroup_; }
+  inline size_t GetTuplesPerTileGroup() const { return tuples_per_tilegroup_; }
 
   bool IsActiveTileGroup(const oid_t &tile_group_id) const;
 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -286,11 +286,11 @@ class DataTable : public AbstractTable {
                        concurrency::TransactionContext *transaction,
                        ItemPointer **index_entry_ptr);
 
-  inline static size_t GetActiveTileGroupCount() {
+  inline static size_t GetDefaultActiveTileGroupCount() {
     return default_active_tilegroup_count_;
   }
 
-  static void SetActiveTileGroupCount(const size_t active_tile_group_count) {
+  static void SetDefaultActiveTileGroupCount(const size_t active_tile_group_count) {
     default_active_tilegroup_count_ = active_tile_group_count;
   }
 

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -294,6 +294,8 @@ class DataTable : public AbstractTable {
     default_active_tilegroup_count_ = active_tile_group_count;
   }
 
+  inline size_t GetActiveTileGroupCount() const { return active_tilegroup_count_; }
+
   inline static size_t GetActiveIndirectionArrayCount() {
     return default_active_indirection_array_count_;
   }

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -150,6 +150,8 @@ class DataTable : public AbstractTable {
   // Get a tile group with given layout
   TileGroup *GetTileGroupWithLayout(const column_map_type &partitioning);
 
+  void DropTileGroup(const oid_t &tile_group_id);
+
   //===--------------------------------------------------------------------===//
   // TRIGGER
   //===--------------------------------------------------------------------===//
@@ -295,6 +297,10 @@ class DataTable : public AbstractTable {
   }
 
   inline size_t GetActiveTileGroupCount() const { return active_tilegroup_count_; }
+
+  inline size_t GetNumTuplesPerTileGroup() const { return tuples_per_tilegroup_; }
+
+  bool IsActiveTileGroup(const oid_t &tile_group_id) const;
 
   inline static size_t GetActiveIndirectionArrayCount() {
     return default_active_indirection_array_count_;

--- a/src/include/storage/tile_group_header.h
+++ b/src/include/storage/tile_group_header.h
@@ -245,6 +245,22 @@ class TileGroupHeader : public Printable {
 
   inline bool GetImmutability() const { return immutable; }
 
+  inline void StopRecycling() { recycling_.store(false); }
+
+  inline bool GetRecycling() const { return recycling_.load(); }
+
+  inline size_t IncrementRecycled() { return num_recycled_.fetch_add(1); }
+
+  inline size_t DecrementRecycled() { return num_recycled_.fetch_sub(1); }
+
+  inline size_t GetRecycled() { return num_recycled_.load(); }
+
+  inline size_t IncrementGCReaders() { return num_gc_readers_.fetch_add(1); }
+
+  inline size_t DecrementGCReaders() { return num_gc_readers_.fetch_sub(1); }
+
+  inline size_t GetGCReaders() { return num_gc_readers_.load(); }
+
   void PrintVisibility(txn_id_t txn_id, cid_t at_cid);
 
   // Getter for spin lock
@@ -307,6 +323,10 @@ class TileGroupHeader : public Printable {
   // Immmutable Flag. Should be set by the indextuner to be true.
   // By default it will be set to false.
   bool immutable;
+
+  std::atomic<bool> recycling_;
+  std::atomic<size_t> num_recycled_;
+  std::atomic<size_t> num_gc_readers_;
 };
 
 }  // namespace storage

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -89,7 +89,7 @@ DataTable::DataTable(catalog::Schema *schema, const std::string &table_name,
   // Register non-catalog tables for GC
   if (is_catalog == false) {
     auto &gc_manager = gc::GCManagerFactory::GetInstance();
-    gc_manager.RegisterTable(table_oid, tuples_per_tilegroup);
+    gc_manager.RegisterTable(table_oid, this);
   }
 
   // Create tile groups.

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -921,6 +921,9 @@ oid_t DataTable::AddDefaultTileGroup(const size_t &active_tile_group_id) {
   // add tile group metadata in locator
   catalog::Manager::GetInstance().AddTileGroup(tile_group_id, tile_group);
 
+  auto &gc_manager = gc::GCManagerFactory::GetInstance();
+  gc_manager.RegisterTileGroup(GetOid(), tile_group_id);
+
   COMPILER_MEMORY_FENCE;
 
   active_tile_groups_[active_tile_group_id] = tile_group;
@@ -963,6 +966,9 @@ void DataTable::AddTileGroupWithOidForRecovery(const oid_t &tile_group_id) {
     // add tile group metadata in locator
     catalog::Manager::GetInstance().AddTileGroup(tile_group_id, tile_group);
 
+    auto &gc_manager = gc::GCManagerFactory::GetInstance();
+    gc_manager.RegisterTileGroup(GetOid(), tile_group_id);
+
     // we must guarantee that the compiler always add tile group before adding
     // tile_group_count_.
     COMPILER_MEMORY_FENCE;
@@ -985,6 +991,9 @@ void DataTable::AddTileGroup(const std::shared_ptr<TileGroup> &tile_group) {
 
   // add tile group in catalog
   catalog::Manager::GetInstance().AddTileGroup(tile_group_id, tile_group);
+
+  auto &gc_manager = gc::GCManagerFactory::GetInstance();
+  gc_manager.RegisterTileGroup(GetOid(), tile_group_id);
 
   // we must guarantee that the compiler always add tile group before adding
   // tile_group_count_.

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -86,9 +86,11 @@ DataTable::DataTable(catalog::Schema *schema, const std::string &table_name,
 
   active_indirection_arrays_.resize(active_indirection_array_count_);
 
-
-  auto &gc_manager = gc::GCManagerFactory::GetInstance();
-  gc_manager.RegisterTable(table_oid);
+  // Register non-catalog tables for GC
+  if (is_catalog == false) {
+    auto &gc_manager = gc::GCManagerFactory::GetInstance();
+    gc_manager.RegisterTable(table_oid);
+  }
 
   // Create tile groups.
   for (size_t i = 0; i < active_tilegroup_count_; ++i) {

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -85,6 +85,11 @@ DataTable::DataTable(catalog::Schema *schema, const std::string &table_name,
   active_tile_groups_.resize(active_tilegroup_count_);
 
   active_indirection_arrays_.resize(active_indirection_array_count_);
+
+
+  auto &gc_manager = gc::GCManagerFactory::GetInstance();
+  gc_manager.RegisterTable(table_oid);
+
   // Create tile groups.
   for (size_t i = 0; i < active_tilegroup_count_; ++i) {
     AddDefaultTileGroup(i);

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -928,9 +928,6 @@ oid_t DataTable::AddDefaultTileGroup(const size_t &active_tile_group_id) {
   // add tile group metadata in locator
   catalog::Manager::GetInstance().AddTileGroup(tile_group_id, tile_group);
 
-  auto &gc_manager = gc::GCManagerFactory::GetInstance();
-  gc_manager.RegisterTileGroup(GetOid(), tile_group_id);
-
   COMPILER_MEMORY_FENCE;
 
   active_tile_groups_[active_tile_group_id] = tile_group;
@@ -973,9 +970,6 @@ void DataTable::AddTileGroupWithOidForRecovery(const oid_t &tile_group_id) {
     // add tile group metadata in locator
     catalog::Manager::GetInstance().AddTileGroup(tile_group_id, tile_group);
 
-    auto &gc_manager = gc::GCManagerFactory::GetInstance();
-    gc_manager.RegisterTileGroup(GetOid(), tile_group_id);
-
     // we must guarantee that the compiler always add tile group before adding
     // tile_group_count_.
     COMPILER_MEMORY_FENCE;
@@ -998,9 +992,6 @@ void DataTable::AddTileGroup(const std::shared_ptr<TileGroup> &tile_group) {
 
   // add tile group in catalog
   catalog::Manager::GetInstance().AddTileGroup(tile_group_id, tile_group);
-
-  auto &gc_manager = gc::GCManagerFactory::GetInstance();
-  gc_manager.RegisterTileGroup(GetOid(), tile_group_id);
 
   // we must guarantee that the compiler always add tile group before adding
   // tile_group_count_.
@@ -1039,11 +1030,9 @@ std::shared_ptr<storage::TileGroup> DataTable::GetTileGroupById(
 }
 
 void DataTable::DropTileGroup(const oid_t &tile_group_id) {
-  auto &gc_manager = gc::GCManagerFactory::GetInstance();
-  gc_manager.DeregisterTileGroup(GetOid(), tile_group_id);
   tile_groups_.Update(tile_group_id, invalid_tile_group_id);
-  auto &manager = catalog::Manager::GetInstance();
-  manager.DropTileGroup(tile_group_id);
+  auto &catalog_manager = catalog::Manager::GetInstance();
+  catalog_manager.DropTileGroup(tile_group_id);
 }
 
 void DataTable::DropTileGroups() {

--- a/src/storage/database.cpp
+++ b/src/storage/database.cpp
@@ -40,17 +40,10 @@ Database::~Database() {
 // TABLE
 //===----------------------------------------------------------------------===//
 
-void Database::AddTable(storage::DataTable *table, bool is_catalog) {
+void Database::AddTable(storage::DataTable *table, bool is_catalog UNUSED_ATTRIBUTE) {
   {
     std::lock_guard<std::mutex> lock(database_mutex);
     tables.push_back(table);
-
-    if (is_catalog == false) {
-      // Register table to GC manager.
-      auto *gc_manager = &gc::GCManagerFactory::GetInstance();
-      assert(gc_manager != nullptr);
-      gc_manager->RegisterTable(table->GetOid());
-    }
   }
 }
 

--- a/src/storage/tile_group.cpp
+++ b/src/storage/tile_group.cpp
@@ -58,7 +58,7 @@ TileGroup::TileGroup(BackendType backend_type,
 
 TileGroup::~TileGroup() {
   // Drop references on all tiles
-
+//  LOG_DEBUG("TileGroup %d destructed!\n", tile_group_id);
   // clean up tile group header
   delete tile_group_header;
 }

--- a/src/storage/tile_group.cpp
+++ b/src/storage/tile_group.cpp
@@ -58,7 +58,7 @@ TileGroup::TileGroup(BackendType backend_type,
 
 TileGroup::~TileGroup() {
   // Drop references on all tiles
-//  LOG_DEBUG("TileGroup %d destructed!\n", tile_group_id);
+  // LOG_DEBUG("TileGroup %d destructed!", tile_group_id);
   // clean up tile group header
   delete tile_group_header;
 }

--- a/src/storage/tile_group_header.cpp
+++ b/src/storage/tile_group_header.cpp
@@ -62,6 +62,10 @@ TileGroupHeader::TileGroupHeader(const BackendType &backend_type,
 
   // Initially immutabile flag to false initially.
   immutable = false;
+
+  recycling_ = true;
+  num_recycled_ = 0;
+  num_gc_readers_ = 0;
 }
 
 TileGroupHeader::~TileGroupHeader() {

--- a/test/executor/loader_test.cpp
+++ b/test/executor/loader_test.cpp
@@ -133,29 +133,29 @@ TEST_F(LoaderTests, LoadingTest) {
 
   int total_tuple_count = loader_threads_count * tilegroup_count_per_loader * TEST_TUPLES_PER_TILEGROUP;
   int max_cached_tuple_count =
-      TEST_TUPLES_PER_TILEGROUP * storage::DataTable::GetActiveTileGroupCount();
+      TEST_TUPLES_PER_TILEGROUP * storage::DataTable::GetDefaultActiveTileGroupCount();
   int max_unfill_cached_tuple_count =
       (TEST_TUPLES_PER_TILEGROUP - 1) *
-      storage::DataTable::GetActiveTileGroupCount();
+          storage::DataTable::GetDefaultActiveTileGroupCount();
 
   if (total_tuple_count - max_cached_tuple_count <= 0) {
     if (total_tuple_count <= max_unfill_cached_tuple_count) {
-      expected_tile_group_count = storage::DataTable::GetActiveTileGroupCount();
+      expected_tile_group_count = storage::DataTable::GetDefaultActiveTileGroupCount();
     } else {
       expected_tile_group_count =
-          storage::DataTable::GetActiveTileGroupCount() + total_tuple_count -
+          storage::DataTable::GetDefaultActiveTileGroupCount() + total_tuple_count -
           max_unfill_cached_tuple_count;
     }
   } else {
-    int filled_tile_group_count = total_tuple_count / max_cached_tuple_count * storage::DataTable::GetActiveTileGroupCount();
+    int filled_tile_group_count = total_tuple_count / max_cached_tuple_count * storage::DataTable::GetDefaultActiveTileGroupCount();
     
     if (total_tuple_count - filled_tile_group_count * TEST_TUPLES_PER_TILEGROUP - max_unfill_cached_tuple_count <= 0) {
       expected_tile_group_count = filled_tile_group_count +
-                                  storage::DataTable::GetActiveTileGroupCount();
+          storage::DataTable::GetDefaultActiveTileGroupCount();
     } else {
       expected_tile_group_count =
           filled_tile_group_count +
-          storage::DataTable::GetActiveTileGroupCount() +
+              storage::DataTable::GetDefaultActiveTileGroupCount() +
           (total_tuple_count - filled_tile_group_count -
            max_unfill_cached_tuple_count);
     }

--- a/test/gc/garbage_collection_test.cpp
+++ b/test/gc/garbage_collection_test.cpp
@@ -134,7 +134,7 @@ TEST_F(GarbageCollectionTests, UpdateTest) {
   std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
       num_key, "UPDATE_TABLE", db_id, INVALID_OID, 1234, true));
 
-  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
+  EXPECT_EQ(gc_manager.GetTableCount(), 1);
 
   gc_manager.StartGC(gc_threads);
 

--- a/test/gc/transaction_level_gc_manager_test.cpp
+++ b/test/gc/transaction_level_gc_manager_test.cpp
@@ -67,6 +67,15 @@ ResultType BulkInsertTuples(storage::DataTable *table, const size_t num_tuples) 
   scheduler.Run();
 
   return scheduler.schedules[0].txn_result;
+
+
+  // Insert tuple
+//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+//  auto txn = txn_manager.BeginTransaction();
+//  for (size_t i = 0; i < num_tuples; i++) {
+//    TestingTransactionUtil::ExecuteInsert(txn, table, i, 0);
+//  }
+//  return txn_manager.CommitTransaction(txn);
 }
 
 ResultType BulkDeleteTuples(storage::DataTable *table, const size_t num_tuples) {
@@ -110,407 +119,407 @@ ResultType SelectTuple(storage::DataTable *table, const int key,
 }
 
 // update -> delete
-TEST_F(TransactionLevelGCManagerTests, UpdateDeleteTest) {
-  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
-  epoch_manager.Reset(1);
-  std::vector<std::unique_ptr<std::thread>> gc_threads;
-
-  gc::GCManagerFactory::Configure(1);
-  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
-  auto storage_manager = storage::StorageManager::GetInstance();
-  // create database
-  auto database = TestingExecutorUtil::InitializeDatabase("DATABASE0");
-  oid_t db_id = database->GetOid();
-  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
-
-  // create a table with only one key
-  const int num_key = 1;
-  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
-      num_key, "TABLE0", db_id, INVALID_OID, 1234, true));
-
-  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
-
-  //===========================
-  // update a version here.
-  //===========================
-  auto ret = UpdateTuple(table.get(), 0);
-  EXPECT_TRUE(ret == ResultType::SUCCESS);
-
-  epoch_manager.SetCurrentEpochId(2);
-
-  // get expired epoch id.
-  // as the current epoch id is set to 2,
-  // the expected expired epoch id should be 1.
-  auto expired_eid = epoch_manager.GetExpiredEpochId();
-
-  EXPECT_EQ(1, expired_eid);
-
-  auto current_eid = epoch_manager.GetCurrentEpochId();
-
-  EXPECT_EQ(2, current_eid);
-
-  auto reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-
-  auto unlinked_count = gc_manager.Unlink(0, expired_eid);
-
-  EXPECT_EQ(0, reclaimed_count);
-
-  EXPECT_EQ(1, unlinked_count);
-
-  epoch_manager.SetCurrentEpochId(3);
-
-  expired_eid = epoch_manager.GetExpiredEpochId();
-
-  EXPECT_EQ(2, expired_eid);
-
-  current_eid = epoch_manager.GetCurrentEpochId();
-
-  EXPECT_EQ(3, current_eid);
-
-  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-
-  unlinked_count = gc_manager.Unlink(0, expired_eid);
-
-  EXPECT_EQ(1, reclaimed_count);
-
-  EXPECT_EQ(0, unlinked_count);
-
-  //===========================
-  // delete a version here.
-  //===========================
-  ret = DeleteTuple(table.get(), 0);
-  EXPECT_TRUE(ret == ResultType::SUCCESS);
-
-  epoch_manager.SetCurrentEpochId(4);
-
-  // get expired epoch id.
-  // as the current epoch id is set to 4,
-  // the expected expired epoch id should be 3.
-  expired_eid = epoch_manager.GetExpiredEpochId();
-
-  EXPECT_EQ(3, expired_eid);
-
-  current_eid = epoch_manager.GetCurrentEpochId();
-
-  EXPECT_EQ(4, current_eid);
-
-  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-
-  unlinked_count = gc_manager.Unlink(0, expired_eid);
-
-  EXPECT_EQ(0, reclaimed_count);
-
-  EXPECT_EQ(1, unlinked_count);
-
-  epoch_manager.SetCurrentEpochId(5);
-
-  expired_eid = epoch_manager.GetExpiredEpochId();
-
-  EXPECT_EQ(4, expired_eid);
-
-  current_eid = epoch_manager.GetCurrentEpochId();
-
-  EXPECT_EQ(5, current_eid);
-
-  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-
-  unlinked_count = gc_manager.Unlink(0, expired_eid);
-
-  EXPECT_EQ(1, reclaimed_count);
-
-  EXPECT_EQ(0, unlinked_count);
-
-  gc_manager.StopGC();
-  gc::GCManagerFactory::Configure(0);
-
-  table.release();
-
-  // DROP!
-  TestingExecutorUtil::DeleteDatabase("DATABASE0");
-
-  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-  auto txn = txn_manager.BeginTransaction();
-  EXPECT_THROW(
-      catalog::Catalog::GetInstance()->GetDatabaseObject("DATABASE0", txn),
-      CatalogException);
-  txn_manager.CommitTransaction(txn);
-  // EXPECT_FALSE(storage_manager->HasDatabase(db_id));
-}
-
-// insert -> delete -> insert
-TEST_F(TransactionLevelGCManagerTests, ReInsertTest) {
-  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
-  epoch_manager.Reset(1);
-
-  std::vector<std::unique_ptr<std::thread>> gc_threads;
-
-  gc::GCManagerFactory::Configure(1);
-  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
-  gc_manager.Reset();
-
-  auto storage_manager = storage::StorageManager::GetInstance();
-  // create database
-  auto database = TestingExecutorUtil::InitializeDatabase("DATABASE1");
-  oid_t db_id = database->GetOid();
-  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
-
-  // create a table with only one key
-  const int num_key = 1;
-  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
-      num_key, "TABLE1", db_id, INVALID_OID, 1234, true));
-
-  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
-
-  //===========================
-  // insert a tuple here.
-  //===========================
-  auto ret = InsertTuple(table.get(), 100);
-  EXPECT_TRUE(ret == ResultType::SUCCESS);
-
-  epoch_manager.SetCurrentEpochId(2);
-
-  // get expired epoch id.
-  // as the current epoch id is set to 2,
-  // the expected expired epoch id should be 1.
-  auto expired_eid = epoch_manager.GetExpiredEpochId();
-
-  EXPECT_EQ(1, expired_eid);
-
-  auto current_eid = epoch_manager.GetCurrentEpochId();
-
-  EXPECT_EQ(2, current_eid);
-
-  auto reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-
-  auto unlinked_count = gc_manager.Unlink(0, expired_eid);
-
-  EXPECT_EQ(0, reclaimed_count);
-
-  EXPECT_EQ(0, unlinked_count);
-
-  epoch_manager.SetCurrentEpochId(3);
-
-  expired_eid = epoch_manager.GetExpiredEpochId();
-
-  EXPECT_EQ(2, expired_eid);
-
-  current_eid = epoch_manager.GetCurrentEpochId();
-
-  EXPECT_EQ(3, current_eid);
-
-  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-
-  unlinked_count = gc_manager.Unlink(0, expired_eid);
-
-  EXPECT_EQ(0, reclaimed_count);
-
-  EXPECT_EQ(0, unlinked_count);
-
-  //===========================
-  // select the tuple.
-  //===========================
-  std::vector<int> results;
-
-  results.clear();
-  ret = SelectTuple(table.get(), 100, results);
-  EXPECT_TRUE(ret == ResultType::SUCCESS);
-  EXPECT_TRUE(results[0] != -1);
-
-  //===========================
-  // delete the tuple.
-  //===========================
-  ret = DeleteTuple(table.get(), 100);
-  EXPECT_TRUE(ret == ResultType::SUCCESS);
-
-  epoch_manager.SetCurrentEpochId(4);
-
-  // get expired epoch id.
-  // as the current epoch id is set to 4,
-  // the expected expired epoch id should be 3.
-  expired_eid = epoch_manager.GetExpiredEpochId();
-
-  EXPECT_EQ(3, expired_eid);
-
-  current_eid = epoch_manager.GetCurrentEpochId();
-
-  EXPECT_EQ(4, current_eid);
-
-  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-
-  unlinked_count = gc_manager.Unlink(0, expired_eid);
-
-  EXPECT_EQ(0, reclaimed_count);
-
-  EXPECT_EQ(1, unlinked_count);
-
-  epoch_manager.SetCurrentEpochId(5);
-
-  expired_eid = epoch_manager.GetExpiredEpochId();
-
-  EXPECT_EQ(4, expired_eid);
-
-  current_eid = epoch_manager.GetCurrentEpochId();
-
-  EXPECT_EQ(5, current_eid);
-
-  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-
-  unlinked_count = gc_manager.Unlink(0, expired_eid);
-
-  EXPECT_EQ(1, reclaimed_count);
-
-  EXPECT_EQ(0, unlinked_count);
-
-  //===========================
-  // select the tuple.
-  //===========================
-  results.clear();
-  ret = SelectTuple(table.get(), 100, results);
-  EXPECT_TRUE(ret == ResultType::SUCCESS);
-  EXPECT_TRUE(results[0] == -1);
-
-  //===========================
-  // insert the tuple again.
-  //===========================
-  ret = InsertTuple(table.get(), 100);
-  EXPECT_TRUE(ret == ResultType::SUCCESS);
-
-  //===========================
-  // select the tuple.
-  //===========================
-  results.clear();
-  ret = SelectTuple(table.get(), 100, results);
-  EXPECT_TRUE(ret == ResultType::SUCCESS);
-  EXPECT_TRUE(results[0] != -1);
-
-  gc_manager.StopGC();
-  gc::GCManagerFactory::Configure(0);
-
-  table.release();
-
-  // DROP!
-  TestingExecutorUtil::DeleteDatabase("DATABASE1");
-
-  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-  auto txn = txn_manager.BeginTransaction();
-  EXPECT_THROW(
-      catalog::Catalog::GetInstance()->GetDatabaseObject("DATABASE0", txn),
-      CatalogException);
-  txn_manager.CommitTransaction(txn);
-  // EXPECT_FALSE(storage_manager->HasDatabase(db_id));
-}
-
-/*
-Brief Summary : This tests tries to check immutability of a tile group.
-Once a tile group is set immutable, gc should not recycle slots from the
-tile group. We will first insert into a tile group and then delete tuples
-from the tile group. After setting immutability further inserts or updates
-should not use slots from the tile group where delete happened.
-*/
-TEST_F(TransactionLevelGCManagerTests, ImmutabilityTest) {
-  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
-  epoch_manager.Reset(1);
-
-  std::vector<std::unique_ptr<std::thread>> gc_threads;
-
-  gc::GCManagerFactory::Configure(1);
-  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
-  gc_manager.Reset();
-
-  auto storage_manager = storage::StorageManager::GetInstance();
-  // create database
-  auto database = TestingExecutorUtil::InitializeDatabase("ImmutabilityDB");
-  oid_t db_id = database->GetOid();
-  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
-
-  // create a table with only one key
-  const int num_key = 25;
-  const size_t tuples_per_tilegroup = 5;
-  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
-      num_key, "TABLE1", db_id, INVALID_OID, 1234, true, tuples_per_tilegroup));
-
-  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
-
-  oid_t num_tile_groups = (table.get())->GetTileGroupCount();
-  EXPECT_EQ(num_tile_groups, (num_key / tuples_per_tilegroup) + 1);
-
-  // Making the 1st tile group immutable
-  auto tile_group = (table.get())->GetTileGroup(0);
-  auto tile_group_ptr = tile_group.get();
-  auto tile_group_header = tile_group_ptr->GetHeader();
-  tile_group_header->SetImmutability();
-
-  // Deleting a tuple from the 1st tilegroup
-  auto ret = DeleteTuple(table.get(), 2);
-  EXPECT_TRUE(ret == ResultType::SUCCESS);
-  epoch_manager.SetCurrentEpochId(2);
-  auto expired_eid = epoch_manager.GetExpiredEpochId();
-  EXPECT_EQ(1, expired_eid);
-  auto current_eid = epoch_manager.GetCurrentEpochId();
-  EXPECT_EQ(2, current_eid);
-  auto reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-  auto unlinked_count = gc_manager.Unlink(0, expired_eid);
-  EXPECT_EQ(0, reclaimed_count);
-  EXPECT_EQ(1, unlinked_count);
-
-  epoch_manager.SetCurrentEpochId(3);
-  expired_eid = epoch_manager.GetExpiredEpochId();
-  EXPECT_EQ(2, expired_eid);
-  current_eid = epoch_manager.GetCurrentEpochId();
-  EXPECT_EQ(3, current_eid);
-  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-  unlinked_count = gc_manager.Unlink(0, expired_eid);
-  EXPECT_EQ(1, reclaimed_count);
-  EXPECT_EQ(0, unlinked_count);
-
-  // ReturnFreeSlot() should return null because deleted tuple was from
-  // immutable tilegroup.
-  auto location = gc_manager.ReturnFreeSlot((table.get())->GetOid());
-  EXPECT_EQ(location.IsNull(), true);
-
-  // Deleting a tuple from the 2nd tilegroup which is mutable.
-  ret = DeleteTuple(table.get(), 6);
-
-  EXPECT_TRUE(ret == ResultType::SUCCESS);
-  epoch_manager.SetCurrentEpochId(4);
-  expired_eid = epoch_manager.GetExpiredEpochId();
-  EXPECT_EQ(3, expired_eid);
-  current_eid = epoch_manager.GetCurrentEpochId();
-  EXPECT_EQ(4, current_eid);
-  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-  unlinked_count = gc_manager.Unlink(0, expired_eid);
-  EXPECT_EQ(0, reclaimed_count);
-  EXPECT_EQ(1, unlinked_count);
-
-  epoch_manager.SetCurrentEpochId(5);
-  expired_eid = epoch_manager.GetExpiredEpochId();
-  EXPECT_EQ(4, expired_eid);
-  current_eid = epoch_manager.GetCurrentEpochId();
-  EXPECT_EQ(5, current_eid);
-  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-  unlinked_count = gc_manager.Unlink(0, expired_eid);
-  EXPECT_EQ(1, reclaimed_count);
-  EXPECT_EQ(0, unlinked_count);
-
-  // ReturnFreeSlot() should not return null because deleted tuple was from
-  // mutable tilegroup.
-  location = gc_manager.ReturnFreeSlot((table.get())->GetOid());
-  EXPECT_EQ(location.IsNull(), false);
-
-  gc_manager.StopGC();
-  gc::GCManagerFactory::Configure(0);
-
-  table.release();
-  // DROP!
-  TestingExecutorUtil::DeleteDatabase("ImmutabilityDB");
-
-  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-  auto txn = txn_manager.BeginTransaction();
-  EXPECT_THROW(
-      catalog::Catalog::GetInstance()->GetDatabaseObject("ImmutabilityDB", txn),
-      CatalogException);
-  txn_manager.CommitTransaction(txn);
-}
+//TEST_F(TransactionLevelGCManagerTests, UpdateDeleteTest) {
+//  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
+//  epoch_manager.Reset(1);
+//  std::vector<std::unique_ptr<std::thread>> gc_threads;
+//
+//  gc::GCManagerFactory::Configure(1);
+//  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
+//  auto storage_manager = storage::StorageManager::GetInstance();
+//  // create database
+//  auto database = TestingExecutorUtil::InitializeDatabase("DATABASE0");
+//  oid_t db_id = database->GetOid();
+//  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
+//
+//  // create a table with only one key
+//  const int num_key = 1;
+//  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
+//      num_key, "TABLE0", db_id, INVALID_OID, 1234, true));
+//
+//  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
+//
+//  //===========================
+//  // update a version here.
+//  //===========================
+//  auto ret = UpdateTuple(table.get(), 0);
+//  EXPECT_TRUE(ret == ResultType::SUCCESS);
+//
+//  epoch_manager.SetCurrentEpochId(2);
+//
+//  // get expired epoch id.
+//  // as the current epoch id is set to 2,
+//  // the expected expired epoch id should be 1.
+//  auto expired_eid = epoch_manager.GetExpiredEpochId();
+//
+//  EXPECT_EQ(1, expired_eid);
+//
+//  auto current_eid = epoch_manager.GetCurrentEpochId();
+//
+//  EXPECT_EQ(2, current_eid);
+//
+//  auto reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+//
+//  auto unlinked_count = gc_manager.Unlink(0, expired_eid);
+//
+//  EXPECT_EQ(0, reclaimed_count);
+//
+//  EXPECT_EQ(1, unlinked_count);
+//
+//  epoch_manager.SetCurrentEpochId(3);
+//
+//  expired_eid = epoch_manager.GetExpiredEpochId();
+//
+//  EXPECT_EQ(2, expired_eid);
+//
+//  current_eid = epoch_manager.GetCurrentEpochId();
+//
+//  EXPECT_EQ(3, current_eid);
+//
+//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+//
+//  unlinked_count = gc_manager.Unlink(0, expired_eid);
+//
+//  EXPECT_EQ(1, reclaimed_count);
+//
+//  EXPECT_EQ(0, unlinked_count);
+//
+//  //===========================
+//  // delete a version here.
+//  //===========================
+//  ret = DeleteTuple(table.get(), 0);
+//  EXPECT_TRUE(ret == ResultType::SUCCESS);
+//
+//  epoch_manager.SetCurrentEpochId(4);
+//
+//  // get expired epoch id.
+//  // as the current epoch id is set to 4,
+//  // the expected expired epoch id should be 3.
+//  expired_eid = epoch_manager.GetExpiredEpochId();
+//
+//  EXPECT_EQ(3, expired_eid);
+//
+//  current_eid = epoch_manager.GetCurrentEpochId();
+//
+//  EXPECT_EQ(4, current_eid);
+//
+//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+//
+//  unlinked_count = gc_manager.Unlink(0, expired_eid);
+//
+//  EXPECT_EQ(0, reclaimed_count);
+//
+//  EXPECT_EQ(1, unlinked_count);
+//
+//  epoch_manager.SetCurrentEpochId(5);
+//
+//  expired_eid = epoch_manager.GetExpiredEpochId();
+//
+//  EXPECT_EQ(4, expired_eid);
+//
+//  current_eid = epoch_manager.GetCurrentEpochId();
+//
+//  EXPECT_EQ(5, current_eid);
+//
+//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+//
+//  unlinked_count = gc_manager.Unlink(0, expired_eid);
+//
+//  EXPECT_EQ(1, reclaimed_count);
+//
+//  EXPECT_EQ(0, unlinked_count);
+//
+//  gc_manager.StopGC();
+//  gc::GCManagerFactory::Configure(0);
+//
+//  table.release();
+//
+//  // DROP!
+//  TestingExecutorUtil::DeleteDatabase("DATABASE0");
+//
+//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+//  auto txn = txn_manager.BeginTransaction();
+//  EXPECT_THROW(
+//      catalog::Catalog::GetInstance()->GetDatabaseObject("DATABASE0", txn),
+//      CatalogException);
+//  txn_manager.CommitTransaction(txn);
+//  // EXPECT_FALSE(storage_manager->HasDatabase(db_id));
+//}
+//
+//// insert -> delete -> insert
+//TEST_F(TransactionLevelGCManagerTests, ReInsertTest) {
+//  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
+//  epoch_manager.Reset(1);
+//
+//  std::vector<std::unique_ptr<std::thread>> gc_threads;
+//
+//  gc::GCManagerFactory::Configure(1);
+//  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
+//  gc_manager.Reset();
+//
+//  auto storage_manager = storage::StorageManager::GetInstance();
+//  // create database
+//  auto database = TestingExecutorUtil::InitializeDatabase("DATABASE1");
+//  oid_t db_id = database->GetOid();
+//  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
+//
+//  // create a table with only one key
+//  const int num_key = 1;
+//  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
+//      num_key, "TABLE1", db_id, INVALID_OID, 1234, true));
+//
+//  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
+//
+//  //===========================
+//  // insert a tuple here.
+//  //===========================
+//  auto ret = InsertTuple(table.get(), 100);
+//  EXPECT_TRUE(ret == ResultType::SUCCESS);
+//
+//  epoch_manager.SetCurrentEpochId(2);
+//
+//  // get expired epoch id.
+//  // as the current epoch id is set to 2,
+//  // the expected expired epoch id should be 1.
+//  auto expired_eid = epoch_manager.GetExpiredEpochId();
+//
+//  EXPECT_EQ(1, expired_eid);
+//
+//  auto current_eid = epoch_manager.GetCurrentEpochId();
+//
+//  EXPECT_EQ(2, current_eid);
+//
+//  auto reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+//
+//  auto unlinked_count = gc_manager.Unlink(0, expired_eid);
+//
+//  EXPECT_EQ(0, reclaimed_count);
+//
+//  EXPECT_EQ(0, unlinked_count);
+//
+//  epoch_manager.SetCurrentEpochId(3);
+//
+//  expired_eid = epoch_manager.GetExpiredEpochId();
+//
+//  EXPECT_EQ(2, expired_eid);
+//
+//  current_eid = epoch_manager.GetCurrentEpochId();
+//
+//  EXPECT_EQ(3, current_eid);
+//
+//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+//
+//  unlinked_count = gc_manager.Unlink(0, expired_eid);
+//
+//  EXPECT_EQ(0, reclaimed_count);
+//
+//  EXPECT_EQ(0, unlinked_count);
+//
+//  //===========================
+//  // select the tuple.
+//  //===========================
+//  std::vector<int> results;
+//
+//  results.clear();
+//  ret = SelectTuple(table.get(), 100, results);
+//  EXPECT_TRUE(ret == ResultType::SUCCESS);
+//  EXPECT_TRUE(results[0] != -1);
+//
+//  //===========================
+//  // delete the tuple.
+//  //===========================
+//  ret = DeleteTuple(table.get(), 100);
+//  EXPECT_TRUE(ret == ResultType::SUCCESS);
+//
+//  epoch_manager.SetCurrentEpochId(4);
+//
+//  // get expired epoch id.
+//  // as the current epoch id is set to 4,
+//  // the expected expired epoch id should be 3.
+//  expired_eid = epoch_manager.GetExpiredEpochId();
+//
+//  EXPECT_EQ(3, expired_eid);
+//
+//  current_eid = epoch_manager.GetCurrentEpochId();
+//
+//  EXPECT_EQ(4, current_eid);
+//
+//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+//
+//  unlinked_count = gc_manager.Unlink(0, expired_eid);
+//
+//  EXPECT_EQ(0, reclaimed_count);
+//
+//  EXPECT_EQ(1, unlinked_count);
+//
+//  epoch_manager.SetCurrentEpochId(5);
+//
+//  expired_eid = epoch_manager.GetExpiredEpochId();
+//
+//  EXPECT_EQ(4, expired_eid);
+//
+//  current_eid = epoch_manager.GetCurrentEpochId();
+//
+//  EXPECT_EQ(5, current_eid);
+//
+//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+//
+//  unlinked_count = gc_manager.Unlink(0, expired_eid);
+//
+//  EXPECT_EQ(1, reclaimed_count);
+//
+//  EXPECT_EQ(0, unlinked_count);
+//
+//  //===========================
+//  // select the tuple.
+//  //===========================
+//  results.clear();
+//  ret = SelectTuple(table.get(), 100, results);
+//  EXPECT_TRUE(ret == ResultType::SUCCESS);
+//  EXPECT_TRUE(results[0] == -1);
+//
+//  //===========================
+//  // insert the tuple again.
+//  //===========================
+//  ret = InsertTuple(table.get(), 100);
+//  EXPECT_TRUE(ret == ResultType::SUCCESS);
+//
+//  //===========================
+//  // select the tuple.
+//  //===========================
+//  results.clear();
+//  ret = SelectTuple(table.get(), 100, results);
+//  EXPECT_TRUE(ret == ResultType::SUCCESS);
+//  EXPECT_TRUE(results[0] != -1);
+//
+//  gc_manager.StopGC();
+//  gc::GCManagerFactory::Configure(0);
+//
+//  table.release();
+//
+//  // DROP!
+//  TestingExecutorUtil::DeleteDatabase("DATABASE1");
+//
+//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+//  auto txn = txn_manager.BeginTransaction();
+//  EXPECT_THROW(
+//      catalog::Catalog::GetInstance()->GetDatabaseObject("DATABASE0", txn),
+//      CatalogException);
+//  txn_manager.CommitTransaction(txn);
+//  // EXPECT_FALSE(storage_manager->HasDatabase(db_id));
+//}
+//
+///*
+//Brief Summary : This tests tries to check immutability of a tile group.
+//Once a tile group is set immutable, gc should not recycle slots from the
+//tile group. We will first insert into a tile group and then delete tuples
+//from the tile group. After setting immutability further inserts or updates
+//should not use slots from the tile group where delete happened.
+//*/
+//TEST_F(TransactionLevelGCManagerTests, ImmutabilityTest) {
+//  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
+//  epoch_manager.Reset(1);
+//
+//  std::vector<std::unique_ptr<std::thread>> gc_threads;
+//
+//  gc::GCManagerFactory::Configure(1);
+//  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
+//  gc_manager.Reset();
+//
+//  auto storage_manager = storage::StorageManager::GetInstance();
+//  // create database
+//  auto database = TestingExecutorUtil::InitializeDatabase("ImmutabilityDB");
+//  oid_t db_id = database->GetOid();
+//  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
+//
+//  // create a table with only one key
+//  const int num_key = 25;
+//  const size_t tuples_per_tilegroup = 5;
+//  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
+//      num_key, "TABLE1", db_id, INVALID_OID, 1234, true, tuples_per_tilegroup));
+//
+//  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
+//
+//  oid_t num_tile_groups = (table.get())->GetTileGroupCount();
+//  EXPECT_EQ(num_tile_groups, (num_key / tuples_per_tilegroup) + 1);
+//
+//  // Making the 1st tile group immutable
+//  auto tile_group = (table.get())->GetTileGroup(0);
+//  auto tile_group_ptr = tile_group.get();
+//  auto tile_group_header = tile_group_ptr->GetHeader();
+//  tile_group_header->SetImmutability();
+//
+//  // Deleting a tuple from the 1st tilegroup
+//  auto ret = DeleteTuple(table.get(), 2);
+//  EXPECT_TRUE(ret == ResultType::SUCCESS);
+//  epoch_manager.SetCurrentEpochId(2);
+//  auto expired_eid = epoch_manager.GetExpiredEpochId();
+//  EXPECT_EQ(1, expired_eid);
+//  auto current_eid = epoch_manager.GetCurrentEpochId();
+//  EXPECT_EQ(2, current_eid);
+//  auto reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+//  auto unlinked_count = gc_manager.Unlink(0, expired_eid);
+//  EXPECT_EQ(0, reclaimed_count);
+//  EXPECT_EQ(1, unlinked_count);
+//
+//  epoch_manager.SetCurrentEpochId(3);
+//  expired_eid = epoch_manager.GetExpiredEpochId();
+//  EXPECT_EQ(2, expired_eid);
+//  current_eid = epoch_manager.GetCurrentEpochId();
+//  EXPECT_EQ(3, current_eid);
+//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+//  unlinked_count = gc_manager.Unlink(0, expired_eid);
+//  EXPECT_EQ(1, reclaimed_count);
+//  EXPECT_EQ(0, unlinked_count);
+//
+//  // ReturnFreeSlot() should return null because deleted tuple was from
+//  // immutable tilegroup.
+//  auto location = gc_manager.ReturnFreeSlot((table.get())->GetOid());
+//  EXPECT_EQ(location.IsNull(), true);
+//
+//  // Deleting a tuple from the 2nd tilegroup which is mutable.
+//  ret = DeleteTuple(table.get(), 6);
+//
+//  EXPECT_TRUE(ret == ResultType::SUCCESS);
+//  epoch_manager.SetCurrentEpochId(4);
+//  expired_eid = epoch_manager.GetExpiredEpochId();
+//  EXPECT_EQ(3, expired_eid);
+//  current_eid = epoch_manager.GetCurrentEpochId();
+//  EXPECT_EQ(4, current_eid);
+//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+//  unlinked_count = gc_manager.Unlink(0, expired_eid);
+//  EXPECT_EQ(0, reclaimed_count);
+//  EXPECT_EQ(1, unlinked_count);
+//
+//  epoch_manager.SetCurrentEpochId(5);
+//  expired_eid = epoch_manager.GetExpiredEpochId();
+//  EXPECT_EQ(4, expired_eid);
+//  current_eid = epoch_manager.GetCurrentEpochId();
+//  EXPECT_EQ(5, current_eid);
+//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+//  unlinked_count = gc_manager.Unlink(0, expired_eid);
+//  EXPECT_EQ(1, reclaimed_count);
+//  EXPECT_EQ(0, unlinked_count);
+//
+//  // ReturnFreeSlot() should not return null because deleted tuple was from
+//  // mutable tilegroup.
+//  location = gc_manager.ReturnFreeSlot((table.get())->GetOid());
+//  EXPECT_EQ(location.IsNull(), false);
+//
+//  gc_manager.StopGC();
+//  gc::GCManagerFactory::Configure(0);
+//
+//  table.release();
+//  // DROP!
+//  TestingExecutorUtil::DeleteDatabase("ImmutabilityDB");
+//
+//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+//  auto txn = txn_manager.BeginTransaction();
+//  EXPECT_THROW(
+//      catalog::Catalog::GetInstance()->GetDatabaseObject("ImmutabilityDB", txn),
+//      CatalogException);
+//  txn_manager.CommitTransaction(txn);
+//}
 
 // check mem -> insert 100k -> check mem -> delete all -> check mem
 TEST_F(TransactionLevelGCManagerTests, FreeTileGroupsTest) {
@@ -531,8 +540,8 @@ TEST_F(TransactionLevelGCManagerTests, FreeTileGroupsTest) {
   EXPECT_TRUE(storage_manager->HasDatabase(db_id));
 
   // create a table with only one key
-  const int num_key = 1;
-  size_t tuples_per_tilegroup = 1000;
+  const int num_key = 0;
+  size_t tuples_per_tilegroup = 2;
 
   std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
       num_key, "TABLE1", db_id, INVALID_OID, 1234, true, tuples_per_tilegroup));
@@ -541,16 +550,89 @@ TEST_F(TransactionLevelGCManagerTests, FreeTileGroupsTest) {
   size_t tile_group_count_after_init = manager.GetNumLiveTileGroups();
   LOG_DEBUG("tile_group_count_after_init: %zu\n", tile_group_count_after_init);
 
-  //===========================
-  // insert tuples here.
-  //===========================
-  size_t num_inserts = 5000;
-  auto insert_result = BulkInsertTuples(table.get(), num_inserts);
-  EXPECT_EQ(ResultType::SUCCESS, insert_result);
+  auto current_eid = epoch_manager.GetCurrentEpochId();
 
-  // capture memory usage
-  size_t tile_group_count_after_insert = manager.GetNumLiveTileGroups();
-  LOG_DEBUG("tile_group_count_after_insert: %zu\n", tile_group_count_after_insert);
+  //  int round = 1;
+  for(int round = 1; round <= 3; round++) {
+
+    LOG_DEBUG("Round: %d\n", round);
+
+    epoch_manager.SetCurrentEpochId(++current_eid);
+    //===========================
+    // insert tuples here.
+    //===========================
+    size_t num_inserts = 100;
+    auto insert_result = BulkInsertTuples(table.get(), num_inserts);
+    EXPECT_EQ(ResultType::SUCCESS, insert_result);
+
+    // capture memory usage
+    size_t tile_group_count_after_insert = manager.GetNumLiveTileGroups();
+    LOG_DEBUG("Round %d: tile_group_count_after_insert: %zu", round, tile_group_count_after_insert);
+
+    epoch_manager.SetCurrentEpochId(++current_eid);
+    //===========================
+    // delete the tuples.
+    //===========================
+    auto delete_result = BulkDeleteTuples(table.get(), num_inserts);
+    EXPECT_EQ(ResultType::SUCCESS, delete_result);
+
+    size_t tile_group_count_after_delete = manager.GetNumLiveTileGroups();
+    LOG_DEBUG("Round %d: tile_group_count_after_delete: %zu", round, tile_group_count_after_delete);
+
+    epoch_manager.SetCurrentEpochId(++current_eid);
+
+    gc_manager.ClearGarbage(0);
+
+    size_t tile_group_count_after_gc = manager.GetNumLiveTileGroups();
+    LOG_DEBUG("Round %d: tile_group_count_after_gc: %zu", round, tile_group_count_after_gc);
+    EXPECT_LT(tile_group_count_after_gc, tile_group_count_after_init + 1);
+  }
+
+  gc_manager.StopGC();
+  gc::GCManagerFactory::Configure(0);
+
+  table.release();
+
+  // DROP!
+  TestingExecutorUtil::DeleteDatabase("FreeTileGroupsDB");
+
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  EXPECT_THROW(
+      catalog::Catalog::GetInstance()->GetDatabaseObject("FreeTileGroupsDB", txn),
+      CatalogException);
+  txn_manager.CommitTransaction(txn);
+}
+
+// Insert a tuple, delete that tuple. Insert 2 tuples. Recycling should make it such that
+// the next_free_slot in the tile_group_header did not increase
+TEST_F(TransactionLevelGCManagerTests, InsertDeleteInsertX2) {
+
+  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
+  epoch_manager.Reset(1);
+
+  std::vector<std::unique_ptr<std::thread>> gc_threads;
+
+  gc::GCManagerFactory::Configure(1);
+  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
+  gc_manager.Reset();
+
+  auto storage_manager = storage::StorageManager::GetInstance();
+  auto database = TestingExecutorUtil::InitializeDatabase("InsertDeleteInsertX2");
+  oid_t db_id = database->GetOid();
+  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
+
+
+  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable());
+
+//  auto &manager = catalog::Manager::GetInstance();
+
+  auto tile_group = table->GetTileGroup(0);
+  auto tile_group_header = tile_group->GetHeader();
+
+  size_t current_next_tuple_slot_after_init = tile_group_header->GetCurrentNextTupleSlot();
+  LOG_DEBUG("current_next_tuple_slot_after_init: %zu\n", current_next_tuple_slot_after_init);
+
 
   epoch_manager.SetCurrentEpochId(2);
 
@@ -576,13 +658,12 @@ TEST_F(TransactionLevelGCManagerTests, FreeTileGroupsTest) {
   //===========================
   // delete the tuples.
   //===========================
-  auto delete_result = BulkDeleteTuples(table.get(), num_inserts);
+  auto delete_result = DeleteTuple(table.get(), 1);
   EXPECT_EQ(ResultType::SUCCESS, delete_result);
 
-  size_t tile_group_count_after_delete = manager.GetNumLiveTileGroups();
-  LOG_DEBUG("tile_group_count_after_delete: %zu\n", tile_group_count_after_delete);
-
-//  std::this_thread::sleep_for(std::chrono::seconds(30));
+  size_t current_next_tuple_slot_after_delete = tile_group_header->GetCurrentNextTupleSlot();
+  LOG_DEBUG("current_next_tuple_slot_after_delete: %zu\n", current_next_tuple_slot_after_delete);
+  EXPECT_EQ(current_next_tuple_slot_after_init + 1, current_next_tuple_slot_after_delete);
 
   do {
     epoch_manager.SetCurrentEpochId(++current_eid);
@@ -598,23 +679,31 @@ TEST_F(TransactionLevelGCManagerTests, FreeTileGroupsTest) {
 
   } while (reclaimed_count || unlinked_count);
 
-  size_t tile_group_count_after_gc = manager.GetNumLiveTileGroups();
-  LOG_DEBUG("tile_group_count_after_gc: %zu\n", tile_group_count_after_gc);
+  size_t current_next_tuple_slot_after_gc = tile_group_header->GetCurrentNextTupleSlot();
+  LOG_DEBUG("current_next_tuple_slot_after_gc: %zu\n", current_next_tuple_slot_after_gc);
+  EXPECT_EQ(current_next_tuple_slot_after_delete, current_next_tuple_slot_after_gc);
+
+
+  auto insert_result = InsertTuple(table.get(), 15721);
+  EXPECT_EQ(ResultType::SUCCESS, insert_result);
+
+  insert_result = InsertTuple(table.get(), 6288);
+  EXPECT_EQ(ResultType::SUCCESS, insert_result);
+
+  size_t current_next_tuple_slot_after_insert = tile_group_header->GetCurrentNextTupleSlot();
+  LOG_DEBUG("current_next_tuple_slot_after_insert: %zu\n", current_next_tuple_slot_after_insert);
+  EXPECT_EQ(current_next_tuple_slot_after_delete, current_next_tuple_slot_after_insert);
 
   gc_manager.StopGC();
   gc::GCManagerFactory::Configure(0);
 
-  EXPECT_LT(tile_group_count_after_gc, tile_group_count_after_delete);
-
   table.release();
-
-  // DROP!
-  TestingExecutorUtil::DeleteDatabase("FreeTileGroupsDB");
+  TestingExecutorUtil::DeleteDatabase("InsertDeleteInsertX2");
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   EXPECT_THROW(
-      catalog::Catalog::GetInstance()->GetDatabaseObject("FreeTileGroupsDB", txn),
+      catalog::Catalog::GetInstance()->GetDatabaseObject("InsertDeleteInsertX2", txn),
       CatalogException);
   txn_manager.CommitTransaction(txn);
 }

--- a/test/gc/transaction_level_gc_manager_test.cpp
+++ b/test/gc/transaction_level_gc_manager_test.cpp
@@ -119,407 +119,407 @@ ResultType SelectTuple(storage::DataTable *table, const int key,
 }
 
 // update -> delete
-//TEST_F(TransactionLevelGCManagerTests, UpdateDeleteTest) {
-//  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
-//  epoch_manager.Reset(1);
-//  std::vector<std::unique_ptr<std::thread>> gc_threads;
-//
-//  gc::GCManagerFactory::Configure(1);
-//  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
-//  auto storage_manager = storage::StorageManager::GetInstance();
-//  // create database
-//  auto database = TestingExecutorUtil::InitializeDatabase("DATABASE0");
-//  oid_t db_id = database->GetOid();
-//  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
-//
-//  // create a table with only one key
-//  const int num_key = 1;
-//  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
-//      num_key, "TABLE0", db_id, INVALID_OID, 1234, true));
-//
-//  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
-//
-//  //===========================
-//  // update a version here.
-//  //===========================
-//  auto ret = UpdateTuple(table.get(), 0);
-//  EXPECT_TRUE(ret == ResultType::SUCCESS);
-//
-//  epoch_manager.SetCurrentEpochId(2);
-//
-//  // get expired epoch id.
-//  // as the current epoch id is set to 2,
-//  // the expected expired epoch id should be 1.
-//  auto expired_eid = epoch_manager.GetExpiredEpochId();
-//
-//  EXPECT_EQ(1, expired_eid);
-//
-//  auto current_eid = epoch_manager.GetCurrentEpochId();
-//
-//  EXPECT_EQ(2, current_eid);
-//
-//  auto reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-//
-//  auto unlinked_count = gc_manager.Unlink(0, expired_eid);
-//
-//  EXPECT_EQ(0, reclaimed_count);
-//
-//  EXPECT_EQ(1, unlinked_count);
-//
-//  epoch_manager.SetCurrentEpochId(3);
-//
-//  expired_eid = epoch_manager.GetExpiredEpochId();
-//
-//  EXPECT_EQ(2, expired_eid);
-//
-//  current_eid = epoch_manager.GetCurrentEpochId();
-//
-//  EXPECT_EQ(3, current_eid);
-//
-//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-//
-//  unlinked_count = gc_manager.Unlink(0, expired_eid);
-//
-//  EXPECT_EQ(1, reclaimed_count);
-//
-//  EXPECT_EQ(0, unlinked_count);
-//
-//  //===========================
-//  // delete a version here.
-//  //===========================
-//  ret = DeleteTuple(table.get(), 0);
-//  EXPECT_TRUE(ret == ResultType::SUCCESS);
-//
-//  epoch_manager.SetCurrentEpochId(4);
-//
-//  // get expired epoch id.
-//  // as the current epoch id is set to 4,
-//  // the expected expired epoch id should be 3.
-//  expired_eid = epoch_manager.GetExpiredEpochId();
-//
-//  EXPECT_EQ(3, expired_eid);
-//
-//  current_eid = epoch_manager.GetCurrentEpochId();
-//
-//  EXPECT_EQ(4, current_eid);
-//
-//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-//
-//  unlinked_count = gc_manager.Unlink(0, expired_eid);
-//
-//  EXPECT_EQ(0, reclaimed_count);
-//
-//  EXPECT_EQ(1, unlinked_count);
-//
-//  epoch_manager.SetCurrentEpochId(5);
-//
-//  expired_eid = epoch_manager.GetExpiredEpochId();
-//
-//  EXPECT_EQ(4, expired_eid);
-//
-//  current_eid = epoch_manager.GetCurrentEpochId();
-//
-//  EXPECT_EQ(5, current_eid);
-//
-//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-//
-//  unlinked_count = gc_manager.Unlink(0, expired_eid);
-//
-//  EXPECT_EQ(1, reclaimed_count);
-//
-//  EXPECT_EQ(0, unlinked_count);
-//
-//  gc_manager.StopGC();
-//  gc::GCManagerFactory::Configure(0);
-//
-//  table.release();
-//
-//  // DROP!
-//  TestingExecutorUtil::DeleteDatabase("DATABASE0");
-//
-//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-//  auto txn = txn_manager.BeginTransaction();
-//  EXPECT_THROW(
-//      catalog::Catalog::GetInstance()->GetDatabaseObject("DATABASE0", txn),
-//      CatalogException);
-//  txn_manager.CommitTransaction(txn);
-//  // EXPECT_FALSE(storage_manager->HasDatabase(db_id));
-//}
-//
-//// insert -> delete -> insert
-//TEST_F(TransactionLevelGCManagerTests, ReInsertTest) {
-//  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
-//  epoch_manager.Reset(1);
-//
-//  std::vector<std::unique_ptr<std::thread>> gc_threads;
-//
-//  gc::GCManagerFactory::Configure(1);
-//  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
-//  gc_manager.Reset();
-//
-//  auto storage_manager = storage::StorageManager::GetInstance();
-//  // create database
-//  auto database = TestingExecutorUtil::InitializeDatabase("DATABASE1");
-//  oid_t db_id = database->GetOid();
-//  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
-//
-//  // create a table with only one key
-//  const int num_key = 1;
-//  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
-//      num_key, "TABLE1", db_id, INVALID_OID, 1234, true));
-//
-//  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
-//
-//  //===========================
-//  // insert a tuple here.
-//  //===========================
-//  auto ret = InsertTuple(table.get(), 100);
-//  EXPECT_TRUE(ret == ResultType::SUCCESS);
-//
-//  epoch_manager.SetCurrentEpochId(2);
-//
-//  // get expired epoch id.
-//  // as the current epoch id is set to 2,
-//  // the expected expired epoch id should be 1.
-//  auto expired_eid = epoch_manager.GetExpiredEpochId();
-//
-//  EXPECT_EQ(1, expired_eid);
-//
-//  auto current_eid = epoch_manager.GetCurrentEpochId();
-//
-//  EXPECT_EQ(2, current_eid);
-//
-//  auto reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-//
-//  auto unlinked_count = gc_manager.Unlink(0, expired_eid);
-//
-//  EXPECT_EQ(0, reclaimed_count);
-//
-//  EXPECT_EQ(0, unlinked_count);
-//
-//  epoch_manager.SetCurrentEpochId(3);
-//
-//  expired_eid = epoch_manager.GetExpiredEpochId();
-//
-//  EXPECT_EQ(2, expired_eid);
-//
-//  current_eid = epoch_manager.GetCurrentEpochId();
-//
-//  EXPECT_EQ(3, current_eid);
-//
-//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-//
-//  unlinked_count = gc_manager.Unlink(0, expired_eid);
-//
-//  EXPECT_EQ(0, reclaimed_count);
-//
-//  EXPECT_EQ(0, unlinked_count);
-//
-//  //===========================
-//  // select the tuple.
-//  //===========================
-//  std::vector<int> results;
-//
-//  results.clear();
-//  ret = SelectTuple(table.get(), 100, results);
-//  EXPECT_TRUE(ret == ResultType::SUCCESS);
-//  EXPECT_TRUE(results[0] != -1);
-//
-//  //===========================
-//  // delete the tuple.
-//  //===========================
-//  ret = DeleteTuple(table.get(), 100);
-//  EXPECT_TRUE(ret == ResultType::SUCCESS);
-//
-//  epoch_manager.SetCurrentEpochId(4);
-//
-//  // get expired epoch id.
-//  // as the current epoch id is set to 4,
-//  // the expected expired epoch id should be 3.
-//  expired_eid = epoch_manager.GetExpiredEpochId();
-//
-//  EXPECT_EQ(3, expired_eid);
-//
-//  current_eid = epoch_manager.GetCurrentEpochId();
-//
-//  EXPECT_EQ(4, current_eid);
-//
-//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-//
-//  unlinked_count = gc_manager.Unlink(0, expired_eid);
-//
-//  EXPECT_EQ(0, reclaimed_count);
-//
-//  EXPECT_EQ(1, unlinked_count);
-//
-//  epoch_manager.SetCurrentEpochId(5);
-//
-//  expired_eid = epoch_manager.GetExpiredEpochId();
-//
-//  EXPECT_EQ(4, expired_eid);
-//
-//  current_eid = epoch_manager.GetCurrentEpochId();
-//
-//  EXPECT_EQ(5, current_eid);
-//
-//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-//
-//  unlinked_count = gc_manager.Unlink(0, expired_eid);
-//
-//  EXPECT_EQ(1, reclaimed_count);
-//
-//  EXPECT_EQ(0, unlinked_count);
-//
-//  //===========================
-//  // select the tuple.
-//  //===========================
-//  results.clear();
-//  ret = SelectTuple(table.get(), 100, results);
-//  EXPECT_TRUE(ret == ResultType::SUCCESS);
-//  EXPECT_TRUE(results[0] == -1);
-//
-//  //===========================
-//  // insert the tuple again.
-//  //===========================
-//  ret = InsertTuple(table.get(), 100);
-//  EXPECT_TRUE(ret == ResultType::SUCCESS);
-//
-//  //===========================
-//  // select the tuple.
-//  //===========================
-//  results.clear();
-//  ret = SelectTuple(table.get(), 100, results);
-//  EXPECT_TRUE(ret == ResultType::SUCCESS);
-//  EXPECT_TRUE(results[0] != -1);
-//
-//  gc_manager.StopGC();
-//  gc::GCManagerFactory::Configure(0);
-//
-//  table.release();
-//
-//  // DROP!
-//  TestingExecutorUtil::DeleteDatabase("DATABASE1");
-//
-//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-//  auto txn = txn_manager.BeginTransaction();
-//  EXPECT_THROW(
-//      catalog::Catalog::GetInstance()->GetDatabaseObject("DATABASE0", txn),
-//      CatalogException);
-//  txn_manager.CommitTransaction(txn);
-//  // EXPECT_FALSE(storage_manager->HasDatabase(db_id));
-//}
-//
-///*
-//Brief Summary : This tests tries to check immutability of a tile group.
-//Once a tile group is set immutable, gc should not recycle slots from the
-//tile group. We will first insert into a tile group and then delete tuples
-//from the tile group. After setting immutability further inserts or updates
-//should not use slots from the tile group where delete happened.
-//*/
-//TEST_F(TransactionLevelGCManagerTests, ImmutabilityTest) {
-//  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
-//  epoch_manager.Reset(1);
-//
-//  std::vector<std::unique_ptr<std::thread>> gc_threads;
-//
-//  gc::GCManagerFactory::Configure(1);
-//  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
-//  gc_manager.Reset();
-//
-//  auto storage_manager = storage::StorageManager::GetInstance();
-//  // create database
-//  auto database = TestingExecutorUtil::InitializeDatabase("ImmutabilityDB");
-//  oid_t db_id = database->GetOid();
-//  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
-//
-//  // create a table with only one key
-//  const int num_key = 25;
-//  const size_t tuples_per_tilegroup = 5;
-//  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
-//      num_key, "TABLE1", db_id, INVALID_OID, 1234, true, tuples_per_tilegroup));
-//
-//  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
-//
-//  oid_t num_tile_groups = (table.get())->GetTileGroupCount();
-//  EXPECT_EQ(num_tile_groups, (num_key / tuples_per_tilegroup) + 1);
-//
-//  // Making the 1st tile group immutable
-//  auto tile_group = (table.get())->GetTileGroup(0);
-//  auto tile_group_ptr = tile_group.get();
-//  auto tile_group_header = tile_group_ptr->GetHeader();
-//  tile_group_header->SetImmutability();
-//
-//  // Deleting a tuple from the 1st tilegroup
-//  auto ret = DeleteTuple(table.get(), 2);
-//  EXPECT_TRUE(ret == ResultType::SUCCESS);
-//  epoch_manager.SetCurrentEpochId(2);
-//  auto expired_eid = epoch_manager.GetExpiredEpochId();
-//  EXPECT_EQ(1, expired_eid);
-//  auto current_eid = epoch_manager.GetCurrentEpochId();
-//  EXPECT_EQ(2, current_eid);
-//  auto reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-//  auto unlinked_count = gc_manager.Unlink(0, expired_eid);
-//  EXPECT_EQ(0, reclaimed_count);
-//  EXPECT_EQ(1, unlinked_count);
-//
-//  epoch_manager.SetCurrentEpochId(3);
-//  expired_eid = epoch_manager.GetExpiredEpochId();
-//  EXPECT_EQ(2, expired_eid);
-//  current_eid = epoch_manager.GetCurrentEpochId();
-//  EXPECT_EQ(3, current_eid);
-//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-//  unlinked_count = gc_manager.Unlink(0, expired_eid);
-//  EXPECT_EQ(1, reclaimed_count);
-//  EXPECT_EQ(0, unlinked_count);
-//
-//  // ReturnFreeSlot() should return null because deleted tuple was from
-//  // immutable tilegroup.
-//  auto location = gc_manager.ReturnFreeSlot((table.get())->GetOid());
-//  EXPECT_EQ(location.IsNull(), true);
-//
-//  // Deleting a tuple from the 2nd tilegroup which is mutable.
-//  ret = DeleteTuple(table.get(), 6);
-//
-//  EXPECT_TRUE(ret == ResultType::SUCCESS);
-//  epoch_manager.SetCurrentEpochId(4);
-//  expired_eid = epoch_manager.GetExpiredEpochId();
-//  EXPECT_EQ(3, expired_eid);
-//  current_eid = epoch_manager.GetCurrentEpochId();
-//  EXPECT_EQ(4, current_eid);
-//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-//  unlinked_count = gc_manager.Unlink(0, expired_eid);
-//  EXPECT_EQ(0, reclaimed_count);
-//  EXPECT_EQ(1, unlinked_count);
-//
-//  epoch_manager.SetCurrentEpochId(5);
-//  expired_eid = epoch_manager.GetExpiredEpochId();
-//  EXPECT_EQ(4, expired_eid);
-//  current_eid = epoch_manager.GetCurrentEpochId();
-//  EXPECT_EQ(5, current_eid);
-//  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
-//  unlinked_count = gc_manager.Unlink(0, expired_eid);
-//  EXPECT_EQ(1, reclaimed_count);
-//  EXPECT_EQ(0, unlinked_count);
-//
-//  // ReturnFreeSlot() should not return null because deleted tuple was from
-//  // mutable tilegroup.
-//  location = gc_manager.ReturnFreeSlot((table.get())->GetOid());
-//  EXPECT_EQ(location.IsNull(), false);
-//
-//  gc_manager.StopGC();
-//  gc::GCManagerFactory::Configure(0);
-//
-//  table.release();
-//  // DROP!
-//  TestingExecutorUtil::DeleteDatabase("ImmutabilityDB");
-//
-//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-//  auto txn = txn_manager.BeginTransaction();
-//  EXPECT_THROW(
-//      catalog::Catalog::GetInstance()->GetDatabaseObject("ImmutabilityDB", txn),
-//      CatalogException);
-//  txn_manager.CommitTransaction(txn);
-//}
+TEST_F(TransactionLevelGCManagerTests, UpdateDeleteTest) {
+  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
+  epoch_manager.Reset(1);
+  std::vector<std::unique_ptr<std::thread>> gc_threads;
+
+  gc::GCManagerFactory::Configure(1);
+  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
+  auto storage_manager = storage::StorageManager::GetInstance();
+  // create database
+  auto database = TestingExecutorUtil::InitializeDatabase("DATABASE0");
+  oid_t db_id = database->GetOid();
+  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
+
+  // create a table with only one key
+  const int num_key = 1;
+  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
+      num_key, "TABLE0", db_id, INVALID_OID, 1234, true));
+
+  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
+
+  //===========================
+  // update a version here.
+  //===========================
+  auto ret = UpdateTuple(table.get(), 0);
+  EXPECT_TRUE(ret == ResultType::SUCCESS);
+
+  epoch_manager.SetCurrentEpochId(2);
+
+  // get expired epoch id.
+  // as the current epoch id is set to 2,
+  // the expected expired epoch id should be 1.
+  auto expired_eid = epoch_manager.GetExpiredEpochId();
+
+  EXPECT_EQ(1, expired_eid);
+
+  auto current_eid = epoch_manager.GetCurrentEpochId();
+
+  EXPECT_EQ(2, current_eid);
+
+  auto reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+
+  auto unlinked_count = gc_manager.Unlink(0, expired_eid);
+
+  EXPECT_EQ(0, reclaimed_count);
+
+  EXPECT_EQ(1, unlinked_count);
+
+  epoch_manager.SetCurrentEpochId(3);
+
+  expired_eid = epoch_manager.GetExpiredEpochId();
+
+  EXPECT_EQ(2, expired_eid);
+
+  current_eid = epoch_manager.GetCurrentEpochId();
+
+  EXPECT_EQ(3, current_eid);
+
+  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+
+  unlinked_count = gc_manager.Unlink(0, expired_eid);
+
+  EXPECT_EQ(1, reclaimed_count);
+
+  EXPECT_EQ(0, unlinked_count);
+
+  //===========================
+  // delete a version here.
+  //===========================
+  ret = DeleteTuple(table.get(), 0);
+  EXPECT_TRUE(ret == ResultType::SUCCESS);
+
+  epoch_manager.SetCurrentEpochId(4);
+
+  // get expired epoch id.
+  // as the current epoch id is set to 4,
+  // the expected expired epoch id should be 3.
+  expired_eid = epoch_manager.GetExpiredEpochId();
+
+  EXPECT_EQ(3, expired_eid);
+
+  current_eid = epoch_manager.GetCurrentEpochId();
+
+  EXPECT_EQ(4, current_eid);
+
+  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+
+  unlinked_count = gc_manager.Unlink(0, expired_eid);
+
+  EXPECT_EQ(0, reclaimed_count);
+
+  EXPECT_EQ(1, unlinked_count);
+
+  epoch_manager.SetCurrentEpochId(5);
+
+  expired_eid = epoch_manager.GetExpiredEpochId();
+
+  EXPECT_EQ(4, expired_eid);
+
+  current_eid = epoch_manager.GetCurrentEpochId();
+
+  EXPECT_EQ(5, current_eid);
+
+  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+
+  unlinked_count = gc_manager.Unlink(0, expired_eid);
+
+  EXPECT_EQ(1, reclaimed_count);
+
+  EXPECT_EQ(0, unlinked_count);
+
+  gc_manager.StopGC();
+  gc::GCManagerFactory::Configure(0);
+
+  table.release();
+
+  // DROP!
+  TestingExecutorUtil::DeleteDatabase("DATABASE0");
+
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  EXPECT_THROW(
+      catalog::Catalog::GetInstance()->GetDatabaseObject("DATABASE0", txn),
+      CatalogException);
+  txn_manager.CommitTransaction(txn);
+  // EXPECT_FALSE(storage_manager->HasDatabase(db_id));
+}
+
+// insert -> delete -> insert
+TEST_F(TransactionLevelGCManagerTests, ReInsertTest) {
+  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
+  epoch_manager.Reset(1);
+
+  std::vector<std::unique_ptr<std::thread>> gc_threads;
+
+  gc::GCManagerFactory::Configure(1);
+  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
+  gc_manager.Reset();
+
+  auto storage_manager = storage::StorageManager::GetInstance();
+  // create database
+  auto database = TestingExecutorUtil::InitializeDatabase("DATABASE1");
+  oid_t db_id = database->GetOid();
+  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
+
+  // create a table with only one key
+  const int num_key = 1;
+  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
+      num_key, "TABLE1", db_id, INVALID_OID, 1234, true));
+
+  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
+
+  //===========================
+  // insert a tuple here.
+  //===========================
+  auto ret = InsertTuple(table.get(), 100);
+  EXPECT_TRUE(ret == ResultType::SUCCESS);
+
+  epoch_manager.SetCurrentEpochId(2);
+
+  // get expired epoch id.
+  // as the current epoch id is set to 2,
+  // the expected expired epoch id should be 1.
+  auto expired_eid = epoch_manager.GetExpiredEpochId();
+
+  EXPECT_EQ(1, expired_eid);
+
+  auto current_eid = epoch_manager.GetCurrentEpochId();
+
+  EXPECT_EQ(2, current_eid);
+
+  auto reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+
+  auto unlinked_count = gc_manager.Unlink(0, expired_eid);
+
+  EXPECT_EQ(0, reclaimed_count);
+
+  EXPECT_EQ(0, unlinked_count);
+
+  epoch_manager.SetCurrentEpochId(3);
+
+  expired_eid = epoch_manager.GetExpiredEpochId();
+
+  EXPECT_EQ(2, expired_eid);
+
+  current_eid = epoch_manager.GetCurrentEpochId();
+
+  EXPECT_EQ(3, current_eid);
+
+  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+
+  unlinked_count = gc_manager.Unlink(0, expired_eid);
+
+  EXPECT_EQ(0, reclaimed_count);
+
+  EXPECT_EQ(0, unlinked_count);
+
+  //===========================
+  // select the tuple.
+  //===========================
+  std::vector<int> results;
+
+  results.clear();
+  ret = SelectTuple(table.get(), 100, results);
+  EXPECT_TRUE(ret == ResultType::SUCCESS);
+  EXPECT_TRUE(results[0] != -1);
+
+  //===========================
+  // delete the tuple.
+  //===========================
+  ret = DeleteTuple(table.get(), 100);
+  EXPECT_TRUE(ret == ResultType::SUCCESS);
+
+  epoch_manager.SetCurrentEpochId(4);
+
+  // get expired epoch id.
+  // as the current epoch id is set to 4,
+  // the expected expired epoch id should be 3.
+  expired_eid = epoch_manager.GetExpiredEpochId();
+
+  EXPECT_EQ(3, expired_eid);
+
+  current_eid = epoch_manager.GetCurrentEpochId();
+
+  EXPECT_EQ(4, current_eid);
+
+  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+
+  unlinked_count = gc_manager.Unlink(0, expired_eid);
+
+  EXPECT_EQ(0, reclaimed_count);
+
+  EXPECT_EQ(1, unlinked_count);
+
+  epoch_manager.SetCurrentEpochId(5);
+
+  expired_eid = epoch_manager.GetExpiredEpochId();
+
+  EXPECT_EQ(4, expired_eid);
+
+  current_eid = epoch_manager.GetCurrentEpochId();
+
+  EXPECT_EQ(5, current_eid);
+
+  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+
+  unlinked_count = gc_manager.Unlink(0, expired_eid);
+
+  EXPECT_EQ(1, reclaimed_count);
+
+  EXPECT_EQ(0, unlinked_count);
+
+  //===========================
+  // select the tuple.
+  //===========================
+  results.clear();
+  ret = SelectTuple(table.get(), 100, results);
+  EXPECT_TRUE(ret == ResultType::SUCCESS);
+  EXPECT_TRUE(results[0] == -1);
+
+  //===========================
+  // insert the tuple again.
+  //===========================
+  ret = InsertTuple(table.get(), 100);
+  EXPECT_TRUE(ret == ResultType::SUCCESS);
+
+  //===========================
+  // select the tuple.
+  //===========================
+  results.clear();
+  ret = SelectTuple(table.get(), 100, results);
+  EXPECT_TRUE(ret == ResultType::SUCCESS);
+  EXPECT_TRUE(results[0] != -1);
+
+  gc_manager.StopGC();
+  gc::GCManagerFactory::Configure(0);
+
+  table.release();
+
+  // DROP!
+  TestingExecutorUtil::DeleteDatabase("DATABASE1");
+
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  EXPECT_THROW(
+      catalog::Catalog::GetInstance()->GetDatabaseObject("DATABASE0", txn),
+      CatalogException);
+  txn_manager.CommitTransaction(txn);
+  // EXPECT_FALSE(storage_manager->HasDatabase(db_id));
+}
+
+/*
+Brief Summary : This tests tries to check immutability of a tile group.
+Once a tile group is set immutable, gc should not recycle slots from the
+tile group. We will first insert into a tile group and then delete tuples
+from the tile group. After setting immutability further inserts or updates
+should not use slots from the tile group where delete happened.
+*/
+TEST_F(TransactionLevelGCManagerTests, ImmutabilityTest) {
+  auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();
+  epoch_manager.Reset(1);
+
+  std::vector<std::unique_ptr<std::thread>> gc_threads;
+
+  gc::GCManagerFactory::Configure(1);
+  auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
+  gc_manager.Reset();
+
+  auto storage_manager = storage::StorageManager::GetInstance();
+  // create database
+  auto database = TestingExecutorUtil::InitializeDatabase("ImmutabilityDB");
+  oid_t db_id = database->GetOid();
+  EXPECT_TRUE(storage_manager->HasDatabase(db_id));
+
+  // create a table with only one key
+  const int num_key = 25;
+  const size_t tuples_per_tilegroup = 5;
+  std::unique_ptr<storage::DataTable> table(TestingTransactionUtil::CreateTable(
+      num_key, "TABLE1", db_id, INVALID_OID, 1234, true, tuples_per_tilegroup));
+
+  EXPECT_TRUE(gc_manager.GetTableCount() == 1);
+
+  oid_t num_tile_groups = (table.get())->GetTileGroupCount();
+  EXPECT_EQ(num_tile_groups, (num_key / tuples_per_tilegroup) + 1);
+
+  // Making the 1st tile group immutable
+  auto tile_group = (table.get())->GetTileGroup(0);
+  auto tile_group_ptr = tile_group.get();
+  auto tile_group_header = tile_group_ptr->GetHeader();
+  tile_group_header->SetImmutability();
+
+  // Deleting a tuple from the 1st tilegroup
+  auto ret = DeleteTuple(table.get(), 2);
+  EXPECT_TRUE(ret == ResultType::SUCCESS);
+  epoch_manager.SetCurrentEpochId(2);
+  auto expired_eid = epoch_manager.GetExpiredEpochId();
+  EXPECT_EQ(1, expired_eid);
+  auto current_eid = epoch_manager.GetCurrentEpochId();
+  EXPECT_EQ(2, current_eid);
+  auto reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+  auto unlinked_count = gc_manager.Unlink(0, expired_eid);
+  EXPECT_EQ(0, reclaimed_count);
+  EXPECT_EQ(1, unlinked_count);
+
+  epoch_manager.SetCurrentEpochId(3);
+  expired_eid = epoch_manager.GetExpiredEpochId();
+  EXPECT_EQ(2, expired_eid);
+  current_eid = epoch_manager.GetCurrentEpochId();
+  EXPECT_EQ(3, current_eid);
+  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+  unlinked_count = gc_manager.Unlink(0, expired_eid);
+  EXPECT_EQ(1, reclaimed_count);
+  EXPECT_EQ(0, unlinked_count);
+
+  // ReturnFreeSlot() should return null because deleted tuple was from
+  // immutable tilegroup.
+  auto location = gc_manager.ReturnFreeSlot((table.get())->GetOid());
+  EXPECT_EQ(location.IsNull(), true);
+
+  // Deleting a tuple from the 2nd tilegroup which is mutable.
+  ret = DeleteTuple(table.get(), 6);
+
+  EXPECT_TRUE(ret == ResultType::SUCCESS);
+  epoch_manager.SetCurrentEpochId(4);
+  expired_eid = epoch_manager.GetExpiredEpochId();
+  EXPECT_EQ(3, expired_eid);
+  current_eid = epoch_manager.GetCurrentEpochId();
+  EXPECT_EQ(4, current_eid);
+  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+  unlinked_count = gc_manager.Unlink(0, expired_eid);
+  EXPECT_EQ(0, reclaimed_count);
+  EXPECT_EQ(1, unlinked_count);
+
+  epoch_manager.SetCurrentEpochId(5);
+  expired_eid = epoch_manager.GetExpiredEpochId();
+  EXPECT_EQ(4, expired_eid);
+  current_eid = epoch_manager.GetCurrentEpochId();
+  EXPECT_EQ(5, current_eid);
+  reclaimed_count = gc_manager.Reclaim(0, expired_eid);
+  unlinked_count = gc_manager.Unlink(0, expired_eid);
+  EXPECT_EQ(1, reclaimed_count);
+  EXPECT_EQ(0, unlinked_count);
+
+  // ReturnFreeSlot() should not return null because deleted tuple was from
+  // mutable tilegroup.
+  location = gc_manager.ReturnFreeSlot((table.get())->GetOid());
+  EXPECT_EQ(location.IsNull(), false);
+
+  gc_manager.StopGC();
+  gc::GCManagerFactory::Configure(0);
+
+  table.release();
+  // DROP!
+  TestingExecutorUtil::DeleteDatabase("ImmutabilityDB");
+
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  EXPECT_THROW(
+      catalog::Catalog::GetInstance()->GetDatabaseObject("ImmutabilityDB", txn),
+      CatalogException);
+  txn_manager.CommitTransaction(txn);
+}
 
 // check mem -> insert 100k -> check mem -> delete all -> check mem
 TEST_F(TransactionLevelGCManagerTests, FreeTileGroupsTest) {
@@ -604,8 +604,8 @@ TEST_F(TransactionLevelGCManagerTests, FreeTileGroupsTest) {
   txn_manager.CommitTransaction(txn);
 }
 
-// Insert a tuple, delete that tuple. Insert 2 tuples. Recycling should make it such that
-// the next_free_slot in the tile_group_header did not increase
+//// Insert a tuple, delete that tuple. Insert 2 tuples. Recycling should make it such that
+//// the next_free_slot in the tile_group_header did not increase
 TEST_F(TransactionLevelGCManagerTests, InsertDeleteInsertX2) {
 
   auto &epoch_manager = concurrency::EpochManagerFactory::GetInstance();

--- a/test/performance/insert_performance_test.cpp
+++ b/test/performance/insert_performance_test.cpp
@@ -120,30 +120,30 @@ TEST_F(InsertPerformanceTests, LoadingTest) {
 
   int total_tuple_count = loader_threads_count * tilegroup_count_per_loader * TEST_TUPLES_PER_TILEGROUP;
   int max_cached_tuple_count =
-      TEST_TUPLES_PER_TILEGROUP * storage::DataTable::GetActiveTileGroupCount();
+      TEST_TUPLES_PER_TILEGROUP * storage::DataTable::GetDefaultActiveTileGroupCount();
   int max_unfill_cached_tuple_count =
       (TEST_TUPLES_PER_TILEGROUP - 1) *
-      storage::DataTable::GetActiveTileGroupCount();
+          storage::DataTable::GetDefaultActiveTileGroupCount();
 
   if (total_tuple_count - max_cached_tuple_count <= 0) {
     if (total_tuple_count <= max_unfill_cached_tuple_count) {
-      expected_tile_group_count = storage::DataTable::GetActiveTileGroupCount();
+      expected_tile_group_count = storage::DataTable::GetDefaultActiveTileGroupCount();
     } else {
       expected_tile_group_count =
-          storage::DataTable::GetActiveTileGroupCount() + total_tuple_count -
+          storage::DataTable::GetDefaultActiveTileGroupCount() + total_tuple_count -
           max_unfill_cached_tuple_count;
     }
   } else {
     int filled_tile_group_count = total_tuple_count / max_cached_tuple_count *
-                                  storage::DataTable::GetActiveTileGroupCount();
+        storage::DataTable::GetDefaultActiveTileGroupCount();
 
     if (total_tuple_count - filled_tile_group_count * TEST_TUPLES_PER_TILEGROUP - max_unfill_cached_tuple_count <= 0) {
       expected_tile_group_count = filled_tile_group_count +
-                                  storage::DataTable::GetActiveTileGroupCount();
+          storage::DataTable::GetDefaultActiveTileGroupCount();
     } else {
       expected_tile_group_count =
           filled_tile_group_count +
-          storage::DataTable::GetActiveTileGroupCount() +
+              storage::DataTable::GetDefaultActiveTileGroupCount() +
           (total_tuple_count - filled_tile_group_count -
            max_unfill_cached_tuple_count);
     }

--- a/test/sql/update_sql_test.cpp
+++ b/test/sql/update_sql_test.cpp
@@ -299,10 +299,10 @@ TEST_F(UpdateSQLTests, HalloweenProblemTest) {
   // it would have caused a second update on an already updated Tuple.
 
   size_t active_tilegroup_count = 3;
-  storage::DataTable::SetActiveTileGroupCount(active_tilegroup_count);
+  storage::DataTable::SetDefaultActiveTileGroupCount(active_tilegroup_count);
 
   LOG_DEBUG("Active tile group count = %zu",
-            storage::DataTable::GetActiveTileGroupCount());
+            storage::DataTable::GetDefaultActiveTileGroupCount());
   // Create a table first
   LOG_DEBUG("Creating a table...");
   LOG_DEBUG("Query: CREATE TABLE test(a INT, b INT)");
@@ -372,10 +372,10 @@ TEST_F(UpdateSQLTests, HalloweenProblemTestWithPK) {
 
   // active_tilegroup_count set to 3, [Reason: Refer to HalloweenProblemTest]
   size_t active_tilegroup_count = 3;
-  storage::DataTable::SetActiveTileGroupCount(active_tilegroup_count);
+  storage::DataTable::SetDefaultActiveTileGroupCount(active_tilegroup_count);
 
   LOG_DEBUG("Active tile group count = %zu",
-            storage::DataTable::GetActiveTileGroupCount());
+            storage::DataTable::GetDefaultActiveTileGroupCount());
   // Create a table first
   LOG_DEBUG("Creating a table...");
   LOG_DEBUG("Query: CREATE TABLE test(a INT PRIMARY KEY, b INT)");
@@ -469,10 +469,10 @@ TEST_F(UpdateSQLTests, MultiTileGroupUpdateSQLTest) {
 
   // active_tilegroup_count set to 3, [Reason: Refer to HalloweenProblemTest]
   size_t active_tilegroup_count = 3;
-  storage::DataTable::SetActiveTileGroupCount(active_tilegroup_count);
+  storage::DataTable::SetDefaultActiveTileGroupCount(active_tilegroup_count);
 
   LOG_DEBUG("Active tile group count = %zu",
-            storage::DataTable::GetActiveTileGroupCount());
+            storage::DataTable::GetDefaultActiveTileGroupCount());
   // Create a table first
   LOG_DEBUG("Creating a table...");
   LOG_DEBUG("Query: CREATE TABLE test(a INT PRIMARY KEY, b INT)");


### PR DESCRIPTION
**Overview of Project**
Our project has 2 main features:
- Enabling the Garbage Collector to free empty tile groups and reclaim their memory
- Merging sparsely occupied tile groups to save memory
[More details here](https://docs.google.com/presentation/d/1r2Rxx3ca9645YJRF6mf9rzap0AxR468_wWutK6hsEpY/edit?usp=sharing)

**Status**
This PR represents our efforts toward the first feature. We enhanced the Garbage Collector to free empty TileGroups when all of its tuple slots have been recycled. We have identified several issues in the TimestampOrderingTransactionManager that prevent all garbage types from being collected. This, in turn, prevents tile groups from being freed for many workloads. Fixing the garbage collector will be a major part of our next checkpoint.

We have also started to make internal changes to Peloton that are necessary to handle freeing TileGroups. In particular, we changed the structure that the CatalogManager uses to maintain a map of TileGroups. Identifying all codepaths that assume TileGroups live forever will be completed for our next checkpoint.

**Most important changes**
gc/transaction_level_gc_manager.cpp
- AddToRecycleMap()
- ReturnFreeSlot()

storage/data_table.cpp

- DropTileGroup()
- Other small changes

catalog/manager.h and .cpp

- Changed tile_group

**Known Issues**
We added more tests to transaction_level_gc_manager_test.cpp, but we have commented them out because they cannot pass without fixes to the garbage collector.