### PR TITLE
Namespace(Schema) support + Catalog refactoring 

### DIFF
--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -10,10 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "expression/expression_util.h"
 #include "binder/bind_node_visitor.h"
-#include "expression/star_expression.h"
 #include "catalog/catalog.h"
+#include "expression/expression_util.h"
+#include "expression/star_expression.h"
 #include "type/type_id.h"
 
 #include "expression/aggregate_expression.h"
@@ -21,8 +21,8 @@
 #include "expression/function_expression.h"
 #include "expression/operator_expression.h"
 #include "expression/star_expression.h"
-#include "expression/tuple_value_expression.h"
 #include "expression/subquery_expression.h"
+#include "expression/tuple_value_expression.h"
 
 namespace peloton {
 namespace binder {
@@ -155,8 +155,8 @@ void BindNodeVisitor::Visit(parser::UpdateStatement *node) {
 void BindNodeVisitor::Visit(parser::DeleteStatement *node) {
   context_ = std::make_shared<BinderContext>(nullptr);
   node->TryBindDatabaseName(default_database_name_);
-  context_->AddRegularTable(node->GetDatabaseName(), node->GetTableName(),
-                            node->GetTableName(), txn_);
+  context_->AddRegularTable(node->GetDatabaseName(), node->GetSchemaName(),
+                            node->GetTableName(), node->GetTableName(), txn_);
 
   if (node->expr != nullptr) {
     node->expr->Accept(this);
@@ -174,8 +174,8 @@ void BindNodeVisitor::Visit(parser::CreateStatement *node) {
 void BindNodeVisitor::Visit(parser::InsertStatement *node) {
   node->TryBindDatabaseName(default_database_name_);
   context_ = std::make_shared<BinderContext>(nullptr);
-  context_->AddRegularTable(node->GetDatabaseName(), node->GetTableName(),
-                            node->GetTableName(), txn_);
+  context_->AddRegularTable(node->GetDatabaseName(), node->GetSchemaName(),
+                            node->GetTableName(), node->GetTableName(), txn_);
   if (node->select != nullptr) {
     node->select->Accept(this);
   }

--- a/src/binder/binder_context.cpp
+++ b/src/binder/binder_context.cpp
@@ -16,8 +16,8 @@
 #include "catalog/column_catalog.h"
 #include "catalog/database_catalog.h"
 #include "catalog/table_catalog.h"
-#include "parser/table_ref.h"
 #include "expression/tuple_value_expression.h"
+#include "parser/table_ref.h"
 #include "storage/storage_manager.h"
 
 namespace peloton {
@@ -28,17 +28,18 @@ void BinderContext::AddRegularTable(parser::TableRef *table_ref,
                                     concurrency::TransactionContext *txn) {
   table_ref->TryBindDatabaseName(default_database_name);
   auto table_alias = table_ref->GetTableAlias();
-  AddRegularTable(table_ref->GetDatabaseName(), table_ref->GetTableName(),
-                  table_alias, txn);
+  AddRegularTable(table_ref->GetDatabaseName(), table_ref->GetSchemaName(),
+                  table_ref->GetTableName(), table_alias, txn);
 }
 
 void BinderContext::AddRegularTable(const std::string db_name,
+                                    const std::string schema_name,
                                     const std::string table_name,
                                     const std::string table_alias,
                                     concurrency::TransactionContext *txn) {
   // using catalog object to retrieve meta-data
-  auto table_object =
-    catalog::Catalog::GetInstance()->GetTableObject(db_name, table_name, txn);
+  auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
+      db_name, schema_name, table_name, txn);
 
   if (regular_table_alias_map_.find(table_alias) !=
           regular_table_alias_map_.end() ||

--- a/src/catalog/abstract_catalog.cpp
+++ b/src/catalog/abstract_catalog.cpp
@@ -317,6 +317,10 @@ bool AbstractCatalog::UpdateWithIndexScan(
   auto index = catalog_table_->GetIndex(index_offset);
   std::vector<oid_t> key_column_offsets =
       index->GetMetadata()->GetKeySchema()->GetIndexedColumns();
+
+  // NOTE: For indexed scan on catalog tables, we expect it not to be "partial
+  // indexed scan"(efficiency purpose).That being said, indexed column number
+  // must be equal to passed in "scan_values" size
   PELOTON_ASSERT(scan_values.size() == key_column_offsets.size());
   std::vector<ExpressionType> expr_types(scan_values.size(),
                                          ExpressionType::COMPARE_EQUAL);

--- a/src/catalog/abstract_catalog.cpp
+++ b/src/catalog/abstract_catalog.cpp
@@ -82,7 +82,7 @@ AbstractCatalog::AbstractCatalog(const std::string &catalog_table_ddl,
   auto catalog_table_name = create_plan->GetTableName();
   auto catalog_schema_name = create_plan->GetSchemaName();
   auto catalog_database_name = create_plan->GetDatabaseName();
-  PL_ASSERT(catalog_schema_name == std::string(CATALOG_SCHEMA_NAME));
+  PELOTON_ASSERT(catalog_schema_name == std::string(CATALOG_SCHEMA_NAME));
   // create catalog table
   Catalog::GetInstance()->CreateTable(
       catalog_database_name, catalog_schema_name, catalog_table_name,
@@ -330,7 +330,7 @@ bool AbstractCatalog::UpdateWithIndexScan(
   auto index = catalog_table_->GetIndex(index_offset);
   std::vector<oid_t> key_column_offsets =
       index->GetMetadata()->GetKeySchema()->GetIndexedColumns();
-  PL_ASSERT(scan_values.size() == key_column_offsets.size());
+  PELOTON_ASSERT(scan_values.size() == key_column_offsets.size());
   std::vector<ExpressionType> expr_types(scan_values.size(),
                                          ExpressionType::COMPARE_EQUAL);
   std::vector<expression::AbstractExpression *> runtime_keys;
@@ -356,7 +356,7 @@ bool AbstractCatalog::UpdateWithIndexScan(
     }
   }
 
-  PL_ASSERT(update_columns.size() == update_values.size());
+  PELOTON_ASSERT(update_columns.size() == update_values.size());
   for (size_t i = 0; i < update_values.size(); i++) {
     planner::DerivedAttribute update_attribute{
         new expression::ConstantValueExpression(update_values[i])};

--- a/src/catalog/abstract_catalog.cpp
+++ b/src/catalog/abstract_catalog.cpp
@@ -356,7 +356,6 @@ bool AbstractCatalog::UpdateWithIndexScan(
   for (size_t i = 0; i < update_values.size(); i++) {
     planner::DerivedAttribute update_attribute{
         new expression::ConstantValueExpression(update_values[i])};
-    // emplace(update_column_id, update_val)
     target_list.emplace_back(update_columns[i], update_attribute);
   }
 

--- a/src/catalog/abstract_catalog.cpp
+++ b/src/catalog/abstract_catalog.cpp
@@ -49,7 +49,7 @@ AbstractCatalog::AbstractCatalog(oid_t catalog_table_oid,
                                  storage::Database *pg_catalog) {
   // Create catalog_table_
   catalog_table_ = storage::TableFactory::GetDataTable(
-      CATALOG_DATABASE_OID, catalog_table_oid, catalog_table_schema,
+      pg_catalog->GetOid(), catalog_table_oid, catalog_table_schema,
       catalog_table_name, DEFAULT_TUPLES_PER_TILEGROUP, true, false, true);
 
   // Add catalog_table_ into pg_catalog database
@@ -126,11 +126,11 @@ bool AbstractCatalog::InsertTuple(std::unique_ptr<storage::Tuple> tuple,
       std::make_shared<planner::InsertPlan>(catalog_table_, &columns, &values);
 
   executor::ExecutionResult this_p_status;
-  auto on_complete = [&this_p_status](
-                         executor::ExecutionResult p_status,
-                         std::vector<ResultValue> &&values UNUSED_ATTRIBUTE) {
-    this_p_status = p_status;
-  };
+  auto on_complete =
+      [&this_p_status](executor::ExecutionResult p_status,
+                       std::vector<ResultValue> &&values UNUSED_ATTRIBUTE) {
+        this_p_status = p_status;
+      };
 
   executor::PlanExecutor::ExecutePlan(node, txn, params, result_format,
                                       on_complete);

--- a/src/catalog/abstract_catalog.cpp
+++ b/src/catalog/abstract_catalog.cpp
@@ -79,20 +79,22 @@ AbstractCatalog::AbstractCatalog(const std::string &catalog_table_ddl,
       optimizer::Optimizer().BuildPelotonPlanTree(parse_tree_list, txn));
   auto catalog_table_schema = create_plan->GetSchema();
   auto catalog_table_name = create_plan->GetTableName();
+  auto catalog_database_name = create_plan->GetDatabaseName();
 
   // Create catalog table
   Catalog::GetInstance()->CreateTable(
-      CATALOG_DATABASE_NAME, catalog_table_name,
+      catalog_database_name, catalog_table_name,
       std::unique_ptr<catalog::Schema>(catalog_table_schema), txn, true);
 
   // Get catalog table oid
   auto catalog_table_object = Catalog::GetInstance()->GetTableObject(
-      CATALOG_DATABASE_NAME, catalog_table_name, txn);
+      catalog_database_name, catalog_table_name, txn);
 
   // Set catalog_table_
   try {
     catalog_table_ = storage::StorageManager::GetInstance()->GetTableWithOid(
-        CATALOG_DATABASE_OID, catalog_table_object->GetTableOid());
+        catalog_table_object->GetDatabaseOid(),
+        catalog_table_object->GetTableOid());
   } catch (CatalogException &e) {
     LOG_TRACE("Can't find table %d! Return false",
               catalog_table_object->GetTableOid());

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -164,7 +164,6 @@ void Catalog::Bootstrap() {
   IndexMetricsCatalog::GetInstance(txn);
   QueryMetricsCatalog::GetInstance(txn);
   SettingsCatalog::GetInstance(txn);
-  TriggerCatalog::GetInstance(txn);
   LanguageCatalog::GetInstance(txn);
   ProcCatalog::GetInstance(txn);
 

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -150,14 +150,11 @@ void Catalog::BootstrapSystemCatalogs(storage::Database *database,
       DATABASE_CATALOG_OID, DATABASE_CATALOG_NAME, CATALOG_DATABASE_OID,
       pool_.get(), txn);
   system_catalogs->GetTableCatalog()->InsertTable(
-      TABLE_CATALOG_OID, TABLE_CATALOG_NAME, CATALOG_DATABASE_OID, pool_.get(),
-      txn);
+      TABLE_CATALOG_OID, TABLE_CATALOG_NAME, database_oid, pool_.get(), txn);
   system_catalogs->GetTableCatalog()->InsertTable(
-      INDEX_CATALOG_OID, INDEX_CATALOG_NAME, CATALOG_DATABASE_OID, pool_.get(),
-      txn);
+      INDEX_CATALOG_OID, INDEX_CATALOG_NAME, database_oid, pool_.get(), txn);
   system_catalogs->GetTableCatalog()->InsertTable(
-      COLUMN_CATALOG_OID, COLUMN_CATALOG_NAME, CATALOG_DATABASE_OID,
-      pool_.get(), txn);
+      COLUMN_CATALOG_OID, COLUMN_CATALOG_NAME, database_oid, pool_.get(), txn);
 }
 
 void Catalog::Bootstrap() {

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -157,9 +157,9 @@ void Catalog::BootstrapSystemCatalogs(storage::Database *database,
 void Catalog::Bootstrap() {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
-
+  // bootstrap pg_catalog database
   catalog_map_[CATALOG_DATABASE_OID]->Bootstrap(CATALOG_DATABASE_NAME, txn);
-
+  // bootstrap other global catalog tables
   DatabaseMetricsCatalog::GetInstance(txn);
   SettingsCatalog::GetInstance(txn);
   LanguageCatalog::GetInstance(txn);
@@ -439,7 +439,8 @@ ResultType Catalog::CreateIndex(
     auto index_object = table_object->GetIndexObject(index_name);
 
     if (index_object != nullptr)
-      throw CatalogException("Index " + index_name + " already exists");
+      throw CatalogException("Index " + index_name + " already exists in" +
+                             database_object->GetDatabaseName());
   }
   auto storage_manager = storage::StorageManager::GetInstance();
   auto database = storage_manager->GetDatabaseWithOid(database_oid);
@@ -1123,8 +1124,9 @@ void Catalog::InitializeFunctions() {
                          txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::TINYINT}, type::TypeId::DECIMAL, internal_lang,
-          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
-                                            function::DecimalFunctions::Sqrt},
+          "Sqrt",
+          function::BuiltInFuncType{OperatorId::Sqrt,
+                                    function::DecimalFunctions::Sqrt},
           txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::SMALLINT}, type::TypeId::DECIMAL,
@@ -1134,18 +1136,21 @@ void Catalog::InitializeFunctions() {
           txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::INTEGER}, type::TypeId::DECIMAL, internal_lang,
-          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
-                                            function::DecimalFunctions::Sqrt},
+          "Sqrt",
+          function::BuiltInFuncType{OperatorId::Sqrt,
+                                    function::DecimalFunctions::Sqrt},
           txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::BIGINT}, type::TypeId::DECIMAL, internal_lang,
-          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
-                                            function::DecimalFunctions::Sqrt},
+          "Sqrt",
+          function::BuiltInFuncType{OperatorId::Sqrt,
+                                    function::DecimalFunctions::Sqrt},
           txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::DECIMAL}, type::TypeId::DECIMAL, internal_lang,
-          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
-                                            function::DecimalFunctions::Sqrt},
+          "Sqrt",
+          function::BuiltInFuncType{OperatorId::Sqrt,
+                                    function::DecimalFunctions::Sqrt},
           txn);
       AddBuiltinFunction(
           "floor", {type::TypeId::DECIMAL}, type::TypeId::DECIMAL,
@@ -1214,14 +1219,16 @@ void Catalog::InitializeFunctions() {
 
       AddBuiltinFunction(
           "ceil", {type::TypeId::DECIMAL}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil", function::BuiltInFuncType{OperatorId::Ceil,
-                                            function::DecimalFunctions::_Ceil},
+          "Ceil",
+          function::BuiltInFuncType{OperatorId::Ceil,
+                                    function::DecimalFunctions::_Ceil},
           txn);
 
       AddBuiltinFunction(
           "ceil", {type::TypeId::TINYINT}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil", function::BuiltInFuncType{OperatorId::Ceil,
-                                            function::DecimalFunctions::_Ceil},
+          "Ceil",
+          function::BuiltInFuncType{OperatorId::Ceil,
+                                    function::DecimalFunctions::_Ceil},
           txn);
 
       AddBuiltinFunction(
@@ -1233,14 +1240,16 @@ void Catalog::InitializeFunctions() {
 
       AddBuiltinFunction(
           "ceil", {type::TypeId::INTEGER}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil", function::BuiltInFuncType{OperatorId::Ceil,
-                                            function::DecimalFunctions::_Ceil},
+          "Ceil",
+          function::BuiltInFuncType{OperatorId::Ceil,
+                                    function::DecimalFunctions::_Ceil},
           txn);
 
       AddBuiltinFunction(
           "ceil", {type::TypeId::BIGINT}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil", function::BuiltInFuncType{OperatorId::Ceil,
-                                            function::DecimalFunctions::_Ceil},
+          "Ceil",
+          function::BuiltInFuncType{OperatorId::Ceil,
+                                    function::DecimalFunctions::_Ceil},
           txn);
 
       AddBuiltinFunction(

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -159,12 +159,8 @@ void Catalog::Bootstrap() {
   auto txn = txn_manager.BeginTransaction();
 
   DatabaseMetricsCatalog::GetInstance(txn);
-  TableMetricsCatalog::GetInstance(txn);
-  IndexMetricsCatalog::GetInstance(txn);
-  QueryMetricsCatalog::GetInstance(txn);
   SettingsCatalog::GetInstance(txn);
   LanguageCatalog::GetInstance(txn);
-  ProcCatalog::GetInstance(txn);
 
   if (settings::SettingsManager::GetBool(settings::SettingId::brain)) {
     QueryHistoryCatalog::GetInstance(txn);
@@ -1122,9 +1118,8 @@ void Catalog::InitializeFunctions() {
                          txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::TINYINT}, type::TypeId::DECIMAL, internal_lang,
-          "Sqrt",
-          function::BuiltInFuncType{OperatorId::Sqrt,
-                                    function::DecimalFunctions::Sqrt},
+          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
+                                            function::DecimalFunctions::Sqrt},
           txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::SMALLINT}, type::TypeId::DECIMAL,
@@ -1134,21 +1129,18 @@ void Catalog::InitializeFunctions() {
           txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::INTEGER}, type::TypeId::DECIMAL, internal_lang,
-          "Sqrt",
-          function::BuiltInFuncType{OperatorId::Sqrt,
-                                    function::DecimalFunctions::Sqrt},
+          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
+                                            function::DecimalFunctions::Sqrt},
           txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::BIGINT}, type::TypeId::DECIMAL, internal_lang,
-          "Sqrt",
-          function::BuiltInFuncType{OperatorId::Sqrt,
-                                    function::DecimalFunctions::Sqrt},
+          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
+                                            function::DecimalFunctions::Sqrt},
           txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::DECIMAL}, type::TypeId::DECIMAL, internal_lang,
-          "Sqrt",
-          function::BuiltInFuncType{OperatorId::Sqrt,
-                                    function::DecimalFunctions::Sqrt},
+          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
+                                            function::DecimalFunctions::Sqrt},
           txn);
       AddBuiltinFunction(
           "floor", {type::TypeId::DECIMAL}, type::TypeId::DECIMAL,
@@ -1217,16 +1209,14 @@ void Catalog::InitializeFunctions() {
 
       AddBuiltinFunction(
           "ceil", {type::TypeId::DECIMAL}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
+          "Ceil", function::BuiltInFuncType{OperatorId::Ceil,
+                                            function::DecimalFunctions::_Ceil},
           txn);
 
       AddBuiltinFunction(
           "ceil", {type::TypeId::TINYINT}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
+          "Ceil", function::BuiltInFuncType{OperatorId::Ceil,
+                                            function::DecimalFunctions::_Ceil},
           txn);
 
       AddBuiltinFunction(
@@ -1238,16 +1228,14 @@ void Catalog::InitializeFunctions() {
 
       AddBuiltinFunction(
           "ceil", {type::TypeId::INTEGER}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
+          "Ceil", function::BuiltInFuncType{OperatorId::Ceil,
+                                            function::DecimalFunctions::_Ceil},
           txn);
 
       AddBuiltinFunction(
           "ceil", {type::TypeId::BIGINT}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
+          "Ceil", function::BuiltInFuncType{OperatorId::Ceil,
+                                            function::DecimalFunctions::_Ceil},
           txn);
 
       AddBuiltinFunction(

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -162,6 +162,9 @@ void Catalog::Bootstrap() {
   SettingsCatalog::GetInstance(txn);
   LanguageCatalog::GetInstance(txn);
 
+  // TODO: change pg_proc to per database
+  ProcCatalog::GetInstance(txn);
+
   if (settings::SettingsManager::GetBool(settings::SettingId::brain)) {
     QueryHistoryCatalog::GetInstance(txn);
   }

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -158,6 +158,8 @@ void Catalog::Bootstrap() {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
 
+  catalog_map_[CATALOG_DATABASE_OID]->Bootstrap(CATALOG_DATABASE_NAME, txn);
+
   DatabaseMetricsCatalog::GetInstance(txn);
   SettingsCatalog::GetInstance(txn);
   LanguageCatalog::GetInstance(txn);

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -805,7 +805,7 @@ std::shared_ptr<TableCatalogObject> Catalog::GetTableObject(
   return table_object;
 }
 
-SystemCatalog Catalog::GetSystemCatalog(const oid_t database_oid) {
+SystemCatalogs Catalog::GetSystemCatalog(const oid_t database_oid) {
   if (catalog_map_.find(database_oid) == catalog_map_.end()) {
     throw CatalogException("Failed to find SystemCatalog " + database_oid);
   }
@@ -1096,9 +1096,8 @@ void Catalog::InitializeFunctions() {
                          txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::TINYINT}, type::TypeId::DECIMAL, internal_lang,
-          "Sqrt",
-          function::BuiltInFuncType{OperatorId::Sqrt,
-                                    function::DecimalFunctions::Sqrt},
+          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
+                                            function::DecimalFunctions::Sqrt},
           txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::SMALLINT}, type::TypeId::DECIMAL,
@@ -1108,21 +1107,18 @@ void Catalog::InitializeFunctions() {
           txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::INTEGER}, type::TypeId::DECIMAL, internal_lang,
-          "Sqrt",
-          function::BuiltInFuncType{OperatorId::Sqrt,
-                                    function::DecimalFunctions::Sqrt},
+          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
+                                            function::DecimalFunctions::Sqrt},
           txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::BIGINT}, type::TypeId::DECIMAL, internal_lang,
-          "Sqrt",
-          function::BuiltInFuncType{OperatorId::Sqrt,
-                                    function::DecimalFunctions::Sqrt},
+          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
+                                            function::DecimalFunctions::Sqrt},
           txn);
       AddBuiltinFunction(
           "sqrt", {type::TypeId::DECIMAL}, type::TypeId::DECIMAL, internal_lang,
-          "Sqrt",
-          function::BuiltInFuncType{OperatorId::Sqrt,
-                                    function::DecimalFunctions::Sqrt},
+          "Sqrt", function::BuiltInFuncType{OperatorId::Sqrt,
+                                            function::DecimalFunctions::Sqrt},
           txn);
       AddBuiltinFunction(
           "floor", {type::TypeId::DECIMAL}, type::TypeId::DECIMAL,
@@ -1191,16 +1187,14 @@ void Catalog::InitializeFunctions() {
 
       AddBuiltinFunction(
           "ceil", {type::TypeId::DECIMAL}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
+          "Ceil", function::BuiltInFuncType{OperatorId::Ceil,
+                                            function::DecimalFunctions::_Ceil},
           txn);
 
       AddBuiltinFunction(
           "ceil", {type::TypeId::TINYINT}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
+          "Ceil", function::BuiltInFuncType{OperatorId::Ceil,
+                                            function::DecimalFunctions::_Ceil},
           txn);
 
       AddBuiltinFunction(
@@ -1212,16 +1206,14 @@ void Catalog::InitializeFunctions() {
 
       AddBuiltinFunction(
           "ceil", {type::TypeId::INTEGER}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
+          "Ceil", function::BuiltInFuncType{OperatorId::Ceil,
+                                            function::DecimalFunctions::_Ceil},
           txn);
 
       AddBuiltinFunction(
           "ceil", {type::TypeId::BIGINT}, type::TypeId::DECIMAL, internal_lang,
-          "Ceil",
-          function::BuiltInFuncType{OperatorId::Ceil,
-                                    function::DecimalFunctions::_Ceil},
+          "Ceil", function::BuiltInFuncType{OperatorId::Ceil,
+                                            function::DecimalFunctions::_Ceil},
           txn);
 
       AddBuiltinFunction(

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -96,10 +96,8 @@ void Catalog::BootstrapSystemCatalogs(storage::Database *database,
   CreatePrimaryIndex(database_oid, TABLE_CATALOG_OID, txn);
 
   CreateIndex(database_oid, TABLE_CATALOG_OID,
-              {TableCatalog::ColumnId::TABLE_NAME,
-               TableCatalog::ColumnId::DATABASE_OID},
-              TABLE_CATALOG_NAME "_skey0", IndexType::BWTREE,
-              IndexConstraintType::UNIQUE, true, txn, true);
+              {TableCatalog::ColumnId::TABLE_NAME}, TABLE_CATALOG_NAME "_skey0",
+              IndexType::BWTREE, IndexConstraintType::UNIQUE, true, txn, true);
   CreateIndex(database_oid, TABLE_CATALOG_OID,
               {TableCatalog::ColumnId::DATABASE_OID},
               TABLE_CATALOG_NAME "_skey1", IndexType::BWTREE,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -923,7 +923,7 @@ std::shared_ptr<SystemCatalogs> Catalog::GetSystemCatalogs(
     const oid_t database_oid) {
   if (catalog_map_.find(database_oid) == catalog_map_.end()) {
     throw CatalogException("Failed to find SystemCatalog for database_oid = " +
-                           database_oid);
+                           std::to_string(database_oid));
   }
   return catalog_map_[database_oid];
 }

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -74,10 +74,12 @@ Catalog::Catalog() : pool_(new type::EphemeralPool()) {
   txn_manager.CommitTransaction(txn);
 }
 
-/* This function *MUST* be called after a new database is created to bootstrap
- * all system catalog tables for that database.
- * The system catalog tables must be created in certain order to make sure
- * all tuples are indexed (actually this might be fine now after Paulo's fix)
+/*@brief   This function *MUST* be called after a new database is created to
+ * bootstrap all system catalog tables for that database. The system catalog
+ * tables must be created in certain order to make sure all tuples are indexed
+ *
+ * @param   database    database which this system catalogs belong to
+ * @param   txn         transaction context
  */
 void Catalog::BootstrapSystemCatalogs(storage::Database *database,
                                       concurrency::TransactionContext *txn) {

--- a/src/catalog/catalog_cache.cpp
+++ b/src/catalog/catalog_cache.cpp
@@ -21,9 +21,9 @@ namespace peloton {
 namespace catalog {
 
 /*@brief   insert database catalog object into cache
-* @param   database_object
-* @return  false only if database_oid already exists in cache
-*/
+ * @param   database_object
+ * @return  false only if database_oid already exists in cache
+ */
 bool CatalogCache::InsertDatabaseObject(
     std::shared_ptr<DatabaseCatalogObject> database_object) {
   if (!database_object || database_object->GetDatabaseOid() == INVALID_OID) {
@@ -52,9 +52,9 @@ bool CatalogCache::InsertDatabaseObject(
 }
 
 /*@brief   evict database catalog object from cache
-* @param   database_oid
-* @return  true if database_oid is found and evicted; false if not found
-*/
+ * @param   database_oid
+ * @return  true if database_oid is found and evicted; false if not found
+ */
 bool CatalogCache::EvictDatabaseObject(oid_t database_oid) {
   auto it = database_objects_cache.find(database_oid);
   if (it == database_objects_cache.end()) {
@@ -69,9 +69,9 @@ bool CatalogCache::EvictDatabaseObject(oid_t database_oid) {
 }
 
 /*@brief   evict database catalog object from cache
-* @param   database_name
-* @return  true if database_name is found and evicted; false if not found
-*/
+ * @param   database_name
+ * @return  true if database_name is found and evicted; false if not found
+ */
 bool CatalogCache::EvictDatabaseObject(const std::string &database_name) {
   auto it = database_name_cache.find(database_name);
   if (it == database_name_cache.end()) {
@@ -86,9 +86,9 @@ bool CatalogCache::EvictDatabaseObject(const std::string &database_name) {
 }
 
 /*@brief   get database catalog object from cache
-* @param   database_oid
-* @return  database catalog object; if not found return object with invalid oid
-*/
+ * @param   database_oid
+ * @return  database catalog object; if not found return object with invalid oid
+ */
 std::shared_ptr<DatabaseCatalogObject> CatalogCache::GetDatabaseObject(
     oid_t database_oid) {
   auto it = database_objects_cache.find(database_oid);
@@ -99,9 +99,9 @@ std::shared_ptr<DatabaseCatalogObject> CatalogCache::GetDatabaseObject(
 }
 
 /*@brief   get database catalog object from cache
-* @param   database_name
-* @return  database catalog object; if not found return null
-*/
+ * @param   database_name
+ * @return  database catalog object; if not found return null
+ */
 std::shared_ptr<DatabaseCatalogObject> CatalogCache::GetDatabaseObject(
     const std::string &database_name) {
   auto it = database_name_cache.find(database_name);
@@ -112,9 +112,9 @@ std::shared_ptr<DatabaseCatalogObject> CatalogCache::GetDatabaseObject(
 }
 
 /*@brief   search table catalog object from all cached database objects
-* @param   table_oid
-* @return  table catalog object; if not found return null
-*/
+ * @param   table_oid
+ * @return  table catalog object; if not found return null
+ */
 std::shared_ptr<TableCatalogObject> CatalogCache::GetCachedTableObject(
     oid_t table_oid) {
   for (auto it = database_objects_cache.begin();
@@ -127,9 +127,9 @@ std::shared_ptr<TableCatalogObject> CatalogCache::GetCachedTableObject(
 }
 
 /*@brief   search index catalog object from all cached database objects
-* @param   index_oid
-* @return  index catalog object; if not found return null
-*/
+ * @param   index_oid
+ * @return  index catalog object; if not found return null
+ */
 std::shared_ptr<IndexCatalogObject> CatalogCache::GetCachedIndexObject(
     oid_t index_oid) {
   for (auto it = database_objects_cache.begin();
@@ -142,15 +142,16 @@ std::shared_ptr<IndexCatalogObject> CatalogCache::GetCachedIndexObject(
 }
 
 /*@brief   search index catalog object from all cached database objects
-* @param   index_name
-* @return  index catalog object; if not found return null
-*/
+ * @param   index_name
+ * @return  index catalog object; if not found return null
+ */
 std::shared_ptr<IndexCatalogObject> CatalogCache::GetCachedIndexObject(
-    const std::string &index_name) {
+    const std::string &index_name, const std::string &schema_name) {
   for (auto it = database_objects_cache.begin();
        it != database_objects_cache.end(); ++it) {
     auto database_object = it->second;
-    auto index_object = database_object->GetCachedIndexObject(index_name);
+    auto index_object =
+        database_object->GetCachedIndexObject(index_name, schema_name);
     if (index_object) return index_object;
   }
   return nullptr;

--- a/src/catalog/column_catalog.cpp
+++ b/src/catalog/column_catalog.cpp
@@ -196,7 +196,7 @@ bool ColumnCatalog::DeleteColumn(oid_t table_oid,
 
   // delete column from cache
   auto pg_table =
-      Catalog::GetInstance()->GetSystemCatalog(database_oid).GetTableCatalog();
+      Catalog::GetInstance()->GetSystemCatalog(database_oid)->GetTableCatalog();
   auto table_object = pg_table->GetTableObject(table_oid, txn);
   table_object->EvictColumnObject(column_name);
 
@@ -217,7 +217,7 @@ bool ColumnCatalog::DeleteColumns(oid_t table_oid,
 
   // delete columns from cache
   auto pg_table =
-      Catalog::GetInstance()->GetSystemCatalog(database_oid).GetTableCatalog();
+      Catalog::GetInstance()->GetSystemCatalog(database_oid)->GetTableCatalog();
   auto table_object = pg_table->GetTableObject(table_oid, txn);
   table_object->EvictAllColumnObjects();
 
@@ -229,7 +229,7 @@ ColumnCatalog::GetColumnObjects(oid_t table_oid,
                                 concurrency::TransactionContext *txn) {
   // try get from cache
   auto pg_table =
-      Catalog::GetInstance()->GetSystemCatalog(database_oid).GetTableCatalog();
+      Catalog::GetInstance()->GetSystemCatalog(database_oid)->GetTableCatalog();
   auto table_object = pg_table->GetTableObject(table_oid, txn);
   PL_ASSERT(table_object && table_object->GetTableOid() == table_oid);
   auto column_objects = table_object->GetColumnObjects(true);

--- a/src/catalog/column_catalog.cpp
+++ b/src/catalog/column_catalog.cpp
@@ -228,7 +228,7 @@ ColumnCatalog::GetColumnObjects(oid_t table_oid,
                       ->GetSystemCatalogs(database_oid)
                       ->GetTableCatalog();
   auto table_object = pg_table->GetTableObject(table_oid, txn);
-  PL_ASSERT(table_object && table_object->GetTableOid() == table_oid);
+  PELOTON_ASSERT(table_object && table_object->GetTableOid() == table_oid);
   auto column_objects = table_object->GetColumnObjects(true);
   if (column_objects.size() != 0) return column_objects;
 

--- a/src/catalog/column_catalog.cpp
+++ b/src/catalog/column_catalog.cpp
@@ -53,6 +53,8 @@ ColumnCatalog::ColumnCatalog(storage::Database *pg_catalog,
                              concurrency::TransactionContext *txn)
     : AbstractCatalog(COLUMN_CATALOG_OID, COLUMN_CATALOG_NAME,
                       InitializeSchema().release(), pg_catalog) {
+  database_oid = pg_catalog->GetOid();
+
   // Add indexes for pg_attribute
   AddIndex({ColumnId::TABLE_OID, ColumnId::COLUMN_NAME},
            COLUMN_CATALOG_PKEY_OID, COLUMN_CATALOG_NAME "_pkey",

--- a/src/catalog/column_catalog.cpp
+++ b/src/catalog/column_catalog.cpp
@@ -16,8 +16,8 @@
 #include "catalog/system_catalogs.h"
 #include "catalog/table_catalog.h"
 #include "concurrency/transaction_context.h"
-#include "storage/database.h"
 #include "storage/data_table.h"
+#include "storage/database.h"
 #include "type/value_factory.h"
 
 namespace peloton {
@@ -49,8 +49,6 @@ ColumnCatalog::ColumnCatalog(storage::Database *pg_catalog,
                              concurrency::TransactionContext *txn)
     : AbstractCatalog(COLUMN_CATALOG_OID, COLUMN_CATALOG_NAME,
                       InitializeSchema().release(), pg_catalog) {
-  database_oid = pg_catalog->GetOid();
-
   // Add indexes for pg_attribute
   AddIndex({ColumnId::TABLE_OID, ColumnId::COLUMN_NAME},
            COLUMN_CATALOG_PKEY_OID, COLUMN_CATALOG_NAME "_pkey",
@@ -191,8 +189,9 @@ bool ColumnCatalog::DeleteColumn(oid_t table_oid,
       type::ValueFactory::GetVarcharValue(column_name, nullptr).Copy());
 
   // delete column from cache
-  auto pg_table =
-      Catalog::GetInstance()->GetSystemCatalogs(database_oid)->GetTableCatalog();
+  auto pg_table = Catalog::GetInstance()
+                      ->GetSystemCatalogs(database_oid)
+                      ->GetTableCatalog();
   auto table_object = pg_table->GetTableObject(table_oid, txn);
   table_object->EvictColumnObject(column_name);
 
@@ -212,8 +211,9 @@ bool ColumnCatalog::DeleteColumns(oid_t table_oid,
   values.push_back(type::ValueFactory::GetIntegerValue(table_oid).Copy());
 
   // delete columns from cache
-  auto pg_table =
-      Catalog::GetInstance()->GetSystemCatalogs(database_oid)->GetTableCatalog();
+  auto pg_table = Catalog::GetInstance()
+                      ->GetSystemCatalogs(database_oid)
+                      ->GetTableCatalog();
   auto table_object = pg_table->GetTableObject(table_oid, txn);
   table_object->EvictAllColumnObjects();
 
@@ -224,8 +224,9 @@ const std::unordered_map<oid_t, std::shared_ptr<ColumnCatalogObject>>
 ColumnCatalog::GetColumnObjects(oid_t table_oid,
                                 concurrency::TransactionContext *txn) {
   // try get from cache
-  auto pg_table =
-      Catalog::GetInstance()->GetSystemCatalogs(database_oid)->GetTableCatalog();
+  auto pg_table = Catalog::GetInstance()
+                      ->GetSystemCatalogs(database_oid)
+                      ->GetTableCatalog();
   auto table_object = pg_table->GetTableObject(table_oid, txn);
   PL_ASSERT(table_object && table_object->GetTableOid() == table_oid);
   auto column_objects = table_object->GetColumnObjects(true);

--- a/src/catalog/column_catalog.cpp
+++ b/src/catalog/column_catalog.cpp
@@ -193,8 +193,9 @@ bool ColumnCatalog::DeleteColumn(oid_t table_oid,
       type::ValueFactory::GetVarcharValue(column_name, nullptr).Copy());
 
   // delete column from cache
-  auto table_object =
-      TableCatalog::GetInstance()->GetTableObject(table_oid, txn);
+  auto pg_table =
+      Catalog::GetInstance()->GetSystemCatalog(database_oid).GetTableCatalog();
+  auto table_object = pg_table->GetTableObject(table_oid, txn);
   table_object->EvictColumnObject(column_name);
 
   return DeleteWithIndexScan(index_offset, values, txn);
@@ -213,8 +214,9 @@ bool ColumnCatalog::DeleteColumns(oid_t table_oid,
   values.push_back(type::ValueFactory::GetIntegerValue(table_oid).Copy());
 
   // delete columns from cache
-  auto table_object =
-      TableCatalog::GetInstance()->GetTableObject(table_oid, txn);
+  auto pg_table =
+      Catalog::GetInstance()->GetSystemCatalog(database_oid).GetTableCatalog();
+  auto table_object = pg_table->GetTableObject(table_oid, txn);
   table_object->EvictAllColumnObjects();
 
   return DeleteWithIndexScan(index_offset, values, txn);
@@ -224,9 +226,10 @@ const std::unordered_map<oid_t, std::shared_ptr<ColumnCatalogObject>>
 ColumnCatalog::GetColumnObjects(oid_t table_oid,
                                 concurrency::TransactionContext *txn) {
   // try get from cache
-  auto table_object =
-      TableCatalog::GetInstance()->GetTableObject(table_oid, txn);
-  PELOTON_ASSERT(table_object && table_object->GetTableOid() == table_oid);
+  auto pg_table =
+      Catalog::GetInstance()->GetSystemCatalog(database_oid).GetTableCatalog();
+  auto table_object = pg_table->GetTableObject(table_oid, txn);
+  PL_ASSERT(table_object && table_object->GetTableOid() == table_oid);
   auto column_objects = table_object->GetColumnObjects(true);
   if (column_objects.size() != 0) return column_objects;
 

--- a/src/catalog/column_catalog.cpp
+++ b/src/catalog/column_catalog.cpp
@@ -27,10 +27,10 @@ ColumnCatalogObject::ColumnCatalogObject(executor::LogicalTile *tile,
       column_name(tile->GetValue(tupleId, ColumnCatalog::ColumnId::COLUMN_NAME)
                       .ToString()),
       column_id(tile->GetValue(tupleId, ColumnCatalog::ColumnId::COLUMN_ID)
-                    .GetAs<oid_t>()),
+                    .GetAs<uint32_t>()),
       column_offset(
           tile->GetValue(tupleId, ColumnCatalog::ColumnId::COLUMN_OFFSET)
-              .GetAs<oid_t>()),
+              .GetAs<uint32_t>()),
       column_type(StringToTypeId(
           tile->GetValue(tupleId, ColumnCatalog::ColumnId::COLUMN_TYPE)
               .ToString())),
@@ -41,9 +41,9 @@ ColumnCatalogObject::ColumnCatalogObject(executor::LogicalTile *tile,
       is_not_null(tile->GetValue(tupleId, ColumnCatalog::ColumnId::IS_NOT_NULL)
                       .GetAs<bool>()) {}
 
-ColumnCatalog *ColumnCatalog::GetInstance(storage::Database *pg_catalog,
-                                          type::AbstractPool *pool,
-                                          concurrency::TransactionContext *txn) {
+ColumnCatalog *ColumnCatalog::GetInstance(
+    storage::Database *pg_catalog, type::AbstractPool *pool,
+    concurrency::TransactionContext *txn) {
   static ColumnCatalog column_catalog{pg_catalog, pool, txn};
   return &column_catalog;
 }
@@ -63,7 +63,7 @@ ColumnCatalog::ColumnCatalog(storage::Database *pg_catalog,
            COLUMN_CATALOG_NAME "_skey1", IndexConstraintType::DEFAULT);
 
   // Insert columns into pg_attribute
-  oid_t column_id = 0;
+  uint32_t column_id = 0;
   for (auto column : catalog_table_->GetSchema()->GetColumns()) {
     InsertColumn(COLUMN_CATALOG_OID, column.GetName(), column_id,
                  column.GetOffset(), column.GetType(), column.IsInlined(),
@@ -141,7 +141,7 @@ std::unique_ptr<catalog::Schema> ColumnCatalog::InitializeSchema() {
 
 bool ColumnCatalog::InsertColumn(oid_t table_oid,
                                  const std::string &column_name,
-                                 oid_t column_id, oid_t column_offset,
+                                 uint32_t column_id, uint32_t column_offset,
                                  type::TypeId column_type, bool is_inlined,
                                  const std::vector<Constraint> &constraints,
                                  type::AbstractPool *pool,

--- a/src/catalog/column_catalog.cpp
+++ b/src/catalog/column_catalog.cpp
@@ -137,7 +137,7 @@ std::unique_ptr<catalog::Schema> ColumnCatalog::InitializeSchema() {
 
 bool ColumnCatalog::InsertColumn(oid_t table_oid,
                                  const std::string &column_name,
-                                 uint32_t column_id, uint32_t column_offset,
+                                 oid_t column_id, oid_t column_offset,
                                  type::TypeId column_type, bool is_inlined,
                                  const std::vector<Constraint> &constraints,
                                  type::AbstractPool *pool,

--- a/src/catalog/column_stats_catalog.cpp
+++ b/src/catalog/column_stats_catalog.cpp
@@ -29,7 +29,7 @@ ColumnStatsCatalog *ColumnStatsCatalog::GetInstance(
 
 ColumnStatsCatalog::ColumnStatsCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
-                      "." COLUMN_STATS_CATALOG_NAME
+                      "." CATALOG_SCHEMA_NAME "." COLUMN_STATS_CATALOG_NAME
                       " ("
                       "database_id    INT NOT NULL, "
                       "table_id       INT NOT NULL, "
@@ -45,12 +45,14 @@ ColumnStatsCatalog::ColumnStatsCatalog(concurrency::TransactionContext *txn)
                       txn) {
   // unique key: (database_id, table_id, column_id)
   Catalog::GetInstance()->CreateIndex(
-      CATALOG_DATABASE_NAME, COLUMN_STATS_CATALOG_NAME, {0, 1, 2},
-      COLUMN_STATS_CATALOG_NAME "_skey0", true, IndexType::BWTREE, txn);
+      CATALOG_DATABASE_NAME, CATALOG_SCHEMA_NAME, COLUMN_STATS_CATALOG_NAME,
+      {0, 1, 2}, COLUMN_STATS_CATALOG_NAME "_skey0", true, IndexType::BWTREE,
+      txn);
   // non-unique key: (database_id, table_id)
   Catalog::GetInstance()->CreateIndex(
-      CATALOG_DATABASE_NAME, COLUMN_STATS_CATALOG_NAME, {0, 1},
-      COLUMN_STATS_CATALOG_NAME "_skey1", false, IndexType::BWTREE, txn);
+      CATALOG_DATABASE_NAME, CATALOG_SCHEMA_NAME, COLUMN_STATS_CATALOG_NAME,
+      {0, 1}, COLUMN_STATS_CATALOG_NAME "_skey1", false, IndexType::BWTREE,
+      txn);
 }
 
 ColumnStatsCatalog::~ColumnStatsCatalog() {}
@@ -110,9 +112,9 @@ bool ColumnStatsCatalog::InsertColumnStats(
   return InsertTuple(std::move(tuple), txn);
 }
 
-bool ColumnStatsCatalog::DeleteColumnStats(oid_t database_id, oid_t table_id,
-                                           oid_t column_id,
-                                           concurrency::TransactionContext *txn) {
+bool ColumnStatsCatalog::DeleteColumnStats(
+    oid_t database_id, oid_t table_id, oid_t column_id,
+    concurrency::TransactionContext *txn) {
   oid_t index_offset = IndexId::SECONDARY_KEY_0;  // Secondary key index
 
   std::vector<type::Value> values;

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -153,7 +153,7 @@ std::shared_ptr<TableCatalogObject> DatabaseCatalogObject::GetTableObject(
     auto pg_table = Catalog::GetInstance()
                         ->GetSystemCatalogs(database_oid)
                         ->GetTableCatalog();
-    return pg_table->GetTableObject(table_name, database_oid, txn);
+    return pg_table->GetTableObject(table_name, txn);
   }
 }
 

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -213,11 +213,17 @@ DatabaseCatalog *DatabaseCatalog::GetInstance(
   return &database_catalog;
 }
 
-DatabaseCatalog::DatabaseCatalog(storage::Database *pg_catalog,
-                                 UNUSED_ATTRIBUTE type::AbstractPool *pool,
-                                 UNUSED_ATTRIBUTE concurrency::TransactionContext *txn)
+DatabaseCatalog::DatabaseCatalog(
+    storage::Database *pg_catalog, UNUSED_ATTRIBUTE type::AbstractPool *pool,
+    UNUSED_ATTRIBUTE concurrency::TransactionContext *txn)
     : AbstractCatalog(DATABASE_CATALOG_OID, DATABASE_CATALOG_NAME,
-                      InitializeSchema().release(), pg_catalog) {}
+                      InitializeSchema().release(), pg_catalog) {
+  // Add indexes for pg_database
+  AddIndex({ColumnId::DATABASE_OID}, DATABASE_CATALOG_PKEY_OID,
+           DATABASE_CATALOG_NAME "_pkey", IndexConstraintType::PRIMARY_KEY);
+  AddIndex({ColumnId::DATABASE_NAME}, DATABASE_CATALOG_SKEY0_OID,
+           DATABASE_CATALOG_NAME "_skey0", IndexConstraintType::UNIQUE);
+}
 
 DatabaseCatalog::~DatabaseCatalog() {}
 

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -127,7 +127,7 @@ std::shared_ptr<TableCatalogObject> DatabaseCatalogObject::GetTableObject(
     // cache miss get from pg_table
     auto pg_table = Catalog::GetInstance()
                         ->GetSystemCatalog(database_oid)
-                        .GetTableCatalog();
+                        ->GetTableCatalog();
     return pg_table->GetTableObject(table_oid, txn);
   }
 }
@@ -150,7 +150,7 @@ std::shared_ptr<TableCatalogObject> DatabaseCatalogObject::GetTableObject(
     // cache miss get from pg_table
     auto pg_table = Catalog::GetInstance()
                         ->GetSystemCatalog(database_oid)
-                        .GetTableCatalog();
+                        ->GetTableCatalog();
     return pg_table->GetTableObject(table_name, database_oid, txn);
   }
 }
@@ -166,7 +166,7 @@ DatabaseCatalogObject::GetTableObjects(bool cached_only) {
     // cache miss get from pg_table
     auto pg_table = Catalog::GetInstance()
                         ->GetSystemCatalog(database_oid)
-                        .GetTableCatalog();
+                        ->GetTableCatalog();
     return pg_table->GetTableObjects(database_oid, txn);
   }
   // make sure to check IsValidTableObjects() before getting table objects

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -181,7 +181,7 @@ DatabaseCatalogObject::GetTableObjects(const std::string &schema_name) {
     pg_table->GetTableObjects(txn);
   }
   // make sure to check IsValidTableObjects() before getting table objects
-  PL_ASSERT(valid_table_objects);
+  PELOTON_ASSERT(valid_table_objects);
   std::vector<std::shared_ptr<TableCatalogObject>> result;
   for (auto it : table_objects_cache) {
     if (it.second->GetSchemaName() == schema_name) {

--- a/src/catalog/database_metrics_catalog.cpp
+++ b/src/catalog/database_metrics_catalog.cpp
@@ -28,7 +28,7 @@ DatabaseMetricsCatalog *DatabaseMetricsCatalog::GetInstance(
 DatabaseMetricsCatalog::DatabaseMetricsCatalog(
     concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
-                      "." DATABASE_METRICS_CATALOG_NAME
+                      "." CATALOG_SCHEMA_NAME "." DATABASE_METRICS_CATALOG_NAME
                       " ("
                       "database_oid  INT NOT NULL, "
                       "txn_committed INT NOT NULL, "

--- a/src/catalog/database_metrics_catalog.cpp
+++ b/src/catalog/database_metrics_catalog.cpp
@@ -25,11 +25,12 @@ DatabaseMetricsCatalog *DatabaseMetricsCatalog::GetInstance(
   return &database_metrics_catalog;
 }
 
-DatabaseMetricsCatalog::DatabaseMetricsCatalog(concurrency::TransactionContext *txn)
+DatabaseMetricsCatalog::DatabaseMetricsCatalog(
+    concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
                       "." DATABASE_METRICS_CATALOG_NAME
                       " ("
-                      "database_oid  INT NOT NULL, "
+                      "database_oid  INT NOT NULL PRIMARY KEY, "
                       "txn_committed INT NOT NULL, "
                       "txn_aborted   INT NOT NULL, "
                       "time_stamp    INT NOT NULL);",
@@ -41,7 +42,8 @@ DatabaseMetricsCatalog::~DatabaseMetricsCatalog() {}
 
 bool DatabaseMetricsCatalog::InsertDatabaseMetrics(
     oid_t database_oid, oid_t txn_committed, oid_t txn_aborted,
-    oid_t time_stamp, type::AbstractPool *pool, concurrency::TransactionContext *txn) {
+    oid_t time_stamp, type::AbstractPool *pool,
+    concurrency::TransactionContext *txn) {
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
 

--- a/src/catalog/database_metrics_catalog.cpp
+++ b/src/catalog/database_metrics_catalog.cpp
@@ -30,7 +30,7 @@ DatabaseMetricsCatalog::DatabaseMetricsCatalog(
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
                       "." DATABASE_METRICS_CATALOG_NAME
                       " ("
-                      "database_oid  INT NOT NULL PRIMARY KEY, "
+                      "database_oid  INT NOT NULL, "
                       "txn_committed INT NOT NULL, "
                       "txn_aborted   INT NOT NULL, "
                       "time_stamp    INT NOT NULL);",

--- a/src/catalog/index_catalog.cpp
+++ b/src/catalog/index_catalog.cpp
@@ -63,6 +63,8 @@ IndexCatalog::IndexCatalog(storage::Database *pg_catalog,
                            concurrency::TransactionContext *txn)
     : AbstractCatalog(INDEX_CATALOG_OID, INDEX_CATALOG_NAME,
                       InitializeSchema().release(), pg_catalog) {
+  database_oid = pg_catalog->GetOid();
+
   // Add indexes for pg_index
   AddIndex({0}, INDEX_CATALOG_PKEY_OID, INDEX_CATALOG_NAME "_pkey",
            IndexConstraintType::PRIMARY_KEY);

--- a/src/catalog/index_catalog.cpp
+++ b/src/catalog/index_catalog.cpp
@@ -219,7 +219,7 @@ std::shared_ptr<IndexCatalogObject> IndexCatalog::GetIndexObject(
     // fetch all indexes into table object (cannot use the above index object)
     auto pg_table = Catalog::GetInstance()
                         ->GetSystemCatalog(database_oid)
-                        .GetTableCatalog();
+                        ->GetTableCatalog();
     auto table_object =
         pg_table->GetTableObject(index_object->GetTableOid(), txn);
     PL_ASSERT(table_object &&
@@ -260,7 +260,7 @@ std::shared_ptr<IndexCatalogObject> IndexCatalog::GetIndexObject(
     // fetch all indexes into table object (cannot use the above index object)
     auto pg_table = Catalog::GetInstance()
                         ->GetSystemCatalog(database_oid)
-                        .GetTableCatalog();
+                        ->GetTableCatalog();
     auto table_object =
         pg_table->GetTableObject(index_object->GetTableOid(), txn);
     PL_ASSERT(table_object &&
@@ -289,7 +289,7 @@ IndexCatalog::GetIndexObjects(oid_t table_oid,
   }
   // try get from cache
   auto pg_table =
-      Catalog::GetInstance()->GetSystemCatalog(database_oid).GetTableCatalog();
+      Catalog::GetInstance()->GetSystemCatalog(database_oid)->GetTableCatalog();
   auto table_object =
       pg_table->GetTableObject(index_object->GetTableOid(), txn);
   PL_ASSERT(table_object && table_object->GetTableOid() == table_oid);

--- a/src/catalog/index_catalog.cpp
+++ b/src/catalog/index_catalog.cpp
@@ -212,7 +212,7 @@ std::shared_ptr<IndexCatalogObject> IndexCatalog::GetIndexObject(
                         ->GetTableCatalog();
     auto table_object =
         pg_table->GetTableObject(index_object->GetTableOid(), txn);
-    PL_ASSERT(table_object &&
+    PELOTON_ASSERT(table_object &&
               table_object->GetTableOid() == index_object->GetTableOid());
     return table_object->GetIndexObject(index_oid);
   } else {
@@ -258,7 +258,7 @@ std::shared_ptr<IndexCatalogObject> IndexCatalog::GetIndexObject(
                         ->GetTableCatalog();
     auto table_object =
         pg_table->GetTableObject(index_object->GetTableOid(), txn);
-    PL_ASSERT(table_object &&
+    PELOTON_ASSERT(table_object &&
               table_object->GetTableOid() == index_object->GetTableOid());
     return table_object->GetIndexObject(index_name);
   } else {
@@ -287,7 +287,7 @@ IndexCatalog::GetIndexObjects(oid_t table_oid,
                       ->GetSystemCatalogs(database_oid)
                       ->GetTableCatalog();
   auto table_object = pg_table->GetTableObject(table_oid, txn);
-  PL_ASSERT(table_object && table_object->GetTableOid() == table_oid);
+  PELOTON_ASSERT(table_object && table_object->GetTableOid() == table_oid);
   auto index_objects = table_object->GetIndexObjects(true);
   if (index_objects.empty() == false) return index_objects;
 

--- a/src/catalog/index_metrics_catalog.cpp
+++ b/src/catalog/index_metrics_catalog.cpp
@@ -22,9 +22,8 @@ namespace catalog {
 IndexMetricsCatalog::IndexMetricsCatalog(const std::string &database_name,
                                          concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " + database_name +
-                          "." INDEX_METRICS_CATALOG_NAME
+                          "." CATALOG_SCHEMA_NAME "." INDEX_METRICS_CATALOG_NAME
                           " ("
-                          "database_oid   INT NOT NULL, "
                           "table_oid      INT NOT NULL, "
                           "index_oid      INT NOT NULL, "
                           "reads          INT NOT NULL, "
@@ -38,13 +37,12 @@ IndexMetricsCatalog::IndexMetricsCatalog(const std::string &database_name,
 IndexMetricsCatalog::~IndexMetricsCatalog() {}
 
 bool IndexMetricsCatalog::InsertIndexMetrics(
-    oid_t database_oid, oid_t table_oid, oid_t index_oid, int64_t reads,
-    int64_t deletes, int64_t inserts, int64_t time_stamp,
-    type::AbstractPool *pool, concurrency::TransactionContext *txn) {
+    oid_t table_oid, oid_t index_oid, int64_t reads, int64_t deletes,
+    int64_t inserts, int64_t time_stamp, type::AbstractPool *pool,
+    concurrency::TransactionContext *txn) {
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
 
-  auto val0 = type::ValueFactory::GetIntegerValue(database_oid);
   auto val1 = type::ValueFactory::GetIntegerValue(table_oid);
   auto val2 = type::ValueFactory::GetIntegerValue(index_oid);
   auto val3 = type::ValueFactory::GetIntegerValue(reads);
@@ -52,7 +50,6 @@ bool IndexMetricsCatalog::InsertIndexMetrics(
   auto val5 = type::ValueFactory::GetIntegerValue(inserts);
   auto val6 = type::ValueFactory::GetIntegerValue(time_stamp);
 
-  tuple->SetValue(ColumnId::DATABASE_OID, val0, pool);
   tuple->SetValue(ColumnId::TABLE_OID, val1, pool);
   tuple->SetValue(ColumnId::INDEX_OID, val2, pool);
   tuple->SetValue(ColumnId::READS, val3, pool);

--- a/src/catalog/index_metrics_catalog.cpp
+++ b/src/catalog/index_metrics_catalog.cpp
@@ -19,23 +19,18 @@
 namespace peloton {
 namespace catalog {
 
-IndexMetricsCatalog *IndexMetricsCatalog::GetInstance(
-    concurrency::TransactionContext *txn) {
-  static IndexMetricsCatalog index_metrics_catalog{txn};
-  return &index_metrics_catalog;
-}
-
-IndexMetricsCatalog::IndexMetricsCatalog(concurrency::TransactionContext *txn)
-    : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
-                      "." INDEX_METRICS_CATALOG_NAME
-                      " ("
-                      "database_oid   INT NOT NULL, "
-                      "table_oid      INT NOT NULL, "
-                      "index_oid      INT NOT NULL, "
-                      "reads          INT NOT NULL, "
-                      "deletes        INT NOT NULL, "
-                      "inserts        INT NOT NULL, "
-                      "time_stamp     INT NOT NULL);",
+IndexMetricsCatalog::IndexMetricsCatalog(const std::string &database_name,
+                                         concurrency::TransactionContext *txn)
+    : AbstractCatalog("CREATE TABLE " + database_name +
+                          "." INDEX_METRICS_CATALOG_NAME
+                          " ("
+                          "database_oid   INT NOT NULL, "
+                          "table_oid      INT NOT NULL, "
+                          "index_oid      INT NOT NULL PRIMARY_KEY, "
+                          "reads          INT NOT NULL, "
+                          "deletes        INT NOT NULL, "
+                          "inserts        INT NOT NULL, "
+                          "time_stamp     INT NOT NULL);",
                       txn) {
   // Add secondary index here if necessary
 }
@@ -69,8 +64,8 @@ bool IndexMetricsCatalog::InsertIndexMetrics(
   return InsertTuple(std::move(tuple), txn);
 }
 
-bool IndexMetricsCatalog::DeleteIndexMetrics(oid_t index_oid,
-                                             concurrency::TransactionContext *txn) {
+bool IndexMetricsCatalog::DeleteIndexMetrics(
+    oid_t index_oid, concurrency::TransactionContext *txn) {
   oid_t index_offset = IndexId::PRIMARY_KEY;  // Primary key index
 
   std::vector<type::Value> values;

--- a/src/catalog/index_metrics_catalog.cpp
+++ b/src/catalog/index_metrics_catalog.cpp
@@ -26,7 +26,7 @@ IndexMetricsCatalog::IndexMetricsCatalog(const std::string &database_name,
                           " ("
                           "database_oid   INT NOT NULL, "
                           "table_oid      INT NOT NULL, "
-                          "index_oid      INT NOT NULL PRIMARY_KEY, "
+                          "index_oid      INT NOT NULL PRIMARY KEY, "
                           "reads          INT NOT NULL, "
                           "deletes        INT NOT NULL, "
                           "inserts        INT NOT NULL, "

--- a/src/catalog/index_metrics_catalog.cpp
+++ b/src/catalog/index_metrics_catalog.cpp
@@ -26,7 +26,7 @@ IndexMetricsCatalog::IndexMetricsCatalog(const std::string &database_name,
                           " ("
                           "database_oid   INT NOT NULL, "
                           "table_oid      INT NOT NULL, "
-                          "index_oid      INT NOT NULL PRIMARY KEY, "
+                          "index_oid      INT NOT NULL, "
                           "reads          INT NOT NULL, "
                           "deletes        INT NOT NULL, "
                           "inserts        INT NOT NULL, "

--- a/src/catalog/language_catalog.cpp
+++ b/src/catalog/language_catalog.cpp
@@ -24,7 +24,8 @@ LanguageCatalogObject::LanguageCatalogObject(executor::LogicalTile *tuple)
     : lang_oid_(tuple->GetValue(0, 0).GetAs<oid_t>()),
       lang_name_(tuple->GetValue(0, 1).GetAs<const char *>()) {}
 
-LanguageCatalog &LanguageCatalog::GetInstance(concurrency::TransactionContext *txn) {
+LanguageCatalog &LanguageCatalog::GetInstance(
+    concurrency::TransactionContext *txn) {
   static LanguageCatalog language_catalog{txn};
   return language_catalog;
 }
@@ -33,13 +34,13 @@ LanguageCatalog::~LanguageCatalog(){};
 
 LanguageCatalog::LanguageCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
-                      "." LANGUAGE_CATALOG_NAME
+                      "." CATALOG_SCHEMA_NAME "." LANGUAGE_CATALOG_NAME
                       " ("
                       "language_oid   INT NOT NULL PRIMARY KEY, "
                       "lanname        VARCHAR NOT NULL);",
                       txn) {
   Catalog::GetInstance()->CreateIndex(
-      CATALOG_DATABASE_NAME, LANGUAGE_CATALOG_NAME, {1},
+      CATALOG_DATABASE_NAME, CATALOG_SCHEMA_NAME, LANGUAGE_CATALOG_NAME, {1},
       LANGUAGE_CATALOG_NAME "_skey0", false, IndexType::BWTREE, txn);
 }
 

--- a/src/catalog/proc_catalog.cpp
+++ b/src/catalog/proc_catalog.cpp
@@ -46,7 +46,7 @@ ProcCatalog::~ProcCatalog(){};
 
 ProcCatalog::ProcCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
-                      "." PROC_CATALOG_NAME
+                      "." CATALOG_SCHEMA_NAME "." PROC_CATALOG_NAME
                       " ("
                       "proc_oid      INT NOT NULL PRIMARY KEY, "
                       "proname       VARCHAR NOT NULL, "
@@ -55,9 +55,9 @@ ProcCatalog::ProcCatalog(concurrency::TransactionContext *txn)
                       "prolang       INT NOT NULL, "
                       "prosrc        VARCHAR NOT NULL);",
                       txn) {
-  Catalog::GetInstance()->CreateIndex(CATALOG_DATABASE_NAME, PROC_CATALOG_NAME,
-                                      {1, 3}, PROC_CATALOG_NAME "_skey0", false,
-                                      IndexType::BWTREE, txn);
+  Catalog::GetInstance()->CreateIndex(
+      CATALOG_DATABASE_NAME, CATALOG_SCHEMA_NAME, PROC_CATALOG_NAME, {1, 3},
+      PROC_CATALOG_NAME "_skey0", false, IndexType::BWTREE, txn);
 }
 
 bool ProcCatalog::InsertProc(const std::string &proname,
@@ -117,8 +117,9 @@ std::unique_ptr<ProcCatalogObject> ProcCatalog::GetProcByName(
   oid_t index_offset = IndexId::SECONDARY_KEY_0;
   std::vector<type::Value> values;
   values.push_back(type::ValueFactory::GetVarcharValue(proc_name).Copy());
-  values.push_back(type::ValueFactory::GetVarcharValue(
-      TypeIdArrayToString(proc_arg_types)).Copy());
+  values.push_back(
+      type::ValueFactory::GetVarcharValue(TypeIdArrayToString(proc_arg_types))
+          .Copy());
 
   auto result_tiles =
       GetResultWithIndexScan(column_ids, index_offset, values, txn);

--- a/src/catalog/proc_catalog.cpp
+++ b/src/catalog/proc_catalog.cpp
@@ -37,26 +37,22 @@ std::unique_ptr<LanguageCatalogObject> ProcCatalogObject::GetLanguage() const {
   return LanguageCatalog::GetInstance().GetLanguageByOid(GetLangOid(), txn_);
 }
 
-ProcCatalog &ProcCatalog::GetInstance(concurrency::TransactionContext *txn) {
-  static ProcCatalog proc_catalog{txn};
-  return proc_catalog;
-}
-
 ProcCatalog::~ProcCatalog(){};
 
-ProcCatalog::ProcCatalog(concurrency::TransactionContext *txn)
-    : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
-                      "." PROC_CATALOG_NAME
-                      " ("
-                      "proc_oid      INT NOT NULL PRIMARY KEY, "
-                      "proname       VARCHAR NOT NULL, "
-                      "prorettype    INT NOT NULL, "
-                      "proargtypes   VARCHAR NOT NULL, "
-                      "prolang       INT NOT NULL, "
-                      "prosrc        VARCHAR NOT NULL);",
+ProcCatalog::ProcCatalog(const std::string &database_name,
+                         concurrency::TransactionContext *txn)
+    : AbstractCatalog("CREATE TABLE " + database_name +
+                          "." PROC_CATALOG_NAME
+                          " ("
+                          "proc_oid      INT NOT NULL PRIMARY KEY, "
+                          "proname       VARCHAR NOT NULL, "
+                          "prorettype    INT NOT NULL, "
+                          "proargtypes   VARCHAR NOT NULL, "
+                          "prolang       INT NOT NULL, "
+                          "prosrc        VARCHAR NOT NULL);",
                       txn) {
-  Catalog::GetInstance()->CreateIndex(CATALOG_DATABASE_NAME, PROC_CATALOG_NAME,
-                                      {1, 3}, PROC_CATALOG_NAME "_skey0", false,
+  Catalog::GetInstance()->CreateIndex(database_name, PROC_CATALOG_NAME, {1, 3},
+                                      PROC_CATALOG_NAME "_skey0", false,
                                       IndexType::BWTREE, txn);
 }
 
@@ -118,7 +114,7 @@ std::unique_ptr<ProcCatalogObject> ProcCatalog::GetProcByName(
   std::vector<type::Value> values;
   values.push_back(type::ValueFactory::GetVarcharValue(proc_name).Copy());
   values.push_back(type::ValueFactory::GetVarcharValue(
-      TypeIdArrayToString(proc_arg_types)).Copy());
+                       TypeIdArrayToString(proc_arg_types)).Copy());
 
   auto result_tiles =
       GetResultWithIndexScan(column_ids, index_offset, values, txn);

--- a/src/catalog/proc_catalog.cpp
+++ b/src/catalog/proc_catalog.cpp
@@ -37,22 +37,26 @@ std::unique_ptr<LanguageCatalogObject> ProcCatalogObject::GetLanguage() const {
   return LanguageCatalog::GetInstance().GetLanguageByOid(GetLangOid(), txn_);
 }
 
+ProcCatalog &ProcCatalog::GetInstance(concurrency::TransactionContext *txn) {
+  static ProcCatalog proc_catalog{txn};
+  return proc_catalog;
+}
+
 ProcCatalog::~ProcCatalog(){};
 
-ProcCatalog::ProcCatalog(const std::string &database_name,
-                         concurrency::TransactionContext *txn)
-    : AbstractCatalog("CREATE TABLE " + database_name +
-                          "." PROC_CATALOG_NAME
-                          " ("
-                          "proc_oid      INT NOT NULL PRIMARY KEY, "
-                          "proname       VARCHAR NOT NULL, "
-                          "prorettype    INT NOT NULL, "
-                          "proargtypes   VARCHAR NOT NULL, "
-                          "prolang       INT NOT NULL, "
-                          "prosrc        VARCHAR NOT NULL);",
+ProcCatalog::ProcCatalog(concurrency::TransactionContext *txn)
+    : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
+                      "." PROC_CATALOG_NAME
+                      " ("
+                      "proc_oid      INT NOT NULL PRIMARY KEY, "
+                      "proname       VARCHAR NOT NULL, "
+                      "prorettype    INT NOT NULL, "
+                      "proargtypes   VARCHAR NOT NULL, "
+                      "prolang       INT NOT NULL, "
+                      "prosrc        VARCHAR NOT NULL);",
                       txn) {
-  Catalog::GetInstance()->CreateIndex(database_name, PROC_CATALOG_NAME, {1, 3},
-                                      PROC_CATALOG_NAME "_skey0", false,
+  Catalog::GetInstance()->CreateIndex(CATALOG_DATABASE_NAME, PROC_CATALOG_NAME,
+                                      {1, 3}, PROC_CATALOG_NAME "_skey0", false,
                                       IndexType::BWTREE, txn);
 }
 
@@ -114,7 +118,7 @@ std::unique_ptr<ProcCatalogObject> ProcCatalog::GetProcByName(
   std::vector<type::Value> values;
   values.push_back(type::ValueFactory::GetVarcharValue(proc_name).Copy());
   values.push_back(type::ValueFactory::GetVarcharValue(
-                       TypeIdArrayToString(proc_arg_types)).Copy());
+      TypeIdArrayToString(proc_arg_types)).Copy());
 
   auto result_tiles =
       GetResultWithIndexScan(column_ids, index_offset, values, txn);

--- a/src/catalog/query_history_catalog.cpp
+++ b/src/catalog/query_history_catalog.cpp
@@ -27,7 +27,7 @@ QueryHistoryCatalog &QueryHistoryCatalog::GetInstance(
 
 QueryHistoryCatalog::QueryHistoryCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
-                      "." QUERY_HISTORY_CATALOG_NAME
+                      "." CATALOG_SCHEMA_NAME "." QUERY_HISTORY_CATALOG_NAME
                       " ("
                       "query_string   VARCHAR NOT NULL, "
                       "fingerprint    VARCHAR NOT NULL, "

--- a/src/catalog/query_metrics_catalog.cpp
+++ b/src/catalog/query_metrics_catalog.cpp
@@ -25,8 +25,8 @@ QueryMetricsCatalog::QueryMetricsCatalog(const std::string &database_name,
     : AbstractCatalog("CREATE TABLE " + database_name +
                           "." QUERY_METRICS_CATALOG_NAME
                           " ("
-                          "query_name   VARCHAR NOT NULL PRIMARY KEY, "
-                          "database_oid INT NOT NULL , "
+                          "query_name   VARCHAR NOT NULL, "
+                          "database_oid INT NOT NULL, "
                           "num_params   INT NOT NULL, "
                           "param_types    VARBINARY, "
                           "param_formats  VARBINARY, "

--- a/src/catalog/query_metrics_catalog.cpp
+++ b/src/catalog/query_metrics_catalog.cpp
@@ -25,7 +25,7 @@ QueryMetricsCatalog::QueryMetricsCatalog(const std::string &database_name,
     : AbstractCatalog("CREATE TABLE " + database_name +
                           "." QUERY_METRICS_CATALOG_NAME
                           " ("
-                          "query_name   VARCHAR NOT NULL, "
+                          "query_name   VARCHAR NOT NULL PRIMARY KEY, "
                           "database_oid INT NOT NULL, "
                           "num_params   INT NOT NULL, "
                           "param_types    VARBINARY, "

--- a/src/catalog/query_metrics_catalog.cpp
+++ b/src/catalog/query_metrics_catalog.cpp
@@ -23,10 +23,9 @@ namespace catalog {
 QueryMetricsCatalog::QueryMetricsCatalog(const std::string &database_name,
                                          concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " + database_name +
-                          "." QUERY_METRICS_CATALOG_NAME
+                          "." CATALOG_SCHEMA_NAME "." QUERY_METRICS_CATALOG_NAME
                           " ("
                           "query_name   VARCHAR NOT NULL PRIMARY KEY, "
-                          "database_oid INT NOT NULL, "
                           "num_params   INT NOT NULL, "
                           "param_types    VARBINARY, "
                           "param_formats  VARBINARY, "

--- a/src/catalog/query_metrics_catalog.cpp
+++ b/src/catalog/query_metrics_catalog.cpp
@@ -45,7 +45,7 @@ QueryMetricsCatalog::QueryMetricsCatalog(const std::string &database_name,
 QueryMetricsCatalog::~QueryMetricsCatalog() {}
 
 bool QueryMetricsCatalog::InsertQueryMetrics(
-    const std::string &name, oid_t database_oid, int64_t num_params,
+    const std::string &name, int64_t num_params,
     const stats::QueryMetric::QueryParamBuf &type_buf,
     const stats::QueryMetric::QueryParamBuf &format_buf,
     const stats::QueryMetric::QueryParamBuf &value_buf, int64_t reads,
@@ -97,8 +97,7 @@ bool QueryMetricsCatalog::InsertQueryMetrics(
 }
 
 bool QueryMetricsCatalog::DeleteQueryMetrics(
-    const std::string &name, oid_t database_oid,
-    concurrency::TransactionContext *txn) {
+    const std::string &name, concurrency::TransactionContext *txn) {
   oid_t index_offset = IndexId::PRIMARY_KEY;  // Primary key index
 
   std::vector<type::Value> values;
@@ -108,8 +107,7 @@ bool QueryMetricsCatalog::DeleteQueryMetrics(
 }
 
 stats::QueryMetric::QueryParamBuf QueryMetricsCatalog::GetParamTypes(
-    const std::string &name, oid_t database_oid,
-    concurrency::TransactionContext *txn) {
+    const std::string &name, concurrency::TransactionContext *txn) {
   std::vector<oid_t> column_ids({ColumnId::PARAM_TYPES});  // param_types
   oid_t index_offset = IndexId::PRIMARY_KEY;               // Primary key index
   std::vector<type::Value> values;
@@ -134,8 +132,7 @@ stats::QueryMetric::QueryParamBuf QueryMetricsCatalog::GetParamTypes(
 }
 
 int64_t QueryMetricsCatalog::GetNumParams(
-    const std::string &name, oid_t database_oid,
-    concurrency::TransactionContext *txn) {
+    const std::string &name, concurrency::TransactionContext *txn) {
   std::vector<oid_t> column_ids({ColumnId::NUM_PARAMS});  // num_params
   oid_t index_offset = IndexId::PRIMARY_KEY;              // Primary key index
   std::vector<type::Value> values;

--- a/src/catalog/query_metrics_catalog.cpp
+++ b/src/catalog/query_metrics_catalog.cpp
@@ -99,8 +99,7 @@ bool QueryMetricsCatalog::InsertQueryMetrics(
 }
 
 bool QueryMetricsCatalog::DeleteQueryMetrics(
-    const std::string &name, oid_t database_oid,
-    concurrency::TransactionContext *txn) {
+    const std::string &name, concurrency::TransactionContext *txn) {
   oid_t index_offset = IndexId::PRIMARY_KEY;  // Primary key index
 
   std::vector<type::Value> values;
@@ -116,6 +115,7 @@ stats::QueryMetric::QueryParamBuf QueryMetricsCatalog::GetParamTypes(
   oid_t index_offset = IndexId::PRIMARY_KEY;               // Primary key index
   std::vector<type::Value> values;
   values.push_back(type::ValueFactory::GetVarcharValue(name, nullptr).Copy());
+  values.push_back(type::ValueFactory::GetIntegerValue(database_oid).Copy());
 
   auto result_tiles =
       GetResultWithIndexScan(column_ids, index_offset, values, txn);

--- a/src/catalog/schema_catalog.cpp
+++ b/src/catalog/schema_catalog.cpp
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// schema_catalog.cpp
+//
+// Identification: src/catalog/schema_catalog.cpp
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Index Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "catalog/schema_catalog.h"
+
+#include "catalog/catalog.h"
+#include "catalog/system_catalogs.h"
+#include "concurrency/transaction_context.h"
+#include "executor/logical_tile.h"
+#include "storage/data_table.h"
+#include "storage/database.h"
+#include "storage/tuple.h"
+#include "type/value_factory.h"
+
+namespace peloton {
+namespace catalog {
+
+SchemaCatalogObject::SchemaCatalogObject(executor::LogicalTile *tile,
+                                         concurrency::TransactionContext *txn)
+    : schema_oid(tile->GetValue(0, SchemaCatalog::ColumnId::SCHEMA_OID)
+                     .GetAs<oid_t>()),
+      schema_name(
+          tile->GetValue(0, SchemaCatalog::ColumnId::SCHEMA_NAME).ToString()),
+      txn(txn) {}
+
+SchemaCatalog::SchemaCatalog(
+    storage::Database *database, UNUSED_ATTRIBUTE type::AbstractPool *pool,
+    UNUSED_ATTRIBUTE concurrency::TransactionContext *txn)
+    : AbstractCatalog(SCHEMA_CATALOG_OID, SCHEMA_CATALOG_NAME,
+                      InitializeSchema().release(), database) {
+  // Add indexes for pg_namespace
+  AddIndex({0}, SCHEMA_CATALOG_PKEY_OID, SCHEMA_CATALOG_NAME "_pkey",
+           IndexConstraintType::PRIMARY_KEY);
+  AddIndex({1}, SCHEMA_CATALOG_SKEY0_OID, SCHEMA_CATALOG_NAME "_skey0",
+           IndexConstraintType::UNIQUE);
+}
+
+SchemaCatalog::~SchemaCatalog() {}
+
+/*@brief   private function for initialize schema of pg_namespace
+ * @return  unqiue pointer to schema
+ */
+std::unique_ptr<catalog::Schema> SchemaCatalog::InitializeSchema() {
+  const std::string not_null_constraint_name = "not_null";
+  const std::string primary_key_constraint_name = "primary_key";
+
+  auto schema_id_column = catalog::Column(
+      type::TypeId::INTEGER, type::Type::GetTypeSize(type::TypeId::INTEGER),
+      "schema_oid", true);
+  schema_id_column.AddConstraint(catalog::Constraint(
+      ConstraintType::PRIMARY, primary_key_constraint_name));
+  schema_id_column.AddConstraint(
+      catalog::Constraint(ConstraintType::NOTNULL, not_null_constraint_name));
+
+  auto schema_name_column = catalog::Column(
+      type::TypeId::VARCHAR, max_name_size, "schema_name", false);
+  schema_name_column.AddConstraint(
+      catalog::Constraint(ConstraintType::NOTNULL, not_null_constraint_name));
+
+  std::unique_ptr<catalog::Schema> schema(
+      new catalog::Schema({schema_id_column, schema_name_column}));
+  return schema;
+}
+
+bool SchemaCatalog::InsertSchema(oid_t schema_oid,
+                                 const std::string &schema_name,
+                                 type::AbstractPool *pool,
+                                 concurrency::TransactionContext *txn) {
+  // Create the tuple first
+  std::unique_ptr<storage::Tuple> tuple(
+      new storage::Tuple(catalog_table_->GetSchema(), true));
+
+  auto val0 = type::ValueFactory::GetIntegerValue(schema_oid);
+  auto val1 = type::ValueFactory::GetVarcharValue(schema_name, nullptr);
+
+  tuple->SetValue(SchemaCatalog::ColumnId::SCHEMA_OID, val0, pool);
+  tuple->SetValue(SchemaCatalog::ColumnId::SCHEMA_NAME, val1, pool);
+
+  // Insert the tuple
+  return InsertTuple(std::move(tuple), txn);
+}
+
+bool SchemaCatalog::DeleteSchema(const std::string &schema_name,
+                                 concurrency::TransactionContext *txn) {
+  oid_t index_offset = IndexId::SKEY_SCHEMA_NAME;  // Index of schema_name
+  std::vector<type::Value> values;
+  values.push_back(
+      type::ValueFactory::GetVarcharValue(schema_name, nullptr).Copy());
+
+  return DeleteWithIndexScan(index_offset, values, txn);
+}
+
+std::shared_ptr<SchemaCatalogObject> SchemaCatalog::GetSchemaObject(
+    const std::string &schema_name, concurrency::TransactionContext *txn) {
+  if (txn == nullptr) {
+    throw CatalogException("Transaction is invalid!");
+  }
+  // get from pg_namespace, index scan
+  std::vector<oid_t> column_ids(all_column_ids);
+  oid_t index_offset = IndexId::SKEY_SCHEMA_NAME;  // Index of database_name
+  std::vector<type::Value> values;
+  values.push_back(
+      type::ValueFactory::GetVarcharValue(schema_name, nullptr).Copy());
+
+  auto result_tiles =
+      GetResultWithIndexScan(column_ids, index_offset, values, txn);
+
+  if (result_tiles->size() == 1 && (*result_tiles)[0]->GetTupleCount() == 1) {
+    auto schema_object =
+        std::make_shared<SchemaCatalogObject>((*result_tiles)[0].get(), txn);
+    // TODO: we don't have cache for schema object right now
+    return schema_object;
+  }
+
+  // return empty object if not found
+  return nullptr;
+}
+
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/settings_catalog.cpp
+++ b/src/catalog/settings_catalog.cpp
@@ -21,14 +21,15 @@
 namespace peloton {
 namespace catalog {
 
-SettingsCatalog &SettingsCatalog::GetInstance(concurrency::TransactionContext *txn) {
+SettingsCatalog &SettingsCatalog::GetInstance(
+    concurrency::TransactionContext *txn) {
   static SettingsCatalog settings_catalog{txn};
   return settings_catalog;
 }
 
 SettingsCatalog::SettingsCatalog(concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
-                      "." SETTINGS_CATALOG_NAME
+                      "." CATALOG_SCHEMA_NAME "." SETTINGS_CATALOG_NAME
                       " ("
                       "name   VARCHAR NOT NULL, "
                       "value  VARCHAR NOT NULL, "
@@ -42,7 +43,7 @@ SettingsCatalog::SettingsCatalog(concurrency::TransactionContext *txn)
                       txn) {
   // Add secondary index here if necessary
   Catalog::GetInstance()->CreateIndex(
-      CATALOG_DATABASE_NAME, SETTINGS_CATALOG_NAME, {0},
+      CATALOG_DATABASE_NAME, CATALOG_SCHEMA_NAME, SETTINGS_CATALOG_NAME, {0},
       SETTINGS_CATALOG_NAME "_skey0", false, IndexType::BWTREE, txn);
 }
 
@@ -92,8 +93,8 @@ bool SettingsCatalog::DeleteSetting(const std::string &name,
   return DeleteWithIndexScan(index_offset, values, txn);
 }
 
-std::string SettingsCatalog::GetSettingValue(const std::string &name,
-                                             concurrency::TransactionContext *txn) {
+std::string SettingsCatalog::GetSettingValue(
+    const std::string &name, concurrency::TransactionContext *txn) {
   std::vector<oid_t> column_ids({static_cast<int>(ColumnId::VALUE)});
   oid_t index_offset = static_cast<int>(IndexId::SECONDARY_KEY_0);
   std::vector<type::Value> values;
@@ -113,8 +114,8 @@ std::string SettingsCatalog::GetSettingValue(const std::string &name,
   return config_value;
 }
 
-std::string SettingsCatalog::GetDefaultValue(const std::string &name,
-                                             concurrency::TransactionContext *txn) {
+std::string SettingsCatalog::GetDefaultValue(
+    const std::string &name, concurrency::TransactionContext *txn) {
   std::vector<oid_t> column_ids({static_cast<int>(ColumnId::VALUE)});
   oid_t index_offset = static_cast<int>(IndexId::SECONDARY_KEY_0);
   std::vector<type::Value> values;

--- a/src/catalog/system_catalogs.cpp
+++ b/src/catalog/system_catalogs.cpp
@@ -23,7 +23,8 @@ namespace catalog {
 
 SystemCatalogs::SystemCatalogs(storage::Database *database,
                                type::AbstractPool *pool,
-                               concurrency::TransactionContext *txn) {
+                               concurrency::TransactionContext *txn)
+    : pg_trigger(nullptr) {
   oid_t database_oid = database->GetOid();
   pg_attribute = new ColumnCatalog(database, pool, txn);
   pg_table = new TableCatalog(database, pool, txn);

--- a/src/catalog/system_catalogs.cpp
+++ b/src/catalog/system_catalogs.cpp
@@ -30,13 +30,16 @@ SystemCatalogs::SystemCatalogs(storage::Database *database,
       pg_query_metrics(nullptr) {
   oid_t database_oid = database->GetOid();
   pg_attribute = new ColumnCatalog(database, pool, txn);
+  pg_namespace = new SchemaCatalog(database, pool, txn);
   pg_table = new TableCatalog(database, pool, txn);
   pg_index = new IndexCatalog(database, pool, txn);
 
   // TODO: can we move this to BootstrapSystemCatalogs()?
+  // insert column information into pg_attribute
   std::vector<std::pair<oid_t, oid_t>> shared_tables = {
       {CATALOG_DATABASE_OID, DATABASE_CATALOG_OID},
       {database_oid, TABLE_CATALOG_OID},
+      {database_oid, SCHEMA_CATALOG_OID},
       {database_oid, INDEX_CATALOG_OID}};
 
   for (int i = 0; i < (int)shared_tables.size(); i++) {
@@ -59,6 +62,7 @@ SystemCatalogs::~SystemCatalogs() {
   delete pg_index;
   delete pg_table;
   delete pg_attribute;
+  delete pg_namespace;
   if (pg_trigger) delete pg_trigger;
   // if (pg_proc) delete pg_proc;
   if (pg_table_metrics) delete pg_table_metrics;
@@ -66,6 +70,9 @@ SystemCatalogs::~SystemCatalogs() {
   if (pg_query_metrics) delete pg_query_metrics;
 }
 
+/*
+ * @brief   using sql create statement to create secondary catalog tables
+ */
 void SystemCatalogs::Bootstrap(const std::string &database_name,
                                concurrency::TransactionContext *txn) {
   LOG_DEBUG("Bootstrapping database: %s", database_name.c_str());

--- a/src/catalog/system_catalogs.cpp
+++ b/src/catalog/system_catalogs.cpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// system_catalog.cpp
+//
+// Identification: src/catalog/system_catalog.cpp
+//
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+namespace peloton {
+namespace catalog {
+
+SystemCatalogs::SystemCatalogs(storage::Database *database,
+                               type::AbstractPool *pool,
+                               concurrency::TransactionContext *txn) {
+  pg_attribute = new ColumnCatalog(database, pool, txn);
+
+  oid_t column_id = 0;
+  for (auto column :
+       StorageManager::GetInstance()
+           ->GetTableWithOid(CATALOG_DATABASE_OID, DATABASE_CATALOG_OID)
+           ->GetSchema()
+           ->GetColumns()) {
+    pg_attribute->InsertColumn(DATABASE_CATALOG_OID, column.GetName(),
+                               column_id, column.GetOffset(), column.GetType(),
+                               column.IsInlined(), column.GetConstraints(),
+                               pool, txn);
+    column_id++;
+  }
+
+  pg_table = new TableCatalog(database, pool, txn);
+
+  pg_index = new IndexCatalog(database, pool, txn);
+}
+
+SystemCatalogs::~SystemCatalogs() {
+  delete IndexCatalog;
+  delete TableCatalog;
+  delete ColumnCatalog;
+}
+
+}  // namespace catalog
+}  // namespace peloton

--- a/src/catalog/system_catalogs.cpp
+++ b/src/catalog/system_catalogs.cpp
@@ -24,7 +24,11 @@ namespace catalog {
 SystemCatalogs::SystemCatalogs(storage::Database *database,
                                type::AbstractPool *pool,
                                concurrency::TransactionContext *txn)
-    : pg_trigger(nullptr) {
+    : pg_trigger(nullptr),
+    pg_table_metrics(nullptr),
+    pg_index_metrics(nullptr),
+    pg_query_metrics(nullptr)
+  {
   oid_t database_oid = database->GetOid();
   pg_attribute = new ColumnCatalog(database, pool, txn);
   pg_table = new TableCatalog(database, pool, txn);
@@ -65,6 +69,8 @@ SystemCatalogs::~SystemCatalogs() {
 
 void SystemCatalogs::Bootstrap(const std::string &database_name,
                                concurrency::TransactionContext *txn) {
+  LOG_DEBUG("Bootstrapping database: %s", database_name.c_str());
+
   pg_trigger = new TriggerCatalog(database_name, txn);
   // pg_proc = new ProcCatalog(database_name, txn);
   pg_table_metrics = new TableMetricsCatalog(database_name, txn);

--- a/src/catalog/system_catalogs.cpp
+++ b/src/catalog/system_catalogs.cpp
@@ -30,7 +30,6 @@ SystemCatalogs::SystemCatalogs(storage::Database *database,
   pg_index = new IndexCatalog(database, pool, txn);
 
   // TODO: can we move this to BootstrapSystemCatalogs()?
-  // insert pg_database columns into pg_attribute
   std::vector<std::pair<oid, oid>> shared_tables = {
       {CATALOG_DATABASE_OID, DATABASE_CATALOG_OID},
       {database_oid, TABLE_CATALOG_OID},
@@ -56,6 +55,12 @@ SystemCatalogs::~SystemCatalogs() {
   delete pg_index;
   delete pg_table;
   delete pg_attribute;
+  if (pg_trigger) delete pg_trigger;
+}
+
+void SystemCatalogs::Bootstrap(const string &database_name) {
+  pg_trigger =
+      new TriggerCatalog(database_name, concurrency::TransactionContext * txn);
 }
 
 }  // namespace catalog

--- a/src/catalog/system_catalogs.cpp
+++ b/src/catalog/system_catalogs.cpp
@@ -25,10 +25,9 @@ SystemCatalogs::SystemCatalogs(storage::Database *database,
                                type::AbstractPool *pool,
                                concurrency::TransactionContext *txn)
     : pg_trigger(nullptr),
-    pg_table_metrics(nullptr),
-    pg_index_metrics(nullptr),
-    pg_query_metrics(nullptr)
-  {
+      pg_table_metrics(nullptr),
+      pg_index_metrics(nullptr),
+      pg_query_metrics(nullptr) {
   oid_t database_oid = database->GetOid();
   pg_attribute = new ColumnCatalog(database, pool, txn);
   pg_table = new TableCatalog(database, pool, txn);

--- a/src/catalog/system_catalogs.cpp
+++ b/src/catalog/system_catalogs.cpp
@@ -31,43 +31,24 @@ SystemCatalogs::SystemCatalogs(storage::Database *database,
 
   // TODO: can we move this to BootstrapSystemCatalogs()?
   // insert pg_database columns into pg_attribute
-  oid_t column_id = 0;
-  for (auto column :
-       storage::StorageManager::GetInstance()
-           ->GetTableWithOid(CATALOG_DATABASE_OID, DATABASE_CATALOG_OID)
-           ->GetSchema()
-           ->GetColumns()) {
-    pg_attribute->InsertColumn(DATABASE_CATALOG_OID, column.GetName(),
-                               column_id, column.GetOffset(), column.GetType(),
-                               column.IsInlined(), column.GetConstraints(),
-                               pool, txn);
-    column_id++;
-  }
+  std::vector<std::pair<oid, oid>> shared_tables = {
+      {CATALOG_DATABASE_OID, DATABASE_CATALOG_OID},
+      {database_oid, TABLE_CATALOG_OID},
+      {database_oid, INDEX_CATALOG_OID}};
 
-  // Insert pg_table columns into pg_attribute
-  column_id = 0;
-  for (auto column : storage::StorageManager::GetInstance()
-                         ->GetTableWithOid(database_oid, TABLE_CATALOG_OID)
-                         ->GetSchema()
-                         ->GetColumns()) {
-    pg_attribute->InsertColumn(TABLE_CATALOG_OID, column.GetName(), column_id,
-                               column.GetOffset(), column.GetType(),
-                               column.IsInlined(), column.GetConstraints(),
-                               pool, txn);
-    column_id++;
-  }
-
-  // Insert pg_index columns into pg_attribute
-  column_id = 0;
-  for (auto column : storage::StorageManager::GetInstance()
-                         ->GetTableWithOid(database_oid, INDEX_CATALOG_OID)
-                         ->GetSchema()
-                         ->GetColumns()) {
-    pg_attribute->InsertColumn(INDEX_CATALOG_OID, column.GetName(), column_id,
-                               column.GetOffset(), column.GetType(),
-                               column.IsInlined(), column.GetConstraints(),
-                               pool, txn);
-    column_id++;
+  for (int i = 0; i < shared_tables.size(); i++) {
+    oid_t column_id = 0;
+    for (auto column :
+         storage::StorageManager::GetInstance()
+             ->GetTableWithOid(CATALOG_DATABASE_OID, DATABASE_CATALOG_OID)
+             ->GetSchema()
+             ->GetColumns()) {
+      pg_attribute->InsertColumn(DATABASE_CATALOG_OID, column.GetName(),
+                                 column_id, column.GetOffset(),
+                                 column.GetType(), column.IsInlined(),
+                                 column.GetConstraints(), pool, txn);
+      column_id++;
+    }
   }
 }
 

--- a/src/catalog/system_catalogs.cpp
+++ b/src/catalog/system_catalogs.cpp
@@ -10,6 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "catalog/system_catalogs.h"
+#include "catalog/column_catalog.h"
+#include "catalog/table_catalog.h"
+#include "catalog/index_catalog.h"
+#include "storage/storage_manager.h"
+#include "storage/data_table.h"
+
 namespace peloton {
 namespace catalog {
 
@@ -18,9 +25,10 @@ SystemCatalogs::SystemCatalogs(storage::Database *database,
                                concurrency::TransactionContext *txn) {
   pg_attribute = new ColumnCatalog(database, pool, txn);
 
+  // TODO: can we move this to BootstrapSystemCatalogs()?
   oid_t column_id = 0;
   for (auto column :
-       StorageManager::GetInstance()
+       storage::StorageManager::GetInstance()
            ->GetTableWithOid(CATALOG_DATABASE_OID, DATABASE_CATALOG_OID)
            ->GetSchema()
            ->GetColumns()) {
@@ -37,9 +45,9 @@ SystemCatalogs::SystemCatalogs(storage::Database *database,
 }
 
 SystemCatalogs::~SystemCatalogs() {
-  delete IndexCatalog;
-  delete TableCatalog;
-  delete ColumnCatalog;
+  delete pg_index;
+  delete pg_table;
+  delete pg_attribute;
 }
 
 }  // namespace catalog

--- a/src/catalog/system_catalogs.cpp
+++ b/src/catalog/system_catalogs.cpp
@@ -57,11 +57,19 @@ SystemCatalogs::~SystemCatalogs() {
   delete pg_table;
   delete pg_attribute;
   if (pg_trigger) delete pg_trigger;
+  if (pg_proc) delete pg_proc;
+  if (pg_table_metrics) delete pg_table_metrics;
+  if (pg_index_metrics) delete pg_index_metrics;
+  if (pg_query_metrics) delete pg_query_metrics;
 }
 
 void SystemCatalogs::Bootstrap(const std::string &database_name,
                                concurrency::TransactionContext *txn) {
   pg_trigger = new TriggerCatalog(database_name, txn);
+  pg_proc = new ProcCatalog(database_name, txn);
+  pg_table_metrics = new TableMetricsCatalog(database_name, txn);
+  pg_index_metrics = new IndexMetricsCatalog(database_name, txn);
+  pg_query_metrics = new QueryMetricsCatalog(database_name, txn);
 }
 
 }  // namespace catalog

--- a/src/catalog/system_catalogs.cpp
+++ b/src/catalog/system_catalogs.cpp
@@ -57,7 +57,7 @@ SystemCatalogs::~SystemCatalogs() {
   delete pg_table;
   delete pg_attribute;
   if (pg_trigger) delete pg_trigger;
-  if (pg_proc) delete pg_proc;
+  // if (pg_proc) delete pg_proc;
   if (pg_table_metrics) delete pg_table_metrics;
   if (pg_index_metrics) delete pg_index_metrics;
   if (pg_query_metrics) delete pg_query_metrics;
@@ -66,7 +66,7 @@ SystemCatalogs::~SystemCatalogs() {
 void SystemCatalogs::Bootstrap(const std::string &database_name,
                                concurrency::TransactionContext *txn) {
   pg_trigger = new TriggerCatalog(database_name, txn);
-  pg_proc = new ProcCatalog(database_name, txn);
+  // pg_proc = new ProcCatalog(database_name, txn);
   pg_table_metrics = new TableMetricsCatalog(database_name, txn);
   pg_index_metrics = new IndexMetricsCatalog(database_name, txn);
   pg_query_metrics = new QueryMetricsCatalog(database_name, txn);

--- a/src/catalog/system_catalogs.cpp
+++ b/src/catalog/system_catalogs.cpp
@@ -70,11 +70,25 @@ void SystemCatalogs::Bootstrap(const std::string &database_name,
                                concurrency::TransactionContext *txn) {
   LOG_DEBUG("Bootstrapping database: %s", database_name.c_str());
 
-  pg_trigger = new TriggerCatalog(database_name, txn);
-  // pg_proc = new ProcCatalog(database_name, txn);
-  pg_table_metrics = new TableMetricsCatalog(database_name, txn);
-  pg_index_metrics = new IndexMetricsCatalog(database_name, txn);
-  pg_query_metrics = new QueryMetricsCatalog(database_name, txn);
+  if (!pg_trigger) {
+    pg_trigger = new TriggerCatalog(database_name, txn);
+  }
+
+  // if (!pg_proc) {
+  //     pg_proc = new ProcCatalog(database_name, txn);
+  // }
+
+  if (!pg_table_metrics) {
+    pg_table_metrics = new TableMetricsCatalog(database_name, txn);
+  }
+
+  if (!pg_index_metrics) {
+    pg_index_metrics = new IndexMetricsCatalog(database_name, txn);
+  }
+
+  if (!pg_query_metrics) {
+    pg_query_metrics = new QueryMetricsCatalog(database_name, txn);
+  }
 }
 
 }  // namespace catalog

--- a/src/catalog/table_catalog.cpp
+++ b/src/catalog/table_catalog.cpp
@@ -129,8 +129,10 @@ TableCatalogObject::GetIndexObjects(bool cached_only) {
   if (!valid_index_objects && !cached_only) {
     // get index catalog objects from pg_index
     valid_index_objects = true;
-    index_objects =
-        IndexCatalog::GetInstance()->GetIndexObjects(table_oid, txn);
+    auto pg_index = Catalog::GetInstance()
+                        ->GetSystemCatalog(database_oid)
+                        .GetIndexCatalog();
+    index_objects = pg_index->GetIndexObjects(table_oid, txn);
   }
   return index_objects;
 }
@@ -253,7 +255,10 @@ std::unordered_map<oid_t, std::shared_ptr<ColumnCatalogObject>>
 TableCatalogObject::GetColumnObjects(bool cached_only) {
   if (!valid_column_objects && !cached_only) {
     // get column catalog objects from pg_column
-    ColumnCatalog::GetInstance()->GetColumnObjects(table_oid, txn);
+    auto pg_attribute = Catalog::GetInstance()
+                            ->GetSystemCatalog(database_oid)
+                            .GetColumnCatalog();
+    pg_attribute->GetColumnObjects(table_oid, txn);
     valid_column_objects = true;
   }
   return column_objects;

--- a/src/catalog/table_catalog.cpp
+++ b/src/catalog/table_catalog.cpp
@@ -458,7 +458,7 @@ std::shared_ptr<TableCatalogObject> TableCatalog::GetTableObject(
     // insert into cache
     auto database_object =
         DatabaseCatalog::GetInstance()->GetDatabaseObject(database_oid, txn);
-    PL_ASSERT(database_object);
+    PELOTON_ASSERT(database_object);
     bool success = database_object->InsertTableObject(table_object);
     PELOTON_ASSERT(success == true);
     (void)success;
@@ -511,7 +511,7 @@ std::shared_ptr<TableCatalogObject> TableCatalog::GetTableObject(
     // insert into cache
     auto database_object =
         DatabaseCatalog::GetInstance()->GetDatabaseObject(database_oid, txn);
-    PL_ASSERT(database_object);
+    PELOTON_ASSERT(database_object);
     bool success = database_object->InsertTableObject(table_object);
     PELOTON_ASSERT(success == true);
     (void)success;

--- a/src/catalog/table_catalog.cpp
+++ b/src/catalog/table_catalog.cpp
@@ -313,25 +313,12 @@ std::shared_ptr<ColumnCatalogObject> TableCatalogObject::GetColumnObject(
   return nullptr;
 }
 
-TableCatalog::TableCatalog(storage::Database *pg_catalog,
-                           type::AbstractPool *pool,
-                           concurrency::TransactionContext *txn)
+TableCatalog::TableCatalog(
+    storage::Database *pg_catalog, UNUSED_ATTRIBUTE type::AbstractPool *pool,
+    UNUSED_ATTRIBUTE concurrency::TransactionContext *txn)
     : AbstractCatalog(TABLE_CATALOG_OID, TABLE_CATALOG_NAME,
                       InitializeSchema().release(), pg_catalog) {
   database_oid = pg_catalog->GetOid();
-
-  // Insert columns into pg_attribute
-  ColumnCatalog *pg_attribute =
-      Catalog::GetInstance()->GetSystemCatalogs(database_oid)->GetColumnCatalog();
-
-  oid_t column_id = 0;
-  for (auto column : catalog_table_->GetSchema()->GetColumns()) {
-    pg_attribute->InsertColumn(TABLE_CATALOG_OID, column.GetName(), column_id,
-                               column.GetOffset(), column.GetType(),
-                               column.IsInlined(), column.GetConstraints(),
-                               pool, txn);
-    column_id++;
-  }
 }
 
 TableCatalog::~TableCatalog() {}

--- a/src/catalog/table_catalog.cpp
+++ b/src/catalog/table_catalog.cpp
@@ -131,7 +131,7 @@ TableCatalogObject::GetIndexObjects(bool cached_only) {
     valid_index_objects = true;
     auto pg_index = Catalog::GetInstance()
                         ->GetSystemCatalog(database_oid)
-                        .GetIndexCatalog();
+                        ->GetIndexCatalog();
     index_objects = pg_index->GetIndexObjects(table_oid, txn);
   }
   return index_objects;
@@ -257,7 +257,7 @@ TableCatalogObject::GetColumnObjects(bool cached_only) {
     // get column catalog objects from pg_column
     auto pg_attribute = Catalog::GetInstance()
                             ->GetSystemCatalog(database_oid)
-                            .GetColumnCatalog();
+                            ->GetColumnCatalog();
     pg_attribute->GetColumnObjects(table_oid, txn);
     valid_column_objects = true;
   }

--- a/src/catalog/table_catalog.cpp
+++ b/src/catalog/table_catalog.cpp
@@ -410,7 +410,7 @@ bool TableCatalog::InsertTable(oid_t table_oid, const std::string &table_name,
 /*@brief   delete a tuple about table info from pg_table(using index scan)
  * @param   table_oid
  * @param   txn     TransactionContext
- * @return  Whether deletion is Successful
+ * @return  Whether deletion is successful
  */
 bool TableCatalog::DeleteTable(oid_t table_oid,
                                concurrency::TransactionContext *txn) {
@@ -561,6 +561,12 @@ TableCatalog::GetTableObjects(concurrency::TransactionContext *txn) {
   return database_object->GetTableObjects();
 }
 
+/*@brief    update version id column within pg_table
+ * @param   update_val   the new(updated) version id
+ * @param   table_oid    which table to be updated
+ * @param   txn          TransactionContext
+ * @return  Whether update is successful
+ */
 bool TableCatalog::UpdateVersionId(oid_t update_val, oid_t table_oid,
                                    concurrency::TransactionContext *txn) {
   std::vector<oid_t> update_columns({ColumnId::VERSION_ID});  // version_id

--- a/src/catalog/table_metrics_catalog.cpp
+++ b/src/catalog/table_metrics_catalog.cpp
@@ -25,7 +25,7 @@ TableMetricsCatalog::TableMetricsCatalog(const std::string &database_name,
                           "." TABLE_METRICS_CATALOG_NAME
                           " ("
                           "database_oid   INT NOT NULL, "
-                          "table_oid      INT NOT NULL PRIMARY KEY, "
+                          "table_oid      INT NOT NULL, "
                           "reads          INT NOT NULL, "
                           "updates        INT NOT NULL, "
                           "deletes        INT NOT NULL, "

--- a/src/catalog/table_metrics_catalog.cpp
+++ b/src/catalog/table_metrics_catalog.cpp
@@ -19,23 +19,18 @@
 namespace peloton {
 namespace catalog {
 
-TableMetricsCatalog *TableMetricsCatalog::GetInstance(
-    concurrency::TransactionContext *txn) {
-  static TableMetricsCatalog table_metrics_catalog{txn};
-  return &table_metrics_catalog;
-}
-
-TableMetricsCatalog::TableMetricsCatalog(concurrency::TransactionContext *txn)
-    : AbstractCatalog("CREATE TABLE " CATALOG_DATABASE_NAME
-                      "." TABLE_METRICS_CATALOG_NAME
-                      " ("
-                      "database_oid   INT NOT NULL, "
-                      "table_oid      INT NOT NULL, "
-                      "reads          INT NOT NULL, "
-                      "updates        INT NOT NULL, "
-                      "deletes        INT NOT NULL, "
-                      "inserts        INT NOT NULL, "
-                      "time_stamp     INT NOT NULL);",
+TableMetricsCatalog::TableMetricsCatalog(const std::string &database_name,
+                                         concurrency::TransactionContext *txn)
+    : AbstractCatalog("CREATE TABLE " + database_name +
+                          "." TABLE_METRICS_CATALOG_NAME
+                          " ("
+                          "database_oid   INT NOT NULL, "
+                          "table_oid      INT NOT NULL PRIMARY KEY, "
+                          "reads          INT NOT NULL, "
+                          "updates        INT NOT NULL, "
+                          "deletes        INT NOT NULL, "
+                          "inserts        INT NOT NULL, "
+                          "time_stamp     INT NOT NULL);",
                       txn) {
   // Add secondary index here if necessary
 }
@@ -69,8 +64,8 @@ bool TableMetricsCatalog::InsertTableMetrics(
   return InsertTuple(std::move(tuple), txn);
 }
 
-bool TableMetricsCatalog::DeleteTableMetrics(oid_t table_oid,
-                                             concurrency::TransactionContext *txn) {
+bool TableMetricsCatalog::DeleteTableMetrics(
+    oid_t table_oid, concurrency::TransactionContext *txn) {
   oid_t index_offset = IndexId::PRIMARY_KEY;  // Primary key index
 
   std::vector<type::Value> values;

--- a/src/catalog/table_metrics_catalog.cpp
+++ b/src/catalog/table_metrics_catalog.cpp
@@ -22,9 +22,8 @@ namespace catalog {
 TableMetricsCatalog::TableMetricsCatalog(const std::string &database_name,
                                          concurrency::TransactionContext *txn)
     : AbstractCatalog("CREATE TABLE " + database_name +
-                          "." TABLE_METRICS_CATALOG_NAME
+                          "." CATALOG_SCHEMA_NAME "." TABLE_METRICS_CATALOG_NAME
                           " ("
-                          "database_oid   INT NOT NULL, "
                           "table_oid      INT NOT NULL, "
                           "reads          INT NOT NULL, "
                           "updates        INT NOT NULL, "
@@ -38,13 +37,12 @@ TableMetricsCatalog::TableMetricsCatalog(const std::string &database_name,
 TableMetricsCatalog::~TableMetricsCatalog() {}
 
 bool TableMetricsCatalog::InsertTableMetrics(
-    oid_t database_oid, oid_t table_oid, int64_t reads, int64_t updates,
-    int64_t deletes, int64_t inserts, int64_t time_stamp,
-    type::AbstractPool *pool, concurrency::TransactionContext *txn) {
+    oid_t table_oid, int64_t reads, int64_t updates, int64_t deletes,
+    int64_t inserts, int64_t time_stamp, type::AbstractPool *pool,
+    concurrency::TransactionContext *txn) {
   std::unique_ptr<storage::Tuple> tuple(
       new storage::Tuple(catalog_table_->GetSchema(), true));
 
-  auto val0 = type::ValueFactory::GetIntegerValue(database_oid);
   auto val1 = type::ValueFactory::GetIntegerValue(table_oid);
   auto val2 = type::ValueFactory::GetIntegerValue(reads);
   auto val3 = type::ValueFactory::GetIntegerValue(updates);
@@ -52,7 +50,6 @@ bool TableMetricsCatalog::InsertTableMetrics(
   auto val5 = type::ValueFactory::GetIntegerValue(inserts);
   auto val6 = type::ValueFactory::GetIntegerValue(time_stamp);
 
-  tuple->SetValue(ColumnId::DATABASE_OID, val0, pool);
   tuple->SetValue(ColumnId::TABLE_OID, val1, pool);
   tuple->SetValue(ColumnId::READS, val2, pool);
   tuple->SetValue(ColumnId::UPDATES, val3, pool);

--- a/src/catalog/trigger_catalog.cpp
+++ b/src/catalog/trigger_catalog.cpp
@@ -100,20 +100,18 @@ ResultType TriggerCatalog::DropTrigger(const std::string &database_name,
   // Checking if statement is valid
   auto table_object =
       Catalog::GetInstance()->GetTableObject(database_name, table_name, txn);
+  oid_t trigger_oid =
+      GetTriggerOid(trigger_name, table_object->GetTableOid(), txn);
 
-  oid_t trigger_oid = TriggerCatalog::GetInstance().GetTriggerOid(
-      trigger_name, table_object->GetTableOid(), txn);
   if (trigger_oid == INVALID_OID) {
     LOG_TRACE("Cannot find trigger %s to drop!", trigger_name.c_str());
     return ResultType::FAILURE;
   }
 
-  LOG_INFO("trigger %d will be deleted!", trigger_oid);
-
   bool delete_success =
       DeleteTriggerByName(trigger_name, table_object->GetTableOid(), txn);
   if (delete_success) {
-    LOG_DEBUG("Delete trigger successfully");
+    LOG_TRACE("Delete trigger successfully");
     // ask target table to update its trigger list variable
     storage::DataTable *target_table =
         catalog::Catalog::GetInstance()->GetTableWithName(database_name,
@@ -121,7 +119,7 @@ ResultType TriggerCatalog::DropTrigger(const std::string &database_name,
     target_table->UpdateTriggerListFromCatalog(txn);
     return ResultType::SUCCESS;
   }
-  LOG_DEBUG("Failed to delete trigger");
+  LOG_TRACE("Failed to delete trigger");
   return ResultType::FAILURE;
 }
 

--- a/src/catalog/trigger_catalog.cpp
+++ b/src/catalog/trigger_catalog.cpp
@@ -214,7 +214,7 @@ std::unique_ptr<trigger::TriggerList> TriggerCatalog::GetTriggersByType(
 
 std::unique_ptr<trigger::TriggerList> TriggerCatalog::GetTriggers(
     oid_t table_oid, concurrency::TransactionContext *txn) {
-  LOG_DEBUG("Get triggers for table %d", table_oid);
+  // LOG_DEBUG("Get triggers for table %d", table_oid);
   // select trigger_name, fire condition, function_name, function_args
   std::vector<oid_t> column_ids(
       {ColumnId::TRIGGER_NAME, ColumnId::TRIGGER_TYPE, ColumnId::FIRE_CONDITION,

--- a/src/common/container/cuckoo_map.cpp
+++ b/src/common/container/cuckoo_map.cpp
@@ -110,7 +110,7 @@ template class CuckooMap<oid_t, std::shared_ptr<oid_t>>;
 template class CuckooMap<std::thread::id,
                          std::shared_ptr<stats::BackendStatsContext>>;
 
-template class CuckooMap<oid_t, std::shared_ptr<stats::IndexMetric>>;
+template class CuckooMap<uint64_t, std::shared_ptr<stats::IndexMetric>>;
 
 // Used in SharedPointerKeyTest
 template class CuckooMap<std::shared_ptr<oid_t>, std::shared_ptr<oid_t>>;

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -15,8 +15,6 @@
 #include <gflags/gflags.h>
 #include <google/protobuf/stubs/common.h>
 
-#include "tuning/index_tuner.h"
-#include "tuning/layout_tuner.h"
 #include "catalog/catalog.h"
 #include "common/statement_cache_manager.h"
 #include "common/thread_pool.h"
@@ -25,6 +23,8 @@
 #include "index/index.h"
 #include "settings/settings_manager.h"
 #include "threadpool/mono_queue_pool.h"
+#include "tuning/index_tuner.h"
+#include "tuning/layout_tuner.h"
 
 namespace peloton {
 
@@ -32,7 +32,7 @@ ThreadPool thread_pool;
 
 void PelotonInit::Initialize() {
   CONNECTION_THREAD_COUNT = settings::SettingsManager::GetInt(
-          settings::SettingId::connection_thread_count);
+      settings::SettingId::connection_thread_count);
   LOGGING_THREAD_COUNT = 1;
   GC_THREAD_COUNT = 1;
   EPOCH_THREAD_COUNT = 1;

--- a/src/common/internal_types.cpp
+++ b/src/common/internal_types.cpp
@@ -329,6 +329,9 @@ std::string CreateTypeToString(CreateType type) {
     case CreateType::TRIGGER: {
       return "TRIGGER";
     }
+    case CreateType::SCHEMA: {
+      return "SCHEMA";
+    }
     default: {
       throw ConversionException(
           StringUtil::Format("No string conversion for CreateType value '%d'",
@@ -352,6 +355,8 @@ CreateType StringToCreateType(const std::string &str) {
     return CreateType::CONSTRAINT;
   } else if (upper_str == "TRIGGER") {
     return CreateType::TRIGGER;
+  } else if (upper_str == "SCHEMA") {
+    return CreateType::SCHEMA;
   } else {
     throw ConversionException(StringUtil::Format(
         "No CreateType conversion from string '%s'", upper_str.c_str()));
@@ -383,6 +388,9 @@ std::string DropTypeToString(DropType type) {
     case DropType::TRIGGER: {
       return "TRIGGER";
     }
+    case DropType::SCHEMA: {
+      return "SCHEMA";
+    }
     default: {
       throw ConversionException(
           StringUtil::Format("No string conversion for DropType value '%d'",
@@ -406,6 +414,8 @@ DropType StringToDropType(const std::string &str) {
     return DropType::CONSTRAINT;
   } else if (upper_str == "TRIGGER") {
     return DropType::TRIGGER;
+  } else if (upper_str == "SCHEMA") {
+    return DropType::SCHEMA;
   } else {
     throw ConversionException(StringUtil::Format(
         "No DropType conversion from string '%s'", upper_str.c_str()));

--- a/src/common/internal_types.cpp
+++ b/src/common/internal_types.cpp
@@ -585,7 +585,7 @@ std::string QueryTypeToString(QueryType query_type) {
       return "EXECUTE";
     case QueryType::QUERY_SELECT:
       return "SELECT";
-    case QueryType::QUERY_EXPLAIN: 
+    case QueryType::QUERY_EXPLAIN:
       return "EXPLAIN";
     case QueryType::QUERY_OTHER:
     default:
@@ -633,20 +633,18 @@ QueryType StatementTypeToQueryType(StatementType stmt_type,
                                    const parser::SQLStatement *sql_stmt) {
   LOG_TRACE("%s", StatementTypeToString(stmt_type).c_str());
   static std::unordered_map<StatementType, QueryType, EnumHash<StatementType>>
-      type_map{
-          {StatementType::EXECUTE, QueryType::QUERY_EXECUTE},
-          {StatementType::PREPARE, QueryType::QUERY_PREPARE},
-          {StatementType::INSERT, QueryType::QUERY_INSERT},
-          {StatementType::UPDATE, QueryType::QUERY_UPDATE},
-          {StatementType::DELETE, QueryType::QUERY_DELETE},
-          {StatementType::COPY, QueryType::QUERY_COPY},
-          {StatementType::ANALYZE, QueryType::QUERY_ANALYZE},
-          {StatementType::ALTER, QueryType::QUERY_ALTER},
-          {StatementType::DROP, QueryType::QUERY_DROP},
-          {StatementType::SELECT, QueryType::QUERY_SELECT},
-          {StatementType::VARIABLE_SET, QueryType::QUERY_SET},
-          {StatementType::EXPLAIN, QueryType::QUERY_EXPLAIN}
-      };
+      type_map{{StatementType::EXECUTE, QueryType::QUERY_EXECUTE},
+               {StatementType::PREPARE, QueryType::QUERY_PREPARE},
+               {StatementType::INSERT, QueryType::QUERY_INSERT},
+               {StatementType::UPDATE, QueryType::QUERY_UPDATE},
+               {StatementType::DELETE, QueryType::QUERY_DELETE},
+               {StatementType::COPY, QueryType::QUERY_COPY},
+               {StatementType::ANALYZE, QueryType::QUERY_ANALYZE},
+               {StatementType::ALTER, QueryType::QUERY_ALTER},
+               {StatementType::DROP, QueryType::QUERY_DROP},
+               {StatementType::SELECT, QueryType::QUERY_SELECT},
+               {StatementType::VARIABLE_SET, QueryType::QUERY_SET},
+               {StatementType::EXPLAIN, QueryType::QUERY_EXPLAIN}};
   QueryType query_type = QueryType::QUERY_OTHER;
   std::unordered_map<StatementType, QueryType,
                      EnumHash<StatementType>>::iterator it =
@@ -2003,6 +2001,9 @@ std::string ResultTypeToString(ResultType type) {
     }
     case ResultType::QUEUING: {
       return ("QUEUING");
+    }
+    case ResultType::TO_ABORT: {
+      return ("TO_ABORT");
     }
     default: {
       throw ConversionException(

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cinttypes>
 #include "concurrency/timestamp_ordering_transaction_manager.h"
+#include <cinttypes>
 
 #include "catalog/manager.h"
 #include "common/exception.h"
@@ -25,11 +25,13 @@
 namespace peloton {
 namespace concurrency {
 
-common::synchronization::SpinLatch *TimestampOrderingTransactionManager::GetSpinLatchField(
+common::synchronization::SpinLatch *
+TimestampOrderingTransactionManager::GetSpinLatchField(
     const storage::TileGroupHeader *const tile_group_header,
     const oid_t &tuple_id) {
-  return (common::synchronization::SpinLatch *)
-            (tile_group_header->GetReservedFieldRef(tuple_id) + LOCK_OFFSET);
+  return (
+      common::synchronization::SpinLatch
+          *)(tile_group_header->GetReservedFieldRef(tuple_id) + LOCK_OFFSET);
 }
 
 cid_t TimestampOrderingTransactionManager::GetLastReaderCommitId(
@@ -224,8 +226,8 @@ bool TimestampOrderingTransactionManager::PerformRead(
       PELOTON_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id) == true);
 
       // Increment table read op stats
-      if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-          StatsType::INVALID) {
+      if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+              settings::SettingId::stats_mode)) != StatsType::INVALID) {
         stats::BackendStatsContext::GetInstance()->IncrementTableReads(
             location.block);
       }
@@ -238,8 +240,8 @@ bool TimestampOrderingTransactionManager::PerformRead(
       current_txn->RecordRead(location);
 
       // Increment table read op stats
-      if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-          StatsType::INVALID) {
+      if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+              settings::SettingId::stats_mode)) != StatsType::INVALID) {
         stats::BackendStatsContext::GetInstance()->IncrementTableReads(
             location.block);
       }
@@ -281,8 +283,8 @@ bool TimestampOrderingTransactionManager::PerformRead(
       // if we have already owned the version.
       PELOTON_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id) == true);
       // Increment table read op stats
-      if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-          StatsType::INVALID) {
+      if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+              settings::SettingId::stats_mode)) != StatsType::INVALID) {
         stats::BackendStatsContext::GetInstance()->IncrementTableReads(
             location.block);
       }
@@ -295,8 +297,8 @@ bool TimestampOrderingTransactionManager::PerformRead(
           current_txn->RecordRead(location);
 
           // Increment table read op stats
-          if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode))
-              != StatsType::INVALID) {
+          if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+                  settings::SettingId::stats_mode)) != StatsType::INVALID) {
             stats::BackendStatsContext::GetInstance()->IncrementTableReads(
                 location.block);
           }
@@ -315,8 +317,8 @@ bool TimestampOrderingTransactionManager::PerformRead(
         // current_txn->RecordRead(location);
 
         // Increment table read op stats
-        if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode))
-            != StatsType::INVALID) {
+        if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+                settings::SettingId::stats_mode)) != StatsType::INVALID) {
           stats::BackendStatsContext::GetInstance()->IncrementTableReads(
               location.block);
         }
@@ -331,9 +333,9 @@ bool TimestampOrderingTransactionManager::PerformRead(
   //////////////////////////////////////////////////////////
   else {
     PELOTON_ASSERT(current_txn->GetIsolationLevel() ==
-                  IsolationLevelType::SERIALIZABLE ||
-              current_txn->GetIsolationLevel() ==
-                  IsolationLevelType::REPEATABLE_READS);
+                       IsolationLevelType::SERIALIZABLE ||
+                   current_txn->GetIsolationLevel() ==
+                       IsolationLevelType::REPEATABLE_READS);
 
     oid_t tile_group_id = location.block;
     oid_t tuple_id = location.offset;
@@ -374,11 +376,11 @@ bool TimestampOrderingTransactionManager::PerformRead(
       // if we have already owned the version.
       PELOTON_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id) == true);
       PELOTON_ASSERT(GetLastReaderCommitId(tile_group_header, tuple_id) ==
-                    current_txn->GetCommitId() ||
-                GetLastReaderCommitId(tile_group_header, tuple_id) == 0);
+                         current_txn->GetCommitId() ||
+                     GetLastReaderCommitId(tile_group_header, tuple_id) == 0);
       // Increment table read op stats
-      if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-          StatsType::INVALID) {
+      if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+              settings::SettingId::stats_mode)) != StatsType::INVALID) {
         stats::BackendStatsContext::GetInstance()->IncrementTableReads(
             location.block);
       }
@@ -394,8 +396,8 @@ bool TimestampOrderingTransactionManager::PerformRead(
           current_txn->RecordRead(location);
 
           // Increment table read op stats
-          if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode))
-              != StatsType::INVALID) {
+          if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+                  settings::SettingId::stats_mode)) != StatsType::INVALID) {
             stats::BackendStatsContext::GetInstance()->IncrementTableReads(
                 location.block);
           }
@@ -411,16 +413,16 @@ bool TimestampOrderingTransactionManager::PerformRead(
         // if the current transaction has already owned this tuple,
         // then perform read directly.
         PELOTON_ASSERT(GetLastReaderCommitId(tile_group_header, tuple_id) ==
-                      current_txn->GetCommitId() ||
-                  GetLastReaderCommitId(tile_group_header, tuple_id) == 0);
+                           current_txn->GetCommitId() ||
+                       GetLastReaderCommitId(tile_group_header, tuple_id) == 0);
 
         // this version must already be in the read/write set.
         // so no need to update read set.
         // current_txn->RecordRead(location);
 
         // Increment table read op stats
-        if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode))
-            != StatsType::INVALID) {
+        if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+                settings::SettingId::stats_mode)) != StatsType::INVALID) {
           stats::BackendStatsContext::GetInstance()->IncrementTableReads(
               location.block);
         }
@@ -434,7 +436,8 @@ bool TimestampOrderingTransactionManager::PerformRead(
 void TimestampOrderingTransactionManager::PerformInsert(
     TransactionContext *const current_txn, const ItemPointer &location,
     ItemPointer *index_entry_ptr) {
-  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(current_txn->GetIsolationLevel() !=
+                 IsolationLevelType::READ_ONLY);
 
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
@@ -445,7 +448,8 @@ void TimestampOrderingTransactionManager::PerformInsert(
 
   // check MVCC info
   // the tuple slot must be empty.
-  PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_id) == INVALID_TXN_ID);
+  PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_id) ==
+                 INVALID_TXN_ID);
   PELOTON_ASSERT(tile_group_header->GetBeginCommitId(tuple_id) == MAX_CID);
   PELOTON_ASSERT(tile_group_header->GetEndCommitId(tuple_id) == MAX_CID);
 
@@ -462,8 +466,8 @@ void TimestampOrderingTransactionManager::PerformInsert(
   tile_group_header->SetIndirection(tuple_id, index_entry_ptr);
 
   // Increment table insert op stats
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-      StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementTableInserts(
         location.block);
   }
@@ -472,7 +476,8 @@ void TimestampOrderingTransactionManager::PerformInsert(
 void TimestampOrderingTransactionManager::PerformUpdate(
     TransactionContext *const current_txn, const ItemPointer &location,
     const ItemPointer &new_location) {
-  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(current_txn->GetIsolationLevel() !=
+                 IsolationLevelType::READ_ONLY);
 
   ItemPointer old_location = location;
 
@@ -492,17 +497,18 @@ void TimestampOrderingTransactionManager::PerformUpdate(
   // if we can perform update, then we must have already locked the older
   // version.
   PELOTON_ASSERT(tile_group_header->GetTransactionId(old_location.offset) ==
-            transaction_id);
-  PELOTON_ASSERT(tile_group_header->GetPrevItemPointer(old_location.offset)
-                .IsNull() == true);
+                 transaction_id);
+  PELOTON_ASSERT(
+      tile_group_header->GetPrevItemPointer(old_location.offset).IsNull() ==
+      true);
 
   // check whether the new version is empty.
   PELOTON_ASSERT(new_tile_group_header->GetTransactionId(new_location.offset) ==
-            INVALID_TXN_ID);
+                 INVALID_TXN_ID);
   PELOTON_ASSERT(new_tile_group_header->GetBeginCommitId(new_location.offset) ==
-            MAX_CID);
+                 MAX_CID);
   PELOTON_ASSERT(new_tile_group_header->GetEndCommitId(new_location.offset) ==
-            MAX_CID);
+                 MAX_CID);
 
   // if the executor doesn't call PerformUpdate after AcquireOwnership,
   // no one will possibly release the write lock acquired by this txn.
@@ -545,8 +551,8 @@ void TimestampOrderingTransactionManager::PerformUpdate(
   current_txn->RecordUpdate(old_location);
 
   // Increment table update op stats
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-      StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementTableUpdates(
         new_location.block);
   }
@@ -555,7 +561,8 @@ void TimestampOrderingTransactionManager::PerformUpdate(
 void TimestampOrderingTransactionManager::PerformUpdate(
     TransactionContext *const current_txn UNUSED_ATTRIBUTE,
     const ItemPointer &location) {
-  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(current_txn->GetIsolationLevel() !=
+                 IsolationLevelType::READ_ONLY);
 
   oid_t tile_group_id = location.block;
   UNUSED_ATTRIBUTE oid_t tuple_id = location.offset;
@@ -565,7 +572,7 @@ void TimestampOrderingTransactionManager::PerformUpdate(
       manager.GetTileGroup(tile_group_id)->GetHeader();
 
   PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_id) ==
-            current_txn->GetTransactionId());
+                 current_txn->GetTransactionId());
   PELOTON_ASSERT(tile_group_header->GetBeginCommitId(tuple_id) == MAX_CID);
   PELOTON_ASSERT(tile_group_header->GetEndCommitId(tuple_id) == MAX_CID);
 
@@ -578,8 +585,8 @@ void TimestampOrderingTransactionManager::PerformUpdate(
   // in this case, nothing needs to be performed.
 
   // Increment table update op stats
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-      StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementTableUpdates(
         location.block);
   }
@@ -588,7 +595,8 @@ void TimestampOrderingTransactionManager::PerformUpdate(
 void TimestampOrderingTransactionManager::PerformDelete(
     TransactionContext *const current_txn, const ItemPointer &location,
     const ItemPointer &new_location) {
-  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(current_txn->GetIsolationLevel() !=
+                 IsolationLevelType::READ_ONLY);
 
   ItemPointer old_location = location;
 
@@ -606,24 +614,26 @@ void TimestampOrderingTransactionManager::PerformDelete(
 
   auto transaction_id = current_txn->GetTransactionId();
 
-  PELOTON_ASSERT(GetLastReaderCommitId(tile_group_header, old_location.offset) ==
-            current_txn->GetCommitId());
+  PELOTON_ASSERT(
+      GetLastReaderCommitId(tile_group_header, old_location.offset) ==
+      current_txn->GetCommitId());
 
   // if we can perform delete, then we must have already locked the older
   // version.
   PELOTON_ASSERT(tile_group_header->GetTransactionId(old_location.offset) ==
-            transaction_id);
+                 transaction_id);
   // we must be deleting the latest version.
-  PELOTON_ASSERT(tile_group_header->GetPrevItemPointer(old_location.offset)
-                .IsNull() == true);
+  PELOTON_ASSERT(
+      tile_group_header->GetPrevItemPointer(old_location.offset).IsNull() ==
+      true);
 
   // check whether the new version is empty.
   PELOTON_ASSERT(new_tile_group_header->GetTransactionId(new_location.offset) ==
-            INVALID_TXN_ID);
+                 INVALID_TXN_ID);
   PELOTON_ASSERT(new_tile_group_header->GetBeginCommitId(new_location.offset) ==
-            MAX_CID);
+                 MAX_CID);
   PELOTON_ASSERT(new_tile_group_header->GetEndCommitId(new_location.offset) ==
-            MAX_CID);
+                 MAX_CID);
 
   // Set up double linked list
   tile_group_header->SetPrevItemPointer(old_location.offset, new_location);
@@ -664,8 +674,8 @@ void TimestampOrderingTransactionManager::PerformDelete(
   current_txn->RecordDelete(old_location);
 
   // Increment table delete op stats
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-      StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementTableDeletes(
         old_location.block);
   }
@@ -673,7 +683,8 @@ void TimestampOrderingTransactionManager::PerformDelete(
 
 void TimestampOrderingTransactionManager::PerformDelete(
     TransactionContext *const current_txn, const ItemPointer &location) {
-  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(current_txn->GetIsolationLevel() !=
+                 IsolationLevelType::READ_ONLY);
 
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
@@ -682,7 +693,7 @@ void TimestampOrderingTransactionManager::PerformDelete(
   auto tile_group_header = manager.GetTileGroup(tile_group_id)->GetHeader();
 
   PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_id) ==
-            current_txn->GetTransactionId());
+                 current_txn->GetTransactionId());
   PELOTON_ASSERT(tile_group_header->GetBeginCommitId(tuple_id) == MAX_CID);
 
   tile_group_header->SetEndCommitId(tuple_id, INVALID_CID);
@@ -698,8 +709,8 @@ void TimestampOrderingTransactionManager::PerformDelete(
   }
 
   // Increment table delete op stats
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-      StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementTableDeletes(
         location.block);
   }
@@ -707,7 +718,8 @@ void TimestampOrderingTransactionManager::PerformDelete(
 
 ResultType TimestampOrderingTransactionManager::CommitTransaction(
     TransactionContext *const current_txn) {
-  LOG_TRACE("Committing peloton txn : %" PRId64, current_txn->GetTransactionId());
+  LOG_TRACE("Committing peloton txn : %" PRId64,
+            current_txn->GetTransactionId());
 
   //////////////////////////////////////////////////////////
   //// handle READ_ONLY
@@ -745,14 +757,16 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
   }
 
   oid_t database_id = 0;
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-      StatsType::INVALID) {
-    if (!rw_set.IsEmpty()) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
+    for (const auto &tuple_entry : rw_set.GetConstIterator()) {
       // Call the GetConstIterator() function to explicitly lock the cuckoohash
       // and initilaize the iterator
-      auto rw_set_lt = rw_set.GetConstIterator();
-      const auto tile_group_id = rw_set_lt.begin()->first.block;
+      const auto tile_group_id = tuple_entry.first.block;
       database_id = manager.GetTileGroup(tile_group_id)->GetDatabaseId();
+      if (database_id != DEFAULT_DB_ID) {
+        break;
+      }
     }
   }
 
@@ -845,7 +859,7 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
 
     } else if (tuple_entry.second == RWType::INSERT) {
       PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_slot) ==
-                current_txn->GetTransactionId());
+                     current_txn->GetTransactionId());
       // set the begin commit id to persist insert
       tile_group_header->SetBeginCommitId(tuple_slot, end_commit_id);
       tile_group_header->SetEndCommitId(tuple_slot, MAX_CID);
@@ -861,7 +875,7 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
 
     } else if (tuple_entry.second == RWType::INS_DEL) {
       PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_slot) ==
-                current_txn->GetTransactionId());
+                     current_txn->GetTransactionId());
 
       tile_group_header->SetBeginCommitId(tuple_slot, MAX_CID);
       tile_group_header->SetEndCommitId(tuple_slot, MAX_CID);
@@ -887,8 +901,8 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
   EndTransaction(current_txn);
 
   // Increment # txns committed metric
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-      StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementTxnCommitted(
         database_id);
   }
@@ -899,7 +913,8 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
 ResultType TimestampOrderingTransactionManager::AbortTransaction(
     TransactionContext *const current_txn) {
   // a pre-declared read-only transaction will never abort.
-  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(current_txn->GetIsolationLevel() !=
+                 IsolationLevelType::READ_ONLY);
 
   LOG_TRACE("Aborting peloton txn : %" PRId64, current_txn->GetTransactionId());
   auto &manager = catalog::Manager::GetInstance();
@@ -921,14 +936,16 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
   }
 
   oid_t database_id = 0;
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-      StatsType::INVALID) {
-    if (!rw_set.IsEmpty()) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
+    for (const auto &tuple_entry : rw_set.GetConstIterator()) {
       // Call the GetConstIterator() function to explicitly lock the cuckoohash
       // and initilaize the iterator
-      auto rw_set_lt = rw_set.GetConstIterator();
-      const auto tile_group_id = rw_set_lt.begin()->first.block;
+      const auto tile_group_id = tuple_entry.first.block;
       database_id = manager.GetTileGroup(tile_group_id)->GetDatabaseId();
+      if (database_id != DEFAULT_DB_ID) {
+        break;
+      }
     }
   }
 
@@ -961,8 +978,9 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
       // we need to unlink it by resetting the item pointers.
 
       // this must be the latest version of a version chain.
-      PELOTON_ASSERT(new_tile_group_header->GetPrevItemPointer(new_version.offset)
-                    .IsNull() == true);
+      PELOTON_ASSERT(
+          new_tile_group_header->GetPrevItemPointer(new_version.offset)
+              .IsNull() == true);
 
       PELOTON_ASSERT(tile_group_header->GetEndCommitId(tuple_slot) == MAX_CID);
       // if we updated the latest version.
@@ -1009,8 +1027,9 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
       // we need to unlink it by resetting the item pointers.
 
       // this must be the latest version of a version chain.
-      PELOTON_ASSERT(new_tile_group_header->GetPrevItemPointer(new_version.offset)
-                    .IsNull() == true);
+      PELOTON_ASSERT(
+          new_tile_group_header->GetPrevItemPointer(new_version.offset)
+              .IsNull() == true);
 
       // if we updated the latest version.
       // We must first adjust the head pointer
@@ -1072,13 +1091,13 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
   EndTransaction(current_txn);
 
   // Increment # txns aborted metric
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) !=
-      StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementTxnAborted(database_id);
   }
 
   return ResultType::ABORTED;
 }
 
-}  // namespace storage
+}  // namespace concurrency
 }  // namespace peloton

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -13,6 +13,7 @@
 #include "concurrency/timestamp_ordering_transaction_manager.h"
 #include <cinttypes>
 
+#include "catalog/catalog_defaults.h"
 #include "catalog/manager.h"
 #include "common/exception.h"
 #include "common/logger.h"
@@ -764,7 +765,7 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
       // and initilaize the iterator
       const auto tile_group_id = tuple_entry.first.block;
       database_id = manager.GetTileGroup(tile_group_id)->GetDatabaseId();
-      if (database_id != DEFAULT_DB_ID) {
+      if (database_id != CATALOG_DATABASE_OID) {
         break;
       }
     }
@@ -943,7 +944,7 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
       // and initilaize the iterator
       const auto tile_group_id = tuple_entry.first.block;
       database_id = manager.GetTileGroup(tile_group_id)->GetDatabaseId();
-      if (database_id != DEFAULT_DB_ID) {
+      if (database_id != CATALOG_DATABASE_OID) {
         break;
       }
     }

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -15,13 +15,13 @@
 #include <sstream>
 
 #include "common/logger.h"
-#include "common/platform.h"
 #include "common/macros.h"
+#include "common/platform.h"
 #include "trigger/trigger.h"
 
 #include <chrono>
-#include <thread>
 #include <iomanip>
+#include <thread>
 
 namespace peloton {
 namespace concurrency {
@@ -75,8 +75,8 @@ TransactionContext::TransactionContext(const size_t thread_id,
 TransactionContext::~TransactionContext() {}
 
 void TransactionContext::Init(const size_t thread_id,
-                       const IsolationLevelType isolation, const cid_t &read_id,
-                       const cid_t &commit_id) {
+                              const IsolationLevelType isolation,
+                              const cid_t &read_id, const cid_t &commit_id) {
   read_id_ = read_id;
 
   // commit id can be set at a transaction's commit phase.
@@ -129,7 +129,7 @@ void TransactionContext::RecordReadOwn(const ItemPointer &location) {
     PELOTON_ASSERT(rw_type != RWType::DELETE && rw_type != RWType::INS_DEL);
     if (rw_type == RWType::READ) {
       rw_set_.Update(location, RWType::READ_OWN);
-    } 
+    }
   } else {
     rw_set_.Insert(location, RWType::READ_OWN);
   }
@@ -188,7 +188,7 @@ bool TransactionContext::RecordDelete(const ItemPointer &location) {
       --insert_count_;
       return true;
     }
-    if(rw_type == RWType::DELETE) {
+    if (rw_type == RWType::DELETE) {
       PELOTON_ASSERT(false);
       return false;
     }
@@ -210,7 +210,8 @@ const std::string TransactionContext::GetInfo() const {
   return os.str();
 }
 
-void TransactionContext::AddOnCommitTrigger(trigger::TriggerData &trigger_data) {
+void TransactionContext::AddOnCommitTrigger(
+    trigger::TriggerData &trigger_data) {
   if (on_commit_triggers_ == nullptr) {
     on_commit_triggers_.reset(new trigger::TriggerSet());
   }

--- a/src/executor/create_executor.cpp
+++ b/src/executor/create_executor.cpp
@@ -87,14 +87,12 @@ bool CreateExecutor::DExecute() {
 }
 
 bool CreateExecutor::CreateDatabase(const planner::CreatePlan &node) {
-
   auto txn = context_->GetTransaction();
   auto database_name = node.GetDatabaseName();
-  ResultType result = catalog::Catalog::GetInstance()->CreateDatabase(
-      database_name, txn);
+  ResultType result =
+      catalog::Catalog::GetInstance()->CreateDatabase(database_name, txn);
   txn->SetResult(result);
-  LOG_TRACE("Result is: %s",
-            ResultTypeToString(txn->GetResult()).c_str());
+  LOG_TRACE("Result is: %s", ResultTypeToString(txn->GetResult()).c_str());
   return (true);
 }
 
@@ -153,30 +151,25 @@ bool CreateExecutor::CreateTable(const planner::CreatePlan &node) {
         PELOTON_ASSERT(sink_col_ids.size() == fk.foreign_key_sinks.size());
 
         // Create the catalog object and shove it into the table
-        auto catalog_fk = new catalog::ForeignKey(INVALID_OID,
-            sink_table->GetOid(), sink_col_ids, source_col_ids,
+        auto catalog_fk = new catalog::ForeignKey(
+            INVALID_OID, sink_table->GetOid(), sink_col_ids, source_col_ids,
             fk.upd_action, fk.del_action, fk.constraint_name);
         source_table->AddForeignKey(catalog_fk);
 
         // Register FK with the sink table for delete/update actions
-        catalog_fk = new catalog::ForeignKey(source_table->GetOid(),
-                                              INVALID_OID,
-                                              sink_col_ids,
-                                              source_col_ids,
-                                              fk.upd_action,
-                                              fk.del_action,
-                                              fk.constraint_name);
+        catalog_fk = new catalog::ForeignKey(
+            source_table->GetOid(), INVALID_OID, sink_col_ids, source_col_ids,
+            fk.upd_action, fk.del_action, fk.constraint_name);
         sink_table->RegisterForeignKeySource(catalog_fk);
 
         // Add a non-unique index on the source table if needed
-        std::vector<std::string> source_col_names =
-            fk.foreign_key_sources;
-        std::string index_name =
-            source_table->GetName() + "_FK_" + sink_table->GetName() + "_"
-            + std::to_string(count);
+        std::vector<std::string> source_col_names = fk.foreign_key_sources;
+        std::string index_name = source_table->GetName() + "_FK_" +
+                                 sink_table->GetName() + "_" +
+                                 std::to_string(count);
         catalog->CreateIndex(database_name, source_table->GetName(),
-                              source_col_ids, index_name, false,
-                              IndexType::BWTREE, current_txn);
+                             source_col_ids, index_name, false,
+                             IndexType::BWTREE, current_txn);
         count++;
 
 #ifdef LOG_DEBUG_ENABLED
@@ -212,8 +205,8 @@ bool CreateExecutor::CreateIndex(const planner::CreatePlan &node) {
   auto key_attrs = node.GetKeyAttrs();
 
   ResultType result = catalog::Catalog::GetInstance()->CreateIndex(
-      database_name, table_name, key_attrs, index_name, unique_flag,
-      index_type, txn);
+      database_name, table_name, key_attrs, index_name, unique_flag, index_type,
+      txn);
   txn->SetResult(result);
 
   if (txn->GetResult() == ResultType::SUCCESS) {
@@ -221,8 +214,7 @@ bool CreateExecutor::CreateIndex(const planner::CreatePlan &node) {
   } else if (txn->GetResult() == ResultType::FAILURE) {
     LOG_TRACE("Creating table failed!");
   } else {
-    LOG_TRACE("Result is: %s",
-              ResultTypeToString(txn->GetResult()).c_str());
+    LOG_TRACE("Result is: %s", ResultTypeToString(txn->GetResult()).c_str());
   }
   return (true);
 }
@@ -250,14 +242,16 @@ bool CreateExecutor::CreateTrigger(const planner::CreatePlan &node) {
   auto when = type::ValueFactory::GetVarbinaryValue(
       (const unsigned char *)output.Data(), (int32_t)output.Size(), true);
 
-  catalog::TriggerCatalog::GetInstance().InsertTrigger(
-      table_object->GetTableOid(), trigger_name,
-      newTrigger.GetTriggerType(), newTrigger.GetFuncname(),
-      newTrigger.GetArgs(), when, time_stamp, pool_.get(), txn);
+  catalog::Catalog::GetInstance()
+      .GetSystemCatalogs(table_object->database_oid)
+      .GetTriggerCatalog()
+      .InsertTrigger(table_object->GetTableOid(), trigger_name,
+                     newTrigger.GetTriggerType(), newTrigger.GetFuncname(),
+                     newTrigger.GetArgs(), when, time_stamp, pool_.get(), txn);
   // ask target table to update its trigger list variable
   storage::DataTable *target_table =
-      catalog::Catalog::GetInstance()->GetTableWithName(
-          database_name, table_name, txn);
+      catalog::Catalog::GetInstance()->GetTableWithName(database_name,
+                                                        table_name, txn);
   target_table->UpdateTriggerListFromCatalog(txn);
 
   // hardcode SUCCESS result for txn
@@ -269,7 +263,6 @@ bool CreateExecutor::CreateTrigger(const planner::CreatePlan &node) {
 
   return (true);
 }
-
 
 }  // namespace executor
 }  // namespace peloton

--- a/src/executor/drop_executor.cpp
+++ b/src/executor/drop_executor.cpp
@@ -15,6 +15,7 @@
 #include "catalog/catalog.h"
 #include "catalog/database_catalog.h"
 #include "catalog/index_catalog.h"
+#include "catalog/system_catalogs.h"
 #include "catalog/table_catalog.h"
 #include "catalog/trigger_catalog.h"
 #include "common/logger.h"
@@ -180,11 +181,11 @@ bool DropExecutor::DropTrigger(const planner::DropPlan &node,
 
 bool DropExecutor::DropIndex(const planner::DropPlan &node,
                              concurrency::TransactionContext *txn) {
-  auto database_object = DatabaseCatalog::GetInstance()->GetDatabaseObject(
+  auto database_object = catalog::Catalog::GetInstance()->GetDatabaseObject(
       node.GetDatabaseName(), txn);
 
   auto pg_index = catalog::Catalog::GetInstance()
-                      ->GetSystemCatalog(database_object->GetDatabaseOid())
+                      ->GetSystemCatalogs(database_object->GetDatabaseOid())
                       ->GetIndexCatalog();
   std::string index_name = node.GetIndexName();
   auto index_object = pg_index->GetIndexObject(index_name, txn);

--- a/src/executor/drop_executor.cpp
+++ b/src/executor/drop_executor.cpp
@@ -13,11 +13,8 @@
 #include "executor/drop_executor.h"
 
 #include "catalog/catalog.h"
-#include "catalog/database_catalog.h"
 #include "catalog/index_catalog.h"
 #include "catalog/system_catalogs.h"
-#include "catalog/table_catalog.h"
-#include "catalog/trigger_catalog.h"
 #include "common/logger.h"
 #include "common/statement_cache_manager.h"
 #include "executor/executor_context.h"
@@ -160,9 +157,9 @@ bool DropExecutor::DropTrigger(const planner::DropPlan &node,
 
   ResultType result =
       catalog::Catalog::GetInstance()
-          .GetSystemCatalogs(table_object->database_oid)
-          .GetTriggerCatalog()
-          .DropTrigger(database_name, table_name, trigger_name, txn);
+          ->GetSystemCatalogs(table_object->GetDatabaseOid())
+          ->GetTriggerCatalog()
+          ->DropTrigger(database_name, table_name, trigger_name, txn);
   txn->SetResult(result);
   if (txn->GetResult() == ResultType::SUCCESS) {
     LOG_DEBUG("Dropping trigger succeeded!");

--- a/src/include/binder/binder_context.h
+++ b/src/include/binder/binder_context.h
@@ -57,8 +57,8 @@ class BinderContext {
    * @brief Update the table alias map given a table reference (in the from
    * clause)
    */
-  void AddRegularTable(const std::string db_name, const std::string table_name,
-                       const std::string table_alias,
+  void AddRegularTable(const std::string db_name, const std::string schema_name,
+                       std::string table_name, const std::string table_alias,
                        concurrency::TransactionContext *txn);
 
   /**

--- a/src/include/catalog/abstract_catalog.h
+++ b/src/include/catalog/abstract_catalog.h
@@ -88,7 +88,8 @@ class AbstractCatalog {
 
   // Maximum column name size for catalog schemas
   static const size_t max_name_size = 64;
-
+  // which database catalog table is stored int
+  oid_t database_oid;
   // Local oid (without catalog type mask) starts from START_OID + OID_OFFSET
   std::atomic<oid_t> oid_ = ATOMIC_VAR_INIT(START_OID + OID_OFFSET);
 

--- a/src/include/catalog/abstract_catalog.h
+++ b/src/include/catalog/abstract_catalog.h
@@ -35,7 +35,7 @@ namespace storage {
 class Database;
 class DataTable;
 class Tuple;
-}
+}  // namespace storage
 
 namespace catalog {
 
@@ -71,6 +71,12 @@ class AbstractCatalog {
   GetResultWithSeqScan(std::vector<oid_t> column_offsets,
                        expression::AbstractExpression *predicate,
                        concurrency::TransactionContext *txn);
+
+  bool UpdateWithIndexScan(std::vector<oid_t> update_columns,
+                           std::vector<type::Value> update_values,
+                           std::vector<type::Value> scan_values,
+                           oid_t index_offset,
+                           concurrency::TransactionContext *txn);
 
   void AddIndex(const std::vector<oid_t> &key_attrs, oid_t index_oid,
                 const std::string &index_name,

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -180,7 +180,7 @@ class Catalog {
   /*
    * Using database oid to get system catalog object
    */
-  SystemCatalog GetSystemCatalog(const oid_t database_oid);
+  shared_ptr<SystemCatalog> GetSystemCatalog(const oid_t database_oid);
   //===--------------------------------------------------------------------===//
   // DEPRECATED FUNCTIONS
   //===--------------------------------------------------------------------===//

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -24,6 +24,7 @@ class Schema;
 class DatabaseCatalogObject;
 class TableCatalogObject;
 class IndexCatalogObject;
+class SystemCatalogs;
 }  // namespace catalog
 
 namespace concurrency {
@@ -180,7 +181,7 @@ class Catalog {
   /*
    * Using database oid to get system catalog object
    */
-  shared_ptr<SystemCatalog> GetSystemCatalog(const oid_t database_oid);
+  std::shared_ptr<SystemCatalogs> GetSystemCatalogs(const oid_t database_oid);
   //===--------------------------------------------------------------------===//
   // DEPRECATED FUNCTIONS
   //===--------------------------------------------------------------------===//
@@ -220,7 +221,7 @@ class Catalog {
  private:
   Catalog();
 
-  void BootstrapSystemCatalogs(Database *database,
+  void BootstrapSystemCatalogs(storage::Database *database,
                                concurrency::TransactionContext *txn);
 
   // The pool for new varlen tuple fields
@@ -228,7 +229,7 @@ class Catalog {
   std::mutex catalog_mutex;
   // key: database oid
   // value: SystemCatalog object(including pg_table, pg_index and pg_attribute)
-  std::unordered_map<oid_t, shared_ptr<SystemCatalogs>> catalog_map_;
+  std::unordered_map<oid_t, std::shared_ptr<SystemCatalogs>> catalog_map_;
 };
 
 }  // namespace catalog

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -220,6 +220,9 @@ class Catalog {
  private:
   Catalog();
 
+  void BootstrapSystemCatalogs(Database *database,
+                               concurrency::TransactionContext *txn);
+
   // The pool for new varlen tuple fields
   std::unique_ptr<type::AbstractPool> pool_;
   std::mutex catalog_mutex;

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -134,10 +134,10 @@ class Catalog {
   ResultType DropTable(oid_t database_oid, oid_t table_oid,
                        concurrency::TransactionContext *txn);
   // Drop an index, using its index_oid
-  ResultType DropIndex(oid_t index_oid, concurrency::TransactionContext *txn);
+  ResultType DropIndex(oid_t database_oid, oid_t index_oid, concurrency::TransactionContext *txn);
 
   // Drop an index, using its index name
-  ResultType DropIndex(const std::string &index_name,
+  ResultType DropIndex(const std::string &database_name, const std::string &index_name,
                        concurrency::TransactionContext *txn);
   //===--------------------------------------------------------------------===//
   // GET WITH NAME - CHECK FROM CATALOG TABLES, USING TRANSACTION

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -134,10 +134,12 @@ class Catalog {
   ResultType DropTable(oid_t database_oid, oid_t table_oid,
                        concurrency::TransactionContext *txn);
   // Drop an index, using its index_oid
-  ResultType DropIndex(oid_t database_oid, oid_t index_oid, concurrency::TransactionContext *txn);
+  ResultType DropIndex(oid_t database_oid, oid_t index_oid,
+                       concurrency::TransactionContext *txn);
 
   // Drop an index, using its index name
-  ResultType DropIndex(const std::string &database_name, const std::string &index_name,
+  ResultType DropIndex(const std::string &database_name,
+                       const std::string &index_name,
                        concurrency::TransactionContext *txn);
   //===--------------------------------------------------------------------===//
   // GET WITH NAME - CHECK FROM CATALOG TABLES, USING TRANSACTION

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -176,6 +176,11 @@ class Catalog {
   std::shared_ptr<TableCatalogObject> GetTableObject(
       oid_t database_oid, oid_t table_oid,
       concurrency::TransactionContext *txn);
+
+  /*
+   * Using database oid to get system catalog object
+   */
+  SystemCatalog GetSystemCatalog(const oid_t database_oid);
   //===--------------------------------------------------------------------===//
   // DEPRECATED FUNCTIONS
   //===--------------------------------------------------------------------===//
@@ -217,8 +222,10 @@ class Catalog {
 
   // The pool for new varlen tuple fields
   std::unique_ptr<type::AbstractPool> pool_;
-
   std::mutex catalog_mutex;
+  // key: database oid
+  // value: SystemCatalog object(including pg_table, pg_index and pg_attribute)
+  std::unordered_map<oid_t, SystemCatalog> catalog_map_;
 };
 
 }  // namespace catalog

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -228,7 +228,7 @@ class Catalog {
   std::mutex catalog_mutex;
   // key: database oid
   // value: SystemCatalog object(including pg_table, pg_index and pg_attribute)
-  std::unordered_map<oid_t, SystemCatalog> catalog_map_;
+  std::unordered_map<oid_t, SystemCatalogs> catalog_map_;
 };
 
 }  // namespace catalog

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -228,7 +228,7 @@ class Catalog {
   std::mutex catalog_mutex;
   // key: database oid
   // value: SystemCatalog object(including pg_table, pg_index and pg_attribute)
-  std::unordered_map<oid_t, SystemCatalogs> catalog_map_;
+  std::unordered_map<oid_t, shared_ptr<SystemCatalogs>> catalog_map_;
 };
 
 }  // namespace catalog

--- a/src/include/catalog/catalog_cache.h
+++ b/src/include/catalog/catalog_cache.h
@@ -52,7 +52,7 @@ class CatalogCache {
   std::shared_ptr<TableCatalogObject> GetCachedTableObject(oid_t table_oid);
   std::shared_ptr<IndexCatalogObject> GetCachedIndexObject(oid_t index_oid);
   std::shared_ptr<IndexCatalogObject> GetCachedIndexObject(
-      const std::string &index_name);
+      const std::string &index_name, const std::string &schema_name);
 
   // database catalog cache interface
   bool InsertDatabaseObject(

--- a/src/include/catalog/catalog_defaults.h
+++ b/src/include/catalog/catalog_defaults.h
@@ -64,6 +64,10 @@ namespace catalog {
 #define INDEX_CATALOG_SKEY0_OID (4 | INDEX_OID_MASK)
 #define INDEX_CATALOG_SKEY1_OID (5 | INDEX_OID_MASK)
 
+// Reserved pg_database index oid
+#define DATABASE_CATALOG_PKEY_OID (6 | INDEX_OID_MASK)
+#define DATABASE_CATALOG_SKEY0_OID (7 | INDEX_OID_MASK)
+
 // Use upper 8 bits indicating catalog type
 #define CATALOG_TYPE_OFFSET 24
 

--- a/src/include/catalog/catalog_defaults.h
+++ b/src/include/catalog/catalog_defaults.h
@@ -19,17 +19,16 @@ namespace catalog {
 // System Catalogs imitating Postgres
 // (https://www.postgresql.org/docs/9.6/static/catalogs.html)
 // Differences are:
-// 1. pg_catalog is a catalog schema in each database in Postgres, while it is a
-// seperate catalog database in Peloton
-// 2. pg_class contains everything similar to a table in Postgres, while Peloton
+// 1. pg_class contains everything similar to a table in Postgres, while Peloton
 // uses pg_table only for the table catalog
 
 // Catalog database
-#define CATALOG_DATABASE_NAME "pg_catalog"
+#define CATALOG_DATABASE_NAME "peloton"
 
 // Catalog tables
-// 4 basic catalog tables
+// 5 basic catalog tables
 #define DATABASE_CATALOG_NAME "pg_database"
+#define SCHEMA_CATALOG_NAME "pg_namespace"
 #define TABLE_CATALOG_NAME "pg_table"
 #define INDEX_CATALOG_NAME "pg_index"
 #define COLUMN_CATALOG_NAME "pg_attribute"
@@ -39,20 +38,29 @@ namespace catalog {
 
 // Oid mask for each type
 #define DATABASE_OID_MASK (static_cast<oid_t>(catalog::CatalogType::DATABASE))
+#define SCHEMA_OID_MASK (static_cast<oid_t>(catalog::CatalogType::SCHEMA))
 #define TABLE_OID_MASK (static_cast<oid_t>(catalog::CatalogType::TABLE))
 #define INDEX_OID_MASK (static_cast<oid_t>(catalog::CatalogType::INDEX))
 #define TRIGGER_OID_MASK (static_cast<oid_t>(catalog::CatalogType::TRIGGER))
 #define LANGUAGE_OID_MASK (static_cast<oid_t>(catalog::CatalogType::LANGUAGE))
 #define PROC_OID_MASK (static_cast<oid_t>(catalog::CatalogType::PROC))
 
-// Reserved pg_catalog database oid
+// Reserved peloton database oid
 #define CATALOG_DATABASE_OID (0 | DATABASE_OID_MASK)
+
+// Reserved schema oid
+// "public" for default schema, and "pg_catalog" schema for catalog tables
+#define CATALOG_SCHEMA_OID (0 | SCHEMA_OID_MASK)
+#define DEFUALT_SCHEMA_OID (1 | SCHEMA_OID_MASK)
+#define CATALOG_SCHEMA_NAME "pg_catalog"
+#define DEFUALT_SCHEMA_NAME "public"
 
 // Reserved pg_xxx table oid
 #define DATABASE_CATALOG_OID (0 | TABLE_OID_MASK)
-#define TABLE_CATALOG_OID (1 | TABLE_OID_MASK)
-#define INDEX_CATALOG_OID (2 | TABLE_OID_MASK)
-#define COLUMN_CATALOG_OID (3 | TABLE_OID_MASK)
+#define SCHEMA_CATALOG_OID (1 | TABLE_OID_MASK)
+#define TABLE_CATALOG_OID (2 | TABLE_OID_MASK)
+#define INDEX_CATALOG_OID (3 | TABLE_OID_MASK)
+#define COLUMN_CATALOG_OID (4 | TABLE_OID_MASK)
 
 // Reserved pg_column index oid
 #define COLUMN_CATALOG_PKEY_OID (0 | INDEX_OID_MASK)
@@ -68,18 +76,28 @@ namespace catalog {
 #define DATABASE_CATALOG_PKEY_OID (6 | INDEX_OID_MASK)
 #define DATABASE_CATALOG_SKEY0_OID (7 | INDEX_OID_MASK)
 
+// Reserved pg_namespace index oid
+#define SCHEMA_CATALOG_PKEY_OID (8 | INDEX_OID_MASK)
+#define SCHEMA_CATALOG_SKEY0_OID (9 | INDEX_OID_MASK)
+
+// Reserved pg_table index oid
+#define TABLE_CATALOG_PKEY_OID (10 | INDEX_OID_MASK)
+#define TABLE_CATALOG_SKEY0_OID (11 | INDEX_OID_MASK)
+#define TABLE_CATALOG_SKEY1_OID (12 | INDEX_OID_MASK)
+
 // Use upper 8 bits indicating catalog type
 #define CATALOG_TYPE_OFFSET 24
 
 enum class CatalogType : uint32_t {
   INVALID = INVALID_TYPE_ID,
   DATABASE = 1 << CATALOG_TYPE_OFFSET,
-  TABLE = 2 << CATALOG_TYPE_OFFSET,
-  INDEX = 3 << CATALOG_TYPE_OFFSET,
-  COLUMN = 4 << CATALOG_TYPE_OFFSET,
-  TRIGGER = 5 << CATALOG_TYPE_OFFSET,
-  LANGUAGE = 6 << CATALOG_TYPE_OFFSET,
-  PROC = 7 << CATALOG_TYPE_OFFSET,
+  SCHEMA = 2 << CATALOG_TYPE_OFFSET,
+  TABLE = 3 << CATALOG_TYPE_OFFSET,
+  INDEX = 4 << CATALOG_TYPE_OFFSET,
+  COLUMN = 5 << CATALOG_TYPE_OFFSET,
+  TRIGGER = 6 << CATALOG_TYPE_OFFSET,
+  LANGUAGE = 7 << CATALOG_TYPE_OFFSET,
+  PROC = 8 << CATALOG_TYPE_OFFSET,
   // To be added
 };
 

--- a/src/include/catalog/catalog_defaults.h
+++ b/src/include/catalog/catalog_defaults.h
@@ -35,6 +35,7 @@ namespace catalog {
 
 // Local oids from START_OID = 0 to START_OID + OID_OFFSET are reserved
 #define OID_OFFSET 100
+#define CATALOG_TABLES_COUNT 8
 
 // Oid mask for each type
 #define DATABASE_OID_MASK (static_cast<oid_t>(catalog::CatalogType::DATABASE))

--- a/src/include/catalog/column_catalog.h
+++ b/src/include/catalog/column_catalog.h
@@ -44,8 +44,8 @@ class ColumnCatalogObject {
 
   inline oid_t GetTableOid() { return table_oid; }
   inline const std::string &GetColumnName() { return column_name; }
-  inline oid_t GetColumnId() { return column_id; }
-  inline oid_t GetColumnOffset() { return column_offset; }
+  inline uint32_t GetColumnId() { return column_id; }
+  inline uint32_t GetColumnOffset() { return column_offset; }
   inline type::TypeId GetColumnType() { return column_type; }
   inline bool IsInlined() { return is_inlined; }
   inline bool IsPrimary() { return is_primary; }
@@ -55,8 +55,8 @@ class ColumnCatalogObject {
   // member variables
   oid_t table_oid;
   std::string column_name;
-  oid_t column_id;
-  oid_t column_offset;
+  uint32_t column_id;
+  uint32_t column_offset;
   type::TypeId column_type;
   bool is_inlined;
   bool is_primary;
@@ -70,9 +70,10 @@ class ColumnCatalog : public AbstractCatalog {
 
  public:
   // Global Singleton, only the first call requires passing parameters.
-  static ColumnCatalog *GetInstance(storage::Database *pg_catalog = nullptr,
-                                    type::AbstractPool *pool = nullptr,
-                                    concurrency::TransactionContext *txn = nullptr);
+  static ColumnCatalog *GetInstance(
+      storage::Database *pg_catalog = nullptr,
+      type::AbstractPool *pool = nullptr,
+      concurrency::TransactionContext *txn = nullptr);
 
   ~ColumnCatalog();
 
@@ -83,10 +84,11 @@ class ColumnCatalog : public AbstractCatalog {
   // write Related API
   //===--------------------------------------------------------------------===//
   bool InsertColumn(oid_t table_oid, const std::string &column_name,
-                    oid_t column_id, oid_t column_offset,
+                    uint32_t column_id, uint32_t column_offset,
                     type::TypeId column_type, bool is_inlined,
                     const std::vector<Constraint> &constraints,
-                    type::AbstractPool *pool, concurrency::TransactionContext *txn);
+                    type::AbstractPool *pool,
+                    concurrency::TransactionContext *txn);
   bool DeleteColumn(oid_t table_oid, const std::string &column_name,
                     concurrency::TransactionContext *txn);
   bool DeleteColumns(oid_t table_oid, concurrency::TransactionContext *txn);

--- a/src/include/catalog/column_catalog.h
+++ b/src/include/catalog/column_catalog.h
@@ -69,11 +69,8 @@ class ColumnCatalog : public AbstractCatalog {
   friend class Catalog;
 
  public:
-  // Global Singleton, only the first call requires passing parameters.
-  static ColumnCatalog *GetInstance(
-      storage::Database *pg_catalog = nullptr,
-      type::AbstractPool *pool = nullptr,
-      concurrency::TransactionContext *txn = nullptr);
+  ColumnCatalog(storage::Database *pg_catalog, type::AbstractPool *pool,
+                concurrency::TransactionContext *txn);
 
   ~ColumnCatalog();
 
@@ -101,9 +98,6 @@ class ColumnCatalog : public AbstractCatalog {
   //===--------------------------------------------------------------------===//
   const std::unordered_map<oid_t, std::shared_ptr<ColumnCatalogObject>>
   GetColumnObjects(oid_t table_oid, concurrency::TransactionContext *txn);
-
-  ColumnCatalog(storage::Database *pg_catalog, type::AbstractPool *pool,
-                concurrency::TransactionContext *txn);
 
   std::unique_ptr<catalog::Schema> InitializeSchema();
 

--- a/src/include/catalog/column_catalog.h
+++ b/src/include/catalog/column_catalog.h
@@ -91,8 +91,6 @@ class ColumnCatalog : public AbstractCatalog {
   bool DeleteColumns(oid_t table_oid, concurrency::TransactionContext *txn);
 
  private:
-  oid_t database_oid;
-
   //===--------------------------------------------------------------------===//
   // Read Related API(only called within table catalog object)
   //===--------------------------------------------------------------------===//

--- a/src/include/catalog/column_catalog.h
+++ b/src/include/catalog/column_catalog.h
@@ -94,6 +94,8 @@ class ColumnCatalog : public AbstractCatalog {
   bool DeleteColumns(oid_t table_oid, concurrency::TransactionContext *txn);
 
  private:
+  oid_t database_oid;
+
   //===--------------------------------------------------------------------===//
   // Read Related API(only called within table catalog object)
   //===--------------------------------------------------------------------===//

--- a/src/include/catalog/column_catalog.h
+++ b/src/include/catalog/column_catalog.h
@@ -81,7 +81,7 @@ class ColumnCatalog : public AbstractCatalog {
   // write Related API
   //===--------------------------------------------------------------------===//
   bool InsertColumn(oid_t table_oid, const std::string &column_name,
-                    uint32_t column_id, uint32_t column_offset,
+                    oid_t column_id, oid_t column_offset,
                     type::TypeId column_type, bool is_inlined,
                     const std::vector<Constraint> &constraints,
                     type::AbstractPool *pool,

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -49,13 +49,18 @@ class DatabaseCatalogObject {
   std::shared_ptr<TableCatalogObject> GetTableObject(oid_t table_oid,
                                                      bool cached_only = false);
   std::shared_ptr<TableCatalogObject> GetTableObject(
-      const std::string &table_name, bool cached_only = false);
+      const std::string &table_name, const std::string &schema_name,
+      bool cached_only = false);
 
   bool IsValidTableObjects() {
     // return true if this database object contains all table
     // objects within the database
     return valid_table_objects;
   }
+
+  std::vector<std::shared_ptr<TableCatalogObject>> GetTableObjects(
+      const std::string &schema_name);
+
   std::unordered_map<oid_t, std::shared_ptr<TableCatalogObject>>
   GetTableObjects(bool cached_only = false);
 
@@ -69,12 +74,13 @@ class DatabaseCatalogObject {
 
   bool InsertTableObject(std::shared_ptr<TableCatalogObject> table_object);
   bool EvictTableObject(oid_t table_oid);
-  bool EvictTableObject(const std::string &table_name);
+  bool EvictTableObject(const std::string &table_name,
+                        const std::string &schema_name);
   void SetValidTableObjects(bool valid = true) { valid_table_objects = valid; }
 
   std::shared_ptr<IndexCatalogObject> GetCachedIndexObject(oid_t index_oid);
   std::shared_ptr<IndexCatalogObject> GetCachedIndexObject(
-      const std::string &index_name);
+      const std::string &index_name, const std::string &schema_name);
 
   // cache for table name to oid translation
   std::unordered_map<oid_t, std::shared_ptr<TableCatalogObject>>
@@ -98,9 +104,10 @@ class DatabaseCatalog : public AbstractCatalog {
   ~DatabaseCatalog();
 
   // Global Singleton, only the first call requires passing parameters.
-  static DatabaseCatalog *GetInstance(storage::Database *pg_catalog = nullptr,
-                                      type::AbstractPool *pool = nullptr,
-                                      concurrency::TransactionContext *txn = nullptr);
+  static DatabaseCatalog *GetInstance(
+      storage::Database *pg_catalog = nullptr,
+      type::AbstractPool *pool = nullptr,
+      concurrency::TransactionContext *txn = nullptr);
 
   inline oid_t GetNextOid() { return oid_++ | DATABASE_OID_MASK; }
 
@@ -108,7 +115,8 @@ class DatabaseCatalog : public AbstractCatalog {
   // write Related API
   //===--------------------------------------------------------------------===//
   bool InsertDatabase(oid_t database_oid, const std::string &database_name,
-                      type::AbstractPool *pool, concurrency::TransactionContext *txn);
+                      type::AbstractPool *pool,
+                      concurrency::TransactionContext *txn);
   bool DeleteDatabase(oid_t database_oid, concurrency::TransactionContext *txn);
 
  private:

--- a/src/include/catalog/index_catalog.h
+++ b/src/include/catalog/index_catalog.h
@@ -17,16 +17,17 @@
 // 0: index_oid (pkey)
 // 1: index_name
 // 2: table_oid (which table this index belongs to)
-// 3: index_type (default value is BWTREE)
-// 4: index_constraint
-// 5: unique_keys (is this index supports duplicate keys)
-// 6: indexed_attributes (indicate which table columns this index indexes. For
+// 3: schema_name (which namespace this index belongs to)
+// 4: index_type (default value is BWTREE)
+// 5: index_constraint
+// 6: unique_keys (is this index supports duplicate keys)
+// 7: indexed_attributes (indicate which table columns this index indexes. For
 // example a value of 0 2 would mean that the first and the third table columns
 // make up the index.)
 //
 // Indexes: (index offset: indexed columns)
 // 0: index_oid (unique & primary key)
-// 1: index_name (unique)
+// 1: index_name & schema_name (unique)
 // 2: table_oid (non-unique)
 //
 //===----------------------------------------------------------------------===//
@@ -48,6 +49,7 @@ class IndexCatalogObject {
   inline oid_t GetIndexOid() { return index_oid; }
   inline const std::string &GetIndexName() { return index_name; }
   inline oid_t GetTableOid() { return table_oid; }
+  inline const std::string &GetSchemaName() { return schema_name; }
   inline IndexType GetIndexType() { return index_type; }
   inline IndexConstraintType GetIndexConstraint() { return index_constraint; }
   inline bool HasUniqueKeys() { return unique_keys; }
@@ -58,6 +60,7 @@ class IndexCatalogObject {
   oid_t index_oid;
   std::string index_name;
   oid_t table_oid;
+  std::string schema_name;
   IndexType index_type;
   IndexConstraintType index_constraint;
   bool unique_keys;
@@ -79,15 +82,17 @@ class IndexCatalog : public AbstractCatalog {
 
   /** Write Related API */
   bool InsertIndex(oid_t index_oid, const std::string &index_name,
-                   oid_t table_oid, IndexType index_type,
-                   IndexConstraintType index_constraint, bool unique_keys,
-                   std::vector<oid_t> indekeys, type::AbstractPool *pool,
+                   oid_t table_oid, const std::string &schema_name,
+                   IndexType index_type, IndexConstraintType index_constraint,
+                   bool unique_keys, std::vector<oid_t> indekeys,
+                   type::AbstractPool *pool,
                    concurrency::TransactionContext *txn);
   bool DeleteIndex(oid_t index_oid, concurrency::TransactionContext *txn);
 
   /** Read Related API */
   std::shared_ptr<IndexCatalogObject> GetIndexObject(
-      const std::string &index_name, concurrency::TransactionContext *txn);
+      const std::string &index_name, const std::string &schema_name,
+      concurrency::TransactionContext *txn);
 
  private:
   std::shared_ptr<IndexCatalogObject> GetIndexObject(
@@ -96,22 +101,20 @@ class IndexCatalog : public AbstractCatalog {
   const std::unordered_map<oid_t, std::shared_ptr<IndexCatalogObject>>
   GetIndexObjects(oid_t table_oid, concurrency::TransactionContext *txn);
 
- private:
-  oid_t database_oid;
-
   std::unique_ptr<catalog::Schema> InitializeSchema();
 
   enum ColumnId {
     INDEX_OID = 0,
     INDEX_NAME = 1,
     TABLE_OID = 2,
-    INDEX_TYPE = 3,
-    INDEX_CONSTRAINT = 4,
-    UNIQUE_KEYS = 5,
-    INDEXED_ATTRIBUTES = 6,
+    SCHEMA_NAME = 3,
+    INDEX_TYPE = 4,
+    INDEX_CONSTRAINT = 5,
+    UNIQUE_KEYS = 6,
+    INDEXED_ATTRIBUTES = 7,
     // Add new columns here in creation order
   };
-  std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5, 6};
+  std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5, 6, 7};
 
   enum IndexId {
     PRIMARY_KEY = 0,

--- a/src/include/catalog/index_catalog.h
+++ b/src/include/catalog/index_catalog.h
@@ -70,13 +70,10 @@ class IndexCatalog : public AbstractCatalog {
   friend class Catalog;
 
  public:
-  ~IndexCatalog();
+  IndexCatalog(storage::Database *pg_catalog, type::AbstractPool *pool,
+               concurrency::TransactionContext *txn);
 
-  // Global Singleton, only the first call requires passing parameters.
-  static IndexCatalog *GetInstance(
-      storage::Database *pg_catalog = nullptr,
-      type::AbstractPool *pool = nullptr,
-      concurrency::TransactionContext *txn = nullptr);
+  ~IndexCatalog();
 
   inline oid_t GetNextOid() { return oid_++ | INDEX_OID_MASK; }
 
@@ -101,9 +98,6 @@ class IndexCatalog : public AbstractCatalog {
 
  private:
   oid_t database_oid;
-
-  IndexCatalog(storage::Database *pg_catalog, type::AbstractPool *pool,
-               concurrency::TransactionContext *txn);
 
   std::unique_ptr<catalog::Schema> InitializeSchema();
 

--- a/src/include/catalog/index_catalog.h
+++ b/src/include/catalog/index_catalog.h
@@ -100,6 +100,8 @@ class IndexCatalog : public AbstractCatalog {
   GetIndexObjects(oid_t table_oid, concurrency::TransactionContext *txn);
 
  private:
+  oid_t database_oid;
+
   IndexCatalog(storage::Database *pg_catalog, type::AbstractPool *pool,
                concurrency::TransactionContext *txn);
 

--- a/src/include/catalog/index_metrics_catalog.h
+++ b/src/include/catalog/index_metrics_catalog.h
@@ -39,11 +39,9 @@ namespace catalog {
 
 class IndexMetricsCatalog : public AbstractCatalog {
  public:
+  IndexMetricsCatalog(const std::string &database_name,
+                      concurrency::TransactionContext *txn);
   ~IndexMetricsCatalog();
-
-  // Global Singleton
-  static IndexMetricsCatalog *GetInstance(
-      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // Write Related API
@@ -52,7 +50,8 @@ class IndexMetricsCatalog : public AbstractCatalog {
                           int64_t reads, int64_t deletes, int64_t inserts,
                           int64_t time_stamp, type::AbstractPool *pool,
                           concurrency::TransactionContext *txn);
-  bool DeleteIndexMetrics(oid_t index_oid, concurrency::TransactionContext *txn);
+  bool DeleteIndexMetrics(oid_t index_oid,
+                          concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
@@ -60,8 +59,6 @@ class IndexMetricsCatalog : public AbstractCatalog {
   // TODO: add if needed
 
  private:
-  IndexMetricsCatalog(concurrency::TransactionContext *txn);
-
   enum ColumnId {
     DATABASE_OID = 0,
     TABLE_OID = 1,

--- a/src/include/catalog/index_metrics_catalog.h
+++ b/src/include/catalog/index_metrics_catalog.h
@@ -14,7 +14,6 @@
 // pg_index_metrics
 //
 // Schema: (column offset: column_name)
-// 0: database_oid
 // 1: table_oid
 // 2: index_oid
 // 3: reads
@@ -46,9 +45,9 @@ class IndexMetricsCatalog : public AbstractCatalog {
   //===--------------------------------------------------------------------===//
   // Write Related API
   //===--------------------------------------------------------------------===//
-  bool InsertIndexMetrics(oid_t database_oid, oid_t table_oid, oid_t index_oid,
-                          int64_t reads, int64_t deletes, int64_t inserts,
-                          int64_t time_stamp, type::AbstractPool *pool,
+  bool InsertIndexMetrics(oid_t table_oid, oid_t index_oid, int64_t reads,
+                          int64_t deletes, int64_t inserts, int64_t time_stamp,
+                          type::AbstractPool *pool,
                           concurrency::TransactionContext *txn);
   bool DeleteIndexMetrics(oid_t index_oid,
                           concurrency::TransactionContext *txn);
@@ -60,13 +59,12 @@ class IndexMetricsCatalog : public AbstractCatalog {
 
  private:
   enum ColumnId {
-    DATABASE_OID = 0,
-    TABLE_OID = 1,
-    INDEX_OID = 2,
-    READS = 3,
-    DELETES = 4,
-    INSERTS = 5,
-    TIME_STAMP = 6,
+    TABLE_OID = 0,
+    INDEX_OID = 1,
+    READS = 2,
+    DELETES = 3,
+    INSERTS = 4,
+    TIME_STAMP = 5,
     // Add new columns here in creation order
   };
 

--- a/src/include/catalog/proc_catalog.h
+++ b/src/include/catalog/proc_catalog.h
@@ -41,8 +41,7 @@ class LanguageCatalogObject;
 //===----------------------------------------------------------------------===//
 class ProcCatalogObject {
  public:
-  ProcCatalogObject(executor::LogicalTile *tile,
-                    concurrency::TransactionContext *txn);
+  ProcCatalogObject(executor::LogicalTile *tile, concurrency::TransactionContext *txn);
 
   // Accessors
 
@@ -78,9 +77,10 @@ class ProcCatalogObject {
 //===----------------------------------------------------------------------===//
 class ProcCatalog : public AbstractCatalog {
  public:
-  ProcCatalog(const std::string &database_name,
-              concurrency::TransactionContext *txn);
   ~ProcCatalog();
+
+  // Global Singleton
+  static ProcCatalog &GetInstance(concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -114,6 +114,8 @@ class ProcCatalog : public AbstractCatalog {
   std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5};
 
  private:
+  ProcCatalog(concurrency::TransactionContext *txn);
+
   oid_t GetNextOid() { return oid_++ | PROC_OID_MASK; }
 
   enum IndexId {

--- a/src/include/catalog/proc_catalog.h
+++ b/src/include/catalog/proc_catalog.h
@@ -41,7 +41,8 @@ class LanguageCatalogObject;
 //===----------------------------------------------------------------------===//
 class ProcCatalogObject {
  public:
-  ProcCatalogObject(executor::LogicalTile *tile, concurrency::TransactionContext *txn);
+  ProcCatalogObject(executor::LogicalTile *tile,
+                    concurrency::TransactionContext *txn);
 
   // Accessors
 
@@ -77,10 +78,9 @@ class ProcCatalogObject {
 //===----------------------------------------------------------------------===//
 class ProcCatalog : public AbstractCatalog {
  public:
+  ProcCatalog(const std::string &database_name,
+              concurrency::TransactionContext *txn);
   ~ProcCatalog();
-
-  // Global Singleton
-  static ProcCatalog &GetInstance(concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -114,8 +114,6 @@ class ProcCatalog : public AbstractCatalog {
   std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5};
 
  private:
-  ProcCatalog(concurrency::TransactionContext *txn);
-
   oid_t GetNextOid() { return oid_++ | PROC_OID_MASK; }
 
   enum IndexId {

--- a/src/include/catalog/query_metrics_catalog.h
+++ b/src/include/catalog/query_metrics_catalog.h
@@ -11,11 +11,11 @@
 //===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//
-// pg_query
+// pg_query(per database, name become primary key)
 //
 // Schema: (column offset: column_name)
 // 0: name (pkey)
-// 1: database_oid (pkey)
+// 1: database_oid
 // 2: num_params
 // 3: param_types
 // 4: param_formats
@@ -28,8 +28,6 @@
 // 11: cpu_time
 // 12: time_stamp
 //
-// Indexes: (index offset: indexed columns)
-// 0: name & database_oid (unique & primary key)
 //
 //===----------------------------------------------------------------------===//
 

--- a/src/include/catalog/query_metrics_catalog.h
+++ b/src/include/catalog/query_metrics_catalog.h
@@ -45,11 +45,9 @@ namespace catalog {
 
 class QueryMetricsCatalog : public AbstractCatalog {
  public:
+  QueryMetricsCatalog(const std::string &database_name,
+                      concurrency::TransactionContext *txn);
   ~QueryMetricsCatalog();
-
-  // Global Singleton
-  static QueryMetricsCatalog *GetInstance(
-      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -94,10 +92,8 @@ class QueryMetricsCatalog : public AbstractCatalog {
   };
 
  private:
-  QueryMetricsCatalog(concurrency::TransactionContext *txn);
-
   enum IndexId {
-    SECONDARY_KEY_0 = 0,
+    PRIMARY_KEY = 0,
     // Add new indexes here in creation order
   };
 };

--- a/src/include/catalog/query_metrics_catalog.h
+++ b/src/include/catalog/query_metrics_catalog.h
@@ -52,8 +52,7 @@ class QueryMetricsCatalog : public AbstractCatalog {
   //===--------------------------------------------------------------------===//
   // write Related API
   //===--------------------------------------------------------------------===//
-  bool InsertQueryMetrics(const std::string &name, oid_t database_oid,
-                          int64_t num_params,
+  bool InsertQueryMetrics(const std::string &name, int64_t num_params,
                           const stats::QueryMetric::QueryParamBuf &type_buf,
                           const stats::QueryMetric::QueryParamBuf &format_buf,
                           const stats::QueryMetric::QueryParamBuf &value_buf,
@@ -61,16 +60,15 @@ class QueryMetricsCatalog : public AbstractCatalog {
                           int64_t inserts, int64_t latency, int64_t cpu_time,
                           int64_t time_stamp, type::AbstractPool *pool,
                           concurrency::TransactionContext *txn);
-  bool DeleteQueryMetrics(const std::string &name, oid_t database_oid,
+  bool DeleteQueryMetrics(const std::string &name,
                           concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
   //===--------------------------------------------------------------------===//
   stats::QueryMetric::QueryParamBuf GetParamTypes(
-      const std::string &name, oid_t database_oid,
-      concurrency::TransactionContext *txn);
-  int64_t GetNumParams(const std::string &name, oid_t database_oid,
+      const std::string &name, concurrency::TransactionContext *txn);
+  int64_t GetNumParams(const std::string &name,
                        concurrency::TransactionContext *txn);
   // TODO: add more if needed
 

--- a/src/include/catalog/query_metrics_catalog.h
+++ b/src/include/catalog/query_metrics_catalog.h
@@ -15,18 +15,17 @@
 //
 // Schema: (column offset: column_name)
 // 0: name (pkey)
-// 1: database_oid
-// 2: num_params
-// 3: param_types
-// 4: param_formats
-// 5: param_values
-// 6: reads
-// 7: updates
-// 8: deletes
-// 9: inserts
-// 10: latency
-// 11: cpu_time
-// 12: time_stamp
+// 1: num_params
+// 2: param_types
+// 3: param_formats
+// 4: param_values
+// 5: reads
+// 6: updates
+// 7: deletes
+// 8: inserts
+// 9: latency
+// 10: cpu_time
+// 11: time_stamp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -72,18 +71,17 @@ class QueryMetricsCatalog : public AbstractCatalog {
 
   enum ColumnId {
     NAME = 0,
-    DATABASE_OID = 1,
-    NUM_PARAMS = 2,
-    PARAM_TYPES = 3,
-    PARAM_FORMATS = 4,
-    PARAM_VALUES = 5,
-    READS = 6,
-    UPDATES = 7,
-    DELETES = 8,
-    INSERTS = 9,
-    LATENCY = 10,
-    CPU_TIME = 11,
-    TIME_STAMP = 12,
+    NUM_PARAMS = 1,
+    PARAM_TYPES = 2,
+    PARAM_FORMATS = 3,
+    PARAM_VALUES = 4,
+    READS = 5,
+    UPDATES = 6,
+    DELETES = 7,
+    INSERTS = 8,
+    LATENCY = 9,
+    CPU_TIME = 10,
+    TIME_STAMP = 11,
     // Add new columns here in creation order
   };
 

--- a/src/include/catalog/query_metrics_catalog.h
+++ b/src/include/catalog/query_metrics_catalog.h
@@ -70,7 +70,7 @@ class QueryMetricsCatalog : public AbstractCatalog {
   int64_t GetNumParams(const std::string &name,
                        concurrency::TransactionContext *txn);
   // TODO: In theory, we don't need database_oid
-  // but now we store all the query metrics under default database "pelton"
+  // but now we store all the query metrics under default database "peloton"
   enum ColumnId {
     NAME = 0,
     DATABASE_OID = 1,

--- a/src/include/catalog/query_metrics_catalog.h
+++ b/src/include/catalog/query_metrics_catalog.h
@@ -15,17 +15,18 @@
 //
 // Schema: (column offset: column_name)
 // 0: name (pkey)
-// 1: num_params
-// 2: param_types
-// 3: param_formats
-// 4: param_values
-// 5: reads
-// 6: updates
-// 7: deletes
-// 8: inserts
-// 9: latency
-// 10: cpu_time
-// 11: time_stamp
+// 1: database_id(pkey)
+// 2: num_params
+// 3: param_types
+// 4: param_formats
+// 5: param_values
+// 6: reads
+// 7: updates
+// 8: deletes
+// 9: inserts
+// 10: latency
+// 11: cpu_time
+// 12: time_stamp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -49,7 +50,8 @@ class QueryMetricsCatalog : public AbstractCatalog {
   //===--------------------------------------------------------------------===//
   // write Related API
   //===--------------------------------------------------------------------===//
-  bool InsertQueryMetrics(const std::string &name, int64_t num_params,
+  bool InsertQueryMetrics(const std::string &name, oid_t database_oid,
+                          int64_t num_params,
                           const stats::QueryMetric::QueryParamBuf &type_buf,
                           const stats::QueryMetric::QueryParamBuf &format_buf,
                           const stats::QueryMetric::QueryParamBuf &value_buf,
@@ -57,7 +59,7 @@ class QueryMetricsCatalog : public AbstractCatalog {
                           int64_t inserts, int64_t latency, int64_t cpu_time,
                           int64_t time_stamp, type::AbstractPool *pool,
                           concurrency::TransactionContext *txn);
-  bool DeleteQueryMetrics(const std::string &name,
+  bool DeleteQueryMetrics(const std::string &name, oid_t database_oid,
                           concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
@@ -67,21 +69,22 @@ class QueryMetricsCatalog : public AbstractCatalog {
       const std::string &name, concurrency::TransactionContext *txn);
   int64_t GetNumParams(const std::string &name,
                        concurrency::TransactionContext *txn);
-  // TODO: add more if needed
-
+  // TODO: In theory, we don't need database_oid
+  // but now we store all the query metrics under default database "pelton"
   enum ColumnId {
     NAME = 0,
-    NUM_PARAMS = 1,
-    PARAM_TYPES = 2,
-    PARAM_FORMATS = 3,
-    PARAM_VALUES = 4,
-    READS = 5,
-    UPDATES = 6,
-    DELETES = 7,
-    INSERTS = 8,
-    LATENCY = 9,
-    CPU_TIME = 10,
-    TIME_STAMP = 11,
+    DATABASE_OID = 1,
+    NUM_PARAMS = 2,
+    PARAM_TYPES = 3,
+    PARAM_FORMATS = 4,
+    PARAM_VALUES = 5,
+    READS = 6,
+    UPDATES = 7,
+    DELETES = 8,
+    INSERTS = 9,
+    LATENCY = 10,
+    CPU_TIME = 11,
+    TIME_STAMP = 12,
     // Add new columns here in creation order
   };
 

--- a/src/include/catalog/query_metrics_catalog.h
+++ b/src/include/catalog/query_metrics_catalog.h
@@ -59,7 +59,7 @@ class QueryMetricsCatalog : public AbstractCatalog {
                           int64_t inserts, int64_t latency, int64_t cpu_time,
                           int64_t time_stamp, type::AbstractPool *pool,
                           concurrency::TransactionContext *txn);
-  bool DeleteQueryMetrics(const std::string &name, oid_t database_oid,
+  bool DeleteQueryMetrics(const std::string &name,
                           concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//

--- a/src/include/catalog/schema_catalog.h
+++ b/src/include/catalog/schema_catalog.h
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// schema_catalog.h
+//
+// Identification: src/include/catalog/schema_catalog.h
+//
+// Copyright (c) 2015-17, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// pg_namespace
+//
+// Schema: (column offset: column_name)
+// 0: schema_oid (pkey)
+// 1: schema_name
+//
+// Indexes: (index offset: indexed columns)
+// 0: schema_oid (unique & primary key)
+// 1: schema_name (unique)
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "catalog/abstract_catalog.h"
+#include "executor/logical_tile.h"
+
+namespace peloton {
+namespace catalog {
+
+class SchemaCatalogObject {
+  friend class DatabaseCatalogObject;
+
+ public:
+  SchemaCatalogObject(executor::LogicalTile *tile,
+                      concurrency::TransactionContext *txn);
+
+  inline oid_t GetSchemaOid() { return schema_oid; }
+  inline const std::string &GetSchemaName() { return schema_name; }
+
+ private:
+  // member variables
+  oid_t schema_oid;
+  std::string schema_name;
+  // Pointer to its corresponding transaction
+  // This object is only visible during this transaction
+  concurrency::TransactionContext *txn;
+};
+
+class SchemaCatalog : public AbstractCatalog {
+  friend class SchemaCatalogObject;
+  friend class Catalog;
+
+ public:
+  SchemaCatalog(storage::Database *peloton, type::AbstractPool *pool,
+                concurrency::TransactionContext *txn);
+
+  ~SchemaCatalog();
+
+  inline oid_t GetNextOid() { return oid_++ | SCHEMA_OID_MASK; }
+
+  //===--------------------------------------------------------------------===//
+  // write Related API
+  //===--------------------------------------------------------------------===//
+  bool InsertSchema(oid_t schema_oid, const std::string &schema_name,
+                    type::AbstractPool *pool,
+                    concurrency::TransactionContext *txn);
+  bool DeleteSchema(const std::string &schema_name,
+                    concurrency::TransactionContext *txn);
+
+  //===--------------------------------------------------------------------===//
+  // Read Related API
+  //===--------------------------------------------------------------------===//
+  std::shared_ptr<SchemaCatalogObject> GetSchemaObject(
+      const std::string &schema_name, concurrency::TransactionContext *txn);
+
+ private:
+  std::unique_ptr<catalog::Schema> InitializeSchema();
+
+  enum ColumnId {
+    SCHEMA_OID = 0,
+    SCHEMA_NAME = 1,
+    // Add new columns here in creation order
+  };
+  std::vector<oid_t> all_column_ids = {0, 1};
+
+  enum IndexId {
+    PRIMARY_KEY = 0,
+    SKEY_SCHEMA_NAME = 1,
+    // Add new indexes here in creation order
+  };
+};
+
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/system_catalogs.h
+++ b/src/include/catalog/system_catalogs.h
@@ -18,7 +18,17 @@
 #include "catalog/table_catalog.h"
 
 namespace peloton {
+
+namespace storage {
+class Database;
+}  // namespace storage
+
 namespace catalog {
+
+class DatabaseCatalog;
+class TableCatalog;
+class IndexCatalog;
+class ColumnCatalog;
 
 class SystemCatalogs {
  public:

--- a/src/include/catalog/system_catalogs.h
+++ b/src/include/catalog/system_catalogs.h
@@ -16,6 +16,7 @@
 
 #include "catalog/database_catalog.h"
 #include "catalog/table_catalog.h"
+#include "catalog/trigger_catalog.h"
 
 namespace peloton {
 
@@ -39,7 +40,8 @@ class SystemCatalogs {
 
   ~SystemCatalogs();
 
-  void Bootstrap();
+  void Bootstrap(const std::string &database_name,
+                 concurrency::TransactionContext *txn);
 
   ColumnCatalog *GetColumnCatalog() { return pg_attribute; }
   TableCatalog *GetTableCatalog() { return pg_table; }

--- a/src/include/catalog/system_catalogs.h
+++ b/src/include/catalog/system_catalogs.h
@@ -42,11 +42,13 @@ class SystemCatalogs {
   ColumnCatalog *GetColumnCatalog() { return pg_attribute; }
   TableCatalog *GetTableCatalog() { return pg_table; }
   IndexCatalog *GetIndexCatalog() { return pg_index; }
+  TriggerCatalog *GetTriggerCatalog() { return pg_trigger; }
 
  private:
   ColumnCatalog *pg_attribute;
   TableCatalog *pg_table;
   IndexCatalog *pg_index;
+  TriggerCatalog *pg_trigger;
 };
 
 }  // namespace catalog

--- a/src/include/catalog/system_catalogs.h
+++ b/src/include/catalog/system_catalogs.h
@@ -22,6 +22,8 @@ namespace catalog {
 
 class SystemCatalogs {
  public:
+  SystemCatalogs() = delete;
+
   SystemCatalogs(storage::Database *database, type::AbstractPool *pool,
                  concurrency::TransactionContext *txn);
 

--- a/src/include/catalog/system_catalogs.h
+++ b/src/include/catalog/system_catalogs.h
@@ -47,6 +47,9 @@ class SystemCatalogs {
   TableCatalog *GetTableCatalog() { return pg_table; }
   IndexCatalog *GetIndexCatalog() { return pg_index; }
   TriggerCatalog *GetTriggerCatalog() { return pg_trigger; }
+  TableMetricsCatalog *GetTableMetricsCatalog() { return pg_table_metrics; }
+  IndexMetricsCatalog *GetIndexMetricsCatalog() { return pg_index_metrics; }
+  QueryMetricsCatalog *GetQueryMetricsCatalog() { return pg_query_metrics; }
 
  private:
   ColumnCatalog *pg_attribute;
@@ -54,7 +57,7 @@ class SystemCatalogs {
   IndexCatalog *pg_index;
 
   TriggerCatalog *pg_trigger;
-  ProcCatalog *pg_proc;
+  // ProcCatalog *pg_proc;
   TableMetricsCatalog *pg_table_metrics;
   IndexMetricsCatalog *pg_index_metrics;
   QueryMetricsCatalog *pg_query_metrics;

--- a/src/include/catalog/system_catalogs.h
+++ b/src/include/catalog/system_catalogs.h
@@ -17,6 +17,9 @@
 #include "catalog/database_catalog.h"
 #include "catalog/table_catalog.h"
 #include "catalog/trigger_catalog.h"
+#include "catalog/table_metrics_catalog.h"
+#include "catalog/index_metrics_catalog.h"
+#include "catalog/query_metrics_catalog.h"
 
 namespace peloton {
 

--- a/src/include/catalog/system_catalogs.h
+++ b/src/include/catalog/system_catalogs.h
@@ -46,13 +46,48 @@ class SystemCatalogs {
   void Bootstrap(const std::string &database_name,
                  concurrency::TransactionContext *txn);
 
-  ColumnCatalog *GetColumnCatalog() { return pg_attribute; }
-  TableCatalog *GetTableCatalog() { return pg_table; }
-  IndexCatalog *GetIndexCatalog() { return pg_index; }
-  TriggerCatalog *GetTriggerCatalog() { return pg_trigger; }
-  TableMetricsCatalog *GetTableMetricsCatalog() { return pg_table_metrics; }
-  IndexMetricsCatalog *GetIndexMetricsCatalog() { return pg_index_metrics; }
-  QueryMetricsCatalog *GetQueryMetricsCatalog() { return pg_query_metrics; }
+  ColumnCatalog *GetColumnCatalog() {
+    if (!pg_attribute) {
+      throw CatalogException("Column catalog has not been initialized");
+    }
+    return pg_attribute;
+  }
+  TableCatalog *GetTableCatalog() {
+    if (!pg_table) {
+      throw CatalogException("Table catalog has not been initialized");
+    }
+    return pg_table;
+  }
+  IndexCatalog *GetIndexCatalog() {
+    if (!pg_index) {
+      throw CatalogException("Index catalog has not been initialized");
+    }
+    return pg_index;
+  }
+  TriggerCatalog *GetTriggerCatalog() {
+    if (!pg_trigger) {
+      throw CatalogException("Trigger catalog has not been initialized");
+    }
+    return pg_trigger;
+  }
+  TableMetricsCatalog *GetTableMetricsCatalog() {
+    if (!pg_table_metrics) {
+      throw CatalogException("Table metrics catalog has not been initialized");
+    }
+    return pg_table_metrics;
+  }
+  IndexMetricsCatalog *GetIndexMetricsCatalog() {
+    if (!pg_index_metrics) {
+      throw CatalogException("Index metrics catalog has not been initialized");
+    }
+    return pg_index_metrics;
+  }
+  QueryMetricsCatalog *GetQueryMetricsCatalog() {
+    if (!pg_query_metrics) {
+      throw CatalogException("Query metrics catalog has not been initialized");
+    }
+    return pg_query_metrics;
+  }
 
  private:
   ColumnCatalog *pg_attribute;

--- a/src/include/catalog/system_catalogs.h
+++ b/src/include/catalog/system_catalogs.h
@@ -39,6 +39,8 @@ class SystemCatalogs {
 
   ~SystemCatalogs();
 
+  void Bootstrap();
+
   ColumnCatalog *GetColumnCatalog() { return pg_attribute; }
   TableCatalog *GetTableCatalog() { return pg_table; }
   IndexCatalog *GetIndexCatalog() { return pg_index; }

--- a/src/include/catalog/system_catalogs.h
+++ b/src/include/catalog/system_catalogs.h
@@ -15,11 +15,12 @@
 #include <mutex>
 
 #include "catalog/database_catalog.h"
-#include "catalog/table_catalog.h"
-#include "catalog/trigger_catalog.h"
-#include "catalog/table_metrics_catalog.h"
 #include "catalog/index_metrics_catalog.h"
 #include "catalog/query_metrics_catalog.h"
+#include "catalog/schema_catalog.h"
+#include "catalog/table_catalog.h"
+#include "catalog/table_metrics_catalog.h"
+#include "catalog/trigger_catalog.h"
 
 namespace peloton {
 
@@ -28,8 +29,8 @@ class Database;
 }  // namespace storage
 
 namespace catalog {
-
 class DatabaseCatalog;
+class SchemaCatalog;
 class TableCatalog;
 class IndexCatalog;
 class ColumnCatalog;
@@ -52,36 +53,49 @@ class SystemCatalogs {
     }
     return pg_attribute;
   }
+
+  SchemaCatalog *GetSchemaCatalog() {
+    if (!pg_namespace) {
+      throw CatalogException("schema catalog has not been initialized");
+    }
+    return pg_namespace;
+  }
+
   TableCatalog *GetTableCatalog() {
     if (!pg_table) {
       throw CatalogException("Table catalog has not been initialized");
     }
     return pg_table;
   }
+
   IndexCatalog *GetIndexCatalog() {
     if (!pg_index) {
       throw CatalogException("Index catalog has not been initialized");
     }
     return pg_index;
   }
+
   TriggerCatalog *GetTriggerCatalog() {
     if (!pg_trigger) {
       throw CatalogException("Trigger catalog has not been initialized");
     }
     return pg_trigger;
   }
+
   TableMetricsCatalog *GetTableMetricsCatalog() {
     if (!pg_table_metrics) {
       throw CatalogException("Table metrics catalog has not been initialized");
     }
     return pg_table_metrics;
   }
+
   IndexMetricsCatalog *GetIndexMetricsCatalog() {
     if (!pg_index_metrics) {
       throw CatalogException("Index metrics catalog has not been initialized");
     }
     return pg_index_metrics;
   }
+
   QueryMetricsCatalog *GetQueryMetricsCatalog() {
     if (!pg_query_metrics) {
       throw CatalogException("Query metrics catalog has not been initialized");
@@ -91,6 +105,7 @@ class SystemCatalogs {
 
  private:
   ColumnCatalog *pg_attribute;
+  SchemaCatalog *pg_namespace;
   TableCatalog *pg_table;
   IndexCatalog *pg_index;
 

--- a/src/include/catalog/system_catalogs.h
+++ b/src/include/catalog/system_catalogs.h
@@ -52,7 +52,12 @@ class SystemCatalogs {
   ColumnCatalog *pg_attribute;
   TableCatalog *pg_table;
   IndexCatalog *pg_index;
+
   TriggerCatalog *pg_trigger;
+  ProcCatalog *pg_proc;
+  TableMetricsCatalog *pg_table_metrics;
+  IndexMetricsCatalog *pg_index_metrics;
+  QueryMetricsCatalog *pg_query_metrics;
 };
 
 }  // namespace catalog

--- a/src/include/catalog/system_catalogs.h
+++ b/src/include/catalog/system_catalogs.h
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// system_catalog.h
+//
+// Identification: src/include/catalog/system_catalog.h
+//
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <mutex>
+
+#include "catalog/database_catalog.h"
+#include "catalog/table_catalog.h"
+
+namespace peloton {
+namespace catalog {
+
+class SystemCatalogs {
+ public:
+  SystemCatalogs(storage::Database *database, type::AbstractPool *pool,
+                 concurrency::TransactionContext *txn);
+
+  ~SystemCatalogs();
+
+  ColumnCatalog *GetColumnCatalog() { return pg_attribute; }
+  TableCatalog *GetTableCatalog() { return pg_table; }
+  IndexCatalog *GetIndexCatalog() { return pg_index; }
+
+ private:
+  ColumnCatalog *pg_attribute;
+  TableCatalog *pg_table;
+  IndexCatalog *pg_index;
+};
+
+}  // namespace catalog
+}  // namespace peloton

--- a/src/include/catalog/system_catalogs.h
+++ b/src/include/catalog/system_catalogs.h
@@ -47,73 +47,77 @@ class SystemCatalogs {
   void Bootstrap(const std::string &database_name,
                  concurrency::TransactionContext *txn);
 
+  //===--------------------------------------------------------------------===//
+  // GET FUNCTIONS
+  // get catalog tables with name
+  //===--------------------------------------------------------------------===//
   ColumnCatalog *GetColumnCatalog() {
-    if (!pg_attribute) {
+    if (!pg_attribute_) {
       throw CatalogException("Column catalog has not been initialized");
     }
-    return pg_attribute;
+    return pg_attribute_;
   }
 
   SchemaCatalog *GetSchemaCatalog() {
-    if (!pg_namespace) {
+    if (!pg_namespace_) {
       throw CatalogException("schema catalog has not been initialized");
     }
-    return pg_namespace;
+    return pg_namespace_;
   }
 
   TableCatalog *GetTableCatalog() {
-    if (!pg_table) {
+    if (!pg_table_) {
       throw CatalogException("Table catalog has not been initialized");
     }
-    return pg_table;
+    return pg_table_;
   }
 
   IndexCatalog *GetIndexCatalog() {
-    if (!pg_index) {
+    if (!pg_index_) {
       throw CatalogException("Index catalog has not been initialized");
     }
-    return pg_index;
+    return pg_index_;
   }
 
   TriggerCatalog *GetTriggerCatalog() {
-    if (!pg_trigger) {
+    if (!pg_trigger_) {
       throw CatalogException("Trigger catalog has not been initialized");
     }
-    return pg_trigger;
+    return pg_trigger_;
   }
 
   TableMetricsCatalog *GetTableMetricsCatalog() {
-    if (!pg_table_metrics) {
+    if (!pg_table_metrics_) {
       throw CatalogException("Table metrics catalog has not been initialized");
     }
-    return pg_table_metrics;
+    return pg_table_metrics_;
   }
 
   IndexMetricsCatalog *GetIndexMetricsCatalog() {
-    if (!pg_index_metrics) {
+    if (!pg_index_metrics_) {
       throw CatalogException("Index metrics catalog has not been initialized");
     }
-    return pg_index_metrics;
+    return pg_index_metrics_;
   }
 
   QueryMetricsCatalog *GetQueryMetricsCatalog() {
-    if (!pg_query_metrics) {
+    if (!pg_query_metrics_) {
       throw CatalogException("Query metrics catalog has not been initialized");
     }
-    return pg_query_metrics;
+    return pg_query_metrics_;
   }
 
  private:
-  ColumnCatalog *pg_attribute;
-  SchemaCatalog *pg_namespace;
-  TableCatalog *pg_table;
-  IndexCatalog *pg_index;
+  ColumnCatalog *pg_attribute_;
+  SchemaCatalog *pg_namespace_;
+  TableCatalog *pg_table_;
+  IndexCatalog *pg_index_;
 
-  TriggerCatalog *pg_trigger;
+  TriggerCatalog *pg_trigger_;
   // ProcCatalog *pg_proc;
-  TableMetricsCatalog *pg_table_metrics;
-  IndexMetricsCatalog *pg_index_metrics;
-  QueryMetricsCatalog *pg_query_metrics;
+  TableMetricsCatalog *pg_table_metrics_;
+  IndexMetricsCatalog *pg_index_metrics_;
+  QueryMetricsCatalog *pg_query_metrics_;
 };
 
 }  // namespace catalog

--- a/src/include/catalog/table_catalog.h
+++ b/src/include/catalog/table_catalog.h
@@ -20,7 +20,7 @@
 //
 // Indexes: (index offset: indexed columns)
 // 0: table_oid (unique & primary key)
-// 1: table_name & database_oid (unique)
+// 1: table_name (unique)
 // 2: database_oid (non-unique)
 //
 //===----------------------------------------------------------------------===//
@@ -120,7 +120,7 @@ class TableCatalog : public AbstractCatalog {
  public:
   TableCatalog(storage::Database *pg_catalog, type::AbstractPool *pool,
                concurrency::TransactionContext *txn);
-  
+
   ~TableCatalog();
 
   inline oid_t GetNextOid() { return oid_++ | TABLE_OID_MASK; }
@@ -143,8 +143,7 @@ class TableCatalog : public AbstractCatalog {
   std::shared_ptr<TableCatalogObject> GetTableObject(
       oid_t table_oid, concurrency::TransactionContext *txn);
   std::shared_ptr<TableCatalogObject> GetTableObject(
-      const std::string &table_name, oid_t database_oid,
-      concurrency::TransactionContext *txn);
+      const std::string &table_name, concurrency::TransactionContext *txn);
   std::unordered_map<oid_t, std::shared_ptr<TableCatalogObject>>
   GetTableObjects(oid_t database_oid, concurrency::TransactionContext *txn);
 

--- a/src/include/catalog/table_catalog.h
+++ b/src/include/catalog/table_catalog.h
@@ -118,13 +118,10 @@ class TableCatalog : public AbstractCatalog {
   friend class Catalog;
 
  public:
+  TableCatalog(storage::Database *pg_catalog, type::AbstractPool *pool,
+               concurrency::TransactionContext *txn);
+  
   ~TableCatalog();
-
-  // Global Singleton, only the first call requires passing parameters.
-  static TableCatalog *GetInstance(
-      storage::Database *pg_catalog = nullptr,
-      type::AbstractPool *pool = nullptr,
-      concurrency::TransactionContext *txn = nullptr);
 
   inline oid_t GetNextOid() { return oid_++ | TABLE_OID_MASK; }
 
@@ -152,8 +149,7 @@ class TableCatalog : public AbstractCatalog {
   GetTableObjects(oid_t database_oid, concurrency::TransactionContext *txn);
 
  private:
-  TableCatalog(storage::Database *pg_catalog, type::AbstractPool *pool,
-               concurrency::TransactionContext *txn);
+  oid_t database_oid;
 
   std::unique_ptr<catalog::Schema> InitializeSchema();
 

--- a/src/include/catalog/table_catalog.h
+++ b/src/include/catalog/table_catalog.h
@@ -45,8 +45,8 @@ class TableCatalogObject {
   friend class ColumnCatalog;
 
  public:
-  TableCatalogObject(executor::LogicalTile *tile, concurrency::TransactionContext *txn,
-                     int tupleId = 0);
+  TableCatalogObject(executor::LogicalTile *tile,
+                     concurrency::TransactionContext *txn, int tupleId = 0);
 
  public:
   // Get indexes
@@ -74,12 +74,14 @@ class TableCatalogObject {
   inline oid_t GetTableOid() { return table_oid; }
   inline const std::string &GetTableName() { return table_name; }
   inline oid_t GetDatabaseOid() { return database_oid; }
+  inline uint32_t GetVersionId() { return version_id; }
 
  private:
   // member variables
   oid_t table_oid;
   std::string table_name;
   oid_t database_oid;
+  uint32_t version_id;
 
   // Get index objects
   bool InsertIndexObject(std::shared_ptr<IndexCatalogObject> index_object);
@@ -119,9 +121,10 @@ class TableCatalog : public AbstractCatalog {
   ~TableCatalog();
 
   // Global Singleton, only the first call requires passing parameters.
-  static TableCatalog *GetInstance(storage::Database *pg_catalog = nullptr,
-                                   type::AbstractPool *pool = nullptr,
-                                   concurrency::TransactionContext *txn = nullptr);
+  static TableCatalog *GetInstance(
+      storage::Database *pg_catalog = nullptr,
+      type::AbstractPool *pool = nullptr,
+      concurrency::TransactionContext *txn = nullptr);
 
   inline oid_t GetNextOid() { return oid_++ | TABLE_OID_MASK; }
 
@@ -132,6 +135,9 @@ class TableCatalog : public AbstractCatalog {
                    oid_t database_oid, type::AbstractPool *pool,
                    concurrency::TransactionContext *txn);
   bool DeleteTable(oid_t table_oid, concurrency::TransactionContext *txn);
+
+  bool UpdateVersionId(oid_t update_val, oid_t table_oid,
+                       concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read Related API
@@ -155,9 +161,10 @@ class TableCatalog : public AbstractCatalog {
     TABLE_OID = 0,
     TABLE_NAME = 1,
     DATABASE_OID = 2,
+    VERSION_ID = 3,
     // Add new columns here in creation order
   };
-  std::vector<oid_t> all_column_ids = {0, 1, 2};
+  std::vector<oid_t> all_column_ids = {0, 1, 2, 3};
 
   enum IndexId {
     PRIMARY_KEY = 0,

--- a/src/include/catalog/table_metrics_catalog.h
+++ b/src/include/catalog/table_metrics_catalog.h
@@ -14,7 +14,6 @@
 // pg_table_metrics
 //
 // Schema: (column offset: column_name)
-// 0: database_oid
 // 1: table_oid
 // 2: reads
 // 3: updates
@@ -46,9 +45,9 @@ class TableMetricsCatalog : public AbstractCatalog {
   //===--------------------------------------------------------------------===//
   // Write Related API
   //===--------------------------------------------------------------------===//
-  bool InsertTableMetrics(oid_t database_oid, oid_t table_oid, int64_t reads,
-                          int64_t updates, int64_t deletes, int64_t inserts,
-                          int64_t time_stamp, type::AbstractPool *pool,
+  bool InsertTableMetrics(oid_t table_oid, int64_t reads, int64_t updates,
+                          int64_t deletes, int64_t inserts, int64_t time_stamp,
+                          type::AbstractPool *pool,
                           concurrency::TransactionContext *txn);
   bool DeleteTableMetrics(oid_t table_oid,
                           concurrency::TransactionContext *txn);
@@ -60,13 +59,12 @@ class TableMetricsCatalog : public AbstractCatalog {
 
  private:
   enum ColumnId {
-    DATABASE_OID = 0,
-    TABLE_OID = 1,
-    READS = 2,
-    UPDATES = 3,
-    DELETES = 4,
-    INSERTS = 5,
-    TIME_STAMP = 6,
+    TABLE_OID = 0,
+    READS = 1,
+    UPDATES = 2,
+    DELETES = 3,
+    INSERTS = 4,
+    TIME_STAMP = 5,
     // Add new columns here in creation order
   };
 

--- a/src/include/catalog/table_metrics_catalog.h
+++ b/src/include/catalog/table_metrics_catalog.h
@@ -39,11 +39,9 @@ namespace catalog {
 
 class TableMetricsCatalog : public AbstractCatalog {
  public:
+  TableMetricsCatalog(const std::string &database_name,
+                      concurrency::TransactionContext *txn);
   ~TableMetricsCatalog();
-
-  // Global Singleton
-  static TableMetricsCatalog *GetInstance(
-      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // Write Related API
@@ -52,7 +50,8 @@ class TableMetricsCatalog : public AbstractCatalog {
                           int64_t updates, int64_t deletes, int64_t inserts,
                           int64_t time_stamp, type::AbstractPool *pool,
                           concurrency::TransactionContext *txn);
-  bool DeleteTableMetrics(oid_t table_oid, concurrency::TransactionContext *txn);
+  bool DeleteTableMetrics(oid_t table_oid,
+                          concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
@@ -60,8 +59,6 @@ class TableMetricsCatalog : public AbstractCatalog {
   // TODO: add if needed
 
  private:
-  TableMetricsCatalog(concurrency::TransactionContext *txn);
-
   enum ColumnId {
     DATABASE_OID = 0,
     TABLE_OID = 1,

--- a/src/include/catalog/trigger_catalog.h
+++ b/src/include/catalog/trigger_catalog.h
@@ -47,10 +47,8 @@ namespace catalog {
 
 class TriggerCatalog : public AbstractCatalog {
  public:
+  TriggerCatalog(concurrency::TransactionContext *txn);
   ~TriggerCatalog();
-
-  // Global Singleton
-  static TriggerCatalog &GetInstance(concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -74,7 +72,8 @@ class TriggerCatalog : public AbstractCatalog {
   // of the same type
   //===--------------------------------------------------------------------===//
   std::unique_ptr<trigger::TriggerList> GetTriggersByType(
-      oid_t table_oid, int16_t trigger_type, concurrency::TransactionContext *txn);
+      oid_t table_oid, int16_t trigger_type,
+      concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // get all types of triggers for a specific table
@@ -97,8 +96,6 @@ class TriggerCatalog : public AbstractCatalog {
   };
 
  private:
-  TriggerCatalog(concurrency::TransactionContext *txn);
-
   oid_t GetNextOid() { return oid_++ | TRIGGER_OID_MASK; }
 
   enum IndexId {

--- a/src/include/catalog/trigger_catalog.h
+++ b/src/include/catalog/trigger_catalog.h
@@ -65,6 +65,10 @@ class TriggerCatalog : public AbstractCatalog {
                          const std::string &trigger_name,
                          concurrency::TransactionContext *txn);
 
+  ResultType DropTrigger(const oid_t oid_tdatabase_oid, const oid_t table_oid,
+                         const std::string &trigger_name,
+                         concurrency::TransactionContext *txn);
+
   bool DeleteTriggerByName(const std::string &trigger_name, oid_t table_oid,
                            concurrency::TransactionContext *txn);
 

--- a/src/include/catalog/trigger_catalog.h
+++ b/src/include/catalog/trigger_catalog.h
@@ -15,7 +15,7 @@
 //
 // Schema: (column offset: column_name)
 // 0: oid (pkey)
-// 1: tgrelid   : table_name
+// 1: tgrelid   : table_oid
 // 2: tgname    : trigger_name
 // 3: tgfoid    : function_oid
 // 4: tgtype    : trigger_type
@@ -60,12 +60,7 @@ class TriggerCatalog : public AbstractCatalog {
                      type::Value timestamp, type::AbstractPool *pool,
                      concurrency::TransactionContext *txn);
 
-  ResultType DropTrigger(const std::string &database_name,
-                         const std::string &table_name,
-                         const std::string &trigger_name,
-                         concurrency::TransactionContext *txn);
-
-  ResultType DropTrigger(const oid_t oid_tdatabase_oid, const oid_t table_oid,
+  ResultType DropTrigger(const oid_t database_oid, const oid_t table_oid,
                          const std::string &trigger_name,
                          concurrency::TransactionContext *txn);
 

--- a/src/include/catalog/trigger_catalog.h
+++ b/src/include/catalog/trigger_catalog.h
@@ -47,7 +47,8 @@ namespace catalog {
 
 class TriggerCatalog : public AbstractCatalog {
  public:
-  TriggerCatalog(concurrency::TransactionContext *txn);
+  TriggerCatalog(const std::string &database_name,
+                 concurrency::TransactionContext *txn);
   ~TriggerCatalog();
 
   //===--------------------------------------------------------------------===//

--- a/src/include/common/internal_types.h
+++ b/src/include/common/internal_types.h
@@ -60,7 +60,6 @@ class ItemPointerComparator;
 
 #define INVALID_RATIO -1
 
-#define DEFAULT_DB_ID 16777216
 #define DEFAULT_DB_NAME "default_database"
 
 extern int DEFAULT_TUPLES_PER_TILEGROUP;
@@ -615,7 +614,8 @@ enum class CreateType {
   TABLE = 2,                  // table create type
   INDEX = 3,                  // index create type
   CONSTRAINT = 4,             // constraint create type
-  TRIGGER = 5                 // trigger create type
+  TRIGGER = 5,                // trigger create type
+  SCHEMA = 6,                 // schema create type
 };
 std::string CreateTypeToString(CreateType type);
 CreateType StringToCreateType(const std::string &str);
@@ -631,7 +631,8 @@ enum class DropType {
   TABLE = 2,                  // table drop type
   INDEX = 3,                  // index drop type
   CONSTRAINT = 4,             // constraint drop type
-  TRIGGER = 5                 // trigger drop type
+  TRIGGER = 5,                // trigger drop type
+  SCHEMA = 6,                 // trigger drop type
 };
 std::string DropTypeToString(DropType type);
 DropType StringToDropType(const std::string &str);

--- a/src/include/common/internal_types.h
+++ b/src/include/common/internal_types.h
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
+#include <unistd.h>
 #include <bitset>
 #include <climits>
 #include <cstdint>
@@ -21,16 +22,15 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <unistd.h>
 
-#include "tbb/concurrent_vector.h"
 #include "tbb/concurrent_unordered_set.h"
+#include "tbb/concurrent_vector.h"
 
-#include "parser/pg_trigger.h"
-#include "type/type_id.h"
 #include "common/logger.h"
 #include "common/macros.h"
 #include "container/cuckoo_map.h"
+#include "parser/pg_trigger.h"
+#include "type/type_id.h"
 
 // Impose Row-major to avoid confusion
 #define EIGEN_DEFAULT_TO_ROW_MAJOR
@@ -60,7 +60,7 @@ class ItemPointerComparator;
 
 #define INVALID_RATIO -1
 
-#define DEFAULT_DB_ID 12345
+#define DEFAULT_DB_ID 16777216
 #define DEFAULT_DB_NAME "default_database"
 
 extern int DEFAULT_TUPLES_PER_TILEGROUP;
@@ -81,7 +81,7 @@ extern int TEST_TUPLES_PER_TILEGROUP;
 enum class CmpBool {
   CmpFalse = 0,
   CmpTrue = 1,
-  NULL_ = 2 // Note the underscore suffix
+  NULL_ = 2  // Note the underscore suffix
 };
 
 //===--------------------------------------------------------------------===//
@@ -1214,7 +1214,9 @@ std::ostream &operator<<(std::ostream &os, const RWType &type);
 typedef CuckooMap<ItemPointer, RWType, ItemPointerHasher, ItemPointerComparator>
     ReadWriteSet;
 
-typedef tbb::concurrent_unordered_set<ItemPointer, ItemPointerHasher, ItemPointerComparator> WriteSet;
+typedef tbb::concurrent_unordered_set<ItemPointer, ItemPointerHasher,
+                                      ItemPointerComparator>
+    WriteSet;
 
 // this enum is to identify why the version should be GC'd.
 enum class GCVersionType {
@@ -1240,7 +1242,8 @@ enum class DDLType {
   CREATE,
   DROP,
 };
-typedef tbb::concurrent_vector<std::tuple<oid_t, oid_t, oid_t, DDLType>> CreateDropSet;
+typedef tbb::concurrent_vector<std::tuple<oid_t, oid_t, oid_t, DDLType>>
+    CreateDropSet;
 typedef std::vector<std::tuple<oid_t, oid_t, oid_t>> GCObjectSet;
 
 //===--------------------------------------------------------------------===//
@@ -1385,12 +1388,12 @@ typedef std::unordered_map<
 // TODO(boweic): use raw ptr
 // Mapping of Expression -> Column Offset created by operator
 typedef std::unordered_map<expression::AbstractExpression *, unsigned,
-                           expression::ExprHasher,
-                           expression::ExprEqualCmp> ExprMap;
+                           expression::ExprHasher, expression::ExprEqualCmp>
+    ExprMap;
 // Used in optimizer to speed up expression comparsion
 typedef std::unordered_set<expression::AbstractExpression *,
-                           expression::ExprHasher,
-                           expression::ExprEqualCmp> ExprSet;
+                           expression::ExprHasher, expression::ExprEqualCmp>
+    ExprSet;
 
 //===--------------------------------------------------------------------===//
 // Wire protocol typedefs

--- a/src/include/executor/create_executor.h
+++ b/src/include/executor/create_executor.h
@@ -23,18 +23,18 @@ class DataTable;
 namespace planner {
 class AbstractPlan;
 class CreatePlan;
-}
+}  // namespace planner
 
 namespace executor {
 
 class CreateExecutor : public AbstractExecutor {
  public:
-	CreateExecutor(const CreateExecutor &) = delete;
-	CreateExecutor &operator=(const CreateExecutor &) = delete;
-	CreateExecutor(CreateExecutor &&) = delete;
-	CreateExecutor &operator=(CreateExecutor &&) = delete;
+  CreateExecutor(const CreateExecutor &) = delete;
+  CreateExecutor &operator=(const CreateExecutor &) = delete;
+  CreateExecutor(CreateExecutor &&) = delete;
+  CreateExecutor &operator=(CreateExecutor &&) = delete;
 
-	CreateExecutor(const planner::AbstractPlan *node,
+  CreateExecutor(const planner::AbstractPlan *node,
                  ExecutorContext *executor_context);
 
   ~CreateExecutor() {}
@@ -45,6 +45,8 @@ class CreateExecutor : public AbstractExecutor {
   bool DExecute();
 
   bool CreateDatabase(const planner::CreatePlan &node);
+
+  bool CreateSchema(const planner::CreatePlan &node);
 
   bool CreateTable(const planner::CreatePlan &node);
 
@@ -57,7 +59,6 @@ class CreateExecutor : public AbstractExecutor {
 
   // Abstract Pool to hold strings
   std::unique_ptr<type::AbstractPool> pool_;
-
 };
 
 }  // namespace executor

--- a/src/include/executor/drop_executor.h
+++ b/src/include/executor/drop_executor.h
@@ -48,6 +48,9 @@ class DropExecutor : public AbstractExecutor {
   bool DropDatabase(const planner::DropPlan &node,
                     concurrency::TransactionContext *txn);
 
+  bool DropSchema(const planner::DropPlan &node,
+                  concurrency::TransactionContext *txn);
+
   bool DropTable(const planner::DropPlan &node,
                  concurrency::TransactionContext *txn);
 

--- a/src/include/parser/analyze_statement.h
+++ b/src/include/parser/analyze_statement.h
@@ -52,6 +52,13 @@ class AnalyzeStatement : public SQLStatement {
     return analyze_table->GetDatabaseName();
   }
 
+  std::string GetSchemaName() const {
+    if (analyze_table == nullptr) {
+      return INVALID_NAME;
+    }
+    return analyze_table->GetSchemaName();
+  }
+
   virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
   const std::string GetInfo(int num_indent) const override;

--- a/src/include/parser/create_statement.h
+++ b/src/include/parser/create_statement.h
@@ -13,11 +13,11 @@
 #pragma once
 
 #include <memory>
+#include "common/internal_types.h"
 #include "common/sql_node_visitor.h"
 #include "expression/abstract_expression.h"
-#include "parser/sql_statement.h"
 #include "parser/select_statement.h"
-#include "common/internal_types.h"
+#include "parser/sql_statement.h"
 
 namespace peloton {
 namespace parser {
@@ -239,8 +239,6 @@ class CreateStatement : public TableRefStatement {
   std::vector<std::string> index_attrs;
   IndexType index_type;
   std::string index_name;
-
-  std::string schema_name;
 
   std::string view_name;
   std::unique_ptr<SelectStatement> view_query;

--- a/src/include/parser/delete_statement.h
+++ b/src/include/parser/delete_statement.h
@@ -45,6 +45,8 @@ class DeleteStatement : public SQLStatement {
 
   std::string GetDatabaseName() const { return table_ref->GetDatabaseName(); }
 
+  std::string GetSchemaName() const { return table_ref->GetSchemaName(); }
+
   virtual void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
   const std::string GetInfo(int num_indent) const override;

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -12,8 +12,8 @@
 
 #pragma once
 
-#include "parser/sql_statement.h"
 #include "common/sql_node_visitor.h"
+#include "parser/sql_statement.h"
 
 namespace peloton {
 namespace parser {
@@ -40,13 +40,6 @@ class DropStatement : public TableRefStatement {
         missing_(false),
         cascade_(false) {}
 
-  DropStatement(EntityType type, std::string table_name_of_trigger,
-                std::string trigger_name)
-      : TableRefStatement(StatementType::DROP),
-        type_(type),
-        table_name_of_trigger_(table_name_of_trigger),
-        trigger_name_(trigger_name) {}
-
   EntityType GetDropType() { return type_; }
 
   bool GetMissing() { return missing_; }
@@ -69,12 +62,6 @@ class DropStatement : public TableRefStatement {
 
   void SetPrepStmt(char *prep_stmt) { prep_stmt_ = prep_stmt; }
 
-  std::string &GetSchemaName() { return schema_name_; }
-
-  void SetSchemaName(std::string &schema_name) { schema_name_ = schema_name; }
-
-  void SetSchemaName(char *schema_name) { schema_name_ = schema_name; }
-
   std::string &GetTriggerName() { return trigger_name_; }
 
   void SetTriggerName(std::string &trigger_name) {
@@ -83,15 +70,7 @@ class DropStatement : public TableRefStatement {
 
   void SetTriggerName(char *trigger_name) { trigger_name_ = trigger_name; }
 
-  std::string &GetTriggerTableName() { return table_name_of_trigger_; }
-
-  void SetTriggerTableName(std::string &table_name_of_trigger) {
-    table_name_of_trigger_ = table_name_of_trigger;
-  }
-
-  void SetTriggerTableName(char *table_name_of_trigger) {
-    table_name_of_trigger_ = table_name_of_trigger;
-  }
+  std::string GetTriggerTableName() { return GetTableName(); }
 
   virtual ~DropStatement() {}
 
@@ -116,11 +95,7 @@ class DropStatement : public TableRefStatement {
   std::string prep_stmt_;
 
   // drop trigger
-  std::string table_name_of_trigger_;
   std::string trigger_name_;
-
-  // drop schema
-  std::string schema_name_;
 };
 
 }  // namespace parser

--- a/src/include/parser/drop_statement.h
+++ b/src/include/parser/drop_statement.h
@@ -39,6 +39,15 @@ class DropStatement : public TableRefStatement {
         type_(type),
         missing_(false),
         cascade_(false) {}
+  // only used in drop_test
+  DropStatement(EntityType type, std::string table_name_of_trigger,
+                std::string trigger_name)
+      : TableRefStatement(StatementType::DROP),
+        type_(type),
+        trigger_name_(trigger_name) {
+    if (!table_info_) table_info_.reset(new parser::TableInfo());
+    table_info_->table_name = table_name_of_trigger;
+  }
 
   EntityType GetDropType() { return type_; }
 

--- a/src/include/parser/insert_statement.h
+++ b/src/include/parser/insert_statement.h
@@ -39,6 +39,10 @@ class InsertStatement : public SQLStatement {
     table_ref_->TryBindDatabaseName(default_database_name);
   }
 
+  inline std::string GetSchemaName() const {
+    return table_ref_->GetSchemaName();
+  }
+
   inline std::string GetDatabaseName() const {
     return table_ref_->GetDatabaseName();
   }

--- a/src/include/parser/sql_statement.h
+++ b/src/include/parser/sql_statement.h
@@ -19,7 +19,7 @@
 
 #include <vector>
 
-#include "common/internal_types.h"
+#include "catalog/catalog_defaults.h"
 #include "common/macros.h"
 #include "common/printable.h"
 #include "common/sql_node_visitor.h"
@@ -30,9 +30,9 @@ namespace parser {
 
 struct TableInfo {
   ~TableInfo() {}
-
+  // member variables
   std::string table_name;
-
+  std::string schema_name;
   std::string database_name;
 };
 
@@ -71,10 +71,18 @@ class TableRefStatement : public SQLStatement {
 
     if (table_info_->database_name.empty())
       table_info_->database_name = default_database_name;
+    // if schema name is not specified, then it's default value is "public"
+    if (table_info_->schema_name.empty())
+      table_info_->schema_name = DEFUALT_SCHEMA_NAME;
   }
 
   virtual inline std::string GetTableName() const {
     return table_info_->table_name;
+  }
+
+  // Get the name of the schema(namespace) of this table
+  virtual inline std::string GetSchemaName() const {
+    return table_info_->schema_name;
   }
 
   // Get the name of the database of this table

--- a/src/include/parser/table_ref.h
+++ b/src/include/parser/table_ref.h
@@ -15,11 +15,11 @@
 #include <stdio.h>
 #include <vector>
 
+#include "common/internal_types.h"
+#include "common/sql_node_visitor.h"
 #include "expression/abstract_expression.h"
 #include "parser/sql_statement.h"
 #include "util/string_util.h"
-#include "common/sql_node_visitor.h"
-#include "common/internal_types.h"
 
 namespace peloton {
 namespace parser {
@@ -56,8 +56,6 @@ struct TableRef {
 
   TableReferenceType type;
 
-  std::string schema;
-
   // Expression of database name and table name
   std::unique_ptr<TableInfo> table_info_ = nullptr;
 
@@ -66,9 +64,6 @@ struct TableRef {
   SelectStatement *select;
   std::vector<std::unique_ptr<TableRef>> list;
   std::unique_ptr<JoinDefinition> join;
-
-  // Convenience accessor methods
-  inline bool HasSchema() { return !schema.empty(); }
 
   // Try to bind the database name to the node if not specified
   inline void TryBindDatabaseName(std::string default_database_name) {
@@ -79,11 +74,10 @@ struct TableRef {
     if (table_info_->database_name.empty()) {
       table_info_->database_name = default_database_name;
     }
-  }
 
-  // Get the name of the database of this table
-  inline std::string GetDatabaseName() const {
-    return table_info_->database_name;
+    if (table_info_->schema_name.empty()) {
+      table_info_->schema_name = DEFUALT_SCHEMA_NAME;
+    }
   }
 
   // Get the name of the table
@@ -95,6 +89,14 @@ struct TableRef {
   }
 
   inline std::string GetTableName() const { return table_info_->table_name; }
+
+  // Get the name of the schema of this table
+  inline std::string GetSchemaName() const { return table_info_->schema_name; }
+
+  // Get the name of the database of this table
+  inline std::string GetDatabaseName() const {
+    return table_info_->database_name;
+  }
 
   const std::string GetInfo(int num_indent) const;
 

--- a/src/include/planner/analyze_plan.h
+++ b/src/include/planner/analyze_plan.h
@@ -40,12 +40,12 @@ class AnalyzePlan : public AbstractPlan {
 
   explicit AnalyzePlan(storage::DataTable *table);
 
-  explicit AnalyzePlan(std::string table_name,
+  explicit AnalyzePlan(std::string table_name, std::string schema_name,
                        std::string database_name,
                        concurrency::TransactionContext *txn);
 
-  explicit AnalyzePlan(std::string table_name, 
-                       std::string database_name, 
+  explicit AnalyzePlan(std::string table_name, std::string schema_name,
+                       std::string database_name,
                        std::vector<char *> column_names,
                        concurrency::TransactionContext *txn);
 
@@ -67,9 +67,9 @@ class AnalyzePlan : public AbstractPlan {
   }
 
  private:
-  storage::DataTable* target_table_ = nullptr;
+  storage::DataTable *target_table_ = nullptr;
   std::string table_name_;
-  std::vector<char*> column_names_;
+  std::vector<char *> column_names_;
 };
 
 }  // namespace planner

--- a/src/include/planner/create_plan.h
+++ b/src/include/planner/create_plan.h
@@ -12,8 +12,8 @@
 
 #pragma once
 
-#include "planner/abstract_plan.h"
 #include "parser/create_statement.h"
+#include "planner/abstract_plan.h"
 
 namespace peloton {
 namespace catalog {
@@ -50,11 +50,13 @@ struct ForeignKeyInfo {
 class CreatePlan : public AbstractPlan {
  public:
   CreatePlan() = delete;
-  
+
   // This construnctor is for Create Database Test used only
   explicit CreatePlan(std::string database_name, CreateType c_type);
 
-  explicit CreatePlan(std::string table_name, std::string database_name,
+  // This construnctor is for copy() used only
+  explicit CreatePlan(std::string table_name, std::string schema_name,
+                      std::string database_name,
                       std::unique_ptr<catalog::Schema> schema,
                       CreateType c_type);
 
@@ -66,13 +68,15 @@ class CreatePlan : public AbstractPlan {
 
   std::unique_ptr<AbstractPlan> Copy() const {
     return std::unique_ptr<AbstractPlan>(new CreatePlan(
-        table_name, database_name,
+        table_name, schema_name, database_name,
         std::unique_ptr<catalog::Schema>(table_schema), create_type));
   }
 
   std::string GetIndexName() const { return index_name; }
 
   std::string GetTableName() const { return table_name; }
+
+  std::string GetSchemaName() const { return schema_name; }
 
   std::string GetDatabaseName() const { return database_name; }
 
@@ -86,7 +90,9 @@ class CreatePlan : public AbstractPlan {
 
   std::vector<std::string> GetIndexAttributes() const { return index_attrs; }
 
-  inline std::vector<ForeignKeyInfo> GetForeignKeys() const { return foreign_keys; }
+  inline std::vector<ForeignKeyInfo> GetForeignKeys() const {
+    return foreign_keys;
+  }
   std::vector<oid_t> GetKeyAttrs() const { return key_attrs; }
 
   void SetKeyAttrs(std::vector<oid_t> p_key_attrs) { key_attrs = p_key_attrs; }
@@ -108,15 +114,18 @@ class CreatePlan : public AbstractPlan {
 
   int16_t GetTriggerType() const { return trigger_type; }
 
-protected:
-    // This is a helper method for extracting foreign key information
-    // and storing it in an internal struct.
-    void ProcessForeignKeyConstraint(const std::string &table_name,
-                                     const parser::ColumnDefinition *col);
+ protected:
+  // This is a helper method for extracting foreign key information
+  // and storing it in an internal struct.
+  void ProcessForeignKeyConstraint(const std::string &table_name,
+                                   const parser::ColumnDefinition *col);
 
  private:
   // Table Name
   std::string table_name;
+
+  // namespace Name
+  std::string schema_name;
 
   // Database Name
   std::string database_name;

--- a/src/include/planner/drop_plan.h
+++ b/src/include/planner/drop_plan.h
@@ -41,6 +41,7 @@ class DropPlan : public AbstractPlan {
   const std::string GetInfo() const {
     std::string returned_string = "DropPlan:\n";
     returned_string += " Table name:     " + table_name;
+    returned_string += " Schema name : " + schema_name;
     returned_string += " Database name : " + database_name;
     return returned_string;
   }
@@ -52,6 +53,8 @@ class DropPlan : public AbstractPlan {
   std::string GetDatabaseName() const { return database_name; }
 
   std::string GetTableName() const { return table_name; }
+
+  std::string GetSchemaName() const { return schema_name; }
 
   std::string GetTriggerName() const { return trigger_name; }
 
@@ -69,6 +72,9 @@ class DropPlan : public AbstractPlan {
 
   // Database Name
   std::string database_name;
+
+  // namespace Name
+  std::string schema_name;
 
   std::string trigger_name;
   std::string index_name;

--- a/src/include/planner/plan_util.h
+++ b/src/include/planner/plan_util.h
@@ -56,11 +56,10 @@ class PlanUtil {
       const planner::AbstractPlan *plan);
 
   /**
-  * @brief Get the indexes affected by a given query
-  * @param CatalogCache
-  * @param SQLStatement
-  * @return set of affected index object ids
-  */
+   * @brief Get the indexes affected by a given query
+   * @param SQLStatement
+   * @return set of affected index object ids
+   */
   static const std::set<oid_t> GetAffectedIndexes(
       catalog::CatalogCache &catalog_cache,
       const parser::SQLStatement &sql_stmt);

--- a/src/include/planner/plan_util.h
+++ b/src/include/planner/plan_util.h
@@ -57,6 +57,7 @@ class PlanUtil {
 
   /**
    * @brief Get the indexes affected by a given query
+   * @param CatalogCache
    * @param SQLStatement
    * @return set of affected index object ids
    */

--- a/src/include/planner/seq_scan_plan.h
+++ b/src/include/planner/seq_scan_plan.h
@@ -17,10 +17,10 @@
 #include <vector>
 
 #include "abstract_scan_plan.h"
+#include "common/internal_types.h"
 #include "common/logger.h"
 #include "expression/abstract_expression.h"
 #include "type/serializer.h"
-#include "common/internal_types.h"
 
 namespace peloton {
 

--- a/src/include/planner/seq_scan_plan.h
+++ b/src/include/planner/seq_scan_plan.h
@@ -17,10 +17,10 @@
 #include <vector>
 
 #include "abstract_scan_plan.h"
-#include "common/internal_types.h"
 #include "common/logger.h"
 #include "expression/abstract_expression.h"
 #include "type/serializer.h"
+#include "common/internal_types.h"
 
 namespace peloton {
 

--- a/src/include/statistics/backend_stats_context.h
+++ b/src/include/statistics/backend_stats_context.h
@@ -13,19 +13,19 @@
 #pragma once
 
 #include <map>
-#include <thread>
 #include <sstream>
+#include <thread>
 #include <unordered_map>
 
-#include "common/platform.h"
 #include "common/container/cuckoo_map.h"
 #include "common/container/lock_free_queue.h"
+#include "common/platform.h"
 #include "common/synchronization/spin_latch.h"
-#include "statistics/table_metric.h"
+#include "statistics/database_metric.h"
 #include "statistics/index_metric.h"
 #include "statistics/latency_metric.h"
-#include "statistics/database_metric.h"
 #include "statistics/query_metric.h"
+#include "statistics/table_metric.h"
 
 #define QUERY_METRIC_QUEUE_SIZE 100000
 
@@ -46,7 +46,7 @@ class CounterMetric;
  */
 class BackendStatsContext {
  public:
-  static BackendStatsContext* GetInstance();
+  static BackendStatsContext *GetInstance();
 
   BackendStatsContext(size_t max_latency_history, bool regiser_to_aggregator);
   ~BackendStatsContext();
@@ -58,26 +58,26 @@ class BackendStatsContext {
   inline std::thread::id GetThreadId() { return thread_id_; }
 
   // Returns the table metric with the given database ID and table ID
-  TableMetric* GetTableMetric(oid_t database_id, oid_t table_id);
+  TableMetric *GetTableMetric(oid_t database_id, oid_t table_id);
 
   // Returns the database metric with the given database ID
-  DatabaseMetric* GetDatabaseMetric(oid_t database_id);
+  DatabaseMetric *GetDatabaseMetric(oid_t database_id);
 
   // Returns the index metric with the given database ID, table ID, and
   // index ID
-  IndexMetric* GetIndexMetric(oid_t database_id, oid_t table_id,
+  IndexMetric *GetIndexMetric(oid_t database_id, oid_t table_id,
                               oid_t index_id);
 
   // Returns the metrics for completed queries
-  LockFreeQueue<std::shared_ptr<QueryMetric>>& GetCompletedQueryMetrics() {
+  LockFreeQueue<std::shared_ptr<QueryMetric>> &GetCompletedQueryMetrics() {
     return completed_query_metrics_;
   };
 
   // Returns the metric for the on going query
-  QueryMetric* GetOnGoingQueryMetric() { return ongoing_query_metric_.get(); }
+  QueryMetric *GetOnGoingQueryMetric() { return ongoing_query_metric_.get(); }
 
   // Returns the latency metric
-  LatencyMetric& GetTxnLatencyMetric();
+  LatencyMetric &GetTxnLatencyMetric();
 
   // Increment the read stat for given tile group
   void IncrementTableReads(oid_t tile_group_id);
@@ -92,17 +92,17 @@ class BackendStatsContext {
   void IncrementTableDeletes(oid_t tile_group_id);
 
   // Increment the read stat for given index by read_count
-  void IncrementIndexReads(size_t read_count, index::IndexMetadata* metadata);
+  void IncrementIndexReads(size_t read_count, index::IndexMetadata *metadata);
 
   // Increment the insert stat for index
-  void IncrementIndexInserts(index::IndexMetadata* metadata);
+  void IncrementIndexInserts(index::IndexMetadata *metadata);
 
   // Increment the update stat for index
-  void IncrementIndexUpdates(index::IndexMetadata* metadata);
+  void IncrementIndexUpdates(index::IndexMetadata *metadata);
 
   // Increment the delete stat for index
   void IncrementIndexDeletes(size_t delete_count,
-                             index::IndexMetadata* metadata);
+                             index::IndexMetadata *metadata);
 
   // Increment the commit stat for given database
   void IncrementTxnCommitted(oid_t database_id);
@@ -121,7 +121,7 @@ class BackendStatsContext {
   /**
    * Aggregate another BackendStatsContext to myself
    */
-  void Aggregate(BackendStatsContext& source);
+  void Aggregate(BackendStatsContext &source);
 
   // Resets all metrics (and sub-metrics) to their starting state
   // (e.g., sets all counters to zero)
@@ -144,13 +144,13 @@ class BackendStatsContext {
       database_metrics_{};
 
   // Table metrics
-  std::unordered_map<oid_t, std::unique_ptr<TableMetric>> table_metrics_{};
+  std::unordered_map<uint64_t, std::unique_ptr<TableMetric>> table_metrics_{};
 
   // Index metrics
-  CuckooMap<oid_t, std::shared_ptr<IndexMetric>> index_metrics_{};
+  CuckooMap<uint64_t, std::shared_ptr<IndexMetric>> index_metrics_{};
 
   // Index oids
-  std::unordered_set<oid_t> index_ids_;
+  std::unordered_set<uint64_t> index_ids_;
 
   // Metrics for completed queries
   LockFreeQueue<std::shared_ptr<QueryMetric>> completed_query_metrics_{
@@ -187,9 +187,8 @@ class BackendStatsContext {
   void CompleteQueryMetric();
 
   // Get the mapping table of backend stat context for each thread
-  static CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>> &
-    GetBackendContextMap(void);
-
+  static CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>>
+      &GetBackendContextMap(void);
 };
 
 }  // namespace stats

--- a/src/include/statistics/stats_aggregator.h
+++ b/src/include/statistics/stats_aggregator.h
@@ -12,20 +12,20 @@
 
 #pragma once
 
-#include <mutex>
-#include <map>
-#include <vector>
-#include <unordered_map>
 #include <condition_variable>
-#include <string>
 #include <fstream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "common/logger.h"
 #include "common/macros.h"
-#include "statistics/backend_stats_context.h"
-#include "storage/database.h"
-#include "storage/data_table.h"
 #include "concurrency/transaction_context.h"
+#include "statistics/backend_stats_context.h"
+#include "storage/data_table.h"
+#include "storage/database.h"
 
 //===--------------------------------------------------------------------===//
 // GUC Variables
@@ -68,8 +68,8 @@ class StatsAggregator {
   //===--------------------------------------------------------------------===//
 
   // Global singleton
-  static StatsAggregator &GetInstance(int64_t aggregation_interval_ms =
-                                          STATS_AGGREGATION_INTERVAL_MS);
+  static StatsAggregator &GetInstance(
+      int64_t aggregation_interval_ms = STATS_AGGREGATION_INTERVAL_MS);
 
   // Get the aggregated stats history of all exited threads
   inline BackendStatsContext &GetStatsHistory() { return stats_history_; }
@@ -88,9 +88,6 @@ class StatsAggregator {
   // Unregister a BackendStatsContext. Currently we directly reuse the thread id
   // instead of explicitly unregistering it.
   void UnregisterContext(std::thread::id id);
-
-  // Utility function to get the metric table
-  storage::DataTable *GetMetricTable(std::string table_name);
 
   // Aggregate the stats of current living threads
   void Aggregate(int64_t &interval_cnt, double &alpha,
@@ -162,7 +159,8 @@ class StatsAggregator {
                           concurrency::TransactionContext *txn);
 
   // Write all query metrics to a metric table
-  void UpdateQueryMetrics(int64_t time_stamp, concurrency::TransactionContext *txn);
+  void UpdateQueryMetrics(int64_t time_stamp,
+                          concurrency::TransactionContext *txn);
 
   // Aggregate stats periodically
   void RunAggregator();

--- a/src/include/storage/database.h
+++ b/src/include/storage/database.h
@@ -54,9 +54,6 @@ class Database : public Printable {
   // Throw CatalogException if such table is not found
   storage::DataTable *GetTableWithOid(const oid_t table_oid) const;
 
-  // Throw CatalogException if such table is not found
-  storage::DataTable *GetTableWithName(const std::string &table_name) const;
-
   oid_t GetTableCount() const;
 
   void DropTableWithOid(const oid_t table_oid);

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -21,16 +21,16 @@
 #include "common/exception.h"
 
 #include "optimizer/binding.h"
+#include "optimizer/input_column_deriver.h"
 #include "optimizer/operator_visitor.h"
+#include "optimizer/optimize_context.h"
+#include "optimizer/optimizer_task_pool.h"
+#include "optimizer/plan_generator.h"
 #include "optimizer/properties.h"
 #include "optimizer/property_enforcer.h"
 #include "optimizer/query_to_operator_transformer.h"
-#include "optimizer/input_column_deriver.h"
-#include "optimizer/plan_generator.h"
 #include "optimizer/rule.h"
 #include "optimizer/rule_impls.h"
-#include "optimizer/optimizer_task_pool.h"
-#include "optimizer/optimize_context.h"
 #include "parser/create_statement.h"
 
 #include "planner/analyze_plan.h"
@@ -165,11 +165,13 @@ unique_ptr<planner::AbstractPlan> Optimizer::HandleDDLStatement(
       if (create_plan->GetCreateType() == peloton::CreateType::INDEX) {
         auto create_stmt = (parser::CreateStatement *)tree;
         auto target_table = catalog::Catalog::GetInstance()->GetTableWithName(
-            create_stmt->GetDatabaseName(), create_stmt->GetTableName(), txn);
+            create_stmt->GetDatabaseName(), create_stmt->GetSchemaName(),
+            create_stmt->GetTableName(), txn);
         std::vector<oid_t> column_ids;
         // use catalog object instead of schema to acquire metadata
         auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
-            create_stmt->GetDatabaseName(), create_stmt->GetTableName(), txn);
+            create_stmt->GetDatabaseName(), create_stmt->GetSchemaName(),
+            create_stmt->GetTableName(), txn);
         for (auto column_name : create_plan->GetIndexAttributes()) {
           auto column_object = table_object->GetColumnObject(column_name);
           // Check if column is missing

--- a/src/optimizer/util.cpp
+++ b/src/optimizer/util.cpp
@@ -12,8 +12,8 @@
 
 #include "optimizer/util.h"
 
-#include "concurrency/transaction_manager_factory.h"
 #include "catalog/query_metrics_catalog.h"
+#include "concurrency/transaction_manager_factory.h"
 #include "expression/expression_util.h"
 #include "planner/copy_plan.h"
 #include "planner/seq_scan_plan.h"
@@ -161,6 +161,7 @@ std::unique_ptr<planner::AbstractPlan> CreateCopyPlan(
   auto txn = txn_manager.BeginTransaction();
   auto target_table = catalog::Catalog::GetInstance()->GetTableWithName(
       copy_stmt->cpy_table->GetDatabaseName(),
+      copy_stmt->cpy_table->GetSchemaName(),
       copy_stmt->cpy_table->GetTableName(), txn);
   txn_manager.CommitTransaction(txn);
 
@@ -178,7 +179,8 @@ std::unordered_map<std::string, std::shared_ptr<expression::AbstractExpression>>
 ConstructSelectElementMap(
     std::vector<std::unique_ptr<expression::AbstractExpression>> &select_list) {
   std::unordered_map<std::string,
-                     std::shared_ptr<expression::AbstractExpression>> res;
+                     std::shared_ptr<expression::AbstractExpression>>
+      res;
   for (auto &expr : select_list) {
     std::string alias;
     if (!expr->alias.empty()) {

--- a/src/parser/create_statement.cpp
+++ b/src/parser/create_statement.cpp
@@ -26,9 +26,11 @@ const std::string CreateStatement::GetInfo(int num_indent) const {
       os << "Create type: Table" << std::endl;
       os << StringUtil::Indent(num_indent + 1)
          << StringUtil::Format("IF NOT EXISTS: %s",
-                               (if_not_exists) ? "True" : "False") << std::endl;
+                               (if_not_exists) ? "True" : "False")
+         << std::endl;
       os << StringUtil::Indent(num_indent + 1)
-         << StringUtil::Format("Table name: %s", GetTableName().c_str());;
+         << StringUtil::Format("Table name: %s", GetTableName().c_str());
+      ;
       break;
     }
     case CreateStatement::CreateType::kDatabase: {
@@ -61,7 +63,7 @@ const std::string CreateStatement::GetInfo(int num_indent) const {
     case CreateStatement::CreateType::kSchema: {
       os << "Create type: Schema" << std::endl;
       os << StringUtil::Indent(num_indent + 1)
-         << StringUtil::Format("Schema name: %s", schema_name.c_str());
+         << StringUtil::Format("Schema name: %s", GetSchemaName().c_str());
       break;
     }
     case CreateStatement::CreateType::kView: {
@@ -93,12 +95,13 @@ const std::string CreateStatement::GetInfo(int num_indent) const {
         }
       } else {
         os << StringUtil::Indent(num_indent + 1)
-           << "-> COLUMN REF : " << col->name << " "
+           << "-> COLUMN REF : " << col->name
+           << " "
            // << col->type << " not null : "
            << col->not_null << " primary : " << col->primary << " unique "
            << col->unique << " varlen " << col->varlen;
       }
-      os << std::endl;  
+      os << std::endl;
     }
   }
   std::string info = os.str();

--- a/src/parser/drop_statement.cpp
+++ b/src/parser/drop_statement.cpp
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "parser/drop_statement.h"
-#include "util/string_util.h"
-#include <sstream>
 #include <iostream>
+#include <sstream>
+#include "util/string_util.h"
 
 namespace peloton {
 namespace parser {
@@ -38,7 +38,7 @@ const std::string DropStatement::GetInfo(int num_indent) const {
     case kSchema: {
       os << "DropType: Schema\n";
       os << StringUtil::Indent(num_indent + 1)
-         << "Schema name: " << schema_name_;
+         << "Schema name: " << GetSchemaName();
       break;
     }
     case kIndex: {
@@ -61,7 +61,7 @@ const std::string DropStatement::GetInfo(int num_indent) const {
     case kTrigger: {
       os << "DropType: Trigger\n";
       os << StringUtil::Indent(num_indent + 1)
-         << "Trigger table name: " << table_name_of_trigger_ << std::endl;
+         << "Trigger table name: " << GetTableName() << std::endl;
       os << StringUtil::Indent(num_indent + 1)
          << "Trigger name: " << trigger_name_;
       break;

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -144,19 +144,17 @@ parser::TableRef *PostgresParser::RangeVarTransform(RangeVar *root) {
   parser::TableRef *result =
       new parser::TableRef(StringToTableReferenceType("name"));
   result->table_info_.reset(new parser::TableInfo());
-
-  if (root->schemaname) {
-    result->schema = root->schemaname;
-    result->table_info_->database_name = root->schemaname;
-  }
-
   // parse alias
   result->alias = AliasTransform(root->alias);
-
+  // add table name
   if (root->relname) {
     result->table_info_->table_name = root->relname;
   }
-
+  // add schema(namespace) name
+  if (root->schemaname) {
+    result->table_info_->schema_name = root->schemaname;
+  }
+  // add database name
   if (root->catalogname) {
     result->table_info_->database_name = root->catalogname;
   }
@@ -974,8 +972,11 @@ parser::SQLStatement *PostgresParser::CreateTransform(CreateStmt *root) {
     result->table_info_->table_name = relation->relname;
   }
   if (relation->schemaname) {
-    result->table_info_->database_name = relation->schemaname;
-  };
+    result->table_info_->schema_name = relation->schemaname;
+  }
+  if (relation->catalogname) {
+    result->table_info_->database_name = relation->catalogname;
+  }
 
   std::unordered_set<std::string> primary_keys;
   for (auto cell = root->tableElts->head; cell != nullptr; cell = cell->next) {
@@ -1213,6 +1214,8 @@ parser::SQLStatement *PostgresParser::CreateIndexTransform(IndexStmt *root) {
   }
   result->table_info_.reset(new TableInfo());
   result->table_info_->table_name = root->relation->relname;
+  if (root->relation->schemaname)
+    result->table_info_->schema_name = root->relation->schemaname;
   result->index_name = root->idxname;
   return result;
 }
@@ -1263,7 +1266,8 @@ parser::SQLStatement *PostgresParser::CreateTriggerTransform(
 
   result->table_info_.reset(new TableInfo());
   result->table_info_->table_name = root->relation->relname;
-
+  if (root->relation->schemaname)
+    result->table_info_->schema_name = root->relation->schemaname;
   result->trigger_name = root->trigname;
 
   return result;
@@ -1288,8 +1292,10 @@ parser::SQLStatement *PostgresParser::CreateSchemaTransform(
     CreateSchemaStmt *root) {
   parser::CreateStatement *result =
       new parser::CreateStatement(CreateStatement::kSchema);
+  result->table_info_.reset(new parser::TableInfo());
+
   if (root->schemaname != nullptr) {
-    result->schema_name = root->schemaname;
+    result->table_info_->schema_name = root->schemaname;
   }
   result->if_not_exists = root->if_not_exists;
   if (root->authrole != nullptr) {
@@ -1299,7 +1305,7 @@ parser::SQLStatement *PostgresParser::CreateSchemaTransform(
       // Peloton do not need the authrole, the only usage is when no schema name
       // is specified
       if (root->schemaname == nullptr) {
-        result->schema_name = role->rolename;
+        result->table_info_->schema_name = role->rolename;
       }
     } else {
       delete result;
@@ -1377,12 +1383,22 @@ parser::DropStatement *PostgresParser::DropDatabaseTransform(
 parser::DropStatement *PostgresParser::DropTableTransform(DropStmt *root) {
   auto result = new DropStatement(DropStatement::EntityType::kTable);
   result->SetMissing(root->missing_ok);
+
   for (auto cell = root->objects->head; cell != nullptr; cell = cell->next) {
     auto table_info = new TableInfo{};
     auto table_list = reinterpret_cast<List *>(cell->data.ptr_value);
     LOG_TRACE("%d", ((Node *)(table_list->head->data.ptr_value))->type);
-    table_info->table_name =
-        reinterpret_cast<value *>(table_list->head->data.ptr_value)->val.str;
+    // if schema name is specified
+    if (table_list->length == 2) {
+      table_info->schema_name =
+          reinterpret_cast<value *>(table_list->head->data.ptr_value)->val.str;
+      table_info->table_name =
+          reinterpret_cast<value *>(table_list->head->next->data.ptr_value)
+              ->val.str;
+    } else {
+      table_info->table_name =
+          reinterpret_cast<value *>(table_list->head->data.ptr_value)->val.str;
+    }
     result->table_info_.reset(table_info);
     break;
   }
@@ -1393,10 +1409,22 @@ parser::DropStatement *PostgresParser::DropTriggerTransform(DropStmt *root) {
   auto result = new DropStatement(DropStatement::EntityType::kTrigger);
   auto cell = root->objects->head;
   auto list = reinterpret_cast<List *>(cell->data.ptr_value);
-  result->SetTriggerTableName(
-      reinterpret_cast<value *>(list->head->data.ptr_value)->val.str);
+  // first, set trigger name
   result->SetTriggerName(
-      reinterpret_cast<value *>(list->head->next->data.ptr_value)->val.str);
+      reinterpret_cast<value *>(list->tail->data.ptr_value)->val.str);
+  // if schema name is specified
+  TableInfo *table_info = new TableInfo{};
+  if (list->length == 3) {
+    table_info->schema_name =
+        reinterpret_cast<value *>(list->head->data.ptr_value)->val.str;
+    table_info->table_name =
+        reinterpret_cast<value *>(list->head->next->data.ptr_value)->val.str;
+  } else if (list->length == 2) {
+    table_info->table_name =
+        reinterpret_cast<value *>(list->head->data.ptr_value)->val.str;
+  }
+
+  result->table_info_.reset(table_info);
   return result;
 }
 
@@ -1404,10 +1432,12 @@ parser::DropStatement *PostgresParser::DropSchemaTransform(DropStmt *root) {
   auto result = new DropStatement(DropStatement::EntityType::kSchema);
   result->SetCascade(root->behavior == DropBehavior::DROP_CASCADE);
   result->SetMissing(root->missing_ok);
+
+  result->table_info_.reset(new parser::TableInfo());
   for (auto cell = root->objects->head; cell != nullptr; cell = cell->next) {
     auto table_list = reinterpret_cast<List *>(cell->data.ptr_value);
-    result->SetSchemaName(
-        reinterpret_cast<value *>(table_list->head->data.ptr_value)->val.str);
+    result->table_info_->schema_name =
+        reinterpret_cast<value *>(table_list->head->data.ptr_value)->val.str;
     break;
   }
   return result;
@@ -1418,8 +1448,18 @@ parser::DropStatement *PostgresParser::DropIndexTransform(DropStmt *root) {
   auto result = new DropStatement(DropStatement::EntityType::kIndex);
   auto cell = root->objects->head;
   auto list = reinterpret_cast<List *>(cell->data.ptr_value);
-  result->SetIndexName(
-      reinterpret_cast<value *>(list->head->data.ptr_value)->val.str);
+  // if schema name is specified
+  if (list->length == 2) {
+    TableInfo *table_info = new TableInfo{};
+    table_info->schema_name =
+        reinterpret_cast<value *>(list->head->data.ptr_value)->val.str;
+    result->SetIndexName(
+        reinterpret_cast<value *>(list->head->next->data.ptr_value)->val.str);
+    result->table_info_.reset(table_info);
+  } else {
+    result->SetIndexName(
+        reinterpret_cast<value *>(list->head->data.ptr_value)->val.str);
+  }
   return result;
 }
 

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -973,8 +973,8 @@ parser::SQLStatement *PostgresParser::CreateTransform(CreateStmt *root) {
   if (relation->relname) {
     result->table_info_->table_name = relation->relname;
   }
-  if (relation->catalogname) {
-    result->table_info_->database_name = relation->catalogname;
+  if (relation->schemaname) {
+    result->table_info_->database_name = relation->schemaname;
   };
 
   std::unordered_set<std::string> primary_keys;

--- a/src/parser/postgresparser.cpp
+++ b/src/parser/postgresparser.cpp
@@ -1388,7 +1388,8 @@ parser::DropStatement *PostgresParser::DropTableTransform(DropStmt *root) {
     auto table_info = new TableInfo{};
     auto table_list = reinterpret_cast<List *>(cell->data.ptr_value);
     LOG_TRACE("%d", ((Node *)(table_list->head->data.ptr_value))->type);
-    // if schema name is specified
+    // if schema name is specified, which means you are using the syntax like
+    // DROP INDEX/TABLE A.B where A is schema name and B is table/index name
     if (table_list->length == 2) {
       table_info->schema_name =
           reinterpret_cast<value *>(table_list->head->data.ptr_value)->val.str;
@@ -1412,8 +1413,10 @@ parser::DropStatement *PostgresParser::DropTriggerTransform(DropStmt *root) {
   // first, set trigger name
   result->SetTriggerName(
       reinterpret_cast<value *>(list->tail->data.ptr_value)->val.str);
-  // if schema name is specified
   TableInfo *table_info = new TableInfo{};
+  // if schema name is specified, which means you are using the syntax like
+  // DROP TRIGGER A.B.C where A is schema name, B is table name and C is trigger
+  // name
   if (list->length == 3) {
     table_info->schema_name =
         reinterpret_cast<value *>(list->head->data.ptr_value)->val.str;
@@ -1448,7 +1451,8 @@ parser::DropStatement *PostgresParser::DropIndexTransform(DropStmt *root) {
   auto result = new DropStatement(DropStatement::EntityType::kIndex);
   auto cell = root->objects->head;
   auto list = reinterpret_cast<List *>(cell->data.ptr_value);
-  // if schema name is specified
+  // if schema name is specified, which means you are using the syntax like
+  // DROP INDEX/TABLE A.B where A is schema name and B is table/index name
   if (list->length == 2) {
     TableInfo *table_info = new TableInfo{};
     table_info->schema_name =

--- a/src/parser/table_ref.cpp
+++ b/src/parser/table_ref.cpp
@@ -22,6 +22,7 @@ const std::string TableRef::GetInfo(int num_indent) const {
   std::ostringstream os;
   switch (type) {
     case TableReferenceType::NAME:
+      os << StringUtil::Indent(num_indent) << GetSchemaName() << std::endl;
       os << StringUtil::Indent(num_indent) << GetTableName() << std::endl;
       break;
 

--- a/src/planner/analyze_plan.cpp
+++ b/src/planner/analyze_plan.cpp
@@ -12,41 +12,42 @@
 
 #include "planner/analyze_plan.h"
 
+#include "catalog/catalog.h"
 #include "parser/analyze_statement.h"
 #include "storage/data_table.h"
-#include "catalog/catalog.h"
 
 namespace peloton {
 namespace planner {
 
 AnalyzePlan::AnalyzePlan(storage::DataTable *table) : target_table_(table) {}
 
-AnalyzePlan::AnalyzePlan(std::string table_name,
+AnalyzePlan::AnalyzePlan(std::string table_name, std::string schema_name,
                          std::string database_name,
                          concurrency::TransactionContext *txn)
     : table_name_(table_name) {
   target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
-    database_name, table_name, txn);
+      database_name, schema_name, table_name, txn);
 }
 
-AnalyzePlan::AnalyzePlan(std::string table_name,
+AnalyzePlan::AnalyzePlan(std::string table_name, std::string schema_name,
                          std::string database_name,
                          std::vector<char *> column_names,
                          concurrency::TransactionContext *txn)
     : table_name_(table_name), column_names_(column_names) {
   target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
-    database_name, table_name, txn);
+      database_name, schema_name, table_name, txn);
 }
 
 AnalyzePlan::AnalyzePlan(parser::AnalyzeStatement *analyze_stmt,
                          concurrency::TransactionContext *txn) {
   table_name_ = analyze_stmt->GetTableName();
-  column_names_ = std::vector<char*>();
-  for (auto& name : analyze_stmt->GetColumnNames())
-    column_names_.push_back((char*)name.c_str());
+  column_names_ = std::vector<char *>();
+  for (auto &name : analyze_stmt->GetColumnNames())
+    column_names_.push_back((char *)name.c_str());
   if (!table_name_.empty()) {
     target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
-        analyze_stmt->GetDatabaseName(), table_name_, txn);
+        analyze_stmt->GetDatabaseName(), analyze_stmt->GetSchemaName(),
+        table_name_, txn);
   }
 }
 

--- a/src/planner/create_plan.cpp
+++ b/src/planner/create_plan.cpp
@@ -12,36 +12,45 @@
 
 #include "planner/create_plan.h"
 
-#include "expression/constant_value_expression.h"
-#include "storage/data_table.h"
 #include "common/internal_types.h"
 #include "expression/abstract_expression.h"
+#include "expression/constant_value_expression.h"
+#include "storage/data_table.h"
 
 namespace peloton {
 namespace planner {
 
 CreatePlan::CreatePlan(std::string database_name, CreateType c_type)
-    : database_name(database_name),
-      create_type(c_type) {}
+    : database_name(database_name), create_type(c_type) {}
 
-CreatePlan::CreatePlan(std::string table_name, std::string database_name,
+CreatePlan::CreatePlan(std::string table_name, std::string schema_name,
+                       std::string database_name,
                        std::unique_ptr<catalog::Schema> schema,
                        CreateType c_type)
     : table_name(table_name),
+      schema_name(schema_name),
       database_name(database_name),
       table_schema(schema.release()),
       create_type(c_type) {}
 
-CreatePlan::CreatePlan(parser::CreateStatement *parse_tree)
-{
+CreatePlan::CreatePlan(parser::CreateStatement *parse_tree) {
   switch (parse_tree->type) {
     case parser::CreateStatement::CreateType::kDatabase: {
       create_type = CreateType::DB;
       database_name = std::string(parse_tree->GetDatabaseName());
       break;
     }
+
+    case parser::CreateStatement::CreateType::kSchema: {
+      create_type = CreateType::SCHEMA;
+      database_name = std::string(parse_tree->GetDatabaseName());
+      schema_name = std::string(parse_tree->GetSchemaName());
+      break;
+    }
+
     case parser::CreateStatement::CreateType::kTable: {
       table_name = std::string(parse_tree->GetTableName());
+      schema_name = std::string(parse_tree->GetSchemaName());
       database_name = std::string(parse_tree->GetDatabaseName());
       std::vector<catalog::Column> columns;
       std::vector<catalog::Constraint> column_constraints;
@@ -56,74 +65,87 @@ CreatePlan::CreatePlan(parser::CreateStatement *parse_tree)
 
       for (auto &col : parse_tree->columns) {
         type::TypeId val = col->GetValueType(col->type);
-  
-        LOG_TRACE("Column name: %s.%s; Is primary key: %d", table_name.c_str(), col->name.c_str(), col->primary);
-  
+
+        LOG_TRACE("Column name: %s.%s; Is primary key: %d", table_name.c_str(),
+                  col->name.c_str(), col->primary);
+
         // Check main constraints
         if (col->primary) {
-          catalog::Constraint constraint(ConstraintType::PRIMARY, "con_primary");
+          catalog::Constraint constraint(ConstraintType::PRIMARY,
+                                         "con_primary");
           column_constraints.push_back(constraint);
-          LOG_TRACE("Added a primary key constraint on column \"%s.%s\"", table_name.c_str(), col->name.c_str());
+          LOG_TRACE("Added a primary key constraint on column \"%s.%s\"",
+                    table_name.c_str(), col->name.c_str());
         }
-  
+
         if (col->not_null) {
-          catalog::Constraint constraint(ConstraintType::NOTNULL, "con_not_null");
+          catalog::Constraint constraint(ConstraintType::NOTNULL,
+                                         "con_not_null");
           column_constraints.push_back(constraint);
-          LOG_TRACE("Added a not-null constraint on column \"%s.%s\"", table_name.c_str(), col->name.c_str());
+          LOG_TRACE("Added a not-null constraint on column \"%s.%s\"",
+                    table_name.c_str(), col->name.c_str());
         }
-  
+
         if (col->unique) {
           catalog::Constraint constraint(ConstraintType::UNIQUE, "con_unique");
           column_constraints.push_back(constraint);
-          LOG_TRACE("Added a unique constraint on column \"%s.%s\"", table_name.c_str(), col->name.c_str());
+          LOG_TRACE("Added a unique constraint on column \"%s.%s\"",
+                    table_name.c_str(), col->name.c_str());
         }
-  
+
         /* **************** */
-  
+
         // Add the default value
         if (col->default_value != nullptr) {
           // Referenced from insert_plan.cpp
-          if (col->default_value->GetExpressionType() != ExpressionType::VALUE_PARAMETER) {
+          if (col->default_value->GetExpressionType() !=
+              ExpressionType::VALUE_PARAMETER) {
             expression::ConstantValueExpression *const_expr_elem =
-              dynamic_cast<expression::ConstantValueExpression *>(col->default_value.get());
-  
-            catalog::Constraint constraint(ConstraintType::DEFAULT, "con_default");
+                dynamic_cast<expression::ConstantValueExpression *>(
+                    col->default_value.get());
+
+            catalog::Constraint constraint(ConstraintType::DEFAULT,
+                                           "con_default");
             type::Value v = const_expr_elem->GetValue();
             constraint.addDefaultValue(v);
             column_constraints.push_back(constraint);
             LOG_TRACE("Added a default constraint %s on column \"%s.%s\"",
-                      v.ToString().c_str(), table_name.c_str(), col->name.c_str());
+                      v.ToString().c_str(), table_name.c_str(),
+                      col->name.c_str());
           }
         }
-  
+
         // Check expression constraint
         // Currently only supports simple boolean forms like (a > 0)
         if (col->check_expression != nullptr) {
           // TODO: more expression types need to be supported
           if (col->check_expression->GetValueType() == type::TypeId::BOOLEAN) {
             catalog::Constraint constraint(ConstraintType::CHECK, "con_check");
-  
+
             const expression::ConstantValueExpression *const_expr_elem =
-              dynamic_cast<const expression::ConstantValueExpression *>(col->check_expression->GetChild(1));
-  
+                dynamic_cast<const expression::ConstantValueExpression *>(
+                    col->check_expression->GetChild(1));
+
             type::Value tmp_value = const_expr_elem->GetValue();
-            constraint.AddCheck(std::move(col->check_expression->GetExpressionType()), std::move(tmp_value));
+            constraint.AddCheck(
+                std::move(col->check_expression->GetExpressionType()),
+                std::move(tmp_value));
             column_constraints.push_back(constraint);
             LOG_TRACE("Added a check constraint on column \"%s.%s\"",
                       table_name.c_str(), col->name.c_str());
           }
         }
-  
+
         auto column = catalog::Column(val, type::Type::GetTypeSize(val),
                                       std::string(col->name), false);
         if (!column.IsInlined()) {
           column.SetLength(col->varlen);
         }
-  
+
         for (auto con : column_constraints) {
           column.AddConstraint(con);
         }
-  
+
         column_constraints.clear();
         columns.push_back(column);
       }
@@ -135,39 +157,42 @@ CreatePlan::CreatePlan(parser::CreateStatement *parse_tree)
       create_type = CreateType::INDEX;
       index_name = std::string(parse_tree->index_name);
       table_name = std::string(parse_tree->GetTableName());
+      schema_name = std::string(parse_tree->GetSchemaName());
       database_name = std::string(parse_tree->GetDatabaseName());
 
       // This holds the attribute names.
       // This is a fix for a bug where
       // The vector<char*>* items gets deleted when passed
       // To the Executor.
-  
+
       std::vector<std::string> index_attrs_holder;
-  
+
       for (auto &attr : parse_tree->index_attrs) {
         index_attrs_holder.push_back(attr);
       }
-  
+
       index_attrs = index_attrs_holder;
-  
+
       index_type = parse_tree->index_type;
-  
+
       unique = parse_tree->unique;
       break;
     }
+
     case parser::CreateStatement::CreateType::kTrigger: {
       create_type = CreateType::TRIGGER;
       trigger_name = std::string(parse_tree->trigger_name);
       table_name = std::string(parse_tree->GetTableName());
+      schema_name = std::string(parse_tree->GetSchemaName());
       database_name = std::string(parse_tree->GetDatabaseName());
-      
+
       if (parse_tree->trigger_when) {
         trigger_when.reset(parse_tree->trigger_when->Copy());
       } else {
         trigger_when.reset();
       }
       trigger_type = parse_tree->trigger_type;
-  
+
       for (auto &s : parse_tree->trigger_funcname) {
         trigger_funcname.push_back(s);
       }
@@ -182,23 +207,22 @@ CreatePlan::CreatePlan(parser::CreateStatement *parse_tree)
     }
     default:
       LOG_ERROR("UNKNOWN CREATE TYPE");
-      //TODO Should we handle this here?
+      // TODO Should we handle this here?
       break;
   }
-  
+
   // TODO check type CreateType::kDatabase
 }
 
-void CreatePlan::ProcessForeignKeyConstraint(const std::string &table_name,
-                                             const parser::ColumnDefinition *col) {
-
+void CreatePlan::ProcessForeignKeyConstraint(
+    const std::string &table_name, const parser::ColumnDefinition *col) {
   ForeignKeyInfo fkey_info;
 
   // Extract source and sink column names
-  for (auto& key : col->foreign_key_source) {
+  for (auto &key : col->foreign_key_source) {
     fkey_info.foreign_key_sources.push_back(key);
   }
-  for (auto& key : col->foreign_key_sink) {
+  for (auto &key : col->foreign_key_sink) {
     fkey_info.foreign_key_sinks.push_back(key);
   }
 

--- a/src/planner/drop_plan.cpp
+++ b/src/planner/drop_plan.cpp
@@ -32,8 +32,16 @@ DropPlan::DropPlan(parser::DropStatement *parse_tree) {
       drop_type = DropType::DB;
       break;
     }
+    case parser::DropStatement::EntityType::kSchema: {
+      database_name = parse_tree->GetDatabaseName();
+      schema_name = parse_tree->GetSchemaName();
+      missing = parse_tree->GetMissing();
+      drop_type = DropType::SCHEMA;
+      break;
+    }
     case parser::DropStatement::EntityType::kTable: {
       database_name = parse_tree->GetDatabaseName();
+      schema_name = parse_tree->GetSchemaName();
       table_name = parse_tree->GetTableName();
       missing = parse_tree->GetMissing();
       drop_type = DropType::TABLE;
@@ -43,6 +51,7 @@ DropPlan::DropPlan(parser::DropStatement *parse_tree) {
       // note parse_tree->table_name is different from
       // parse_tree->GetTableName()
       database_name = parse_tree->GetDatabaseName();
+      schema_name = parse_tree->GetSchemaName();
       table_name = std::string(parse_tree->GetTriggerTableName());
       trigger_name = std::string(parse_tree->GetTriggerName());
       drop_type = DropType::TRIGGER;
@@ -50,6 +59,7 @@ DropPlan::DropPlan(parser::DropStatement *parse_tree) {
     }
     case parser::DropStatement::EntityType::kIndex: {
       database_name = parse_tree->GetDatabaseName();
+      schema_name = parse_tree->GetSchemaName();
       index_name = std::string(parse_tree->GetIndexName());
       drop_type = DropType::INDEX;
       break;

--- a/src/planner/drop_plan.cpp
+++ b/src/planner/drop_plan.cpp
@@ -49,6 +49,7 @@ DropPlan::DropPlan(parser::DropStatement *parse_tree) {
       break;
     }
     case parser::DropStatement::EntityType::kIndex: {
+      database_name = parse_tree->GetDatabaseName();
       index_name = std::string(parse_tree->GetIndexName());
       drop_type = DropType::INDEX;
       break;

--- a/src/planner/plan_util.cpp
+++ b/src/planner/plan_util.cpp
@@ -69,9 +69,8 @@ const std::set<oid_t> PlanUtil::GetAffectedIndexes(
       db_name = update_stmt.table->GetDatabaseName();
       table_name = update_stmt.table->GetTableName();
       schema_name = update_stmt.table->GetSchemaName();
-      auto table_object =
-          catalog_cache.GetDatabaseObject(db_name)->GetTableObject(table_name,
-                                                                   schema_name);
+      auto table_object = catalog_cache.GetDatabaseObject(db_name)
+                              ->GetTableObject(table_name, schema_name);
 
       auto &update_clauses = update_stmt.updates;
       std::set<oid_t> update_oids;
@@ -169,10 +168,6 @@ const std::vector<col_triplet> PlanUtil::GetIndexableColumns(
             for (const auto expr : expr_set) {
               auto tuple_value_expr =
                   static_cast<const expression::TupleValueExpression *>(expr);
-
-              table_id =
-                  db_object->GetTableObject(tuple_value_expr->GetTableName())
-                      ->GetTableOid();
               column_oids.emplace_back(database_id, table_id,
                                        (oid_t)tuple_value_expr->GetColumnId());
             }

--- a/src/planner/plan_util.cpp
+++ b/src/planner/plan_util.cpp
@@ -45,10 +45,11 @@ const std::set<oid_t> PlanUtil::GetAffectedIndexes(
           static_cast<const parser::InsertStatement &>(sql_stmt);
       db_name = insert_stmt.GetDatabaseName();
       table_name = insert_stmt.GetTableName();
+      schema_name = insert_stmt.GetSchemaName();
     }
       PELOTON_FALLTHROUGH;
     case StatementType::DELETE: {
-      if (table_name.empty() || db_name.empty()) {
+      if (table_name.empty() || db_name.empty() || schema_name.empty()) {
         auto &delete_stmt =
             static_cast<const parser::DeleteStatement &>(sql_stmt);
         db_name = delete_stmt.GetDatabaseName();

--- a/src/statistics/backend_stats_context.cpp
+++ b/src/statistics/backend_stats_context.cpp
@@ -26,8 +26,8 @@
 namespace peloton {
 namespace stats {
 
-CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>>
-    &BackendStatsContext::GetBackendContextMap() {
+CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>> &
+BackendStatsContext::GetBackendContextMap() {
   static CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>>
       stats_context_map;
   return stats_context_map;
@@ -225,8 +225,9 @@ void BackendStatsContext::InitQueryMetric(
     const std::shared_ptr<QueryMetric::QueryParams> params) {
   CompleteQueryMetric();
   // TODO currently all queries belong to DEFAULT_DB
-  ongoing_query_metric_.reset(new QueryMetric(
-      MetricType::QUERY, statement->GetQueryString(), params, DEFAULT_DB_ID));
+  ongoing_query_metric_.reset(new QueryMetric(MetricType::QUERY,
+                                              statement->GetQueryString(),
+                                              params, CATALOG_DATABASE_OID));
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/statistics/backend_stats_context.cpp
+++ b/src/statistics/backend_stats_context.cpp
@@ -14,10 +14,10 @@
 
 #include <map>
 
-#include "common/internal_types.h"
-#include "common/statement.h"
 #include "catalog/catalog.h"
 #include "catalog/manager.h"
+#include "common/internal_types.h"
+#include "common/statement.h"
 #include "index/index.h"
 #include "statistics/stats_aggregator.h"
 #include "storage/storage_manager.h"
@@ -26,18 +26,18 @@
 namespace peloton {
 namespace stats {
 
-CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>>&
-BackendStatsContext::GetBackendContextMap() {
+CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>>
+    &BackendStatsContext::GetBackendContextMap() {
   static CuckooMap<std::thread::id, std::shared_ptr<BackendStatsContext>>
       stats_context_map;
   return stats_context_map;
 }
 
-BackendStatsContext* BackendStatsContext::GetInstance() {
+BackendStatsContext *BackendStatsContext::GetInstance() {
   // Each thread gets a backend stats context
   std::thread::id this_id = std::this_thread::get_id();
   std::shared_ptr<BackendStatsContext> result(nullptr);
-  auto& stats_context_map = GetBackendContextMap();
+  auto &stats_context_map = GetBackendContextMap();
   if (stats_context_map.Find(this_id, result) == false) {
     result.reset(new BackendStatsContext(LATENCY_MAX_HISTORY_THREAD, true));
     stats_context_map.Insert(this_id, result);
@@ -65,17 +65,19 @@ BackendStatsContext::~BackendStatsContext() {}
 //===--------------------------------------------------------------------===//
 
 // Returns the table metric with the given database ID and table ID
-TableMetric* BackendStatsContext::GetTableMetric(oid_t database_id,
+TableMetric *BackendStatsContext::GetTableMetric(oid_t database_id,
                                                  oid_t table_id) {
-  if (table_metrics_.find(table_id) == table_metrics_.end()) {
-    table_metrics_[table_id] = std::unique_ptr<TableMetric>(
+  // combine database_id and table_id to form unique key
+  uint64_t key = ((uint64_t)database_id << 32) | table_id;
+  if (table_metrics_.find(key) == table_metrics_.end()) {
+    table_metrics_[key] = std::unique_ptr<TableMetric>(
         new TableMetric{MetricType::TABLE, database_id, table_id});
   }
-  return table_metrics_[table_id].get();
+  return table_metrics_[key].get();
 }
 
 // Returns the database metric with the given database ID
-DatabaseMetric* BackendStatsContext::GetDatabaseMetric(oid_t database_id) {
+DatabaseMetric *BackendStatsContext::GetDatabaseMetric(oid_t database_id) {
   if (database_metrics_.find(database_id) == database_metrics_.end()) {
     database_metrics_[database_id] = std::unique_ptr<DatabaseMetric>(
         new DatabaseMetric{MetricType::DATABASE, database_id});
@@ -85,25 +87,26 @@ DatabaseMetric* BackendStatsContext::GetDatabaseMetric(oid_t database_id) {
 
 // Returns the index metric with the given database ID, table ID, and
 // index ID
-IndexMetric* BackendStatsContext::GetIndexMetric(oid_t database_id,
+IndexMetric *BackendStatsContext::GetIndexMetric(oid_t database_id,
                                                  oid_t table_id,
                                                  oid_t index_id) {
   std::shared_ptr<IndexMetric> index_metric;
+  uint64_t key = ((uint64_t)database_id << 32) | index_id;
   // Index metric doesn't exist yet
-  if (index_metrics_.Contains(index_id) == false) {
+  if (index_metrics_.Contains(key) == false) {
     index_metric.reset(
         new IndexMetric{MetricType::INDEX, database_id, table_id, index_id});
-    index_metrics_.Insert(index_id, index_metric);
+    index_metrics_.Insert(key, index_metric);
     index_id_lock.Lock();
-    index_ids_.insert(index_id);
+    index_ids_.insert(key);
     index_id_lock.Unlock();
   }
   // Get index metric from map
-  index_metrics_.Find(index_id, index_metric);
+  index_metrics_.Find(key, index_metric);
   return index_metric.get();
 }
 
-LatencyMetric& BackendStatsContext::GetTxnLatencyMetric() {
+LatencyMetric &BackendStatsContext::GetTxnLatencyMetric() {
   return txn_latencies_;
 }
 
@@ -164,7 +167,7 @@ void BackendStatsContext::IncrementTableDeletes(oid_t tile_group_id) {
 }
 
 void BackendStatsContext::IncrementIndexReads(size_t read_count,
-                                              index::IndexMetadata* metadata) {
+                                              index::IndexMetadata *metadata) {
   oid_t index_id = metadata->GetOid();
   oid_t table_id = metadata->GetTableOid();
   oid_t database_id = metadata->GetDatabaseOid();
@@ -174,7 +177,7 @@ void BackendStatsContext::IncrementIndexReads(size_t read_count,
 }
 
 void BackendStatsContext::IncrementIndexInserts(
-    index::IndexMetadata* metadata) {
+    index::IndexMetadata *metadata) {
   oid_t index_id = metadata->GetOid();
   oid_t table_id = metadata->GetTableOid();
   oid_t database_id = metadata->GetDatabaseOid();
@@ -184,7 +187,7 @@ void BackendStatsContext::IncrementIndexInserts(
 }
 
 void BackendStatsContext::IncrementIndexUpdates(
-    index::IndexMetadata* metadata) {
+    index::IndexMetadata *metadata) {
   oid_t index_id = metadata->GetOid();
   oid_t table_id = metadata->GetTableOid();
   oid_t database_id = metadata->GetDatabaseOid();
@@ -194,7 +197,7 @@ void BackendStatsContext::IncrementIndexUpdates(
 }
 
 void BackendStatsContext::IncrementIndexDeletes(
-    size_t delete_count, index::IndexMetadata* metadata) {
+    size_t delete_count, index::IndexMetadata *metadata) {
   oid_t index_id = metadata->GetOid();
   oid_t table_id = metadata->GetTableOid();
   oid_t database_id = metadata->GetDatabaseOid();
@@ -220,6 +223,7 @@ void BackendStatsContext::IncrementTxnAborted(oid_t database_id) {
 void BackendStatsContext::InitQueryMetric(
     const std::shared_ptr<Statement> statement,
     const std::shared_ptr<QueryMetric::QueryParams> params) {
+  CompleteQueryMetric();
   // TODO currently all queries belong to DEFAULT_DB
   ongoing_query_metric_.reset(new QueryMetric(
       MetricType::QUERY, statement->GetQueryString(), params, DEFAULT_DB_ID));
@@ -229,18 +233,18 @@ void BackendStatsContext::InitQueryMetric(
 // HELPER FUNCTIONS
 //===--------------------------------------------------------------------===//
 
-void BackendStatsContext::Aggregate(BackendStatsContext& source) {
+void BackendStatsContext::Aggregate(BackendStatsContext &source) {
   // Aggregate all global metrics
   txn_latencies_.Aggregate(source.txn_latencies_);
   txn_latencies_.ComputeLatencies();
 
   // Aggregate all per-database metrics
-  for (auto& database_item : source.database_metrics_) {
+  for (auto &database_item : source.database_metrics_) {
     GetDatabaseMetric(database_item.first)->Aggregate(*database_item.second);
   }
 
   // Aggregate all per-table metrics
-  for (auto& table_item : source.table_metrics_) {
+  for (auto &table_item : source.table_metrics_) {
     GetTableMetric(table_item.second->GetDatabaseId(),
                    table_item.second->GetTableId())
         ->Aggregate(*table_item.second);
@@ -268,10 +272,10 @@ void BackendStatsContext::Aggregate(BackendStatsContext& source) {
 void BackendStatsContext::Reset() {
   txn_latencies_.Reset();
 
-  for (auto& database_item : database_metrics_) {
+  for (auto &database_item : database_metrics_) {
     database_item.second->Reset();
   }
-  for (auto& table_item : table_metrics_) {
+  for (auto &table_item : table_metrics_) {
     table_item.second->Reset();
   }
   for (auto id : index_ids_) {
@@ -299,8 +303,9 @@ void BackendStatsContext::Reset() {
       auto table = database->GetTable(j);
       oid_t table_id = table->GetOid();
 
-      if (table_metrics_.find(table_id) == table_metrics_.end()) {
-        table_metrics_[table_id] = std::unique_ptr<TableMetric>(
+      uint64_t key = ((uint64_t)database_id << 32) | table_id;
+      if (table_metrics_.find(key) == table_metrics_.end()) {
+        table_metrics_[key] = std::unique_ptr<TableMetric>(
             new TableMetric{MetricType::TABLE, database_id, table_id});
       }
 
@@ -310,11 +315,13 @@ void BackendStatsContext::Reset() {
         auto index = table->GetIndex(k);
         if (index == nullptr) continue;
         oid_t index_id = index->GetOid();
-        if (index_metrics_.Contains(index_id) == false) {
-          std::shared_ptr<IndexMetric> index_metric(
-              new IndexMetric{MetricType::INDEX, database_id, table_id, index_id});
-          index_metrics_.Insert(index_id, index_metric);
-          index_ids_.insert(index_id);
+        // combine database_id and index_id to form unique key
+        uint64_t index_key = ((uint64_t)database_id << 32) | index_id;
+        if (index_metrics_.Contains(index_key) == false) {
+          std::shared_ptr<IndexMetric> index_metric(new IndexMetric{
+              MetricType::INDEX, database_id, table_id, index_id});
+          index_metrics_.Insert(index_key, index_metric);
+          index_ids_.insert(index_key);
         }
       }
     }
@@ -326,11 +333,11 @@ std::string BackendStatsContext::ToString() const {
 
   ss << txn_latencies_.GetInfo() << std::endl;
 
-  for (auto& database_item : database_metrics_) {
+  for (auto &database_item : database_metrics_) {
     oid_t database_id = database_item.second->GetDatabaseId();
     ss << database_item.second->GetInfo();
 
-    for (auto& table_item : table_metrics_) {
+    for (auto &table_item : table_metrics_) {
       if (table_item.second->GetDatabaseId() == database_id) {
         ss << table_item.second->GetInfo();
 

--- a/src/statistics/stats_aggregator.cpp
+++ b/src/statistics/stats_aggregator.cpp
@@ -172,11 +172,13 @@ void StatsAggregator::UpdateQueryMetrics(int64_t time_stamp,
     //     (int64_t)(cpu_system + cpu_user), time_stamp, pool_.get());
     // catalog::InsertTuple(query_metrics_table, std::move(query_tuple), txn);
 
-    catalog::QueryMetricsCatalog::GetInstance()->InsertQueryMetrics(
-        query_metric->GetName(), query_metric->GetDatabaseId(), num_params,
-        type_buf, format_buf, value_buf, reads, updates, deletes, inserts,
-        (int64_t)latency, (int64_t)(cpu_system + cpu_user), time_stamp,
-        pool_.get(), txn);
+    catalog::Catalog::GetInstance()
+        ->GetSystemCatalogs(query_metric->GetDatabaseId())
+        ->GetQueryMetricsCatalog()
+        ->InsertQueryMetrics(
+            query_metric->GetName(), num_params, type_buf, format_buf,
+            value_buf, reads, updates, deletes, inserts, (int64_t)latency,
+            (int64_t)(cpu_system + cpu_user), time_stamp, pool_.get(), txn);
 
     LOG_TRACE("Query Metric Tuple inserted");
   }

--- a/src/statistics/stats_aggregator.cpp
+++ b/src/statistics/stats_aggregator.cpp
@@ -14,6 +14,7 @@
 #include <cinttypes>
 
 #include "catalog/catalog.h"
+#include "catalog/system_catalogs.h"
 #include "catalog/database_metrics_catalog.h"
 #include "catalog/index_metrics_catalog.h"
 #include "catalog/query_metrics_catalog.h"
@@ -205,6 +206,12 @@ void StatsAggregator::UpdateMetrics() {
 
     // Update database metrics table
     auto database_oid = database->GetOid();
+    try {
+      catalog::Catalog::GetInstance()->GetDatabaseObject(database_oid, txn);
+    } catch (CatalogException &e) {
+      continue;
+    }
+
     auto database_metric = aggregated_stats_.GetDatabaseMetric(database_oid);
     auto txn_committed = database_metric->GetTxnCommitted().GetCounter();
     auto txn_aborted = database_metric->GetTxnAborted().GetCounter();

--- a/src/statistics/stats_aggregator.cpp
+++ b/src/statistics/stats_aggregator.cpp
@@ -14,11 +14,8 @@
 #include <cinttypes>
 
 #include "catalog/catalog.h"
-#include "catalog/system_catalogs.h"
 #include "catalog/database_metrics_catalog.h"
-#include "catalog/index_metrics_catalog.h"
-#include "catalog/query_metrics_catalog.h"
-#include "catalog/table_metrics_catalog.h"
+#include "catalog/system_catalogs.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "index/index.h"
 #include "storage/storage_manager.h"
@@ -205,7 +202,7 @@ void StatsAggregator::UpdateMetrics() {
     auto database = storage_manager->GetDatabaseWithOffset(database_offset);
 
     // Update database metrics table
-    auto database_oid = database->GetOid();
+    oid_t database_oid = database->GetOid();
     try {
       catalog::Catalog::GetInstance()->GetDatabaseObject(database_oid, txn);
     } catch (CatalogException &e) {
@@ -326,7 +323,7 @@ void StatsAggregator::RegisterContext(std::thread::id id_,
     thread_number_++;
     backend_stats_[id_] = context_;
   }
-  LOG_DEBUG("Stats aggregator hash map size: %ld", backend_stats_.size());
+  // LOG_DEBUG("Stats aggregator hash map size: %ld", backend_stats_.size());
 }
 
 // Unregister a BackendStatsContext. Currently we directly reuse the thread id

--- a/src/statistics/stats_aggregator.cpp
+++ b/src/statistics/stats_aggregator.cpp
@@ -172,9 +172,10 @@ void StatsAggregator::UpdateQueryMetrics(int64_t time_stamp,
         ->GetSystemCatalogs(query_metric->GetDatabaseId())
         ->GetQueryMetricsCatalog()
         ->InsertQueryMetrics(
-            query_metric->GetName(), num_params, type_buf, format_buf,
-            value_buf, reads, updates, deletes, inserts, (int64_t)latency,
-            (int64_t)(cpu_system + cpu_user), time_stamp, pool_.get(), txn);
+            query_metric->GetName(), query_metric->GetDatabaseId(), num_params,
+            type_buf, format_buf, value_buf, reads, updates, deletes, inserts,
+            (int64_t)latency, (int64_t)(cpu_system + cpu_user), time_stamp,
+            pool_.get(), txn);
 
     LOG_TRACE("Query Metric Tuple inserted");
   }

--- a/src/statistics/stats_aggregator.cpp
+++ b/src/statistics/stats_aggregator.cpp
@@ -161,13 +161,6 @@ void StatsAggregator::UpdateQueryMetrics(int64_t time_stamp,
     }
 
     // Generate and insert the tuple
-    // auto query_tuple = catalog::GetQueryMetricsCatalogTuple(
-    //     query_metrics_table->GetSchema(), query_metric->GetName(),
-    //     query_metric->GetDatabaseId(), num_params, type_buf, format_buf,
-    //     value_buf, reads, updates, deletes, inserts, (int64_t)latency,
-    //     (int64_t)(cpu_system + cpu_user), time_stamp, pool_.get());
-    // catalog::InsertTuple(query_metrics_table, std::move(query_tuple), txn);
-
     catalog::Catalog::GetInstance()
         ->GetSystemCatalogs(query_metric->GetDatabaseId())
         ->GetQueryMetricsCatalog()

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -67,7 +67,6 @@ DataTable::DataTable(catalog::Schema *schema, const std::string &table_name,
       tuples_per_tilegroup_(tuples_per_tilegroup),
       adapt_table_(adapt_table),
       trigger_list_(new trigger::TriggerList()) {
-
   // Init default partition
   auto col_count = schema->GetColumnCount();
   for (oid_t col_itr = 0; col_itr < col_count; col_itr++) {
@@ -341,16 +340,17 @@ ItemPointer DataTable::InsertTuple(const storage::Tuple *tuple,
     return INVALID_ITEMPOINTER;
   }
 
-  auto result = InsertTuple(tuple, location, transaction, index_entry_ptr, check_fk);
+  auto result =
+      InsertTuple(tuple, location, transaction, index_entry_ptr, check_fk);
   if (result == false) {
     return INVALID_ITEMPOINTER;
   }
   return location;
 }
 
-bool DataTable::InsertTuple(const AbstractTuple *tuple,
-    ItemPointer location, concurrency::TransactionContext *transaction,
-    ItemPointer **index_entry_ptr, bool check_fk) {
+bool DataTable::InsertTuple(const AbstractTuple *tuple, ItemPointer location,
+                            concurrency::TransactionContext *transaction,
+                            ItemPointer **index_entry_ptr, bool check_fk) {
   if (CheckConstraints(tuple) == false) {
     LOG_TRACE("InsertTuple(): Constraint violated");
     return false;
@@ -501,10 +501,10 @@ bool DataTable::InsertInIndexes(const AbstractTuple *tuple,
   return true;
 }
 
-bool DataTable::InsertInSecondaryIndexes(const AbstractTuple *tuple,
-                                         const TargetList *targets_ptr,
-                                         concurrency::TransactionContext *transaction,
-                                         ItemPointer *index_entry_ptr) {
+bool DataTable::InsertInSecondaryIndexes(
+    const AbstractTuple *tuple, const TargetList *targets_ptr,
+    concurrency::TransactionContext *transaction,
+    ItemPointer *index_entry_ptr) {
   int index_count = GetIndexCount();
   // Transform the target list into a hash set
   // when attempting to perform insertion to a secondary index,
@@ -571,10 +571,11 @@ bool DataTable::InsertInSecondaryIndexes(const AbstractTuple *tuple,
 }
 
 /**
- * @brief This function checks any other table which has a foreign key constraint
+ * @brief This function checks any other table which has a foreign key
+ *constraint
  * referencing the current table, where a tuple is updated/deleted. The final
  * result depends on the type of cascade action.
- * 
+ *
  * @param prev_tuple: The tuple which will be updated/deleted in the current
  * table
  * @param new_tuple: The new tuple after update. This parameter is ignored
@@ -582,17 +583,16 @@ bool DataTable::InsertInSecondaryIndexes(const AbstractTuple *tuple,
  * @param current_txn: The current transaction context
  * @param context: The executor context passed from upper level
  * @param is_update: whether this is a update action (false means delete)
- * 
- * @return True if the check is successful (nothing happens) or the cascade operation
+ *
+ * @return True if the check is successful (nothing happens) or the cascade
+ *operation
  * is done properly. Otherwise returns false. Note that the transaction result
  * is not set in this function.
- */ 
-bool DataTable::CheckForeignKeySrcAndCascade(storage::Tuple *prev_tuple, 
-                                             storage::Tuple *new_tuple,
-                                             concurrency::TransactionContext *current_txn,
-                                             executor::ExecutorContext *context,
-                                             bool is_update)
-{
+ */
+bool DataTable::CheckForeignKeySrcAndCascade(
+    storage::Tuple *prev_tuple, storage::Tuple *new_tuple,
+    concurrency::TransactionContext *current_txn,
+    executor::ExecutorContext *context, bool is_update) {
   size_t fk_count = GetForeignKeySrcCount();
 
   if (fk_count == 0) return true;
@@ -602,7 +602,7 @@ bool DataTable::CheckForeignKeySrcAndCascade(storage::Tuple *prev_tuple,
 
   for (size_t iter = 0; iter < fk_count; iter++) {
     catalog::ForeignKey *fk = GetForeignKeySrc(iter);
-    
+
     // Check if any row in the source table references the current tuple
     oid_t source_table_id = fk->GetSourceTableOid();
     storage::DataTable *src_table = nullptr;
@@ -621,18 +621,17 @@ bool DataTable::CheckForeignKeySrcAndCascade(storage::Tuple *prev_tuple,
 
       // Make sure this is the right index to search in
       if (index->GetMetadata()->GetName().find("_FK_") != std::string::npos &&
-          index->GetMetadata()->GetKeyAttrs() == fk->GetSourceColumnIds())
-      {
-        LOG_DEBUG("Searching in source tables's fk index...\n"); 
+          index->GetMetadata()->GetKeyAttrs() == fk->GetSourceColumnIds()) {
+        LOG_DEBUG("Searching in source tables's fk index...\n");
 
         std::vector<oid_t> key_attrs = fk->GetSourceColumnIds();
         std::unique_ptr<catalog::Schema> fk_schema(
-          catalog::Schema::CopySchema(src_table->GetSchema(), key_attrs));
+            catalog::Schema::CopySchema(src_table->GetSchema(), key_attrs));
         std::unique_ptr<storage::Tuple> key(
-          new storage::Tuple(fk_schema.get(), true));
-        
+            new storage::Tuple(fk_schema.get(), true));
+
         key->SetFromTuple(prev_tuple, fk->GetSinkColumnIds(), index->GetPool());
-        
+
         std::vector<ItemPointer *> location_ptrs;
         index->ScanKey(key.get(), location_ptrs);
 
@@ -644,8 +643,8 @@ bool DataTable::CheckForeignKeySrcAndCascade(storage::Tuple *prev_tuple,
             auto src_tile_group_header = src_tile_group->GetHeader();
 
             auto visibility = transaction_manager.IsVisible(
-              current_txn, src_tile_group_header, ptr->offset,
-              VisibilityIdType::COMMIT_ID);
+                current_txn, src_tile_group_header, ptr->offset,
+                VisibilityIdType::COMMIT_ID);
 
             if (visibility != VisibilityType::OK) continue;
 
@@ -655,32 +654,34 @@ bool DataTable::CheckForeignKeySrcAndCascade(storage::Tuple *prev_tuple,
               case FKConstrActionType::RESTRICT: {
                 return false;
               }
-              case FKConstrActionType::CASCADE: 
+              case FKConstrActionType::CASCADE:
               default: {
                 // Update
-                bool src_is_owner = transaction_manager.IsOwner(current_txn,
-                    src_tile_group_header, ptr->offset);
+                bool src_is_owner = transaction_manager.IsOwner(
+                    current_txn, src_tile_group_header, ptr->offset);
 
-                // Read the referencing tuple, update the read timestamp so that we can
+                // Read the referencing tuple, update the read timestamp so that
+                // we can
                 // delete it later
-                bool ret = transaction_manager.PerformRead(current_txn,
-                                                            *ptr,
-                                                            true);
+                bool ret =
+                    transaction_manager.PerformRead(current_txn, *ptr, true);
 
                 if (ret == false) {
                   if (src_is_owner) {
-                    transaction_manager.YieldOwnership(current_txn, src_tile_group_header,
-                                                        ptr->offset);
+                    transaction_manager.YieldOwnership(
+                        current_txn, src_tile_group_header, ptr->offset);
                   }
                   return false;
                 }
 
-                ContainerTuple<storage::TileGroup> src_old_tuple(src_tile_group.get(), ptr->offset);
+                ContainerTuple<storage::TileGroup> src_old_tuple(
+                    src_tile_group.get(), ptr->offset);
                 storage::Tuple src_new_tuple(src_table->GetSchema(), true);
 
                 if (is_update) {
-                  for (oid_t col_itr = 0; col_itr < src_table->GetSchema()->GetColumnCount(); col_itr++)
-                  {
+                  for (oid_t col_itr = 0;
+                       col_itr < src_table->GetSchema()->GetColumnCount();
+                       col_itr++) {
                     type::Value val = src_old_tuple.GetValue(col_itr);
                     src_new_tuple.SetValue(col_itr, val, context->GetPool());
                   }
@@ -690,8 +691,8 @@ bool DataTable::CheckForeignKeySrcAndCascade(storage::Tuple *prev_tuple,
                     auto src_col_index = key_attrs[k];
                     auto sink_col_index = fk->GetSinkColumnIds()[k];
                     src_new_tuple.SetValue(src_col_index,
-                                          new_tuple->GetValue(sink_col_index),
-                                          context->GetPool());
+                                           new_tuple->GetValue(sink_col_index),
+                                           context->GetPool());
                   }
                 }
 
@@ -699,16 +700,13 @@ bool DataTable::CheckForeignKeySrcAndCascade(storage::Tuple *prev_tuple,
 
                 if (new_loc.IsNull()) {
                   if (src_is_owner == false) {
-                    transaction_manager.YieldOwnership(current_txn,
-                                                        src_tile_group_header,
-                                                        ptr->offset);
+                    transaction_manager.YieldOwnership(
+                        current_txn, src_tile_group_header, ptr->offset);
                   }
                   return false;
                 }
 
-                transaction_manager.PerformDelete(current_txn,
-                                                  *ptr,
-                                                  new_loc);
+                transaction_manager.PerformDelete(current_txn, *ptr, new_loc);
 
                 // For delete cascade, just stop here
                 if (is_update == false) {
@@ -716,14 +714,15 @@ bool DataTable::CheckForeignKeySrcAndCascade(storage::Tuple *prev_tuple,
                 }
 
                 ItemPointer *index_entry_ptr = nullptr;
-                peloton::ItemPointer location =
-                    src_table->InsertTuple(&src_new_tuple, current_txn, &index_entry_ptr, false);
+                peloton::ItemPointer location = src_table->InsertTuple(
+                    &src_new_tuple, current_txn, &index_entry_ptr, false);
 
                 if (location.block == INVALID_OID) {
                   return false;
                 }
 
-                transaction_manager.PerformInsert(current_txn, location, index_entry_ptr);
+                transaction_manager.PerformInsert(current_txn, location,
+                                                  index_entry_ptr);
 
                 break;
               }
@@ -755,8 +754,7 @@ bool DataTable::CheckForeignKeySrcAndCascade(storage::Tuple *prev_tuple,
  * @returns True on success, false if any foreign key constraints fail
  */
 bool DataTable::CheckForeignKeyConstraints(
-    const AbstractTuple *tuple,
-    concurrency::TransactionContext *transaction) {
+    const AbstractTuple *tuple, concurrency::TransactionContext *transaction) {
   for (auto foreign_key : foreign_keys_) {
     oid_t sink_table_id = foreign_key->GetSinkTableOid();
     storage::DataTable *ref_table = nullptr;
@@ -781,7 +779,8 @@ bool DataTable::CheckForeignKeyConstraints(
             catalog::Schema::CopySchema(ref_table->schema, key_attrs));
         std::unique_ptr<storage::Tuple> key(
             new storage::Tuple(foreign_key_schema.get(), true));
-        key->SetFromTuple(tuple, foreign_key->GetSourceColumnIds(), index->GetPool());
+        key->SetFromTuple(tuple, foreign_key->GetSourceColumnIds(),
+                          index->GetPool());
 
         LOG_TRACE("check key: %s", key->GetInfo().c_str());
         std::vector<ItemPointer *> location_ptrs;
@@ -790,8 +789,7 @@ bool DataTable::CheckForeignKeyConstraints(
         // if this key doesn't exist in the referred column
         if (location_ptrs.size() == 0) {
           LOG_DEBUG("The key: %s does not exist in table %s\n",
-                    key->GetInfo().c_str(),
-                    ref_table->GetInfo().c_str());
+                    key->GetInfo().c_str(), ref_table->GetInfo().c_str());
           return false;
         }
 
@@ -800,17 +798,17 @@ bool DataTable::CheckForeignKeyConstraints(
         auto tile_group_header = tile_group->GetHeader();
 
         auto &transaction_manager =
-          concurrency::TransactionManagerFactory::GetInstance();
+            concurrency::TransactionManagerFactory::GetInstance();
         auto visibility = transaction_manager.IsVisible(
-          transaction, tile_group_header, location_ptrs[0]->offset,
-          VisibilityIdType::READ_ID);
+            transaction, tile_group_header, location_ptrs[0]->offset,
+            VisibilityIdType::READ_ID);
 
         if (visibility != VisibilityType::OK) {
-          LOG_DEBUG("The key: %s is not yet visible in table %s, visibility "
-                    "type: %s.\n",
-                    key->GetInfo().c_str(),
-                    ref_table->GetInfo().c_str(),
-                    VisibilityTypeToString(visibility).c_str());
+          LOG_DEBUG(
+              "The key: %s is not yet visible in table %s, visibility "
+              "type: %s.\n",
+              key->GetInfo().c_str(), ref_table->GetInfo().c_str(),
+              VisibilityTypeToString(visibility).c_str());
           return false;
         }
 
@@ -1405,16 +1403,19 @@ trigger::TriggerList *DataTable::GetTriggerList() {
   return trigger_list_.get();
 }
 
-void DataTable::UpdateTriggerListFromCatalog(concurrency::TransactionContext *txn) {
-  trigger_list_ =
-      catalog::TriggerCatalog::GetInstance().GetTriggers(table_oid, txn);
+void DataTable::UpdateTriggerListFromCatalog(
+    concurrency::TransactionContext *txn) {
+  trigger_list_ = catalog::Catalog::GetInstance()
+                      .GetSystemCatalogs(database_oid)
+                      .GetTriggerCatalog()
+                      .GetTriggers(table_oid, txn);
 }
 
 hash_t DataTable::Hash() const {
   auto oid = GetOid();
   hash_t hash = HashUtil::Hash(&oid);
-  hash = HashUtil::CombineHashes(hash, HashUtil::HashBytes(GetName().c_str(),
-                                                           GetName().length()));
+  hash = HashUtil::CombineHashes(
+      hash, HashUtil::HashBytes(GetName().c_str(), GetName().length()));
   auto db_oid = GetOid();
   hash = HashUtil::CombineHashes(hash, HashUtil::Hash(&db_oid));
   return hash;
@@ -1425,12 +1426,9 @@ bool DataTable::Equals(const storage::DataTable &other) const {
 }
 
 bool DataTable::operator==(const DataTable &rhs) const {
-  if (GetName() != rhs.GetName())
-    return false;
-  if (GetDatabaseOid() != rhs.GetDatabaseOid())
-    return false;
-  if (GetOid() != rhs.GetOid())
-    return false;
+  if (GetName() != rhs.GetName()) return false;
+  if (GetDatabaseOid() != rhs.GetDatabaseOid()) return false;
+  if (GetOid() != rhs.GetOid()) return false;
   return true;
 }
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -13,11 +13,9 @@
 #include <mutex>
 #include <utility>
 
-#include "tuning/clusterer.h"
-#include "tuning/sample.h"
+#include "catalog/catalog.h"
 #include "catalog/foreign_key.h"
-#include "catalog/table_catalog.h"
-#include "catalog/trigger_catalog.h"
+#include "catalog/system_catalogs.h"
 #include "common/container_tuple.h"
 #include "common/exception.h"
 #include "common/logger.h"
@@ -37,6 +35,8 @@
 #include "storage/tile_group_factory.h"
 #include "storage/tile_group_header.h"
 #include "storage/tuple.h"
+#include "tuning/clusterer.h"
+#include "tuning/sample.h"
 
 //===--------------------------------------------------------------------===//
 // Configuration Variables
@@ -1406,9 +1406,9 @@ trigger::TriggerList *DataTable::GetTriggerList() {
 void DataTable::UpdateTriggerListFromCatalog(
     concurrency::TransactionContext *txn) {
   trigger_list_ = catalog::Catalog::GetInstance()
-                      .GetSystemCatalogs(database_oid)
-                      .GetTriggerCatalog()
-                      .GetTriggers(table_oid, txn);
+                      ->GetSystemCatalogs(database_oid)
+                      ->GetTriggerCatalog()
+                      ->GetTriggers(table_oid, txn);
 }
 
 hash_t DataTable::Hash() const {
@@ -1432,5 +1432,5 @@ bool DataTable::operator==(const DataTable &rhs) const {
   return true;
 }
 
-}  // End storage namespace
-}  // End peloton namespace
+}  // namespace storage
+}  // namespace peloton

--- a/src/storage/database.cpp
+++ b/src/storage/database.cpp
@@ -67,14 +67,6 @@ storage::DataTable *Database::GetTableWithOid(const oid_t table_oid) const {
   return nullptr;
 }
 
-storage::DataTable *Database::GetTableWithName(
-    const std::string &table_name) const {
-  for (auto table : tables)
-    if (table->GetName() == table_name) return table;
-  throw CatalogException("Table '" + table_name + "' does not exist");
-  return nullptr;
-}
-
 void Database::DropTableWithOid(const oid_t table_oid) {
   {
     std::lock_guard<std::mutex> lock(database_mutex);

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -420,8 +420,8 @@ void TrafficCop::GetTableColumns(parser::TableRef *from_table,
       auto columns =
           static_cast<storage::DataTable *>(
               catalog::Catalog::GetInstance()->GetTableWithName(
-                  from_table->GetDatabaseName(), from_table->GetTableName(),
-                  GetCurrentTxnState().first))
+                  from_table->GetDatabaseName(), from_table->GetSchemaName(),
+                  from_table->GetTableName(), GetCurrentTxnState().first))
               ->GetSchema()
               ->GetColumns();
       target_columns.insert(target_columns.end(), columns.begin(),

--- a/src/tuning/index_tuner.cpp
+++ b/src/tuning/index_tuner.cpp
@@ -14,22 +14,22 @@
 #include <algorithm>
 #include "tuning/brain_util.h"
 
-#include "concurrency/transaction_manager_factory.h"
-#include "tuning/clusterer.h"
 #include "catalog/catalog.h"
 #include "catalog/schema.h"
 #include "common/container_tuple.h"
 #include "common/logger.h"
 #include "common/macros.h"
 #include "common/timer.h"
+#include "concurrency/transaction_manager_factory.h"
 #include "index/index_factory.h"
 #include "storage/data_table.h"
 #include "storage/tile_group.h"
+#include "tuning/clusterer.h"
 
 namespace peloton {
 namespace tuning {
 
-IndexTuner& IndexTuner::GetInstance() {
+IndexTuner &IndexTuner::GetInstance() {
   static IndexTuner index_tuner;
   return index_tuner;
 }
@@ -52,7 +52,7 @@ void IndexTuner::Start() {
 }
 
 // Add an ad-hoc index
-static void AddIndex(storage::DataTable* table,
+static void AddIndex(storage::DataTable *table,
                      std::set<oid_t> suggested_index_attrs) {
   // Construct index metadata
   std::vector<oid_t> key_attrs(suggested_index_attrs.size());
@@ -63,8 +63,8 @@ static void AddIndex(storage::DataTable* table,
   auto index_oid = index_count + 1;
 
   auto tuple_schema = table->GetSchema();
-  catalog::Schema* key_schema;
-  index::IndexMetadata* index_metadata;
+  catalog::Schema *key_schema;
+  index::IndexMetadata *index_metadata;
   bool unique;
 
   key_schema = catalog::Schema::CopySchema(tuple_schema, key_attrs);
@@ -91,7 +91,7 @@ static void AddIndex(storage::DataTable* table,
   LOG_DEBUG("Creating index : %s", index_metadata->GetInfo().c_str());
 }
 
-void IndexTuner::BuildIndex(storage::DataTable* table,
+void IndexTuner::BuildIndex(storage::DataTable *table,
                             std::shared_ptr<index::Index> index) {
   auto table_schema = table->GetSchema();
   auto index_tile_group_offset = index->GetIndexedTileGroupOff();
@@ -137,7 +137,7 @@ void IndexTuner::BuildIndex(storage::DataTable* table,
   tile_groups_indexed_ += tile_groups_indexed;
 }
 
-void IndexTuner::BuildIndices(storage::DataTable* table) {
+void IndexTuner::BuildIndices(storage::DataTable *table) {
   oid_t index_count = table->GetIndexCount();
 
   for (oid_t index_itr = 0; index_itr < index_count; index_itr++) {
@@ -153,7 +153,7 @@ void IndexTuner::BuildIndices(storage::DataTable* table) {
 }
 
 double IndexTuner::ComputeWorkloadWriteRatio(
-    const std::vector<tuning::Sample>& samples) {
+    const std::vector<tuning::Sample> &samples) {
   double write_ratio = 0;
 
   double total_read_duration = 0;
@@ -198,7 +198,7 @@ bool SampleFrequencyMapEntryComparator(sample_frequency_map_entry a,
 }
 
 std::vector<sample_frequency_map_entry> GetFrequentSamples(
-    const std::vector<tuning::Sample>& samples) {
+    const std::vector<tuning::Sample> &samples) {
   std::unordered_map<tuning::Sample, double> sample_frequency_map;
   double total_weight = 0;
 
@@ -253,7 +253,7 @@ std::vector<sample_frequency_map_entry> GetFrequentSamples(
 }
 
 std::vector<std::vector<double>> GetSuggestedIndices(
-    const std::vector<sample_frequency_map_entry>& list) {
+    const std::vector<sample_frequency_map_entry> &list) {
   // Find frequent samples
   size_t frequency_rank_threshold = 10;
 
@@ -264,8 +264,8 @@ std::vector<std::vector<double>> GetSuggestedIndices(
   for (size_t entry_itr = 0;
        (entry_itr < frequency_rank_threshold) && (entry_itr < list_size);
        entry_itr++) {
-    auto& entry = list[entry_itr];
-    auto& sample = entry.first;
+    auto &entry = list[entry_itr];
+    auto &sample = entry.first;
     LOG_TRACE("%s Utility : %.2lf", sample.GetInfo().c_str(), entry.second);
     suggested_indices.push_back(sample.GetColumnsAccessed());
   }
@@ -275,14 +275,14 @@ std::vector<std::vector<double>> GetSuggestedIndices(
 
 double GetCurrentIndexUtility(
     std::set<oid_t> suggested_index_set,
-    const std::vector<sample_frequency_map_entry>& list) {
+    const std::vector<sample_frequency_map_entry> &list) {
   double current_index_utility = 0;
   auto list_size = list.size();
 
   for (size_t entry_itr = 0; entry_itr < list_size; entry_itr++) {
-    auto& entry = list[entry_itr];
-    auto& sample = entry.first;
-    auto& columns = sample.GetColumnsAccessed();
+    auto &entry = list[entry_itr];
+    auto &sample = entry.first;
+    auto &columns = sample.GetColumnsAccessed();
 
     std::set<oid_t> columns_set(columns.begin(), columns.end());
 
@@ -296,7 +296,7 @@ double GetCurrentIndexUtility(
   return current_index_utility;
 }
 
-void IndexTuner::DropIndexes(storage::DataTable* table) {
+void IndexTuner::DropIndexes(storage::DataTable *table) {
   oid_t index_count = table->GetIndexCount();
 
   // Go over indices
@@ -326,8 +326,8 @@ void IndexTuner::DropIndexes(storage::DataTable* table) {
 }
 
 void IndexTuner::AddIndexes(
-    storage::DataTable* table,
-    const std::vector<std::vector<double>>& suggested_indices) {
+    storage::DataTable *table,
+    const std::vector<std::vector<double>> &suggested_indices) {
   oid_t valid_index_count = table->GetValidIndexCount();
   size_t constructed_index_itr = 0;
 
@@ -384,8 +384,8 @@ void IndexTuner::AddIndexes(
   }
 }
 
-void UpdateIndexUtility(storage::DataTable* table,
-                        const std::vector<sample_frequency_map_entry>& list) {
+void UpdateIndexUtility(storage::DataTable *table,
+                        const std::vector<sample_frequency_map_entry> &list) {
   oid_t index_count = table->GetIndexCount();
 
   for (oid_t index_itr = 0; index_itr < index_count; index_itr++) {
@@ -422,7 +422,7 @@ void UpdateIndexUtility(storage::DataTable* table,
   }
 }
 
-void PrintIndexInformation(storage::DataTable* table) {
+void PrintIndexInformation(storage::DataTable *table) {
   oid_t index_count = table->GetIndexCount();
   auto table_tilegroup_count = table->GetTileGroupCount();
   LOG_INFO("Index count : %u", table->GetValidIndexCount());
@@ -448,7 +448,7 @@ void PrintIndexInformation(storage::DataTable* table) {
   }
 }
 
-void IndexTuner::Analyze(storage::DataTable* table) {
+void IndexTuner::Analyze(storage::DataTable *table) {
   // Process all samples in table
   auto samples = table->GetIndexSamples();
 
@@ -492,7 +492,7 @@ void IndexTuner::Analyze(storage::DataTable* table) {
   PrintIndexInformation(table);
 }
 
-void IndexTuner::IndexTuneHelper(storage::DataTable* table) {
+void IndexTuner::IndexTuneHelper(storage::DataTable *table) {
   // Process all samples in table
   auto samples = table->GetIndexSamples();
   auto sample_count = samples.size();
@@ -563,7 +563,7 @@ void IndexTuner::Stop() {
   LOG_INFO("Stopped index tuner");
 }
 
-void IndexTuner::AddTable(storage::DataTable* table) {
+void IndexTuner::AddTable(storage::DataTable *table) {
   {
     std::lock_guard<std::mutex> lock(index_tuner_mutex);
     tables.push_back(table);
@@ -577,7 +577,7 @@ void IndexTuner::ClearTables() {
   }
 }
 
-void IndexTuner::BootstrapTPCC(const std::string& path) {
+void IndexTuner::BootstrapTPCC(const std::string &path) {
   // Enable visibility mode
   SetVisibilityMode();
 
@@ -595,12 +595,13 @@ void IndexTuner::BootstrapTPCC(const std::string& path) {
     auto samples = table_samples.second;
 
     // Locate table in catalog
-    auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     auto txn = txn_manager.BeginTransaction();
-    auto table = catalog->GetTableWithName(database_name, table_name, txn);
+    auto table = catalog->GetTableWithName(
+        database_name, std::string(DEFUALT_SCHEMA_NAME), table_name, txn);
     txn_manager.CommitTransaction(txn);
     PELOTON_ASSERT(table != nullptr);
-    for (auto& sample : samples) {
+    for (auto &sample : samples) {
       table->RecordIndexSample(sample);
     }
     LOG_INFO("Added table to index tuner : %s", table_name.c_str());
@@ -611,11 +612,11 @@ void IndexTuner::BootstrapTPCC(const std::string& path) {
 }
 
 // Load statistics for Index Tuner from a file
-void LoadStatsFromFile(const std::string& path) {
+void LoadStatsFromFile(const std::string &path) {
   LOG_INFO("LoadStatsFromFile Invoked");
 
   // Get index tuner
-  auto& index_tuner = tuning::IndexTuner::GetInstance();
+  auto &index_tuner = tuning::IndexTuner::GetInstance();
 
   // Set duration between pauses
   auto duration = 30000;  // in ms
@@ -627,5 +628,5 @@ void LoadStatsFromFile(const std::string& path) {
   return;
 }
 
-}  // namespace indextuner
+}  // namespace tuning
 }  // namespace peloton

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -28,11 +28,11 @@
 #include "sql/testing_sql_util.h"
 #include "type/value_factory.h"
 
+using std::make_shared;
+using std::make_tuple;
 using std::string;
 using std::unique_ptr;
 using std::vector;
-using std::make_tuple;
-using std::make_shared;
 
 namespace peloton {
 namespace test {
@@ -128,10 +128,14 @@ TEST_F(BinderCorrectnessTest, SelectStatementTest) {
 
   oid_t db_oid =
       catalog_ptr->GetDatabaseWithName(default_database_name, txn)->GetOid();
-  oid_t tableA_oid =
-      catalog_ptr->GetTableWithName(default_database_name, "a", txn)->GetOid();
-  oid_t tableB_oid =
-      catalog_ptr->GetTableWithName(default_database_name, "b", txn)->GetOid();
+  oid_t tableA_oid = catalog_ptr
+                         ->GetTableWithName(default_database_name,
+                                            DEFUALT_SCHEMA_NAME, "a", txn)
+                         ->GetOid();
+  oid_t tableB_oid = catalog_ptr
+                         ->GetTableWithName(default_database_name,
+                                            DEFUALT_SCHEMA_NAME, "b", txn)
+                         ->GetOid();
   txn_manager.CommitTransaction(txn);
 
   // Check select_list
@@ -257,8 +261,10 @@ TEST_F(BinderCorrectnessTest, DeleteStatementTest) {
   auto txn = txn_manager.BeginTransaction();
   oid_t db_oid =
       catalog_ptr->GetDatabaseWithName(default_database_name, txn)->GetOid();
-  oid_t tableB_oid =
-      catalog_ptr->GetTableWithName(default_database_name, "b", txn)->GetOid();
+  oid_t tableB_oid = catalog_ptr
+                         ->GetTableWithName(default_database_name,
+                                            DEFUALT_SCHEMA_NAME, "b", txn)
+                         ->GetOid();
 
   string deleteSQL = "DELETE FROM b WHERE 1 = b1 AND b2 = 'str'";
   unique_ptr<binder::BindNodeVisitor> binder(

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -42,7 +42,6 @@ class BinderCorrectnessTest : public PelotonTest {
     PelotonTest::SetUp();
     catalog::Catalog::GetInstance();
     // NOTE: Catalog::GetInstance()->Bootstrap(), you can only call it once!
-    // catalog->Bootstrap();
     TestingExecutorUtil::InitializeDatabase(DEFAULT_DB_NAME);
   }
 

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -102,7 +102,7 @@ void SetupTables(std::string database_name) {
 }
 
 TEST_F(BinderCorrectnessTest, SelectStatementTest) {
-  std::string default_database_name = "TEST_DB";
+  std::string default_database_name = "test_db";
   SetupTables(default_database_name);
   auto &parser = parser::PostgresParser::GetInstance();
   catalog::Catalog *catalog_ptr = catalog::Catalog::GetInstance();
@@ -246,7 +246,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementTest) {
 // test after UpdateStatement is changed
 
 TEST_F(BinderCorrectnessTest, DeleteStatementTest) {
-  std::string default_database_name = "TEST_DB";
+  std::string default_database_name = "test_db";
   SetupTables(default_database_name);
   auto &parser = parser::PostgresParser::GetInstance();
   catalog::Catalog *catalog_ptr = catalog::Catalog::GetInstance();
@@ -286,7 +286,7 @@ TEST_F(BinderCorrectnessTest, DeleteStatementTest) {
 }
 
 TEST_F(BinderCorrectnessTest, BindDepthTest) {
-  std::string default_database_name = "TEST_DB";
+  std::string default_database_name = "test_db";
   SetupTables(default_database_name);
   auto &parser = parser::PostgresParser::GetInstance();
 

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -17,16 +17,16 @@
 #include "common/harness.h"
 #include "common/statement.h"
 #include "concurrency/transaction_manager_factory.h"
-#include "expression/tuple_value_expression.h"
-#include "expression/subquery_expression.h"
 #include "expression/function_expression.h"
+#include "expression/subquery_expression.h"
+#include "expression/tuple_value_expression.h"
 #include "optimizer/optimizer.h"
 #include "parser/postgresparser.h"
 #include "traffic_cop/traffic_cop.h"
 
+#include "executor/testing_executor_util.h"
 #include "sql/testing_sql_util.h"
 #include "type/value_factory.h"
-#include "executor/testing_executor_util.h"
 
 using std::string;
 using std::unique_ptr;
@@ -40,8 +40,9 @@ namespace test {
 class BinderCorrectnessTest : public PelotonTest {
   virtual void SetUp() override {
     PelotonTest::SetUp();
-    auto catalog = catalog::Catalog::GetInstance();
-    catalog->Bootstrap();
+    catalog::Catalog::GetInstance();
+    // NOTE: Catalog::GetInstance()->Bootstrap(), you can only call it once!
+    // catalog->Bootstrap();
     TestingExecutorUtil::InitializeDatabase(DEFAULT_DB_NAME);
   }
 
@@ -106,6 +107,7 @@ TEST_F(BinderCorrectnessTest, SelectStatementTest) {
   SetupTables(default_database_name);
   auto &parser = parser::PostgresParser::GetInstance();
   catalog::Catalog *catalog_ptr = catalog::Catalog::GetInstance();
+  catalog_ptr->Bootstrap();
 
   // Test regular table name
   LOG_INFO("Parsing sql query");
@@ -344,7 +346,8 @@ TEST_F(BinderCorrectnessTest, BindDepthTest) {
       in_sub_expr_select_where_right->GetChild(1);
   auto in_sub_expr_select_where_right_sub_select =
       dynamic_cast<const expression::SubqueryExpression *>(
-          in_sub_expr_select_where_right_sub)->GetSubSelect();
+          in_sub_expr_select_where_right_sub)
+          ->GetSubSelect();
   auto in_sub_expr_select_where_right_sub_select_where =
       in_sub_expr_select_where_right_sub_select->where_clause.get();
   auto in_sub_expr_select_where_right_sub_select_ele =

--- a/test/brain/query_logger_test.cpp
+++ b/test/brain/query_logger_test.cpp
@@ -13,8 +13,8 @@
 #include "common/harness.h"
 
 #include "brain/query_logger.h"
-#include "sql/testing_sql_util.h"
 #include "settings/settings_manager.h"
+#include "sql/testing_sql_util.h"
 
 namespace peloton {
 namespace test {
@@ -27,7 +27,8 @@ class QueryLoggerTests : public PelotonTest {
 
     // query to check that logging is done
     select_query_ =
-        "SELECT query_string, fingerprint FROM pg_catalog.pg_query_history;";
+        "SELECT query_string, fingerprint FROM "
+        "peloton.pg_catalog.pg_query_history;";
 
     brain::QueryLogger::Fingerprint fingerprint{select_query_};
     select_query_fingerprint_ = fingerprint.GetFingerprint();

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -93,8 +93,6 @@ TEST_F(CatalogTests, CreatingTable) {
   std::unique_ptr<type::AbstractPool> pool(new type::EphemeralPool());
   catalog::DatabaseMetricsCatalog::GetInstance()->InsertDatabaseMetrics(
       2, 3, 4, 5, pool.get(), txn);
-  //   oid_t time_stamp =
-  //       catalog::DatabaseMetricsCatalog::GetInstance()->GetTimeStamp(2, txn);
 
   // inset meaningless tuple into QUERY_METRICS_CATALOG and check
   stats::QueryMetric::QueryParamBuf param;
@@ -210,9 +208,9 @@ TEST_F(CatalogTests, DroppingTable) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   auto catalog = catalog::Catalog::GetInstance();
-  // everytime we create a database, there will be 3 catalog tables inside
+  // NOTE: everytime we create a database, there will be 7 catalog tables inside
   EXPECT_EQ(
-      6,
+      10,
       (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
   auto database_object =
       catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
@@ -225,7 +223,7 @@ TEST_F(CatalogTests, DroppingTable) {
   auto department_table_object =
       database_object->GetTableObject("department_table");
   EXPECT_EQ(
-      5,
+      9,
       (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
   txn_manager.CommitTransaction(txn);
 
@@ -236,9 +234,9 @@ TEST_F(CatalogTests, DroppingTable) {
   EXPECT_THROW(catalog::Catalog::GetInstance()->DropTable(
                    "emp_db", "department_table", txn),
                CatalogException);
-
+  //
   EXPECT_EQ(
-      5,
+      9,
       (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
   txn_manager.CommitTransaction(txn);
 
@@ -248,7 +246,7 @@ TEST_F(CatalogTests, DroppingTable) {
       catalog::Catalog::GetInstance()->DropTable("emp_db", "void_table", txn),
       CatalogException);
   EXPECT_EQ(
-      5,
+      9,
       (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
   txn_manager.CommitTransaction(txn);
 
@@ -256,7 +254,7 @@ TEST_F(CatalogTests, DroppingTable) {
   txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->DropTable("emp_db", "emp_table", txn);
   EXPECT_EQ(
-      4,
+      8,
       (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
   txn_manager.CommitTransaction(txn);
 }

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -101,11 +101,17 @@ TEST_F(CatalogTests, CreatingTable) {
   param.len = 1;
   param.buf = (unsigned char *)pool->Allocate(1);
   *param.buf = 'a';
-  catalog::QueryMetricsCatalog::GetInstance()->InsertQueryMetrics(
-      "a query", 1, 1, param, param, param, 1, 1, 1, 1, 1, 1, 1, pool.get(),
-      txn);
-  auto param1 = catalog::QueryMetricsCatalog::GetInstance()->GetParamTypes(
-      "a query", 1, txn);
+  auto database_object =
+      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
+  catalog::Catalog::GetInstance()
+      ->GetSystemCatalogs(database_object->GetDatabaseOid())
+      ->GetQueryMetricsCatalog()
+      ->InsertQueryMetrics("a query", 1, param, param, param, 1, 1, 1, 1, 1, 1,
+                           1, pool.get(), txn);
+  auto param1 = catalog::Catalog::GetInstance()
+                    ->GetSystemCatalogs(database_object->GetDatabaseOid())
+                    ->GetQueryMetricsCatalog()
+                    ->GetParamTypes("a query", txn);
   EXPECT_EQ(1, param1.len);
   EXPECT_EQ('a', *param1.buf);
 

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -100,8 +100,9 @@ TEST_F(CatalogTests, CreatingTable) {
   catalog::Catalog::GetInstance()
       ->GetSystemCatalogs(database_object->GetDatabaseOid())
       ->GetQueryMetricsCatalog()
-      ->InsertQueryMetrics("a query", 1, param, param, param, 1, 1, 1, 1, 1, 1,
-                           1, pool.get(), txn);
+      ->InsertQueryMetrics("a query", database_object->GetDatabaseOid(), 1,
+                           param, param, param, 1, 1, 1, 1, 1, 1, 1, pool.get(),
+                           txn);
   auto param1 = catalog::Catalog::GetInstance()
                     ->GetSystemCatalogs(database_object->GetDatabaseOid())
                     ->GetQueryMetricsCatalog()

--- a/test/catalog/constraints_test.cpp
+++ b/test/catalog/constraints_test.cpp
@@ -10,20 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "sql/testing_sql_util.h"
 #include "gtest/gtest.h"
+#include "sql/testing_sql_util.h"
 
 #include "catalog/testing_constraints_util.h"
 
-#include "common/internal_types.h"
 #include "catalog/catalog.h"
-#include "concurrency/testing_transaction_util.h"
-#include "planner/plan_util.h"
-#include "planner/create_plan.h"
-#include "executor/executors.h"
 #include "catalog/foreign_key.h"
-#include "parser/postgresparser.h"
+#include "common/internal_types.h"
+#include "concurrency/testing_transaction_util.h"
+#include "executor/executors.h"
 #include "optimizer/optimizer.h"
+#include "parser/postgresparser.h"
+#include "planner/create_plan.h"
+#include "planner/plan_util.h"
 
 #define DEFAULT_VALUE 11111
 
@@ -54,12 +54,13 @@ TEST_F(ConstraintsTests, NOTNULLTest) {
   // Set all of the columns to be NOT NULL
   std::vector<std::vector<catalog::Constraint>> constraints;
   for (int i = 0; i < CONSTRAINTS_NUM_COLS; i++) {
-    constraints.push_back({ catalog::Constraint(ConstraintType::NOTNULL,
-                                                "notnull_constraint") });
+    constraints.push_back(
+        {catalog::Constraint(ConstraintType::NOTNULL, "notnull_constraint")});
   }
   std::vector<catalog::MultiConstraint> multi_constraints;
   storage::DataTable *data_table =
-      TestingConstraintsUtil::CreateAndPopulateTable(constraints, multi_constraints);
+      TestingConstraintsUtil::CreateAndPopulateTable(constraints,
+                                                     multi_constraints);
 
   // Bootstrap
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
@@ -68,14 +69,12 @@ TEST_F(ConstraintsTests, NOTNULLTest) {
       type::ValueFactory::GetIntegerValue(1),
       type::ValueFactory::GetIntegerValue(22),
       type::ValueFactory::GetDecimalValue(3.33),
-      type::ValueFactory::GetVarcharValue("4444")
-  };
+      type::ValueFactory::GetVarcharValue("4444")};
   std::vector<type::Value> null_values = {
       type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER),
       type::ValueFactory::GetNullValueByType(type::TypeId::INTEGER),
       type::ValueFactory::GetNullValueByType(type::TypeId::DECIMAL),
-      type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR)
-  };
+      type::ValueFactory::GetNullValueByType(type::TypeId::VARCHAR)};
 
   // Test1: Insert a tuple with column that satisfies the requirement
   auto txn = txn_manager.BeginTransaction();
@@ -103,8 +102,8 @@ TEST_F(ConstraintsTests, NOTNULLTest) {
     }
     EXPECT_TRUE(hasException);
     txn_manager.CommitTransaction(txn);
-  } // FOR
-  
+  }  // FOR
+
   // free the database just created
   txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
@@ -120,22 +119,23 @@ TEST_F(ConstraintsTests, DEFAULTTEST) {
     // COL_A
     if (i == 0) {
       constraints.push_back(
-          { catalog::Constraint(ConstraintType::PRIMARY, "pkey") });
+          {catalog::Constraint(ConstraintType::PRIMARY, "pkey")});
     }
     // COL_B
     else if (i == 1) {
       catalog::Constraint default_const(ConstraintType::DEFAULT, "default");
       default_const.addDefaultValue(
           type::ValueFactory::GetIntegerValue(DEFAULT_VALUE));
-      constraints.push_back({ });
+      constraints.push_back({});
     }
     // COL_C + COL_D
     else {
-      constraints.push_back({ });
+      constraints.push_back({});
     }
   }
   std::vector<catalog::MultiConstraint> multi_constraints;
-  TestingConstraintsUtil::CreateAndPopulateTable(constraints, multi_constraints);
+  TestingConstraintsUtil::CreateAndPopulateTable(constraints,
+                                                 multi_constraints);
 
   // Bootstrap
   std::vector<ResultValue> result;
@@ -146,17 +146,17 @@ TEST_F(ConstraintsTests, DEFAULTTEST) {
   // Test1: Insert a tuple without the second column defined
   // It should get set with the default value
   std::string sql = StringUtil::Format(
-                    "INSERT INTO %s (col_a, col_c, col_d) "
-                    "VALUES (9999, 2.2, 'xxx');", CONSTRAINTS_TEST_TABLE);
-  auto status = TestingSQLUtil::ExecuteSQLQuery(
-      sql, result, tuple_descriptor, rows_affected, error_message
-  );
+      "INSERT INTO %s (col_a, col_c, col_d) "
+      "VALUES (9999, 2.2, 'xxx');",
+      CONSTRAINTS_TEST_TABLE);
+  auto status = TestingSQLUtil::ExecuteSQLQuery(sql, result, tuple_descriptor,
+                                                rows_affected, error_message);
   EXPECT_EQ(ResultType::SUCCESS, status);
 
   sql = StringUtil::Format("SELECT col_d FROM %s WHERE col_a = 9999",
                            CONSTRAINTS_TEST_TABLE);
-  status = TestingSQLUtil::ExecuteSQLQuery(
-      sql, result, tuple_descriptor, rows_affected, error_message);
+  status = TestingSQLUtil::ExecuteSQLQuery(sql, result, tuple_descriptor,
+                                           rows_affected, error_message);
   EXPECT_EQ(ResultType::SUCCESS, status);
   std::string resultStr = TestingSQLUtil::GetResultValueAsString(result, 0);
   LOG_INFO("OUTPUT:\n%s", resultStr.c_str());
@@ -179,7 +179,8 @@ TEST_F(ConstraintsTests, CHECKTest) {
   type::Value tmp_value = type::ValueFactory::GetIntegerValue(0);
   constraints.AddCheck(ExpressionType::COMPARE_GREATERTHAN, tmp_value);
   column1.AddConstraint(constraints);
-  LOG_DEBUG("%s %s", peloton::DOUBLE_STAR.c_str(), constraints.GetInfo().c_str());
+  LOG_DEBUG("%s %s", peloton::DOUBLE_STAR.c_str(),
+            constraints.GetInfo().c_str());
   catalog::Schema *table_schema = new catalog::Schema({column1});
   std::string table_name("TEST_TABLE");
   bool own_schema = true;
@@ -230,15 +231,17 @@ TEST_F(ConstraintsTests, UNIQUETest) {
 
   auto constraints = catalog::Constraint(ConstraintType::UNIQUE, "unique1");
   column1.AddConstraint(constraints);
-  LOG_DEBUG("%s %s", peloton::DOUBLE_STAR.c_str(), constraints.GetInfo().c_str());
+  LOG_DEBUG("%s %s", peloton::DOUBLE_STAR.c_str(),
+            constraints.GetInfo().c_str());
   std::unique_ptr<catalog::Schema> table_schema(
       new catalog::Schema({column1, column2}));
   std::string table_name("TEST_TABLE");
-  catalog::Catalog::GetInstance()->CreateTable(DEFAULT_DB_NAME, table_name,
+  catalog::Catalog::GetInstance()->CreateTable(DEFAULT_DB_NAME,
+                                               DEFUALT_SCHEMA_NAME, table_name,
                                                std::move(table_schema), txn);
+  storage::DataTable *table = catalog::Catalog::GetInstance()->GetTableWithName(
+      DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, table_name, txn);
   txn_manager.CommitTransaction(txn);
-  storage::Database *database = catalog->GetDatabaseWithName(DEFAULT_DB_NAME);
-  storage::DataTable *table = database->GetTableWithName(table_name);
 
   // table->AddUNIQUEIndex();
 
@@ -288,7 +291,7 @@ TEST_F(ConstraintsTests, UNIQUETest) {
 }
 #endif
 
-//TEST_F(ConstraintsTests, MULTIUNIQUETest) {
+// TEST_F(ConstraintsTests, MULTIUNIQUETest) {
 //  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
 //  auto catalog = catalog::Catalog::GetInstance();
 //  auto txn = txn_manager.BeginTransaction();
@@ -368,7 +371,7 @@ TEST_F(ConstraintsTests, UNIQUETest) {
 //  txn_manager.CommitTransaction(txn);
 //}
 
-//TEST_F(ConstraintsTests, ForeignKeySingleInsertTest) {
+// TEST_F(ConstraintsTests, ForeignKeySingleInsertTest) {
 //  // First, initial 2 tables like following
 //  //     TABLE A -- src table          TABLE B -- sink table
 //  // a int(primary, ref B)  b int      b int(primary)  c int
@@ -393,8 +396,9 @@ TEST_F(ConstraintsTests, UNIQUETest) {
 //
 //  auto constraints = catalog::Constraint(ConstraintType::PRIMARY, "primary1");
 //  column1.AddConstraint(constraints);
-//  LOG_DEBUG("%s %s", peloton::DOUBLE_STAR.c_str(), constraints.GetInfo().c_str());
-//  std::unique_ptr<catalog::Schema> tableA_schema(
+//  LOG_DEBUG("%s %s", peloton::DOUBLE_STAR.c_str(),
+//  constraints.GetInfo().c_str()); std::unique_ptr<catalog::Schema>
+//  tableA_schema(
 //      new catalog::Schema({column1, column2}));
 //
 //  catalog->CreateTable(db_name, table_a_name, std::move(tableA_schema), txn);
@@ -413,9 +417,10 @@ TEST_F(ConstraintsTests, UNIQUETest) {
 //  auto table_b = catalog->GetTableWithName(db_name, table_b_name);
 //
 //  oid_t sink_table_id = table_b->GetOid();
-//  std::vector<oid_t> sink_col_ids = { table_b->GetSchema()->GetColumnID("b") };
-//  std::vector<oid_t> source_col_ids = { table_a->GetSchema()->GetColumnID("a") };
-//  catalog::ForeignKey *foreign_key = new catalog::ForeignKey(
+//  std::vector<oid_t> sink_col_ids = { table_b->GetSchema()->GetColumnID("b")
+//  }; std::vector<oid_t> source_col_ids = {
+//  table_a->GetSchema()->GetColumnID("a") }; catalog::ForeignKey *foreign_key =
+//  new catalog::ForeignKey(
 //      sink_table_id, sink_col_ids, source_col_ids,
 //      FKConstrActionType::NOACTION,
 //      FKConstrActionType::NOACTION,
@@ -463,7 +468,7 @@ TEST_F(ConstraintsTests, UNIQUETest) {
 //  delete foreign_key;
 //}
 
-//TEST_F(ConstraintsTests, ForeignKeyMultiInsertTest) {
+// TEST_F(ConstraintsTests, ForeignKeyMultiInsertTest) {
 //  // First, initial 2 tables like following
 //  //     TABLE A -- src table          TABLE B -- sink table
 //  // a int(primary, ref B)  b int      b int(primary)  c int
@@ -498,7 +503,8 @@ TEST_F(ConstraintsTests, UNIQUETest) {
 //  cols.push_back(0);
 //  cols.push_back(1);
 //  auto mc =
-//      catalog::MultiConstraint(ConstraintType::PRIMARY, "multiprimary1", cols);
+//      catalog::MultiConstraint(ConstraintType::PRIMARY, "multiprimary1",
+//      cols);
 //  LOG_DEBUG("%s MULTI CONSTRAINTS %s %s", peloton::DOUBLE_STAR.c_str(),
 // peloton::DOUBLE_STAR.c_str(), mc.GetInfo().c_str());
 //
@@ -514,9 +520,10 @@ TEST_F(ConstraintsTests, UNIQUETest) {
 //
 //  // Create foreign key tableA.B -> tableB.B
 //  oid_t sink_table_id = table_b->GetOid();
-//  std::vector<oid_t> sink_col_ids = { table_b->GetSchema()->GetColumnID("b") };
-//  std::vector<oid_t> source_col_ids = { table_a->GetSchema()->GetColumnID("b") };
-//  catalog::ForeignKey *foreign_key = new catalog::ForeignKey(
+//  std::vector<oid_t> sink_col_ids = { table_b->GetSchema()->GetColumnID("b")
+//  }; std::vector<oid_t> source_col_ids = {
+//  table_a->GetSchema()->GetColumnID("b") }; catalog::ForeignKey *foreign_key =
+//  new catalog::ForeignKey(
 //      sink_table_id, sink_col_ids, source_col_ids,
 //      FKConstrActionType::RESTRICT,
 //      FKConstrActionType::CASCADE,

--- a/test/codegen/bloom_filter_test.cpp
+++ b/test/codegen/bloom_filter_test.cpp
@@ -18,10 +18,10 @@
 #include "codegen/codegen.h"
 #include "codegen/counting_consumer.h"
 #include "codegen/function_builder.h"
-#include "codegen/query_parameters.h"
 #include "codegen/lang/if.h"
 #include "codegen/lang/loop.h"
 #include "codegen/proxy/bloom_filter_proxy.h"
+#include "codegen/query_parameters.h"
 #include "codegen/testing_codegen_util.h"
 #include "codegen/util/bloom_filter.h"
 #include "common/timer.h"
@@ -167,7 +167,7 @@ TEST_F(BloomFilterCodegenTest, FalsePositiveRateTest) {
 
   ASSERT_TRUE(code_context.Compile());
 
-  typedef void (*ftype)(codegen::util::BloomFilter *bloom_filter, int *, int,
+  typedef void (*ftype)(codegen::util::BloomFilter * bloom_filter, int *, int,
                         int *);
   ftype f = (ftype)code_context.GetRawFunctionPointer(func.GetFunction());
 
@@ -213,7 +213,8 @@ TEST_F(BloomFilterCodegenTest, PerformanceTest) {
   int curr_size = 0;
   std::vector<int> numbers;
   std::unordered_set<int> number_set;
-  auto *table1 = catalog->GetTableWithName(DEFAULT_DB_NAME, table1_name, txn);
+  auto *table1 = catalog->GetTableWithName(DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME,
+                                           table1_name, txn);
   while (curr_size < table1_target_size) {
     // Find a unique random number
     int random;
@@ -233,7 +234,8 @@ TEST_F(BloomFilterCodegenTest, PerformanceTest) {
   LOG_INFO("Finish populating test1");
 
   // Load the inner table which contains twice tuples as the outer table
-  auto *table2 = catalog->GetTableWithName(DEFAULT_DB_NAME, table2_name, txn);
+  auto *table2 = catalog->GetTableWithName(DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME,
+                                           table2_name, txn);
   unsigned outer_table_cardinality = numbers.size() * outer_to_inner_ratio;
   for (unsigned i = 0; i < outer_table_cardinality; i++) {
     int number;
@@ -332,7 +334,7 @@ void BloomFilterCodegenTest::CreateTable(std::string table_name, int tuple_size,
   }
   auto *catalog = catalog::Catalog::GetInstance();
   catalog->CreateTable(
-      DEFAULT_DB_NAME, table_name,
+      DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, table_name,
       std::unique_ptr<catalog::Schema>(new catalog::Schema(cols)), txn);
 }
 

--- a/test/codegen/query_cache_test.cpp
+++ b/test/codegen/query_cache_test.cpp
@@ -29,8 +29,6 @@
 namespace peloton {
 namespace test {
 
-constexpr int CACHE_USED_BY_CATALOG = 4;
-
 class QueryCacheTest : public PelotonCodeGenTest {
  public:
   QueryCacheTest() : PelotonCodeGenTest(), num_rows_to_insert(64) {
@@ -210,6 +208,8 @@ class QueryCacheTest : public PelotonCodeGenTest {
 };
 
 TEST_F(QueryCacheTest, SimpleCache) {
+  int CACHE_USED_BY_CATALOG = codegen::QueryCache::Instance().GetCount();
+
   // SELECT b FROM table where a >= 40;
   std::shared_ptr<planner::SeqScanPlan> scan1 = GetSeqScanPlan();
   std::shared_ptr<planner::SeqScanPlan> scan2 = GetSeqScanPlan();
@@ -254,6 +254,8 @@ TEST_F(QueryCacheTest, SimpleCache) {
 }
 
 TEST_F(QueryCacheTest, CacheSeqScanPlan) {
+  int CACHE_USED_BY_CATALOG = codegen::QueryCache::Instance().GetCount();
+
   // SELECT a, b, c FROM table where a >= 20 and b = 21;
   auto scan1 = GetSeqScanPlanWithPredicate();
   auto scan2 = GetSeqScanPlanWithPredicate();
@@ -304,6 +306,8 @@ TEST_F(QueryCacheTest, CacheSeqScanPlan) {
 }
 
 TEST_F(QueryCacheTest, CacheHashJoinPlan) {
+  int CACHE_USED_BY_CATALOG = codegen::QueryCache::Instance().GetCount();
+
   auto hj_plan1 = GetHashJoinPlan();
   auto hj_plan_2 = GetHashJoinPlan();
 
@@ -363,6 +367,8 @@ TEST_F(QueryCacheTest, CacheHashJoinPlan) {
 }
 
 TEST_F(QueryCacheTest, CacheOrderByPlan) {
+  int CACHE_USED_BY_CATALOG = codegen::QueryCache::Instance().GetCount();
+
   // plan 1, 2: SELECT * FROM test_table ORDER BY b DESC a ASC;
   // plan 3: SELECT * FROM test_table ORDER BY b ASC a DESC;
   std::shared_ptr<planner::OrderByPlan> order_by_plan_1{
@@ -442,6 +448,8 @@ TEST_F(QueryCacheTest, CacheOrderByPlan) {
 }
 
 TEST_F(QueryCacheTest, CacheAggregatePlan) {
+  int CACHE_USED_BY_CATALOG = codegen::QueryCache::Instance().GetCount();
+
   auto agg_plan1 = GetAggregatePlan();
   auto agg_plan_2 = GetAggregatePlan();
 
@@ -492,6 +500,8 @@ TEST_F(QueryCacheTest, CacheAggregatePlan) {
 }
 
 TEST_F(QueryCacheTest, CacheNestedLoopJoinPlan) {
+  int CACHE_USED_BY_CATALOG = codegen::QueryCache::Instance().GetCount();
+
   auto nlj_plan_1 = GetBlockNestedLoopJoinPlan();
   auto nlj_plan_2 = GetBlockNestedLoopJoinPlan();
 

--- a/test/executor/copy_test.cpp
+++ b/test/executor/copy_test.cpp
@@ -112,7 +112,8 @@ TEST_F(CopyTests, Copying) {
   // Now Copying end-to-end
   LOG_TRACE("Copying a table...");
   std::string copy_sql =
-      "COPY emp_db.department_table TO './copy_output.csv' DELIMITER ',';";
+      "COPY emp_db.public.department_table TO './copy_output.csv' DELIMITER "
+      "',';";
   txn = txn_manager.BeginTransaction();
   LOG_TRACE("Query: %s", copy_sql.c_str());
   std::unique_ptr<Statement> statement(new Statement("COPY", copy_sql));

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "traffic_cop/traffic_cop.h"
 #include <cstdio>
 #include "sql/testing_sql_util.h"
+#include "traffic_cop/traffic_cop.h"
 
 #include "binder/bind_node_visitor.h"
 #include "catalog/catalog.h"
@@ -118,7 +118,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   EXPECT_EQ(catalog::Catalog::GetInstance()
                 ->GetDatabaseWithName(DEFAULT_DB_NAME, txn)
                 ->GetTableCount(),
-            1);
+            4);
 
   // Inserting a tuple end-to-end
   traffic_cop.SetTcopTxnState(txn);

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -205,7 +205,7 @@ TEST_F(CreateIndexTests, CreatingIndex) {
 
   txn = txn_manager.BeginTransaction();
   auto target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
-      DEFAULT_DB_NAME, "department_table", txn);
+      DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table", txn);
   // Expected 2 , Primary key index + created index
   EXPECT_EQ(target_table_->GetIndexCount(), 2);
 

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -115,11 +115,6 @@ TEST_F(CreateIndexTests, CreatingIndex) {
   traffic_cop.CommitQueryHelper();
 
   txn = txn_manager.BeginTransaction();
-  EXPECT_EQ(catalog::Catalog::GetInstance()
-                ->GetDatabaseWithName(DEFAULT_DB_NAME, txn)
-                ->GetTableCount(),
-            4);
-
   // Inserting a tuple end-to-end
   traffic_cop.SetTcopTxnState(txn);
   LOG_INFO("Inserting a tuple...");

--- a/test/executor/create_test.cpp
+++ b/test/executor/create_test.cpp
@@ -47,7 +47,7 @@ TEST_F(CreateTests, CreatingDB) {
   auto txn = txn_manager.BeginTransaction();
 
   // Create plans with database name set.
-  planner::CreatePlan node("PelotonDB", CreateType::DB);
+  planner::CreatePlan node("pelotondb", CreateType::DB);
 
   std::unique_ptr<executor::ExecutorContext> context(
       new executor::ExecutorContext(txn));
@@ -58,9 +58,9 @@ TEST_F(CreateTests, CreatingDB) {
   executor.Execute();
   // Check if the database exists in the same txn
   EXPECT_EQ(0, catalog::Catalog::GetInstance()
-                   ->GetDatabaseObject("PelotonDB", txn)
+                   ->GetDatabaseObject("pelotondb", txn)
                    ->GetDatabaseName()
-                   .compare("PelotonDB"));
+                   .compare("pelotondb"));
 
   txn_manager.CommitTransaction(txn);
 
@@ -68,12 +68,12 @@ TEST_F(CreateTests, CreatingDB) {
   txn = txn_manager.BeginTransaction();
   // Check if the database exists in a new txn
   EXPECT_EQ(0, catalog::Catalog::GetInstance()
-                   ->GetDatabaseObject("PelotonDB", txn)
+                   ->GetDatabaseObject("pelotondb", txn)
                    ->GetDatabaseName()
-                   .compare("PelotonDB"));
+                   .compare("pelotondb"));
 
   // free the database just created
-  catalog::Catalog::GetInstance()->DropDatabaseWithName("PelotonDB", txn);
+  catalog::Catalog::GetInstance()->DropDatabaseWithName("pelotondb", txn);
 
   txn_manager.CommitTransaction(txn);
 }
@@ -314,15 +314,13 @@ TEST_F(CreateTests, CreatingTrigger) {
   EXPECT_EQ(ExpressionType::VALUE_TUPLE, left->GetExpressionType());
   EXPECT_EQ("old", static_cast<const expression::TupleValueExpression *>(left)
                        ->GetTableName());
-  EXPECT_EQ("balance",
-            static_cast<const expression::TupleValueExpression *>(left)
-                ->GetColumnName());
+  EXPECT_EQ("balance", static_cast<const expression::TupleValueExpression *>(
+                           left)->GetColumnName());
   EXPECT_EQ(ExpressionType::VALUE_TUPLE, right->GetExpressionType());
   EXPECT_EQ("new", static_cast<const expression::TupleValueExpression *>(right)
                        ->GetTableName());
-  EXPECT_EQ("balance",
-            static_cast<const expression::TupleValueExpression *>(right)
-                ->GetColumnName());
+  EXPECT_EQ("balance", static_cast<const expression::TupleValueExpression *>(
+                           right)->GetColumnName());
   // type (level, timing, event)
   auto trigger_type = plan.GetTriggerType();
   // level

--- a/test/executor/create_test.cpp
+++ b/test/executor/create_test.cpp
@@ -13,10 +13,8 @@
 #include <cstdio>
 
 #include "catalog/catalog.h"
-#include "catalog/database_catalog.h"
 #include "catalog/proc_catalog.h"
-#include "catalog/table_catalog.h"
-#include "catalog/trigger_catalog.h"
+#include "catalog/system_catalogs.h"
 #include "common/harness.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/create_executor.h"
@@ -526,9 +524,14 @@ TEST_F(CreateTests, CreatingTriggerInCatalog) {
   // check whether the trigger catalog table contains this new trigger
   auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
       DEFAULT_DB_NAME, "accounts", txn);
-  auto trigger_list = catalog::TriggerCatalog::GetInstance().GetTriggersByType(
-      table_object->GetTableOid(),
-      (TRIGGER_TYPE_ROW | TRIGGER_TYPE_BEFORE | TRIGGER_TYPE_UPDATE), txn);
+  auto trigger_list =
+      catalog::Catalog::GetInstance()
+          ->GetSystemCatalogs(table_object->GetDatabaseOid())
+          ->GetTriggerCatalog()
+          ->GetTriggersByType(
+              table_object->GetTableOid(),
+              (TRIGGER_TYPE_ROW | TRIGGER_TYPE_BEFORE | TRIGGER_TYPE_UPDATE),
+              txn);
 
   txn_manager.CommitTransaction(txn);
 

--- a/test/executor/create_test.cpp
+++ b/test/executor/create_test.cpp
@@ -110,7 +110,7 @@ TEST_F(CreateTests, CreatingTable) {
   executor.Init();
   executor.Execute();
 
-  EXPECT_EQ(1, (int)catalog::Catalog::GetInstance()
+  EXPECT_EQ(4, (int)catalog::Catalog::GetInstance()
                    ->GetDatabaseObject(DEFAULT_DB_NAME, txn)
                    ->GetTableObjects()
                    .size());
@@ -155,7 +155,7 @@ TEST_F(CreateTests, CreatingUDFs) {
   executor.Init();
   executor.Execute();
 
-  EXPECT_EQ(1, (int)catalog::Catalog::GetInstance()
+  EXPECT_EQ(4, (int)catalog::Catalog::GetInstance()
                    ->GetDatabaseObject(DEFAULT_DB_NAME, txn)
                    ->GetTableObjects()
                    .size());

--- a/test/executor/create_test.cpp
+++ b/test/executor/create_test.cpp
@@ -108,10 +108,6 @@ TEST_F(CreateTests, CreatingTable) {
   executor.Init();
   executor.Execute();
 
-  EXPECT_EQ(4, (int)catalog::Catalog::GetInstance()
-                   ->GetDatabaseObject(DEFAULT_DB_NAME, txn)
-                   ->GetTableObjects()
-                   .size());
   txn_manager.CommitTransaction(txn);
 
   // free the database just created
@@ -152,11 +148,6 @@ TEST_F(CreateTests, CreatingUDFs) {
 
   executor.Init();
   executor.Execute();
-
-  EXPECT_EQ(4, (int)catalog::Catalog::GetInstance()
-                   ->GetDatabaseObject(DEFAULT_DB_NAME, txn)
-                   ->GetTableObjects()
-                   .size());
   txn_manager.CommitTransaction(txn);
 
   // Create statement
@@ -234,10 +225,7 @@ TEST_F(CreateTests, CreatingTrigger) {
   // Bootstrap
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
-  // catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-  auto catalog = catalog::Catalog::GetInstance();
-  catalog->Bootstrap();
-  catalog->CreateDatabase(DEFAULT_DB_NAME, txn);
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
 
   // Insert a table first
   auto id_column = catalog::Column(
@@ -263,10 +251,6 @@ TEST_F(CreateTests, CreatingTrigger) {
   executor.Init();
   executor.Execute();
 
-  EXPECT_EQ(1, (int)catalog::Catalog::GetInstance()
-                   ->GetDatabaseObject(DEFAULT_DB_NAME, txn)
-                   ->GetTableObjects()
-                   .size());
   txn_manager.CommitTransaction(txn);
 
   // Create statement
@@ -314,13 +298,15 @@ TEST_F(CreateTests, CreatingTrigger) {
   EXPECT_EQ(ExpressionType::VALUE_TUPLE, left->GetExpressionType());
   EXPECT_EQ("old", static_cast<const expression::TupleValueExpression *>(left)
                        ->GetTableName());
-  EXPECT_EQ("balance", static_cast<const expression::TupleValueExpression *>(
-                           left)->GetColumnName());
+  EXPECT_EQ("balance",
+            static_cast<const expression::TupleValueExpression *>(left)
+                ->GetColumnName());
   EXPECT_EQ(ExpressionType::VALUE_TUPLE, right->GetExpressionType());
   EXPECT_EQ("new", static_cast<const expression::TupleValueExpression *>(right)
                        ->GetTableName());
-  EXPECT_EQ("balance", static_cast<const expression::TupleValueExpression *>(
-                           right)->GetColumnName());
+  EXPECT_EQ("balance",
+            static_cast<const expression::TupleValueExpression *>(right)
+                ->GetColumnName());
   // type (level, timing, event)
   auto trigger_type = plan.GetTriggerType();
   // level
@@ -395,10 +381,6 @@ TEST_F(CreateTests, CreatingTriggerWithoutWhen) {
   executor.Init();
   executor.Execute();
 
-  EXPECT_EQ(1, (int)catalog::Catalog::GetInstance()
-                   ->GetDatabaseObject(DEFAULT_DB_NAME, txn)
-                   ->GetTableObjects()
-                   .size());
   txn_manager.CommitTransaction(txn);
 
   // Create statement
@@ -459,7 +441,9 @@ TEST_F(CreateTests, CreatingTriggerInCatalog) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   auto catalog = catalog::Catalog::GetInstance();
-  catalog->Bootstrap();
+  // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
+  // you can only call it once!
+  // catalog->Bootstrap();
   catalog->CreateDatabase(DEFAULT_DB_NAME, txn);
 
   // Insert a table first
@@ -486,10 +470,6 @@ TEST_F(CreateTests, CreatingTriggerInCatalog) {
   executor.Init();
   executor.Execute();
 
-  EXPECT_EQ(1, (int)catalog::Catalog::GetInstance()
-                   ->GetDatabaseObject(DEFAULT_DB_NAME, txn)
-                   ->GetTableObjects()
-                   .size());
   txn_manager.CommitTransaction(txn);
 
   // Create statement

--- a/test/executor/create_test.cpp
+++ b/test/executor/create_test.cpp
@@ -99,8 +99,9 @@ TEST_F(CreateTests, CreatingTable) {
       new executor::ExecutorContext(txn));
 
   // Create plans
-  planner::CreatePlan node("department_table", DEFAULT_DB_NAME,
-                           std::move(table_schema), CreateType::TABLE);
+  planner::CreatePlan node("department_table", DEFUALT_SCHEMA_NAME,
+                           DEFAULT_DB_NAME, std::move(table_schema),
+                           CreateType::TABLE);
 
   // Create executer
   executor::CreateExecutor executor(&node, context.get());
@@ -140,8 +141,8 @@ TEST_F(CreateTests, CreatingUDFs) {
       new executor::ExecutorContext(txn));
 
   // Create plans
-  planner::CreatePlan node("accounts", DEFAULT_DB_NAME, std::move(table_schema),
-                           CreateType::TABLE);
+  planner::CreatePlan node("accounts", DEFUALT_SCHEMA_NAME, DEFAULT_DB_NAME,
+                           std::move(table_schema), CreateType::TABLE);
 
   // Create executer
   executor::CreateExecutor executor(&node, context.get());
@@ -242,8 +243,8 @@ TEST_F(CreateTests, CreatingTrigger) {
       new executor::ExecutorContext(txn));
 
   // Create plans
-  planner::CreatePlan node("accounts", DEFAULT_DB_NAME, std::move(table_schema),
-                           CreateType::TABLE);
+  planner::CreatePlan node("accounts", DEFUALT_SCHEMA_NAME, DEFAULT_DB_NAME,
+                           std::move(table_schema), CreateType::TABLE);
 
   // Create executer
   executor::CreateExecutor executor(&node, context.get());
@@ -331,8 +332,8 @@ TEST_F(CreateTests, CreatingTrigger) {
 
   // Check the effect of creation
   storage::DataTable *target_table =
-      catalog::Catalog::GetInstance()->GetTableWithName(DEFAULT_DB_NAME,
-                                                        "accounts", txn);
+      catalog::Catalog::GetInstance()->GetTableWithName(
+          DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "accounts", txn);
   txn_manager.CommitTransaction(txn);
   EXPECT_EQ(1, target_table->GetTriggerNumber());
   trigger::Trigger *new_trigger = target_table->GetTriggerByIndex(0);
@@ -372,8 +373,8 @@ TEST_F(CreateTests, CreatingTriggerWithoutWhen) {
       new executor::ExecutorContext(txn));
 
   // Create plans
-  planner::CreatePlan node("accounts", DEFAULT_DB_NAME, std::move(table_schema),
-                           CreateType::TABLE);
+  planner::CreatePlan node("accounts", DEFUALT_SCHEMA_NAME, DEFAULT_DB_NAME,
+                           std::move(table_schema), CreateType::TABLE);
 
   // Create executer
   executor::CreateExecutor executor(&node, context.get());
@@ -419,8 +420,8 @@ TEST_F(CreateTests, CreatingTriggerWithoutWhen) {
 
   // Check the effect of creation
   storage::DataTable *target_table =
-      catalog::Catalog::GetInstance()->GetTableWithName(DEFAULT_DB_NAME,
-                                                        "accounts", txn);
+      catalog::Catalog::GetInstance()->GetTableWithName(
+          DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "accounts", txn);
   txn_manager.CommitTransaction(txn);
   EXPECT_EQ(1, target_table->GetTriggerNumber());
   trigger::Trigger *new_trigger = target_table->GetTriggerByIndex(0);
@@ -461,8 +462,8 @@ TEST_F(CreateTests, CreatingTriggerInCatalog) {
       new executor::ExecutorContext(txn));
 
   // Create plans
-  planner::CreatePlan node("accounts", DEFAULT_DB_NAME, std::move(table_schema),
-                           CreateType::TABLE);
+  planner::CreatePlan node("accounts", DEFUALT_SCHEMA_NAME, DEFAULT_DB_NAME,
+                           std::move(table_schema), CreateType::TABLE);
 
   // Create executer
   executor::CreateExecutor executor(&node, context.get());
@@ -501,7 +502,7 @@ TEST_F(CreateTests, CreatingTriggerInCatalog) {
 
   // check whether the trigger catalog table contains this new trigger
   auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
-      DEFAULT_DB_NAME, "accounts", txn);
+      DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "accounts", txn);
   auto trigger_list =
       catalog::Catalog::GetInstance()
           ->GetSystemCatalogs(table_object->GetDatabaseOid())

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -121,7 +121,7 @@ TEST_F(DeleteTests, VariousOperations) {
   executor::CreateExecutor create_executor(&node, context.get());
   create_executor.Init();
   create_executor.Execute();
-  EXPECT_EQ(1, (int)catalog::Catalog::GetInstance()
+  EXPECT_EQ(4, (int)catalog::Catalog::GetInstance()
                    ->GetDatabaseObject(DEFAULT_DB_NAME, txn)
                    ->GetTableObjects()
                    .size());

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -121,10 +121,6 @@ TEST_F(DeleteTests, VariousOperations) {
   executor::CreateExecutor create_executor(&node, context.get());
   create_executor.Init();
   create_executor.Execute();
-  EXPECT_EQ(4, (int)catalog::Catalog::GetInstance()
-                   ->GetDatabaseObject(DEFAULT_DB_NAME, txn)
-                   ->GetTableObjects()
-                   .size());
   LOG_INFO("Table created!");
 
   storage::DataTable *table = catalog::Catalog::GetInstance()->GetTableWithName(

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -116,15 +116,16 @@ TEST_F(DeleteTests, VariousOperations) {
       new catalog::Schema({id_column, name_column}));
   std::unique_ptr<executor::ExecutorContext> context(
       new executor::ExecutorContext(txn));
-  planner::CreatePlan node("department_table", DEFAULT_DB_NAME,
-                           std::move(table_schema), CreateType::TABLE);
+  planner::CreatePlan node("department_table", DEFUALT_SCHEMA_NAME,
+                           DEFAULT_DB_NAME, std::move(table_schema),
+                           CreateType::TABLE);
   executor::CreateExecutor create_executor(&node, context.get());
   create_executor.Init();
   create_executor.Execute();
   LOG_INFO("Table created!");
 
   storage::DataTable *table = catalog::Catalog::GetInstance()->GetTableWithName(
-      DEFAULT_DB_NAME, "department_table", txn);
+      DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table", txn);
   txn_manager.CommitTransaction(txn);
 
   txn = txn_manager.BeginTransaction();

--- a/test/executor/drop_test.cpp
+++ b/test/executor/drop_test.cpp
@@ -75,7 +75,9 @@ TEST_F(DropTests, DroppingDatabase) {
 
 TEST_F(DropTests, DroppingTable) {
   auto catalog = catalog::Catalog::GetInstance();
-  catalog->Bootstrap();
+  // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
+  // you can only call it once!
+  // catalog->Bootstrap();
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
@@ -105,17 +107,18 @@ TEST_F(DropTests, DroppingTable) {
   txn_manager.CommitTransaction(txn);
 
   txn = txn_manager.BeginTransaction();
+  // NOTE: everytime we create a database, there will be 7 catalog tables inside
   EXPECT_EQ((int)catalog->GetDatabaseObject(TEST_DB_NAME, txn)
                 ->GetTableObjects()
                 .size(),
-            5);
+            9);
 
   // Now dropping the table using the executor
   catalog->DropTable(TEST_DB_NAME, "department_table", txn);
   EXPECT_EQ((int)catalog->GetDatabaseObject(TEST_DB_NAME, txn)
                 ->GetTableObjects()
                 .size(),
-            4);
+            8);
 
   // free the database just created
   catalog->DropDatabaseWithName(TEST_DB_NAME, txn);
@@ -124,7 +127,9 @@ TEST_F(DropTests, DroppingTable) {
 
 TEST_F(DropTests, DroppingTrigger) {
   auto catalog = catalog::Catalog::GetInstance();
-  catalog->Bootstrap();
+  // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
+  // you can only call it once!
+  // catalog->Bootstrap();
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
@@ -208,7 +213,7 @@ TEST_F(DropTests, DroppingTrigger) {
   // Now dropping the table using the executer
   txn = txn_manager.BeginTransaction();
   catalog->DropTable(TEST_DB_NAME, "department_table", txn);
-  EXPECT_EQ(3, (int)catalog::Catalog::GetInstance()
+  EXPECT_EQ(7, (int)catalog::Catalog::GetInstance()
                    ->GetDatabaseObject(TEST_DB_NAME, txn)
                    ->GetTableObjects()
                    .size());
@@ -222,7 +227,9 @@ TEST_F(DropTests, DroppingTrigger) {
 
 TEST_F(DropTests, DroppingIndexByName) {
   auto catalog = catalog::Catalog::GetInstance();
-  catalog->Bootstrap();
+  // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
+  // you can only call it once!
+  // catalog->Bootstrap();
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();

--- a/test/executor/drop_test.cpp
+++ b/test/executor/drop_test.cpp
@@ -97,28 +97,29 @@ TEST_F(DropTests, DroppingTable) {
   txn_manager.CommitTransaction(txn);
 
   txn = txn_manager.BeginTransaction();
-  catalog->CreateTable(TEST_DB_NAME, "department_table",
+  catalog->CreateTable(TEST_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table",
                        std::move(table_schema), txn);
   txn_manager.CommitTransaction(txn);
 
   txn = txn_manager.BeginTransaction();
-  catalog->CreateTable(TEST_DB_NAME, "department_table_2",
+  catalog->CreateTable(TEST_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table_2",
                        std::move(table_schema2), txn);
   txn_manager.CommitTransaction(txn);
 
   txn = txn_manager.BeginTransaction();
-  // NOTE: everytime we create a database, there will be 7 catalog tables inside
+  // NOTE: everytime we create a database, there will be 8 catalog tables inside
+  EXPECT_EQ((int)catalog->GetDatabaseObject(TEST_DB_NAME, txn)
+                ->GetTableObjects()
+                .size(),
+            10);
+
+  // Now dropping the table using the executor
+  catalog->DropTable(TEST_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table",
+                     txn);
   EXPECT_EQ((int)catalog->GetDatabaseObject(TEST_DB_NAME, txn)
                 ->GetTableObjects()
                 .size(),
             9);
-
-  // Now dropping the table using the executor
-  catalog->DropTable(TEST_DB_NAME, "department_table", txn);
-  EXPECT_EQ((int)catalog->GetDatabaseObject(TEST_DB_NAME, txn)
-                ->GetTableObjects()
-                .size(),
-            8);
 
   // free the database just created
   catalog->DropDatabaseWithName(TEST_DB_NAME, txn);
@@ -148,7 +149,7 @@ TEST_F(DropTests, DroppingTrigger) {
   txn_manager.CommitTransaction(txn);
 
   txn = txn_manager.BeginTransaction();
-  catalog->CreateTable(TEST_DB_NAME, "department_table",
+  catalog->CreateTable(TEST_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table",
                        std::move(table_schema), txn);
   txn_manager.CommitTransaction(txn);
 
@@ -180,7 +181,7 @@ TEST_F(DropTests, DroppingTrigger) {
   // Check the effect of creation
   storage::DataTable *target_table =
       catalog::Catalog::GetInstance()->GetTableWithName(
-          TEST_DB_NAME, "department_table", txn);
+          TEST_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table", txn);
   txn_manager.CommitTransaction(txn);
   EXPECT_EQ(1, target_table->GetTriggerNumber());
   trigger::Trigger *new_trigger = target_table->GetTriggerByIndex(0);
@@ -212,8 +213,9 @@ TEST_F(DropTests, DroppingTrigger) {
 
   // Now dropping the table using the executer
   txn = txn_manager.BeginTransaction();
-  catalog->DropTable(TEST_DB_NAME, "department_table", txn);
-  EXPECT_EQ(7, (int)catalog::Catalog::GetInstance()
+  catalog->DropTable(TEST_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table",
+                     txn);
+  EXPECT_EQ(8, (int)catalog::Catalog::GetInstance()
                    ->GetDatabaseObject(TEST_DB_NAME, txn)
                    ->GetTableObjects()
                    .size());
@@ -233,9 +235,8 @@ TEST_F(DropTests, DroppingIndexByName) {
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
-
+  // create database
   catalog->CreateDatabase(TEST_DB_NAME, txn);
-  auto db = catalog->GetDatabaseWithName(TEST_DB_NAME, txn);
   // Insert a table first
   auto id_column = catalog::Column(
       type::TypeId::INTEGER, type::Type::GetTypeSize(type::TypeId::INTEGER),
@@ -250,18 +251,20 @@ TEST_F(DropTests, DroppingIndexByName) {
   txn_manager.CommitTransaction(txn);
 
   txn = txn_manager.BeginTransaction();
-  catalog->CreateTable(TEST_DB_NAME, "department_table_01",
+  catalog->CreateTable(TEST_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table_01",
                        std::move(table_schema), txn);
   txn_manager.CommitTransaction(txn);
 
   txn = txn_manager.BeginTransaction();
-  auto source_table = db->GetTableWithName("department_table_01");
+  auto source_table = catalog->GetTableWithName(
+      TEST_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table_01", txn);
   oid_t col_id = source_table->GetSchema()->GetColumnID(id_column.column_name);
   std::vector<oid_t> source_col_ids;
   source_col_ids.push_back(col_id);
   std::string index_name1 = "Testing_Drop_Index_By_Name";
-  catalog->CreateIndex(TEST_DB_NAME, "department_table_01", source_col_ids,
-                       index_name1, false, IndexType::BWTREE, txn);
+  catalog->CreateIndex(TEST_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table_01",
+                       source_col_ids, index_name1, false, IndexType::BWTREE,
+                       txn);
   txn_manager.CommitTransaction(txn);
 
   txn = txn_manager.BeginTransaction();
@@ -273,21 +276,27 @@ TEST_F(DropTests, DroppingIndexByName) {
   auto pg_index = catalog::Catalog::GetInstance()
                       ->GetSystemCatalogs(database_object->GetDatabaseOid())
                       ->GetIndexCatalog();
-  EXPECT_NE(nullptr, pg_index);
+  auto index_object =
+      pg_index->GetIndexObject(index_name1, DEFUALT_SCHEMA_NAME, txn);
+  EXPECT_NE(nullptr, index_object);
   // Check the effect of drop
   // Most major check in this test case
   // Now dropping the index using the DropIndex functionality
-  catalog->DropIndex(TEST_DB_NAME, index_name1, txn);
-  EXPECT_EQ(pg_index->GetIndexObject(index_name1, txn), nullptr);
+  catalog->DropIndex(database_object->GetDatabaseOid(),
+                     index_object->GetIndexOid(), txn);
+  EXPECT_EQ(pg_index->GetIndexObject(index_name1, DEFUALT_SCHEMA_NAME, txn),
+            nullptr);
   txn_manager.CommitTransaction(txn);
 
   // Drop the table just created
   txn = txn_manager.BeginTransaction();
   // Check the effect of drop index
-  EXPECT_EQ(pg_index->GetIndexObject(index_name1, txn), nullptr);
+  EXPECT_EQ(pg_index->GetIndexObject(index_name1, DEFUALT_SCHEMA_NAME, txn),
+            nullptr);
 
   // Now dropping the table
-  catalog->DropTable(TEST_DB_NAME, "department_table_01", txn);
+  catalog->DropTable(TEST_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table_01",
+                     txn);
   txn_manager.CommitTransaction(txn);
 
   // free the database just created

--- a/test/executor/drop_test.cpp
+++ b/test/executor/drop_test.cpp
@@ -77,7 +77,6 @@ TEST_F(DropTests, DroppingTable) {
   auto catalog = catalog::Catalog::GetInstance();
   // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
   // you can only call it once!
-  // catalog->Bootstrap();
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();

--- a/test/executor/insert_test.cpp
+++ b/test/executor/insert_test.cpp
@@ -17,8 +17,8 @@
 #include "catalog/catalog.h"
 #include "common/harness.h"
 #include "concurrency/transaction_manager_factory.h"
-#include "executor/insert_executor.h"
 #include "executor/executor_context.h"
+#include "executor/insert_executor.h"
 #include "expression/constant_value_expression.h"
 #include "parser/insert_statement.h"
 #include "planner/insert_plan.h"
@@ -52,11 +52,12 @@ TEST_F(InsertTests, InsertRecord) {
   txn_manager.CommitTransaction(txn);
 
   txn = txn_manager.BeginTransaction();
-  catalog::Catalog::GetInstance()->CreateTable(DEFAULT_DB_NAME, "TEST_TABLE",
-                                               std::move(table_schema), txn);
+  catalog::Catalog::GetInstance()->CreateTable(
+      DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "TEST_TABLE",
+      std::move(table_schema), txn);
 
   auto table = catalog::Catalog::GetInstance()->GetTableWithName(
-      DEFAULT_DB_NAME, "TEST_TABLE", txn);
+      DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "TEST_TABLE", txn);
   txn_manager.CommitTransaction(txn);
 
   txn = txn_manager.BeginTransaction();
@@ -83,13 +84,15 @@ TEST_F(InsertTests, InsertRecord) {
 
   insert_node->insert_values.push_back(
       std::vector<std::unique_ptr<expression::AbstractExpression>>());
-  auto& values_ptr = insert_node->insert_values[0];
+  auto &values_ptr = insert_node->insert_values[0];
 
   values_ptr.push_back(std::unique_ptr<expression::AbstractExpression>(
-      new expression::ConstantValueExpression(type::ValueFactory::GetIntegerValue(70))));
+      new expression::ConstantValueExpression(
+          type::ValueFactory::GetIntegerValue(70))));
 
   values_ptr.push_back(std::unique_ptr<expression::AbstractExpression>(
-      new expression::ConstantValueExpression(type::ValueFactory::GetVarcharValue("Hello"))));
+      new expression::ConstantValueExpression(
+          type::ValueFactory::GetVarcharValue("Hello"))));
 
   insert_node->select.reset(new parser::SelectStatement());
 
@@ -113,16 +116,19 @@ TEST_F(InsertTests, InsertRecord) {
 
   insert_node->insert_values.push_back(
       std::vector<std::unique_ptr<expression::AbstractExpression>>());
-  auto& values_ptr2 = insert_node->insert_values[1];
+  auto &values_ptr2 = insert_node->insert_values[1];
 
   values_ptr2.push_back(std::unique_ptr<expression::AbstractExpression>(
-      new expression::ConstantValueExpression(type::ValueFactory::GetIntegerValue(100))));
+      new expression::ConstantValueExpression(
+          type::ValueFactory::GetIntegerValue(100))));
 
   values_ptr2.push_back(std::unique_ptr<expression::AbstractExpression>(
-      new expression::ConstantValueExpression(type::ValueFactory::GetVarcharValue("Hello"))));
+      new expression::ConstantValueExpression(
+          type::ValueFactory::GetVarcharValue("Hello"))));
 
-  insert_node->insert_values[0].at(0).reset(new expression::ConstantValueExpression(
-      type::ValueFactory::GetIntegerValue(90)));
+  insert_node->insert_values[0].at(0).reset(
+      new expression::ConstantValueExpression(
+          type::ValueFactory::GetIntegerValue(90)));
   planner::InsertPlan node3(table, &insert_node->columns,
                             &insert_node->insert_values);
   executor::InsertExecutor executor3(&node3, context.get());

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -176,16 +176,17 @@ TEST_F(UpdateTests, UpdatingOld) {
       new catalog::Schema({id_column, manager_id_column, name_column}));
   std::unique_ptr<executor::ExecutorContext> context(
       new executor::ExecutorContext(txn));
-  planner::CreatePlan node("department_table", DEFAULT_DB_NAME,
-                           std::move(table_schema), CreateType::TABLE);
+  planner::CreatePlan node("department_table", DEFUALT_SCHEMA_NAME,
+                           DEFAULT_DB_NAME, std::move(table_schema),
+                           CreateType::TABLE);
   executor::CreateExecutor create_executor(&node, context.get());
   create_executor.Init();
   create_executor.Execute();
 
   LOG_INFO("Table created!");
 
-  storage::DataTable *table =
-      catalog->GetTableWithName(DEFAULT_DB_NAME, "department_table", txn);
+  storage::DataTable *table = catalog->GetTableWithName(
+      DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table", txn);
   txn_manager.CommitTransaction(txn);
 
   // Inserting a tuple end-to-end

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -12,13 +12,14 @@
 
 #include <cstdio>
 
+#include "common/harness.h"
 #include "executor/testing_executor_util.h"
 #include "sql/testing_sql_util.h"
-#include "common/harness.h"
 
 #include "binder/bind_node_visitor.h"
 #include "catalog/catalog.h"
 #include "catalog/schema.h"
+#include "common/internal_types.h"
 #include "common/logger.h"
 #include "common/statement.h"
 #include "concurrency/transaction_context.h"
@@ -46,7 +47,6 @@
 #include "storage/data_table.h"
 #include "storage/tile_group_factory.h"
 #include "traffic_cop/traffic_cop.h"
-#include "common/internal_types.h"
 #include "type/value.h"
 #include "type/value_factory.h"
 
@@ -182,7 +182,7 @@ TEST_F(UpdateTests, UpdatingOld) {
   create_executor.Init();
   create_executor.Execute();
   EXPECT_EQ(catalog->GetDatabaseWithName(DEFAULT_DB_NAME, txn)->GetTableCount(),
-            1);
+            4);
 
   LOG_INFO("Table created!");
 
@@ -416,6 +416,6 @@ TEST_F(UpdateTests, UpdatingOld) {
   catalog->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
 }
-}  // namespace?
+}  // namespace
 }  // namespace test
 }  // namespace peloton

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -181,8 +181,6 @@ TEST_F(UpdateTests, UpdatingOld) {
   executor::CreateExecutor create_executor(&node, context.get());
   create_executor.Init();
   create_executor.Execute();
-  EXPECT_EQ(catalog->GetDatabaseWithName(DEFAULT_DB_NAME, txn)->GetTableCount(),
-            4);
 
   LOG_INFO("Table created!");
 

--- a/test/function/functions_test.cpp
+++ b/test/function/functions_test.cpp
@@ -31,16 +31,14 @@ class FunctionsTests : public PelotonTest {
 
   virtual void SetUp() {
     PelotonTest::SetUp();
-    // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous
-    // unit tests you can only call it once!
-    // auto catalog =
-    // catalog::Catalog::GetInstance(); catalog->Bootstrap();
+    // Bootstrap catalog
+    auto catalog = catalog::Catalog::GetInstance();
+    catalog->Bootstrap();
   }
 };
 
 TEST_F(FunctionsTests, CatalogTest) {
   auto catalog = catalog::Catalog::GetInstance();
-  catalog->Bootstrap();
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto &pg_language = catalog::LanguageCatalog::GetInstance();

--- a/test/gc/garbage_collection_test.cpp
+++ b/test/gc/garbage_collection_test.cpp
@@ -125,7 +125,7 @@ TEST_F(GarbageCollectionTests, UpdateTest) {
 
   auto storage_manager = storage::StorageManager::GetInstance();
   // create database
-  auto database = TestingExecutorUtil::InitializeDatabase("UPDATE_DB");
+  auto database = TestingExecutorUtil::InitializeDatabase("update_db");
   oid_t db_id = database->GetOid();
   EXPECT_TRUE(storage_manager->HasDatabase(db_id));
 
@@ -197,7 +197,7 @@ TEST_F(GarbageCollectionTests, UpdateTest) {
   table.release();
 
   // DROP!
-  TestingExecutorUtil::DeleteDatabase("UPDATE_DB");
+  TestingExecutorUtil::DeleteDatabase("update_db");
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   EXPECT_THROW(catalog::Catalog::GetInstance()->GetDatabaseObject(db_id, txn),
@@ -219,7 +219,7 @@ TEST_F(GarbageCollectionTests, DeleteTest) {
   auto &gc_manager = gc::GCManagerFactory::GetInstance();
   auto storage_manager = storage::StorageManager::GetInstance();
   // create database
-  auto database = TestingExecutorUtil::InitializeDatabase("DELETE_DB");
+  auto database = TestingExecutorUtil::InitializeDatabase("delete_db");
   oid_t db_id = database->GetOid();
   EXPECT_TRUE(storage_manager->HasDatabase(db_id));
   // create a table with only one key
@@ -295,7 +295,7 @@ TEST_F(GarbageCollectionTests, DeleteTest) {
   table.release();
 
   // DROP!
-  TestingExecutorUtil::DeleteDatabase("DELETE_DB");
+  TestingExecutorUtil::DeleteDatabase("delete_db");
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   EXPECT_THROW(

--- a/test/gc/transaction_level_gc_manager_test.cpp
+++ b/test/gc/transaction_level_gc_manager_test.cpp
@@ -224,7 +224,7 @@ TEST_F(TransactionLevelGCManagerTests, ReInsertTest) {
 
   auto storage_manager = storage::StorageManager::GetInstance();
   // create database
-  auto database = TestingExecutorUtil::InitializeDatabase("DATABASE1");
+  auto database = TestingExecutorUtil::InitializeDatabase("database1");
   oid_t db_id = database->GetOid();
   EXPECT_TRUE(storage_manager->HasDatabase(db_id));
 
@@ -363,7 +363,7 @@ TEST_F(TransactionLevelGCManagerTests, ReInsertTest) {
   table.release();
 
   // DROP!
-  TestingExecutorUtil::DeleteDatabase("DATABASE1");
+  TestingExecutorUtil::DeleteDatabase("database1");
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
@@ -393,7 +393,7 @@ TEST_F(TransactionLevelGCManagerTests, ImmutabilityTest) {
 
   auto storage_manager = storage::StorageManager::GetInstance();
   // create database
-  auto database = TestingExecutorUtil::InitializeDatabase("ImmutabilityDB");
+  auto database = TestingExecutorUtil::InitializeDatabase("immutabilitydb");
   oid_t db_id = database->GetOid();
   EXPECT_TRUE(storage_manager->HasDatabase(db_id));
 
@@ -476,12 +476,12 @@ TEST_F(TransactionLevelGCManagerTests, ImmutabilityTest) {
 
   table.release();
   // DROP!
-  TestingExecutorUtil::DeleteDatabase("ImmutabilityDB");
+  TestingExecutorUtil::DeleteDatabase("immutabilitydb");
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   EXPECT_THROW(
-      catalog::Catalog::GetInstance()->GetDatabaseObject("ImmutabilityDB", txn),
+      catalog::Catalog::GetInstance()->GetDatabaseObject("immutabilitydb", txn),
       CatalogException);
   txn_manager.CommitTransaction(txn);
 }

--- a/test/gc/transaction_level_gc_manager_test.cpp
+++ b/test/gc/transaction_level_gc_manager_test.cpp
@@ -93,7 +93,7 @@ TEST_F(TransactionLevelGCManagerTests, UpdateDeleteTest) {
   auto &gc_manager = gc::TransactionLevelGCManager::GetInstance();
   auto storage_manager = storage::StorageManager::GetInstance();
   // create database
-  auto database = TestingExecutorUtil::InitializeDatabase("DATABASE0");
+  auto database = TestingExecutorUtil::InitializeDatabase("database0");
   oid_t db_id = database->GetOid();
   EXPECT_TRUE(storage_manager->HasDatabase(db_id));
 
@@ -200,12 +200,12 @@ TEST_F(TransactionLevelGCManagerTests, UpdateDeleteTest) {
   table.release();
 
   // DROP!
-  TestingExecutorUtil::DeleteDatabase("DATABASE0");
+  TestingExecutorUtil::DeleteDatabase("database0");
 
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   EXPECT_THROW(
-      catalog::Catalog::GetInstance()->GetDatabaseObject("DATABASE0", txn),
+      catalog::Catalog::GetInstance()->GetDatabaseObject("database0", txn),
       CatalogException);
   txn_manager.CommitTransaction(txn);
   // EXPECT_FALSE(storage_manager->HasDatabase(db_id));
@@ -368,7 +368,7 @@ TEST_F(TransactionLevelGCManagerTests, ReInsertTest) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   EXPECT_THROW(
-      catalog::Catalog::GetInstance()->GetDatabaseObject("DATABASE0", txn),
+      catalog::Catalog::GetInstance()->GetDatabaseObject("database0", txn),
       CatalogException);
   txn_manager.CommitTransaction(txn);
   // EXPECT_FALSE(storage_manager->HasDatabase(db_id));

--- a/test/include/codegen/testing_codegen_util.h
+++ b/test/include/codegen/testing_codegen_util.h
@@ -47,7 +47,7 @@ using ConstPlanPtr = std::unique_ptr<const planner::AbstractPlan>;
 //===----------------------------------------------------------------------===//
 class PelotonCodeGenTest : public PelotonTest {
  public:
-  std::string test_db_name = "PELOTON_CODEGEN";
+  std::string test_db_name = "peloton_codegen";
   std::vector<std::string> test_table_names = {"table1", "table2", "table3",
                                                "table4", "table5"};
   std::vector<oid_t> test_table_oids;

--- a/test/optimizer/old_optimizer_test.cpp
+++ b/test/optimizer/old_optimizer_test.cpp
@@ -101,11 +101,6 @@ TEST_F(OldOptimizerTests, UpdateDelWithIndexScanTest) {
   traffic_cop.CommitQueryHelper();
 
   txn = txn_manager.BeginTransaction();
-  EXPECT_EQ(catalog::Catalog::GetInstance()
-                ->GetDatabaseWithName(DEFAULT_DB_NAME, txn)
-                ->GetTableCount(),
-            4);
-
   // Inserting a tuple end-to-end
   traffic_cop.SetTcopTxnState(txn);
   LOG_TRACE("Inserting a tuple...");

--- a/test/optimizer/old_optimizer_test.cpp
+++ b/test/optimizer/old_optimizer_test.cpp
@@ -171,7 +171,7 @@ TEST_F(OldOptimizerTests, UpdateDelWithIndexScanTest) {
 
   txn = txn_manager.BeginTransaction();
   auto target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
-      DEFAULT_DB_NAME, "department_table", txn);
+      DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table", txn);
   // Expected 1 , Primary key index + created index
   EXPECT_EQ(target_table_->GetIndexCount(), 2);
   txn_manager.CommitTransaction(txn);

--- a/test/optimizer/old_optimizer_test.cpp
+++ b/test/optimizer/old_optimizer_test.cpp
@@ -104,7 +104,7 @@ TEST_F(OldOptimizerTests, UpdateDelWithIndexScanTest) {
   EXPECT_EQ(catalog::Catalog::GetInstance()
                 ->GetDatabaseWithName(DEFAULT_DB_NAME, txn)
                 ->GetTableCount(),
-            1);
+            4);
 
   // Inserting a tuple end-to-end
   traffic_cop.SetTcopTxnState(txn);

--- a/test/optimizer/optimizer_rule_test.cpp
+++ b/test/optimizer/optimizer_rule_test.cpp
@@ -23,6 +23,8 @@
 #include "executor/update_executor.h"
 #include "expression/abstract_expression.h"
 #include "expression/operator_expression.h"
+
+#define private public
 #include "optimizer/operator_expression.h"
 #include "optimizer/operators.h"
 #include "optimizer/optimizer.h"

--- a/test/optimizer/optimizer_rule_test.cpp
+++ b/test/optimizer/optimizer_rule_test.cpp
@@ -24,7 +24,6 @@
 #include "expression/abstract_expression.h"
 #include "expression/operator_expression.h"
 
-#define private public
 #include "optimizer/operator_expression.h"
 #include "optimizer/operators.h"
 #include "optimizer/optimizer.h"

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -118,11 +118,6 @@ TEST_F(OptimizerTests, HashJoinTest) {
   traffic_cop.CommitQueryHelper();
 
   txn = txn_manager.BeginTransaction();
-  EXPECT_EQ(catalog::Catalog::GetInstance()
-                ->GetDatabaseWithName(DEFAULT_DB_NAME, txn)
-                ->GetTableCount(),
-            4);
-
   traffic_cop.SetTcopTxnState(txn);
   LOG_INFO("Creating table");
   LOG_INFO("Query: CREATE TABLE table_b(bid INT PRIMARY KEY,value INT);");
@@ -153,11 +148,6 @@ TEST_F(OptimizerTests, HashJoinTest) {
   traffic_cop.CommitQueryHelper();
 
   txn = txn_manager.BeginTransaction();
-  EXPECT_EQ(catalog::Catalog::GetInstance()
-                ->GetDatabaseWithName(DEFAULT_DB_NAME, txn)
-                ->GetTableCount(),
-            5);
-
   // Inserting a tuple to table_a
   traffic_cop.SetTcopTxnState(txn);
   LOG_INFO("Inserting a tuple...");

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -124,7 +124,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
   EXPECT_EQ(catalog::Catalog::GetInstance()
                 ->GetDatabaseWithName(DEFAULT_DB_NAME, txn)
                 ->GetTableCount(),
-            9);
+            1 + CATALOG_TABLES_COUNT);
 
   traffic_cop.SetTcopTxnState(txn);
   LOG_INFO("Creating table");
@@ -159,7 +159,7 @@ TEST_F(OptimizerTests, HashJoinTest) {
   EXPECT_EQ(catalog::Catalog::GetInstance()
                 ->GetDatabaseWithName(DEFAULT_DB_NAME, txn)
                 ->GetTableCount(),
-            10);
+            2 + CATALOG_TABLES_COUNT);
 
   // Inserting a tuple to table_a
   traffic_cop.SetTcopTxnState(txn);

--- a/test/optimizer/selectivity_test.cpp
+++ b/test/optimizer/selectivity_test.cpp
@@ -72,7 +72,8 @@ TEST_F(SelectivityTests, RangeSelectivityTest) {
   txn = txn_manager.BeginTransaction();
   auto catalog = catalog::Catalog::GetInstance();
   auto database = catalog->GetDatabaseWithName(DEFAULT_DB_NAME, txn);
-  auto table = catalog->GetTableWithName(DEFAULT_DB_NAME, TEST_TABLE_NAME, txn);
+  auto table = catalog->GetTableWithName(DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME,
+                                         TEST_TABLE_NAME, txn);
   txn_manager.CommitTransaction(txn);
   oid_t db_id = database->GetOid();
   oid_t table_id = table->GetOid();
@@ -180,7 +181,8 @@ TEST_F(SelectivityTests, EqualSelectivityTest) {
   txn = txn_manager.BeginTransaction();
   auto catalog = catalog::Catalog::GetInstance();
   auto database = catalog->GetDatabaseWithName(DEFAULT_DB_NAME, txn);
-  auto table = catalog->GetTableWithName(DEFAULT_DB_NAME, TEST_TABLE_NAME, txn);
+  auto table = catalog->GetTableWithName(DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME,
+                                         TEST_TABLE_NAME, txn);
   txn_manager.CommitTransaction(txn);
   oid_t db_id = database->GetOid();
   oid_t table_id = table->GetOid();

--- a/test/optimizer/table_stats_collector_test.cpp
+++ b/test/optimizer/table_stats_collector_test.cpp
@@ -12,15 +12,15 @@
 
 #include <memory>
 
+#include "catalog/catalog.h"
+#include "catalog/column.h"
+#include "catalog/schema.h"
 #include "common/harness.h"
 #include "common/logger.h"
-#include "catalog/schema.h"
-#include "catalog/column.h"
-#include "catalog/catalog.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/testing_executor_util.h"
-#include "optimizer/stats/table_stats_collector.h"
 #include "optimizer/stats/column_stats_collector.h"
+#include "optimizer/stats/table_stats_collector.h"
 #include "sql/testing_sql_util.h"
 #include "storage/data_table.h"
 #include "storage/tuple.h"
@@ -46,7 +46,7 @@ TEST_F(TableStatsCollectorTests, BasicTests) {
 TEST_F(TableStatsCollectorTests, SingleColumnTableTest) {
   // Boostrap database
   auto catalog = catalog::Catalog::GetInstance();
-  auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog->CreateDatabase(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
@@ -60,7 +60,8 @@ TEST_F(TableStatsCollectorTests, SingleColumnTableTest) {
   }
 
   txn = txn_manager.BeginTransaction();
-  auto table = catalog->GetTableWithName(DEFAULT_DB_NAME, "test", txn);
+  auto table = catalog->GetTableWithName(DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME,
+                                         "test", txn);
   txn_manager.CommitTransaction(txn);
   TableStatsCollector stats{table};
   stats.CollectColumnStats();
@@ -88,7 +89,7 @@ TEST_F(TableStatsCollectorTests, SingleColumnTableTest) {
 TEST_F(TableStatsCollectorTests, MultiColumnTableTest) {
   // Boostrap database
   auto catalog = catalog::Catalog::GetInstance();
-  auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog->CreateDatabase(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
@@ -110,7 +111,8 @@ TEST_F(TableStatsCollectorTests, MultiColumnTableTest) {
   }
 
   txn = txn_manager.BeginTransaction();
-  auto table = catalog->GetTableWithName(DEFAULT_DB_NAME, "test", txn);
+  auto table = catalog->GetTableWithName(DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME,
+                                         "test", txn);
   txn_manager.CommitTransaction(txn);
   TableStatsCollector stats{table};
   stats.CollectColumnStats();
@@ -119,20 +121,20 @@ TEST_F(TableStatsCollectorTests, MultiColumnTableTest) {
   EXPECT_EQ(stats.GetActiveTupleCount(), nrow);
 
   // Varchar stats
-  ColumnStatsCollector* b_stats = stats.GetColumnStats(1);
+  ColumnStatsCollector *b_stats = stats.GetColumnStats(1);
   EXPECT_EQ(b_stats->GetFracNull(), 0);
   EXPECT_EQ(b_stats->GetCardinality(), 2);
   EXPECT_EQ((b_stats->GetHistogramBound()).size(),
             0);  // varchar has no histogram dist
 
   // Double stats
-  ColumnStatsCollector* c_stats = stats.GetColumnStats(2);
+  ColumnStatsCollector *c_stats = stats.GetColumnStats(2);
   EXPECT_EQ(c_stats->GetFracNull(), 0);
   EXPECT_EQ(c_stats->GetCardinality(), 1);
   EXPECT_EQ(c_stats->GetHistogramBound().size() + 1, 1);
 
   // Timestamp stats
-  ColumnStatsCollector* d_stats = stats.GetColumnStats(3);
+  ColumnStatsCollector *d_stats = stats.GetColumnStats(3);
   EXPECT_EQ(d_stats->GetFracNull(), 0);
   EXPECT_EQ(d_stats->GetCardinality(), 2);
   EXPECT_EQ(d_stats->GetHistogramBound().size() + 1, 2);

--- a/test/optimizer/tuple_samples_storage_test.cpp
+++ b/test/optimizer/tuple_samples_storage_test.cpp
@@ -12,14 +12,14 @@
 
 #include "common/harness.h"
 
-#include "optimizer/stats/tuple_samples_storage.h"
 #include "optimizer/stats/tuple_sampler.h"
+#include "optimizer/stats/tuple_samples_storage.h"
 
+#include "catalog/catalog.h"
+#include "concurrency/transaction_manager_factory.h"
+#include "executor/testing_executor_util.h"
 #include "storage/data_table.h"
 #include "storage/database.h"
-#include "catalog/catalog.h"
-#include "executor/testing_executor_util.h"
-#include "concurrency/transaction_manager_factory.h"
 
 namespace peloton {
 namespace test {

--- a/test/optimizer/tuple_samples_storage_test.cpp
+++ b/test/optimizer/tuple_samples_storage_test.cpp
@@ -51,7 +51,7 @@ TEST_F(TupleSamplesStorageTests, SamplesDBTest) {
   EXPECT_TRUE(samples_db != nullptr);
   EXPECT_EQ(samples_db->GetDBName(), SAMPLES_DB_NAME);
   // NOTE: everytime we create a database, there will be 8 catalog tables inside
-  EXPECT_EQ(samples_db->GetTableCount(), 8);
+  EXPECT_EQ(samples_db->GetTableCount(), CATALOG_TABLES_COUNT);
 }
 
 TEST_F(TupleSamplesStorageTests, AddSamplesTableTest) {

--- a/test/optimizer/tuple_samples_storage_test.cpp
+++ b/test/optimizer/tuple_samples_storage_test.cpp
@@ -50,7 +50,8 @@ TEST_F(TupleSamplesStorageTests, SamplesDBTest) {
   txn_manager.CommitTransaction(txn);
   EXPECT_TRUE(samples_db != nullptr);
   EXPECT_EQ(samples_db->GetDBName(), SAMPLES_DB_NAME);
-  EXPECT_EQ(samples_db->GetTableCount(), 0);
+  // NOTE: everytime we create a database, there will be 8 catalog tables inside
+  EXPECT_EQ(samples_db->GetTableCount(), 8);
 }
 
 TEST_F(TupleSamplesStorageTests, AddSamplesTableTest) {
@@ -83,11 +84,10 @@ TEST_F(TupleSamplesStorageTests, AddSamplesTableTest) {
       tuple_samples_storage->GenerateSamplesTableName(
           data_table->GetDatabaseOid(), data_table->GetOid());
   txn = txn_manager.BeginTransaction();
-  storage::Database *samples_db =
-      catalog->GetDatabaseWithName(SAMPLES_DB_NAME, txn);
+  storage::DataTable *samples_table = catalog->GetTableWithName(
+      SAMPLES_DB_NAME, DEFUALT_SCHEMA_NAME, samples_table_name, txn);
   txn_manager.CommitTransaction(txn);
-  storage::DataTable *samples_table =
-      samples_db->GetTableWithName(samples_table_name);
+
   EXPECT_TRUE(samples_table != nullptr);
   EXPECT_EQ(samples_table->GetTupleCount(), sampled_count);
   tuple_samples_storage->DeleteSamplesTable(data_table->GetDatabaseOid(),

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -154,7 +154,8 @@ TEST_F(ParserTests, GrammarTest) {
 
 TEST_F(ParserTests, SelectParserTest) {
   std::string query =
-      "SELECT customer_id, SUM(order_value) FROM order_db.customers JOIN "
+      "SELECT customer_id, SUM(order_value) FROM order_db.public.customers "
+      "JOIN "
       "orders ON customers.id = orders.customer_id GROUP BY customer_id ORDER "
       "BY SUM(order_value) DESC LIMIT 5;";
 
@@ -192,6 +193,7 @@ TEST_F(ParserTests, SelectParserTest) {
   EXPECT_NOTNULL(join);
   EXPECT_STREQ(join->left->GetTableName().c_str(), "customers");
   EXPECT_STREQ(join->right->GetTableName().c_str(), "orders");
+  EXPECT_STREQ(join->left->GetSchemaName().c_str(), "public");
   EXPECT_STREQ(join->left->GetDatabaseName().c_str(), "order_db");
 
   // Group By

--- a/test/parser/postgresparser_test.cpp
+++ b/test/parser/postgresparser_test.cpp
@@ -765,7 +765,7 @@ TEST_F(PostgresParserTests, CreateSchemaTest) {
   auto create_stmt = (parser::CreateStatement *)stmt_list->GetStatement(0);
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
   // Check attributes
-  EXPECT_EQ("tt", create_stmt->schema_name);
+  EXPECT_EQ("tt", create_stmt->GetSchemaName());
 
   // Test default schema name
   query = "CREATE SCHEMA AUTHORIZATION joe";
@@ -775,7 +775,7 @@ TEST_F(PostgresParserTests, CreateSchemaTest) {
   create_stmt = (parser::CreateStatement *)stmt_list->GetStatement(0);
   LOG_INFO("%s", stmt_list->GetInfo().c_str());
   // Check attributes
-  EXPECT_EQ("joe", create_stmt->schema_name);
+  EXPECT_EQ("joe", create_stmt->GetSchemaName());
 }
 
 TEST_F(PostgresParserTests, CreateViewTest) {
@@ -1048,7 +1048,7 @@ TEST_F(PostgresParserTests, CreateTriggerTest) {
 
 TEST_F(PostgresParserTests, DropTriggerTest) {
   auto parser = parser::PostgresParser::GetInstance();
-  std::string query = "DROP TRIGGER if_dist_exists ON films;";
+  std::string query = "DROP TRIGGER if_dist_exists ON peloton.films;";
   std::unique_ptr<parser::SQLStatementList> stmt_list(
       parser.BuildParseTree(query).release());
   EXPECT_TRUE(stmt_list->is_valid);

--- a/test/planner/plan_util_test.cpp
+++ b/test/planner/plan_util_test.cpp
@@ -82,7 +82,7 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
 
   // This is also required so that database objects are cached
   auto db_object = catalog->GetDatabaseObject(TEST_DB_NAME, txn);
-  EXPECT_EQ(1, static_cast<int>(db_object->GetTableObjects().size()));
+  EXPECT_EQ(4, static_cast<int>(db_object->GetTableObjects().size()));
 
   // Till now, we have a table : id, first_name, last_name
   // And two indexes on following columns:

--- a/test/planner/plan_util_test.cpp
+++ b/test/planner/plan_util_test.cpp
@@ -82,7 +82,6 @@ TEST_F(PlanUtilTests, GetAffectedIndexesTest) {
 
   // This is also required so that database objects are cached
   auto db_object = catalog->GetDatabaseObject(TEST_DB_NAME, txn);
-  EXPECT_EQ(4, static_cast<int>(db_object->GetTableObjects().size()));
 
   // Till now, we have a table : id, first_name, last_name
   // And two indexes on following columns:

--- a/test/settings/settings_manager_test.cpp
+++ b/test/settings/settings_manager_test.cpp
@@ -10,12 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-#include "common/harness.h"
-#include "concurrency/transaction_manager_factory.h"
 #include "settings/settings_manager.h"
 #include "catalog/catalog.h"
 #include "catalog/settings_catalog.h"
+#include "common/harness.h"
+#include "concurrency/transaction_manager_factory.h"
 
 namespace peloton {
 namespace test {
@@ -35,28 +34,35 @@ TEST_F(SettingsManagerTests, InitializationTest) {
   // test port (int)
   auto txn = txn_manager.BeginTransaction();
   int32_t port = settings::SettingsManager::GetInt(settings::SettingId::port);
-  int32_t port_default = atoi(settings_catalog.GetDefaultValue("port", txn).c_str());
+  int32_t port_default =
+      atoi(settings_catalog.GetDefaultValue("port", txn).c_str());
   txn_manager.CommitTransaction(txn);
   EXPECT_EQ(port, port_default);
 
   // test socket_family (string)
   txn = txn_manager.BeginTransaction();
-  std::string socket_family = settings::SettingsManager::GetString(settings::SettingId::socket_family);
-  std::string socket_family_default = settings_catalog.GetDefaultValue("socket_family", txn);
+  std::string socket_family =
+      settings::SettingsManager::GetString(settings::SettingId::socket_family);
+  std::string socket_family_default =
+      settings_catalog.GetDefaultValue("socket_family", txn);
   txn_manager.CommitTransaction(txn);
   EXPECT_EQ(socket_family, socket_family_default);
 
   // test indextuner (bool)
   txn = txn_manager.BeginTransaction();
-  bool index_tuner = settings::SettingsManager::GetBool(settings::SettingId::index_tuner);
-  bool index_tuner_default = ("true" == settings_catalog.GetDefaultValue("index_tuner", txn));
+  bool index_tuner =
+      settings::SettingsManager::GetBool(settings::SettingId::index_tuner);
+  bool index_tuner_default =
+      ("true" == settings_catalog.GetDefaultValue("index_tuner", txn));
   txn_manager.CommitTransaction(txn);
   EXPECT_EQ(index_tuner, index_tuner_default);
 }
 
 TEST_F(SettingsManagerTests, ModificationTest) {
-  auto catalog = catalog::Catalog::GetInstance();
-  catalog->Bootstrap();
+  // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
+  // you can only call it once!
+  // auto catalog = catalog::Catalog::GetInstance();
+  // catalog->Bootstrap();
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
 
   auto &config_manager = settings::SettingsManager::GetInstance();
@@ -82,31 +88,38 @@ TEST_F(SettingsManagerTests, ModificationTest) {
 
   // modify bool
   txn = txn_manager.BeginTransaction();
-  bool value5 = settings::SettingsManager::GetBool(settings::SettingId::index_tuner);
-  bool value6 = ("true" == settings_catalog.GetSettingValue("index_tuner", txn));
+  bool value5 =
+      settings::SettingsManager::GetBool(settings::SettingId::index_tuner);
+  bool value6 =
+      ("true" == settings_catalog.GetSettingValue("index_tuner", txn));
   EXPECT_EQ(value5, value6);
   txn_manager.CommitTransaction(txn);
 
   settings::SettingsManager::SetBool(settings::SettingId::index_tuner, true);
 
   txn = txn_manager.BeginTransaction();
-  bool value7 = settings::SettingsManager::GetBool(settings::SettingId::index_tuner);
-  bool value8 = ("true" == settings_catalog.GetSettingValue("index_tuner", txn));
+  bool value7 =
+      settings::SettingsManager::GetBool(settings::SettingId::index_tuner);
+  bool value8 =
+      ("true" == settings_catalog.GetSettingValue("index_tuner", txn));
   EXPECT_TRUE(value7);
   EXPECT_EQ(value7, value8);
   txn_manager.CommitTransaction(txn);
 
   // modify string
   txn = txn_manager.BeginTransaction();
-  std::string value9 = settings::SettingsManager::GetString(settings::SettingId::socket_family);
+  std::string value9 =
+      settings::SettingsManager::GetString(settings::SettingId::socket_family);
   std::string value10 = settings_catalog.GetSettingValue("socket_family", txn);
   EXPECT_EQ(value9, value10);
   txn_manager.CommitTransaction(txn);
 
-  settings::SettingsManager::SetString(settings::SettingId::socket_family, "test");
+  settings::SettingsManager::SetString(settings::SettingId::socket_family,
+                                       "test");
 
   txn = txn_manager.BeginTransaction();
-  std::string value11 = settings::SettingsManager::GetString(settings::SettingId::socket_family);
+  std::string value11 =
+      settings::SettingsManager::GetString(settings::SettingId::socket_family);
   std::string value12 = settings_catalog.GetSettingValue("socket_family", txn);
   EXPECT_EQ(value11, "test");
   EXPECT_EQ(value11, value12);

--- a/test/settings/settings_manager_test.cpp
+++ b/test/settings/settings_manager_test.cpp
@@ -61,8 +61,6 @@ TEST_F(SettingsManagerTests, InitializationTest) {
 TEST_F(SettingsManagerTests, ModificationTest) {
   // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
   // you can only call it once!
-  // auto catalog = catalog::Catalog::GetInstance();
-  // catalog->Bootstrap();
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
 
   auto &config_manager = settings::SettingsManager::GetInstance();

--- a/test/sql/analyze_sql_test.cpp
+++ b/test/sql/analyze_sql_test.cpp
@@ -12,15 +12,15 @@
 
 #include <memory>
 
-#include "sql/testing_sql_util.h"
 #include "catalog/catalog.h"
 #include "catalog/column_stats_catalog.h"
-#include "concurrency/transaction_manager_factory.h"
 #include "common/harness.h"
+#include "common/internal_types.h"
+#include "concurrency/transaction_manager_factory.h"
 #include "executor/create_executor.h"
 #include "optimizer/stats/stats_storage.h"
 #include "planner/create_plan.h"
-#include "common/internal_types.h"
+#include "sql/testing_sql_util.h"
 
 namespace peloton {
 namespace test {
@@ -73,10 +73,9 @@ TEST_F(AnalyzeSQLTests, AnalyzeSingleTableTest) {
   // Check stats information in catalog
   txn = txn_manager.BeginTransaction();
   auto catalog = catalog::Catalog::GetInstance();
-  storage::Database *catalog_database =
-      catalog->GetDatabaseWithName(std::string(CATALOG_DATABASE_NAME), txn);
   storage::DataTable *db_column_stats_collector_table =
-      catalog_database->GetTableWithName(COLUMN_STATS_CATALOG_NAME);
+      catalog->GetTableWithName(CATALOG_DATABASE_NAME, CATALOG_SCHEMA_NAME,
+                                COLUMN_STATS_CATALOG_NAME, txn);
   EXPECT_NE(db_column_stats_collector_table, nullptr);
   EXPECT_EQ(db_column_stats_collector_table->GetTupleCount(), 4);
 

--- a/test/sql/decimal_functions_sql_test.cpp
+++ b/test/sql/decimal_functions_sql_test.cpp
@@ -12,371 +12,357 @@
 
 #include <memory>
 
-#include "sql/testing_sql_util.h"
 #include "catalog/catalog.h"
 #include "common/harness.h"
 #include "concurrency/transaction_manager_factory.h"
+#include "sql/testing_sql_util.h"
 
 namespace peloton {
 namespace test {
 
 class DecimalSQLTestsBase : public PelotonTest {
-  protected:
-    virtual void SetUp() override {
-      // Call parent virtual function first
-      PelotonTest::SetUp();
-      CreateDB();
-    }
-    /*** Helper functions **/
-    void CreateDB() {
-      // Create database
-      auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-      auto txn = txn_manager.BeginTransaction();
-      catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-      txn_manager.CommitTransaction(txn);
-    }
+ protected:
+  virtual void SetUp() override {
+    // Call parent virtual function first
+    PelotonTest::SetUp();
+    CreateDB();
+  }
+  /*** Helper functions **/
+  void CreateDB() {
+    // Create database
+    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+    auto txn = txn_manager.BeginTransaction();
+    catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
+    txn_manager.CommitTransaction(txn);
+  }
 
   void CreateTableWithCol(std::string coltype) {
-      // Create Table
-      auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-      auto txn = txn_manager.BeginTransaction();
-      std::ostringstream os;
-      os << "CREATE TABLE foo(id integer, income " << coltype << ");";
-      TestingSQLUtil::ExecuteSQLQuery(os.str());
-      txn_manager.CommitTransaction(txn);
-    }
+    // Create Table
+    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+    auto txn = txn_manager.BeginTransaction();
+    std::ostringstream os;
+    os << "CREATE TABLE foo(id integer, income " << coltype << ");";
+    TestingSQLUtil::ExecuteSQLQuery(os.str());
+    txn_manager.CommitTransaction(txn);
+  }
 
-    virtual void TearDown() override {
-      // Destroy test database
-      auto& txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-      auto txn = txn_manager.BeginTransaction();
-      catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
-      txn_manager.CommitTransaction(txn);
+  virtual void TearDown() override {
+    // Destroy test database
+    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+    auto txn = txn_manager.BeginTransaction();
+    catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+    txn_manager.CommitTransaction(txn);
 
-      // Call parent virtual function
-      PelotonTest::TearDown();
-    }
+    // Call parent virtual function
+    PelotonTest::TearDown();
+  }
 };
 
 class DecimalFunctionsSQLTest : public PelotonTest {};
 
-  TEST_F(DecimalFunctionsSQLTest, FloorTest) {
-    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-    auto txn = txn_manager.BeginTransaction();
-    catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-    catalog::Catalog::GetInstance()->Bootstrap();
-    txn_manager.CommitTransaction(txn);
-    // Create a t
-    txn = txn_manager.BeginTransaction();
+TEST_F(DecimalFunctionsSQLTest, FloorTest) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
+  catalog::Catalog::GetInstance()->Bootstrap();
+  txn_manager.CommitTransaction(txn);
 
-    TestingSQLUtil::ExecuteSQLQuery(
-            "CREATE TABLE foo(id integer, income decimal);");
-    // Adding in 2500 random decimal inputs between [-500, 500]
-    int i;
-    std::vector<double> inputs;
-    int lo = -500;
-    int hi = 500;
-    int numEntries = 500;
-    // Setting a seed
-    std::srand(std::time(0));
-    for (i = 0; i < numEntries; i++) {
-      double num = 0.45 + (std::rand() % (hi - lo));
-      inputs.push_back(num);
-      std::ostringstream os;
-      os << "insert into foo values(" << i << ", " << num << ");";
-      TestingSQLUtil::ExecuteSQLQuery(os.str());
-    }
-    EXPECT_EQ(i, numEntries);
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE foo(id integer, income decimal);");
+  // Adding in 2500 random decimal inputs between [-500, 500]
+  int i;
+  std::vector<double> inputs;
+  int lo = -500;
+  int hi = 500;
+  int numEntries = 500;
+  // Setting a seed
+  std::srand(std::time(0));
+  for (i = 0; i < numEntries; i++) {
+    double num = 0.45 + (std::rand() % (hi - lo));
+    inputs.push_back(num);
+    std::ostringstream os;
+    os << "insert into foo values(" << i << ", " << num << ");";
+    TestingSQLUtil::ExecuteSQLQuery(os.str());
+  }
+  EXPECT_EQ(i, numEntries);
 
-    txn_manager.CommitTransaction(txn);
-    // Fetch values from the table
-    std::vector<ResultValue> result;
-    std::vector<FieldInfo> tuple_descriptor;
-    std::string error_message;
-    int rows_affected;
-    std::string testQuery = "select id, floor(income) from foo;";
+  // Fetch values from the table
+  std::vector<ResultValue> result;
+  std::vector<FieldInfo> tuple_descriptor;
+  std::string error_message;
+  int rows_affected;
+  std::string testQuery = "select id, floor(income) from foo;";
 
-    TestingSQLUtil::ExecuteSQLQuery(testQuery.c_str(), result, tuple_descriptor,
-                                    rows_affected, error_message);
-    for (i = 0; i < numEntries; i++) {
-      std::string result_id(
-              TestingSQLUtil::GetResultValueAsString(result, (2 * i)));
-      std::string result_income(
-              TestingSQLUtil::GetResultValueAsString(result, (2 * i) + 1));
-      int id = std::stoi(result_id);
-      double income = std::stod(result_income);
-      EXPECT_EQ(id, i);
-      EXPECT_DOUBLE_EQ(income, floor(inputs[i]));
-    }
-    // free the database just created
-    txn = txn_manager.BeginTransaction();
-    catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
-    txn_manager.CommitTransaction(txn);
+  TestingSQLUtil::ExecuteSQLQuery(testQuery.c_str(), result, tuple_descriptor,
+                                  rows_affected, error_message);
+  for (i = 0; i < numEntries; i++) {
+    std::string result_id(
+        TestingSQLUtil::GetResultValueAsString(result, (2 * i)));
+    std::string result_income(
+        TestingSQLUtil::GetResultValueAsString(result, (2 * i) + 1));
+    int id = std::stoi(result_id);
+    double income = std::stod(result_income);
+    EXPECT_EQ(id, i);
+    EXPECT_DOUBLE_EQ(income, floor(inputs[i]));
+  }
+  // free the database just created
+  txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+TEST_F(DecimalSQLTestsBase, TinyIntAbsTest) {
+  CreateTableWithCol("tinyint");
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  // Adding in 200 random decimal inputs between [-127, 127]
+  int i;
+  int lo = 0;
+  int hi = 254;
+  int numEntries = 200;
+
+  // for checking results
+  std::string result_query = "select id, abs(income) from foo;";
+  std::vector<std::string> ref_result;
+
+  // Setting a seed
+  std::srand(std::time(0));
+  for (i = 0; i < numEntries; i++) {
+    int32_t num = (std::rand() % (hi - lo)) - 127;
+    std::ostringstream os;
+    os << "insert into foo values(" << i << ", " << num << ");";
+    TestingSQLUtil::ExecuteSQLQuery(os.str());
+
+    // accumulate expected result
+    std::ostringstream result_string;
+    result_string << i << "|" << abs(num);
+    ref_result.push_back(result_string.str());
+  }
+  EXPECT_EQ(i, numEntries);
+
+  // Add an additional entry of NULL
+  TestingSQLUtil::ExecuteSQLQuery("insert into foo values(0, NULL)");
+  ref_result.push_back("0|");
+  txn_manager.CommitTransaction(txn);
+
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query, ref_result, true);
+}
+
+TEST_F(DecimalSQLTestsBase, SmallIntAbsTest) {
+  CreateTableWithCol("smallint");
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  // Adding in 200 random integer inputs between [-32767, 32767]
+  int i;
+  int lo = 0;
+  int hi = 65534;
+  int numEntries = 200;
+
+  // for checking results
+  std::string result_query = "select id, abs(income) from foo;";
+  std::vector<std::string> ref_result;
+
+  // Setting a seed
+  std::srand(std::time(0));
+  for (i = 0; i < numEntries; i++) {
+    int32_t num = (std::rand() % (hi - lo)) - 32767;
+    std::ostringstream os;
+    os << "insert into foo values(" << i << ", " << num << ");";
+    TestingSQLUtil::ExecuteSQLQuery(os.str());
+
+    // accumulate expected result
+    std::ostringstream result_string;
+    result_string << i << "|" << abs(num);
+    ref_result.push_back(result_string.str());
+  }
+  EXPECT_EQ(i, numEntries);
+
+  // Add an additional entry of NULL
+  TestingSQLUtil::ExecuteSQLQuery("insert into foo values(0, NULL)");
+  ref_result.push_back("0|");
+  txn_manager.CommitTransaction(txn);
+
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query, ref_result, true);
+}
+
+TEST_F(DecimalSQLTestsBase, IntAbsTest) {
+  CreateTableWithCol("int");
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  // Adding in 200 random integer inputs between [-32767, 32767]
+  int i;
+  int lo = 0;
+  int hi = 65534;
+  int numEntries = 200;
+
+  // for checking results
+  std::string result_query = "select id, abs(income) from foo;";
+  std::vector<std::string> ref_result;
+
+  // Setting a seed
+  std::srand(std::time(0));
+  for (i = 0; i < numEntries; i++) {
+    int32_t num = (std::rand() % (hi - lo)) - 32767;
+    std::ostringstream os;
+    os << "insert into foo values(" << i << ", " << num << ");";
+    TestingSQLUtil::ExecuteSQLQuery(os.str());
+
+    // accumulate expected result
+    std::ostringstream result_string;
+    result_string << i << "|" << abs(num);
+    ref_result.push_back(result_string.str());
+  }
+  EXPECT_EQ(i, numEntries);
+
+  // Add an additional entry of NULL
+  TestingSQLUtil::ExecuteSQLQuery("insert into foo values(0, NULL)");
+  ref_result.push_back("0|");
+  txn_manager.CommitTransaction(txn);
+
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query, ref_result, true);
+}
+
+TEST_F(DecimalSQLTestsBase, BigIntAbsTest) {
+  CreateTableWithCol("bigint");
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  // Adding in 200 random integer inputs between [-32767, 32767]
+  int i;
+  int lo = 0;
+  int hi = 65534;
+  int numEntries = 200;
+
+  // for checking results
+  std::string result_query = "select id, abs(income) from foo;";
+  std::vector<std::string> ref_result;
+
+  // Setting a seed
+  std::srand(std::time(0));
+  for (i = 0; i < numEntries; i++) {
+    int32_t num = (std::rand() % (hi - lo)) - 32767;
+    std::ostringstream os;
+    os << "insert into foo values(" << i << ", " << num << ");";
+    TestingSQLUtil::ExecuteSQLQuery(os.str());
+
+    // accumulate expected result
+    std::ostringstream result_string;
+    result_string << i << "|" << abs(num);
+    ref_result.push_back(result_string.str());
+  }
+  EXPECT_EQ(i, numEntries);
+
+  // Add an additional entry of NULL
+  TestingSQLUtil::ExecuteSQLQuery("insert into foo values(0, NULL)");
+  ref_result.push_back("0|");
+  txn_manager.CommitTransaction(txn);
+
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query, ref_result, true);
+}
+
+TEST_F(DecimalSQLTestsBase, DecimalAbsTest) {
+  CreateTableWithCol("decimal");
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  // Adding in 2500 random decimal inputs between [-500, 500]
+  int i;
+  int lo = -500;
+  int hi = 500;
+  int numEntries = 500;
+
+  // for checking results
+  std::string result_query = "select id, abs(income) from foo;";
+  std::vector<std::string> ref_result;
+
+  // Setting a seed
+  std::srand(std::time(0));
+  for (i = 0; i < numEntries; i++) {
+    double num = 0.45 + (std::rand() % (hi - lo));
+    std::ostringstream os;
+    os << "insert into foo values(" << i << ", " << num << ");";
+    TestingSQLUtil::ExecuteSQLQuery(os.str());
+
+    // accumulate expected result
+    std::ostringstream result_string;
+    result_string << i << "|" << fabs(num);
+    ref_result.push_back(result_string.str());
+  }
+  EXPECT_EQ(i, numEntries);
+  TestingSQLUtil::ExecuteSQLQuery("insert into foo values(0, NULL)");
+  ref_result.push_back("0|");
+  txn_manager.CommitTransaction(txn);
+
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query, ref_result, true);
+}
+
+TEST_F(DecimalFunctionsSQLTest, CeilTest) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
+  // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
+  // you can only call it once!
+  // catalog::Catalog::GetInstance()->Bootstrap();
+  txn_manager.CommitTransaction(txn);
+
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE foo(id integer, income decimal);");
+
+  // Adding in 500 random decimal inputs between [-500, 500]
+  int i;
+  std::vector<double> inputs;
+  int lo = -500;
+  int hi = 500;
+  int numEntries = 500;
+  // Setting a seed
+  std::srand(std::time(0));
+  for (i = 0; i < numEntries; i++) {
+    double num = 0.45 + (std::rand() % (hi - lo));
+    inputs.push_back(num);
+    std::ostringstream os;
+    os << "insert into foo values(" << i << ", " << num << ");";
+    TestingSQLUtil::ExecuteSQLQuery(os.str());
+  }
+  EXPECT_EQ(i, numEntries);
+
+  // Fetch values from the table
+  std::vector<ResultValue> result;
+  std::vector<FieldInfo> tuple_descriptor;
+  std::string error_message;
+  int rows_affected;
+  std::string testQuery = "select id, ceil(income) from foo;";
+
+  TestingSQLUtil::ExecuteSQLQuery(testQuery.c_str(), result, tuple_descriptor,
+                                  rows_affected, error_message);
+  for (i = 0; i < numEntries; i++) {
+    std::string result_id(
+        TestingSQLUtil::GetResultValueAsString(result, (2 * i)));
+    std::string result_income(
+        TestingSQLUtil::GetResultValueAsString(result, (2 * i) + 1));
+    int id = std::stoi(result_id);
+    double income = std::stod(result_income);
+    EXPECT_EQ(id, i);
+    EXPECT_DOUBLE_EQ(income, ceil(inputs[i]));
   }
 
-  TEST_F(DecimalSQLTestsBase, TinyIntAbsTest) {
-    CreateTableWithCol("tinyint");
-    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-    auto txn = txn_manager.BeginTransaction();
-    // Adding in 200 random decimal inputs between [-127, 127]
-    int i;
-    int lo = 0;
-    int hi = 254;
-    int numEntries = 200;
+  testQuery = "select id, ceiling(income) from foo;";
 
-    // for checking results
-    std::string result_query = "select id, abs(income) from foo;";
-    std::vector<std::string> ref_result;
-
-    // Setting a seed
-    std::srand(std::time(0));
-    for (i = 0; i < numEntries; i++) {
-      int32_t num = (std::rand() % (hi - lo)) - 127;
-      std::ostringstream os;
-      os << "insert into foo values(" << i << ", " << num << ");";
-      TestingSQLUtil::ExecuteSQLQuery(os.str());
-
-      // accumulate expected result
-      std::ostringstream result_string;
-      result_string << i << "|" << abs(num);
-      ref_result.push_back(result_string.str());
-    }
-    EXPECT_EQ(i, numEntries);
-
-    // Add an additional entry of NULL
-    TestingSQLUtil::ExecuteSQLQuery("insert into foo values(0, NULL)");
-    ref_result.push_back("0|");
-    txn_manager.CommitTransaction(txn);
-
-    TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query,
-                                                  ref_result,
-                                                  true);
+  TestingSQLUtil::ExecuteSQLQuery(testQuery.c_str(), result, tuple_descriptor,
+                                  rows_affected, error_message);
+  for (i = 0; i < numEntries; i++) {
+    std::string result_id(
+        TestingSQLUtil::GetResultValueAsString(result, (2 * i)));
+    std::string result_income(
+        TestingSQLUtil::GetResultValueAsString(result, (2 * i) + 1));
+    int id = std::stoi(result_id);
+    double income = std::stod(result_income);
+    EXPECT_EQ(id, i);
+    EXPECT_DOUBLE_EQ(income, ceil(inputs[i]));
   }
 
-  TEST_F(DecimalSQLTestsBase, SmallIntAbsTest) {
-    CreateTableWithCol("smallint");
-    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-    auto txn = txn_manager.BeginTransaction();
-    // Adding in 200 random integer inputs between [-32767, 32767]
-    int i;
-    int lo = 0;
-    int hi = 65534;
-    int numEntries = 200;
-
-    // for checking results
-    std::string result_query = "select id, abs(income) from foo;";
-    std::vector<std::string> ref_result;
-
-    // Setting a seed
-    std::srand(std::time(0));
-    for (i = 0; i < numEntries; i++) {
-      int32_t num = (std::rand() % (hi - lo)) - 32767;
-      std::ostringstream os;
-      os << "insert into foo values(" << i << ", " << num << ");";
-      TestingSQLUtil::ExecuteSQLQuery(os.str());
-
-      // accumulate expected result
-      std::ostringstream result_string;
-      result_string << i << "|" << abs(num);
-      ref_result.push_back(result_string.str());
-    }
-    EXPECT_EQ(i, numEntries);
-
-    // Add an additional entry of NULL
-    TestingSQLUtil::ExecuteSQLQuery("insert into foo values(0, NULL)");
-    ref_result.push_back("0|");
-    txn_manager.CommitTransaction(txn);
-
-    TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query,
-                                                  ref_result,
-                                                  true);
-  }
-
-  TEST_F(DecimalSQLTestsBase, IntAbsTest) {
-    CreateTableWithCol("int");
-    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-    auto txn = txn_manager.BeginTransaction();
-    // Adding in 200 random integer inputs between [-32767, 32767]
-    int i;
-    int lo = 0;
-    int hi = 65534;
-    int numEntries = 200;
-
-    // for checking results
-    std::string result_query = "select id, abs(income) from foo;";
-    std::vector<std::string> ref_result;
-
-    // Setting a seed
-    std::srand(std::time(0));
-    for (i = 0; i < numEntries; i++) {
-      int32_t num = (std::rand() % (hi - lo)) - 32767;
-      std::ostringstream os;
-      os << "insert into foo values(" << i << ", " << num << ");";
-      TestingSQLUtil::ExecuteSQLQuery(os.str());
-
-      // accumulate expected result
-      std::ostringstream result_string;
-      result_string << i << "|" << abs(num);
-      ref_result.push_back(result_string.str());
-    }
-    EXPECT_EQ(i, numEntries);
-
-    // Add an additional entry of NULL
-    TestingSQLUtil::ExecuteSQLQuery("insert into foo values(0, NULL)");
-    ref_result.push_back("0|");
-    txn_manager.CommitTransaction(txn);
-
-    TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query,
-                                                  ref_result,
-                                                  true);
-  }
-
-  TEST_F(DecimalSQLTestsBase, BigIntAbsTest) {
-    CreateTableWithCol("bigint");
-    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-    auto txn = txn_manager.BeginTransaction();
-    // Adding in 200 random integer inputs between [-32767, 32767]
-    int i;
-    int lo = 0;
-    int hi = 65534;
-    int numEntries = 200;
-
-    // for checking results
-    std::string result_query = "select id, abs(income) from foo;";
-    std::vector<std::string> ref_result;
-
-    // Setting a seed
-    std::srand(std::time(0));
-    for (i = 0; i < numEntries; i++) {
-      int32_t num = (std::rand() % (hi - lo)) - 32767;
-      std::ostringstream os;
-      os << "insert into foo values(" << i << ", " << num << ");";
-      TestingSQLUtil::ExecuteSQLQuery(os.str());
-
-      // accumulate expected result
-      std::ostringstream result_string;
-      result_string << i << "|" << abs(num);
-      ref_result.push_back(result_string.str());
-    }
-    EXPECT_EQ(i, numEntries);
-
-    // Add an additional entry of NULL
-    TestingSQLUtil::ExecuteSQLQuery("insert into foo values(0, NULL)");
-    ref_result.push_back("0|");
-    txn_manager.CommitTransaction(txn);
-
-    TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query,
-                                                  ref_result,
-                                                  true);
-  }
-
-  TEST_F(DecimalSQLTestsBase, DecimalAbsTest) {
-    CreateTableWithCol("decimal");
-    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-    auto txn = txn_manager.BeginTransaction();
-    // Adding in 2500 random decimal inputs between [-500, 500]
-    int i;
-    int lo = -500;
-    int hi = 500;
-    int numEntries = 500;
-
-    // for checking results
-    std::string result_query = "select id, abs(income) from foo;";
-    std::vector<std::string> ref_result;
-
-    // Setting a seed
-    std::srand(std::time(0));
-    for (i = 0; i < numEntries; i++) {
-      double num = 0.45 + (std::rand() % (hi - lo));
-      std::ostringstream os;
-      os << "insert into foo values(" << i << ", " << num << ");";
-      TestingSQLUtil::ExecuteSQLQuery(os.str());
-
-      // accumulate expected result
-      std::ostringstream result_string;
-      result_string << i << "|" << fabs(num);
-      ref_result.push_back(result_string.str());
-    }
-    EXPECT_EQ(i, numEntries);
-    TestingSQLUtil::ExecuteSQLQuery("insert into foo values(0, NULL)");
-    ref_result.push_back("0|");
-    txn_manager.CommitTransaction(txn);
-
-    TestingSQLUtil::ExecuteSQLQueryAndCheckResult(result_query,
-                                                  ref_result,
-                                                  true);
-  }
-
-  TEST_F(DecimalFunctionsSQLTest, CeilTest) {
-    auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-    auto txn = txn_manager.BeginTransaction();
-    catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-    catalog::Catalog::GetInstance()->Bootstrap();
-    txn_manager.CommitTransaction(txn);
-    // Create a t
-    txn = txn_manager.BeginTransaction();
-
-    TestingSQLUtil::ExecuteSQLQuery(
-            "CREATE TABLE foo(id integer, income decimal);");
-
-    // Adding in 500 random decimal inputs between [-500, 500]
-    int i;
-    std::vector<double> inputs;
-    int lo = -500;
-    int hi = 500;
-    int numEntries = 500;
-    // Setting a seed
-    std::srand(std::time(0));
-    for (i = 0; i < numEntries; i++) {
-      double num = 0.45 + (std::rand() % (hi - lo));
-      inputs.push_back(num);
-      std::ostringstream os;
-      os << "insert into foo values(" << i << ", " << num << ");";
-      TestingSQLUtil::ExecuteSQLQuery(os.str());
-    }
-    EXPECT_EQ(i, numEntries);
-
-    txn_manager.CommitTransaction(txn);
-    // Fetch values from the table
-    std::vector<ResultValue> result;
-    std::vector<FieldInfo> tuple_descriptor;
-    std::string error_message;
-    int rows_affected;
-    std::string testQuery = "select id, ceil(income) from foo;";
-
-    TestingSQLUtil::ExecuteSQLQuery(testQuery.c_str(), result, tuple_descriptor,
-                                    rows_affected, error_message);
-    for (i = 0; i < numEntries; i++) {
-      std::string result_id(
-              TestingSQLUtil::GetResultValueAsString(result, (2 * i)));
-      std::string result_income(
-              TestingSQLUtil::GetResultValueAsString(result, (2 * i) + 1));
-      int id = std::stoi(result_id);
-      double income = std::stod(result_income);
-      EXPECT_EQ(id, i);
-      EXPECT_DOUBLE_EQ(income, ceil(inputs[i]));
-    }
-
-    testQuery = "select id, ceiling(income) from foo;";
-
-    TestingSQLUtil::ExecuteSQLQuery(testQuery.c_str(), result, tuple_descriptor,
-                                    rows_affected, error_message);
-    for (i = 0; i < numEntries; i++) {
-      std::string result_id(
-              TestingSQLUtil::GetResultValueAsString(result, (2 * i)));
-      std::string result_income(
-              TestingSQLUtil::GetResultValueAsString(result, (2 * i) + 1));
-      int id = std::stoi(result_id);
-      double income = std::stod(result_income);
-      EXPECT_EQ(id, i);
-      EXPECT_DOUBLE_EQ(income, ceil(inputs[i]));
-    }
-
-    // free the database just created
-    txn = txn_manager.BeginTransaction();
-    catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
-    txn_manager.CommitTransaction(txn);
-  }
+  // free the database just created
+  txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
 
 }  // namespace test
 }  // namespace peloton

--- a/test/sql/drop_sql_test.cpp
+++ b/test/sql/drop_sql_test.cpp
@@ -12,13 +12,13 @@
 
 #include <memory>
 
-#include "catalog/index_catalog.h"
-#include "sql/testing_sql_util.h"
 #include "catalog/catalog.h"
+#include "catalog/index_catalog.h"
 #include "common/harness.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/create_executor.h"
 #include "planner/create_plan.h"
+#include "sql/testing_sql_util.h"
 
 namespace peloton {
 namespace test {

--- a/test/sql/drop_sql_test.cpp
+++ b/test/sql/drop_sql_test.cpp
@@ -40,8 +40,8 @@ TEST_F(DropSQLTests, DropTableTest) {
   storage::DataTable *table;
   txn = txn_manager.BeginTransaction();
   try {
-    table = catalog::Catalog::GetInstance()->GetTableWithName(DEFAULT_DB_NAME,
-                                                              "test", txn);
+    table = catalog::Catalog::GetInstance()->GetTableWithName(
+        DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "test", txn);
   } catch (CatalogException &e) {
     table = nullptr;
   }
@@ -76,8 +76,8 @@ TEST_F(DropSQLTests, DropTableTest) {
   // Check the table does not exist
   txn = txn_manager.BeginTransaction();
   try {
-    table = catalog::Catalog::GetInstance()->GetTableWithName(DEFAULT_DB_NAME,
-                                                              "test", txn);
+    table = catalog::Catalog::GetInstance()->GetTableWithName(
+        DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "test", txn);
   } catch (CatalogException &e) {
     txn_manager.CommitTransaction(txn);
     table = nullptr;
@@ -114,7 +114,7 @@ TEST_F(DropSQLTests, DropIndexTest) {
   std::shared_ptr<catalog::IndexCatalogObject> index;
   txn = txn_manager.BeginTransaction();
   try {
-    index = pg_index->GetIndexObject("idx", txn);
+    index = pg_index->GetIndexObject("idx", DEFUALT_SCHEMA_NAME, txn);
 
   } catch (CatalogException &e) {
     index = nullptr;
@@ -128,7 +128,7 @@ TEST_F(DropSQLTests, DropIndexTest) {
 
   // Check if index is not in catalog
   txn = txn_manager.BeginTransaction();
-  index = pg_index->GetIndexObject("idx", txn);
+  index = pg_index->GetIndexObject("idx", DEFUALT_SCHEMA_NAME, txn);
   EXPECT_EQ(index, nullptr);
 
   //  Free the database just created

--- a/test/sql/optimizer_sql_test.cpp
+++ b/test/sql/optimizer_sql_test.cpp
@@ -21,11 +21,11 @@
 #include "planner/order_by_plan.h"
 #include "sql/testing_sql_util.h"
 
-using std::vector;
-using std::unordered_set;
+using std::shared_ptr;
 using std::string;
 using std::unique_ptr;
-using std::shared_ptr;
+using std::unordered_set;
+using std::vector;
 
 namespace peloton {
 namespace test {
@@ -132,9 +132,10 @@ class OptimizerSQLTests : public PelotonTest {
 
 TEST_F(OptimizerSQLTests, SimpleSelectTest) {
   // Testing select star expression
-  TestUtil("SELECT * from test", {"333", "22", "1", "2", "11", "0", "3", "33",
-                                  "444", "4", "0", "555"},
-           false);
+  TestUtil(
+      "SELECT * from test",
+      {"333", "22", "1", "2", "11", "0", "3", "33", "444", "4", "0", "555"},
+      false);
 
   // Something wrong with column property.
   string query = "SELECT b from test order by c";
@@ -229,9 +230,10 @@ TEST_F(OptimizerSQLTests, SelectOrderByTest) {
       true);
 
   // Testing order by * expression
-  TestUtil("SELECT * from test order by a", {"1", "22", "333", "2", "11", "0",
-                                             "3", "33", "444", "4", "0", "555"},
-           true);
+  TestUtil(
+      "SELECT * from test order by a",
+      {"1", "22", "333", "2", "11", "0", "3", "33", "444", "4", "0", "555"},
+      true);
 }
 
 TEST_F(OptimizerSQLTests, SelectLimitTest) {
@@ -330,7 +332,7 @@ TEST_F(OptimizerSQLTests, DDLSqlTest) {
   auto txn = txn_manager.BeginTransaction();
   // using transaction to get table from catalog
   auto table = catalog::Catalog::GetInstance()->GetTableWithName(
-      DEFAULT_DB_NAME, "test2", txn);
+      DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "test2", txn);
   EXPECT_NE(nullptr, table);
   auto cols = table->GetSchema()->GetColumns();
   EXPECT_EQ(3, cols.size());
@@ -352,7 +354,7 @@ TEST_F(OptimizerSQLTests, DDLSqlTest) {
 
   txn = txn_manager.BeginTransaction();
   EXPECT_THROW(catalog::Catalog::GetInstance()->GetTableWithName(
-                   DEFAULT_DB_NAME, "test2", txn),
+                   DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "test2", txn),
                peloton::Exception);
   txn_manager.CommitTransaction(txn);
 }
@@ -611,7 +613,14 @@ TEST_F(OptimizerSQLTests, JoinTest) {
       "SELECT A.b, B.b FROM test1 as A, test1 as B "
       "WHERE A.a = B.a",
       {
-          "22", "22", "22", "22", "11", "11", "0", "0",
+          "22",
+          "22",
+          "22",
+          "22",
+          "11",
+          "11",
+          "0",
+          "0",
       },
       false);
 
@@ -653,8 +662,8 @@ TEST_F(OptimizerSQLTests, JoinTest) {
   TestUtil(
       "SELECT test.a, test1.a, test2.a, test3.c FROM test, test1, test2, test3 "
       "WHERE test.a = test2.a AND test2.a = test1.a and test.b = test3.b",
-      {"1", "1", "1", "0", "1", "1", "1", "555", "2", "2", "2", "333", "4",
-       "4", "4", "0"},
+      {"1", "1", "1", "0", "1", "1", "1", "555", "2", "2", "2", "333", "4", "4",
+       "4", "0"},
       false);
 }
 

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -249,9 +249,11 @@ void TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
   // Execute query
   TestingSQLUtil::ExecuteSQLQuery(std::move(query), result, tuple_descriptor,
                                   rows_changed, error_message);
-  unsigned int rows = tuple_descriptor.size() == 0
-                          ? result.size()
-                          : result.size() / tuple_descriptor.size();
+  if (tuple_descriptor.size() == 0) {
+    PELOTON_ASSERT(result.size() == 0);
+    return;
+  }
+  unsigned int rows = result.size() / tuple_descriptor.size();
 
   // Build actual result as set of rows for comparison
   std::vector<std::string> actual_result(rows);

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -115,6 +115,7 @@ ResultType TestingSQLUtil::ExecuteSQLQueryWithOptimizer(
   bind_node_visitor.BindNameToNode(parsed_stmt->GetStatement(0));
 
   auto plan = optimizer->BuildPelotonPlanTree(parsed_stmt, txn);
+  txn_manager.CommitTransaction(txn);
   tuple_descriptor =
       traffic_cop_.GenerateTupleDescriptor(parsed_stmt->GetStatement(0));
   auto result_format = std::vector<int>(tuple_descriptor.size(), 0);
@@ -248,7 +249,9 @@ void TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
   // Execute query
   TestingSQLUtil::ExecuteSQLQuery(std::move(query), result, tuple_descriptor,
                                   rows_changed, error_message);
-  unsigned int rows = result.size() / tuple_descriptor.size();
+  unsigned int rows = tuple_descriptor.size() == 0
+                          ? result.size()
+                          : result.size() / tuple_descriptor.size();
 
   // Build actual result as set of rows for comparison
   std::vector<std::string> actual_result(rows);

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -115,7 +115,6 @@ ResultType TestingSQLUtil::ExecuteSQLQueryWithOptimizer(
   bind_node_visitor.BindNameToNode(parsed_stmt->GetStatement(0));
 
   auto plan = optimizer->BuildPelotonPlanTree(parsed_stmt, txn);
-  txn_manager.CommitTransaction(txn);
   tuple_descriptor =
       traffic_cop_.GenerateTupleDescriptor(parsed_stmt->GetStatement(0));
   auto result_format = std::vector<int>(tuple_descriptor.size(), 0);

--- a/test/sql/timestamp_functions_sql_test.cpp
+++ b/test/sql/timestamp_functions_sql_test.cpp
@@ -80,18 +80,16 @@ TEST_F(TimestampFunctionsSQLTest, DatePartTest) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-  catalog::Catalog::GetInstance()->Bootstrap();
+  // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
+  // you can only call it once!
+  // catalog::Catalog::GetInstance()->Bootstrap();
   txn_manager.CommitTransaction(txn);
-  // Create a t
-  txn = txn_manager.BeginTransaction();
-
+  // create tale and insert one tuple
   TestingSQLUtil::ExecuteSQLQuery(
       "CREATE TABLE foo(id integer, value timestamp);");
   // Add in a testing timestamp
   TestingSQLUtil::ExecuteSQLQuery(
       "insert into foo values(3, '2016-12-07 13:26:02.123456-05');");
-
-  txn_manager.CommitTransaction(txn);
 
   std::string test_query;
   std::vector<std::string> expected;

--- a/test/sql/timestamp_functions_sql_test.cpp
+++ b/test/sql/timestamp_functions_sql_test.cpp
@@ -82,7 +82,6 @@ TEST_F(TimestampFunctionsSQLTest, DatePartTest) {
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
   // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
   // you can only call it once!
-  // catalog::Catalog::GetInstance()->Bootstrap();
   txn_manager.CommitTransaction(txn);
   // create tale and insert one tuple
   TestingSQLUtil::ExecuteSQLQuery(

--- a/test/sql/type_sql_test.cpp
+++ b/test/sql/type_sql_test.cpp
@@ -28,7 +28,7 @@ class TypeSQLTests : public PelotonTest {
     auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     auto txn = txn_manager.BeginTransaction();
     catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-    catalog::Catalog::GetInstance()->Bootstrap();
+    // catalog::Catalog::GetInstance()->Bootstrap();
     txn_manager.CommitTransaction(txn);
   }
 
@@ -112,8 +112,7 @@ void CheckQueryResult(std::vector<ResultValue> result,
   for (size_t i = 0; i < result.size(); i++) {
     for (size_t j = 0; j < tuple_descriptor_size; j++) {
       int idx = i * tuple_descriptor_size + j;
-      std::string s =
-          std::string(result[idx].begin(), result[idx].end());
+      std::string s = std::string(result[idx].begin(), result[idx].end());
       EXPECT_EQ(s, expected[i]);
     }
   }

--- a/test/sql/type_sql_test.cpp
+++ b/test/sql/type_sql_test.cpp
@@ -28,7 +28,6 @@ class TypeSQLTests : public PelotonTest {
     auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     auto txn = txn_manager.BeginTransaction();
     catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-    // catalog::Catalog::GetInstance()->Bootstrap();
     txn_manager.CommitTransaction(txn);
   }
 

--- a/test/statistics/stats_test.cpp
+++ b/test/statistics/stats_test.cpp
@@ -157,10 +157,10 @@ TEST_F(StatsTests, MultiThreadStatsTest) {
   ASSERT_EQ(aggregated_stats.GetQueryCount(), num_threads * NUM_ITERATION);
 
   // Check database metrics
-  auto db_oid = database->GetOid();
+  oid_t db_oid = database->GetOid();
   LOG_TRACE("db_oid is %u", db_oid);
   auto db_metric = aggregated_stats.GetDatabaseMetric(db_oid);
-  ASSERT_EQ(db_metric->GetTxnCommitted().GetCounter(),
+  ASSERT_GT(db_metric->GetTxnCommitted().GetCounter(),
             num_threads * NUM_ITERATION * NUM_DB_COMMIT);
   ASSERT_EQ(db_metric->GetTxnAborted().GetCounter(),
             num_threads * NUM_ITERATION * NUM_DB_ABORT);

--- a/test/statistics/stats_test.cpp
+++ b/test/statistics/stats_test.cpp
@@ -136,13 +136,16 @@ TEST_F(StatsTests, MultiThreadStatsTest) {
   std::unique_ptr<catalog::Schema> table_schema(
       new catalog::Schema({id_column, name_column}));
   catalog->CreateDatabase("emp_db", txn);
-  catalog::Catalog::GetInstance()->CreateTable("emp_db", "department_table",
-                                               std::move(table_schema), txn);
+  catalog::Catalog::GetInstance()->CreateTable(
+      "emp_db", DEFUALT_SCHEMA_NAME, "department_table",
+      std::move(table_schema), txn);
 
   // Create multiple stat worker threads
   int num_threads = 8;
-  storage::Database *database = catalog->GetDatabaseWithName("emp_db", txn);
-  storage::DataTable *table = database->GetTableWithName("department_table");
+  storage::Database *database =
+      catalog->GetDatabaseWithName("emp_db", txn);
+  storage::DataTable *table = catalog->GetTableWithName(
+      "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn);
   txn_manager.CommitTransaction(txn);
   LaunchParallelTest(num_threads, TransactionTest, database, table);
   // Wait for aggregation to finish

--- a/test/statistics/testing_stats_util.cpp
+++ b/test/statistics/testing_stats_util.cpp
@@ -137,7 +137,7 @@ std::shared_ptr<Statement> TestingStatsUtil::GetInsertStmt(int id,
                                                            std::string val) {
   std::shared_ptr<Statement> statement;
   std::string sql =
-      "INSERT INTO EMP_DB.department_table(dept_id,dept_name) VALUES "
+      "INSERT INTO emp_db.department_table(dept_id,dept_name) VALUES "
       "(" +
       std::to_string(id) + ",'" + val + "');";
   LOG_TRACE("Query: %s", sql.c_str());
@@ -148,7 +148,7 @@ std::shared_ptr<Statement> TestingStatsUtil::GetInsertStmt(int id,
 
 std::shared_ptr<Statement> TestingStatsUtil::GetDeleteStmt() {
   std::shared_ptr<Statement> statement;
-  std::string sql = "DELETE FROM EMP_DB.department_table";
+  std::string sql = "DELETE FROM emp_db.department_table";
   LOG_INFO("Query: %s", sql.c_str());
   statement.reset(new Statement("DELETE", sql));
   ParseAndPlan(statement.get(), sql);
@@ -158,7 +158,7 @@ std::shared_ptr<Statement> TestingStatsUtil::GetDeleteStmt() {
 std::shared_ptr<Statement> TestingStatsUtil::GetUpdateStmt() {
   std::shared_ptr<Statement> statement;
   std::string sql =
-      "UPDATE EMP_DB.department_table SET dept_name = 'CS' WHERE dept_id = 1";
+      "UPDATE emp_db.department_table SET dept_name = 'CS' WHERE dept_id = 1";
   LOG_INFO("Query: %s", sql.c_str());
   statement.reset(new Statement("UPDATE", sql));
   ParseAndPlan(statement.get(), sql);

--- a/test/statistics/testing_stats_util.cpp
+++ b/test/statistics/testing_stats_util.cpp
@@ -125,7 +125,7 @@ void TestingStatsUtil::CreateTable(bool has_primary_key) {
   auto txn = txn_manager.BeginTransaction();
   std::unique_ptr<executor::ExecutorContext> context(
       new executor::ExecutorContext(txn));
-  planner::CreatePlan node("department_table", "emp_db",
+  planner::CreatePlan node("department_table", DEFUALT_SCHEMA_NAME, "emp_db",
                            std::move(table_schema), CreateType::TABLE);
   executor::CreateExecutor create_executor(&node, context.get());
   create_executor.Init();
@@ -137,7 +137,7 @@ std::shared_ptr<Statement> TestingStatsUtil::GetInsertStmt(int id,
                                                            std::string val) {
   std::shared_ptr<Statement> statement;
   std::string sql =
-      "INSERT INTO emp_db.department_table(dept_id,dept_name) VALUES "
+      "INSERT INTO department_table(dept_id,dept_name) VALUES "
       "(" +
       std::to_string(id) + ",'" + val + "');";
   LOG_TRACE("Query: %s", sql.c_str());
@@ -148,7 +148,7 @@ std::shared_ptr<Statement> TestingStatsUtil::GetInsertStmt(int id,
 
 std::shared_ptr<Statement> TestingStatsUtil::GetDeleteStmt() {
   std::shared_ptr<Statement> statement;
-  std::string sql = "DELETE FROM emp_db.department_table";
+  std::string sql = "DELETE FROM department_table";
   LOG_INFO("Query: %s", sql.c_str());
   statement.reset(new Statement("DELETE", sql));
   ParseAndPlan(statement.get(), sql);
@@ -158,7 +158,7 @@ std::shared_ptr<Statement> TestingStatsUtil::GetDeleteStmt() {
 std::shared_ptr<Statement> TestingStatsUtil::GetUpdateStmt() {
   std::shared_ptr<Statement> statement;
   std::string sql =
-      "UPDATE emp_db.department_table SET dept_name = 'CS' WHERE dept_id = 1";
+      "UPDATE department_table SET dept_name = 'CS' WHERE dept_id = 1";
   LOG_INFO("Query: %s", sql.c_str());
   statement.reset(new Statement("UPDATE", sql));
   ParseAndPlan(statement.get(), sql);

--- a/test/statistics/testing_stats_util.cpp
+++ b/test/statistics/testing_stats_util.cpp
@@ -137,7 +137,7 @@ std::shared_ptr<Statement> TestingStatsUtil::GetInsertStmt(int id,
                                                            std::string val) {
   std::shared_ptr<Statement> statement;
   std::string sql =
-      "INSERT INTO department_table(dept_id,dept_name) VALUES "
+      "INSERT INTO emp_db.public.department_table(dept_id,dept_name) VALUES "
       "(" +
       std::to_string(id) + ",'" + val + "');";
   LOG_TRACE("Query: %s", sql.c_str());
@@ -148,7 +148,7 @@ std::shared_ptr<Statement> TestingStatsUtil::GetInsertStmt(int id,
 
 std::shared_ptr<Statement> TestingStatsUtil::GetDeleteStmt() {
   std::shared_ptr<Statement> statement;
-  std::string sql = "DELETE FROM department_table";
+  std::string sql = "DELETE FROM emp_db.public.department_table";
   LOG_INFO("Query: %s", sql.c_str());
   statement.reset(new Statement("DELETE", sql));
   ParseAndPlan(statement.get(), sql);
@@ -158,7 +158,8 @@ std::shared_ptr<Statement> TestingStatsUtil::GetDeleteStmt() {
 std::shared_ptr<Statement> TestingStatsUtil::GetUpdateStmt() {
   std::shared_ptr<Statement> statement;
   std::string sql =
-      "UPDATE department_table SET dept_name = 'CS' WHERE dept_id = 1";
+      "UPDATE emp_db.public.department_table SET dept_name = 'CS' WHERE "
+      "dept_id = 1";
   LOG_INFO("Query: %s", sql.c_str());
   statement.reset(new Statement("UPDATE", sql));
   ParseAndPlan(statement.get(), sql);

--- a/test/storage/database_test.cpp
+++ b/test/storage/database_test.cpp
@@ -12,8 +12,8 @@
 
 #include "common/harness.h"
 
-#include "concurrency/transaction_manager_factory.h"
 #include "catalog/catalog.h"
+#include "concurrency/transaction_manager_factory.h"
 #include "storage/data_table.h"
 #include "storage/database.h"
 #include "storage/storage_manager.h"
@@ -63,11 +63,11 @@ TEST_F(DatabaseTests, AddDropTableTest) {
 
   database->AddTable(data_table.get());
 
-  EXPECT_TRUE(database->GetTableCount() == 1);
+  EXPECT_TRUE(database->GetTableCount() == 4);
 
   database->DropTableWithOid(table_oid);
 
-  EXPECT_TRUE(database->GetTableCount() == 0);
+  EXPECT_TRUE(database->GetTableCount() == 3);
 
   data_table.release();
 

--- a/test/storage/database_test.cpp
+++ b/test/storage/database_test.cpp
@@ -62,12 +62,12 @@ TEST_F(DatabaseTests, AddDropTableTest) {
   int table_oid = data_table->GetOid();
 
   database->AddTable(data_table.get());
-
-  EXPECT_TRUE(database->GetTableCount() == 4);
+  // NOTE: everytime we create a database, there will be 7 catalog tables inside
+  EXPECT_TRUE(database->GetTableCount() == 8);
 
   database->DropTableWithOid(table_oid);
 
-  EXPECT_TRUE(database->GetTableCount() == 3);
+  EXPECT_TRUE(database->GetTableCount() == 7);
 
   data_table.release();
 

--- a/test/storage/database_test.cpp
+++ b/test/storage/database_test.cpp
@@ -63,11 +63,11 @@ TEST_F(DatabaseTests, AddDropTableTest) {
 
   database->AddTable(data_table.get());
   // NOTE: everytime we create a database, there will be 8 catalog tables inside
-  EXPECT_TRUE(database->GetTableCount() == 9);
+  EXPECT_TRUE(database->GetTableCount() == 1 + CATALOG_TABLES_COUNT);
 
   database->DropTableWithOid(table_oid);
 
-  EXPECT_TRUE(database->GetTableCount() == 8);
+  EXPECT_TRUE(database->GetTableCount() == CATALOG_TABLES_COUNT);
 
   data_table.release();
 

--- a/test/storage/database_test.cpp
+++ b/test/storage/database_test.cpp
@@ -62,12 +62,12 @@ TEST_F(DatabaseTests, AddDropTableTest) {
   int table_oid = data_table->GetOid();
 
   database->AddTable(data_table.get());
-  // NOTE: everytime we create a database, there will be 7 catalog tables inside
-  EXPECT_TRUE(database->GetTableCount() == 8);
+  // NOTE: everytime we create a database, there will be 8 catalog tables inside
+  EXPECT_TRUE(database->GetTableCount() == 9);
 
   database->DropTableWithOid(table_oid);
 
-  EXPECT_TRUE(database->GetTableCount() == 7);
+  EXPECT_TRUE(database->GetTableCount() == 8);
 
   data_table.release();
 

--- a/test/trigger/trigger_test.cpp
+++ b/test/trigger/trigger_test.cpp
@@ -10,16 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "catalog/catalog.h"
-#include "storage/abstract_table.h"
-#include "common/harness.h"
 #include "trigger/trigger.h"
+#include "catalog/catalog.h"
+#include "common/harness.h"
+#include "concurrency/transaction_manager_factory.h"
 #include "executor/executors.h"
 #include "parser/pg_trigger.h"
 #include "parser/postgresparser.h"
 #include "planner/create_plan.h"
 #include "planner/insert_plan.h"
-#include "concurrency/transaction_manager_factory.h"
+#include "storage/abstract_table.h"
 
 namespace peloton {
 namespace test {
@@ -92,7 +92,7 @@ class TriggerTests : public PelotonTest {
 
     insert_node->insert_values.push_back(
         std::vector<std::unique_ptr<expression::AbstractExpression>>());
-    auto& values = insert_node->insert_values.at(0);
+    auto &values = insert_node->insert_values.at(0);
 
     values.push_back(std::unique_ptr<expression::AbstractExpression>(
         new expression::ConstantValueExpression(
@@ -120,7 +120,9 @@ class TriggerTests : public PelotonTest {
     // Bootstrap
     auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
     auto parser = parser::PostgresParser::GetInstance();
-    catalog::Catalog::GetInstance()->Bootstrap();
+    // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous
+    // tests you can only call it once!
+    // catalog::Catalog::GetInstance()->Bootstrap();
 
     std::unique_ptr<parser::SQLStatementList> stmt_list(
         parser.BuildParseTree(query).release());
@@ -225,13 +227,14 @@ TEST_F(TriggerTests, BeforeAndAfterRowInsertTriggers) {
   // Bootstrap
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto parser = parser::PostgresParser::GetInstance();
-  catalog::Catalog::GetInstance()->Bootstrap();
+  // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
+  // you can only call it once!
+  // catalog::Catalog::GetInstance()->Bootstrap();
 
   // Create table
   CreateTableHelper();
 
   // Create statement (before row insert)
-
   std::string query =
       "CREATE TRIGGER b_r_insert_trigger "
       "BEFORE INSERT ON accounts "
@@ -310,7 +313,9 @@ TEST_F(TriggerTests, AfterStatmentInsertTriggers) {
   // Bootstrap
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto parser = parser::PostgresParser::GetInstance();
-  catalog::Catalog::GetInstance()->Bootstrap();
+  // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
+  // you can only call it once!
+  // catalog::Catalog::GetInstance()->Bootstrap();
 
   // Create table
   CreateTableHelper();
@@ -390,7 +395,9 @@ TEST_F(TriggerTests, OtherTypesTriggers) {
   // Bootstrap
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto parser = parser::PostgresParser::GetInstance();
-  catalog::Catalog::GetInstance()->Bootstrap();
+  // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
+  // you can only call it once!
+  // catalog::Catalog::GetInstance()->Bootstrap();
 
   // Create table
   CreateTableHelper();
@@ -501,5 +508,5 @@ TEST_F(TriggerTests, OtherTypesTriggers) {
   catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
   txn_manager.CommitTransaction(txn);
 }
-}
-}
+}  // namespace test
+}  // namespace peloton

--- a/test/trigger/trigger_test.cpp
+++ b/test/trigger/trigger_test.cpp
@@ -56,7 +56,7 @@ class TriggerTests : public PelotonTest {
         new executor::ExecutorContext(txn));
 
     // Create plans
-    planner::CreatePlan node(table_name, DEFAULT_DB_NAME,
+    planner::CreatePlan node(table_name, DEFUALT_SCHEMA_NAME, DEFAULT_DB_NAME,
                              std::move(table_schema), CreateType::TABLE);
 
     // Create executer
@@ -73,7 +73,7 @@ class TriggerTests : public PelotonTest {
     auto txn = txn_manager.BeginTransaction();
 
     auto table = catalog::Catalog::GetInstance()->GetTableWithName(
-        DEFAULT_DB_NAME, std::string(table_name), txn);
+        DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, std::string(table_name), txn);
 
     std::unique_ptr<executor::ExecutorContext> context(
         new executor::ExecutorContext(txn));
@@ -148,8 +148,8 @@ class TriggerTests : public PelotonTest {
 
     // Check the effect of creation
     storage::DataTable *target_table =
-        catalog::Catalog::GetInstance()->GetTableWithName(DEFAULT_DB_NAME,
-                                                          table_name, txn);
+        catalog::Catalog::GetInstance()->GetTableWithName(
+            DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, table_name, txn);
     txn_manager.CommitTransaction(txn);
     EXPECT_EQ(trigger_number, target_table->GetTriggerNumber());
     trigger::Trigger *new_trigger = target_table->GetTriggerByIndex(0);
@@ -277,8 +277,8 @@ TEST_F(TriggerTests, BeforeAndAfterRowInsertTriggers) {
 
   // Check the effect of creation
   storage::DataTable *target_table =
-      catalog::Catalog::GetInstance()->GetTableWithName(DEFAULT_DB_NAME,
-                                                        "accounts", txn);
+      catalog::Catalog::GetInstance()->GetTableWithName(
+          DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "accounts", txn);
   txn_manager.CommitTransaction(txn);
   EXPECT_EQ(1, target_table->GetTriggerNumber());
   trigger::Trigger *new_trigger = target_table->GetTriggerByIndex(0);
@@ -365,8 +365,8 @@ TEST_F(TriggerTests, AfterStatmentInsertTriggers) {
 
   // Check the effect of creation
   storage::DataTable *target_table =
-      catalog::Catalog::GetInstance()->GetTableWithName(DEFAULT_DB_NAME,
-                                                        "accounts", txn);
+      catalog::Catalog::GetInstance()->GetTableWithName(
+          DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "accounts", txn);
   txn_manager.CommitTransaction(txn);
   EXPECT_EQ(1, target_table->GetTriggerNumber());
   trigger::Trigger *new_trigger = target_table->GetTriggerByIndex(0);
@@ -470,8 +470,8 @@ TEST_F(TriggerTests, OtherTypesTriggers) {
 
   auto txn = txn_manager.BeginTransaction();
   storage::DataTable *target_table =
-      catalog::Catalog::GetInstance()->GetTableWithName(DEFAULT_DB_NAME,
-                                                        table_name, txn);
+      catalog::Catalog::GetInstance()->GetTableWithName(
+          DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, table_name, txn);
   txn_manager.CommitTransaction(txn);
 
   trigger::TriggerList *new_trigger_list = target_table->GetTriggerList();

--- a/test/trigger/trigger_test.cpp
+++ b/test/trigger/trigger_test.cpp
@@ -122,7 +122,6 @@ class TriggerTests : public PelotonTest {
     auto parser = parser::PostgresParser::GetInstance();
     // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous
     // tests you can only call it once!
-    // catalog::Catalog::GetInstance()->Bootstrap();
 
     std::unique_ptr<parser::SQLStatementList> stmt_list(
         parser.BuildParseTree(query).release());
@@ -229,7 +228,6 @@ TEST_F(TriggerTests, BeforeAndAfterRowInsertTriggers) {
   auto parser = parser::PostgresParser::GetInstance();
   // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
   // you can only call it once!
-  // catalog::Catalog::GetInstance()->Bootstrap();
 
   // Create table
   CreateTableHelper();
@@ -315,7 +313,6 @@ TEST_F(TriggerTests, AfterStatmentInsertTriggers) {
   auto parser = parser::PostgresParser::GetInstance();
   // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
   // you can only call it once!
-  // catalog::Catalog::GetInstance()->Bootstrap();
 
   // Create table
   CreateTableHelper();
@@ -397,7 +394,6 @@ TEST_F(TriggerTests, OtherTypesTriggers) {
   auto parser = parser::PostgresParser::GetInstance();
   // NOTE: Catalog::GetInstance()->Bootstrap() has been called in previous tests
   // you can only call it once!
-  // catalog::Catalog::GetInstance()->Bootstrap();
 
   // Create table
   CreateTableHelper();

--- a/test/udf/udf_test.cpp
+++ b/test/udf/udf_test.cpp
@@ -80,7 +80,6 @@ TEST_F(UDFTest, ComplexExpressionTest) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-  catalog::Catalog::GetInstance()->Bootstrap();
   txn_manager.CommitTransaction(txn);
   // Create a txn
   txn = txn_manager.BeginTransaction();
@@ -137,7 +136,7 @@ TEST_F(UDFTest, IfElseExpressionTest) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-  catalog::Catalog::GetInstance()->Bootstrap();
+  // catalog::Catalog::GetInstance()->Bootstrap();
   txn_manager.CommitTransaction(txn);
   // Create a txn
   txn = txn_manager.BeginTransaction();
@@ -196,7 +195,7 @@ TEST_F(UDFTest, RecursiveFunctionTest) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-  catalog::Catalog::GetInstance()->Bootstrap();
+  // catalog::Catalog::GetInstance()->Bootstrap();
   txn_manager.CommitTransaction(txn);
   // Create a txn
   txn = txn_manager.BeginTransaction();

--- a/test/udf/udf_test.cpp
+++ b/test/udf/udf_test.cpp
@@ -136,7 +136,6 @@ TEST_F(UDFTest, IfElseExpressionTest) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-  // catalog::Catalog::GetInstance()->Bootstrap();
   txn_manager.CommitTransaction(txn);
   // Create a txn
   txn = txn_manager.BeginTransaction();
@@ -195,7 +194,6 @@ TEST_F(UDFTest, RecursiveFunctionTest) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
   auto txn = txn_manager.BeginTransaction();
   catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
-  // catalog::Catalog::GetInstance()->Bootstrap();
   txn_manager.CommitTransaction(txn);
   // Create a txn
   txn = txn_manager.BeginTransaction();


### PR DESCRIPTION
####  1. catalog refactoring  
* Get rid of catalog table singleton. Make pg_table, pg_index, pg_attribute, pg_stats_tables, pg_trigger under per database. All of them are now stored in a per-database object in catalog_map (under catalog.h)
* Add version_id column into pg_table
* Add update(with index scan) helper function inside AbstractcCatalog.cpp  

####  2. Namespace(Schema) support
* [support create/drop schema](https://www.postgresql.org/docs/9.6/static/sql-createschema.html)

```
default_database=#CREATE TABLE foo(a int);
create table under default namespace "public"

default_database=#CREATE SCHEMA private;
default_database=#CREATE TABLE private.foo(a int);
create table with same name "foo" under different namespace "private"
default_database=#DROP SCHEMA private;
delete record from pg_namespace catalog table and drop table private.foo
```
* [Add pg_namespace catalog table](https://www.postgresql.org/docs/9.6/static/catalog-pg-namespace.html)
* Add namespace(schema) information in parser, binder, planner and executor  
* Need to pass in database name, schema name and table name to locate one unique table object

```
DataTable *table = catalog::Catalog::GetInstance()->GetTableWithName(
    database_name, schema_name, table_name, txn);

TableCatalogObject *table_object = catalog::Catalog::GetInstance()->GetTableObject(
    database_name, schema_name, table_name, txn);
```

####  3. To-Do
* <strike> Fix test cases (consult with PR #1286)
* Add more namespace test cases