### PR TITLE
fix #1313  Remove read only isolation level

### DIFF
--- a/src/common/internal_types.cpp
+++ b/src/common/internal_types.cpp
@@ -2392,9 +2392,6 @@ std::string IsolationLevelTypeToString(IsolationLevelType type) {
     case IsolationLevelType::READ_COMMITTED: {
       return "READ_COMMITTED";
     }
-    case IsolationLevelType::READ_ONLY: {
-      return "READ_ONLY";
-    }
     default: {
       throw ConversionException(StringUtil::Format(
           "No string conversion for IsolationLevelType value '%d'",
@@ -2416,8 +2413,6 @@ IsolationLevelType StringToIsolationLevelType(const std::string &str) {
     return IsolationLevelType::REPEATABLE_READS;
   } else if (upper_str == "READ_COMMITTED") {
     return IsolationLevelType::READ_COMMITTED;
-  } else if (upper_str == "READ_ONLY") {
-    return IsolationLevelType::READ_ONLY;
   } else {
     throw ConversionException(
         StringUtil::Format("No IsolationLevelType conversion from string '%s'",

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -175,7 +175,7 @@ bool TimestampOrderingTransactionManager::PerformRead(
   //////////////////////////////////////////////////////////
   //// handle READ_ONLY
   //////////////////////////////////////////////////////////
-  if (current_txn->GetIsolationLevel() == IsolationLevelType::READ_ONLY) {
+  if (current_txn->IsReadOnly()) {
     // do not update read set for read-only transactions.
     return true;
   }  // end READ ONLY
@@ -434,7 +434,7 @@ bool TimestampOrderingTransactionManager::PerformRead(
 void TimestampOrderingTransactionManager::PerformInsert(
     TransactionContext *const current_txn, const ItemPointer &location,
     ItemPointer *index_entry_ptr) {
-  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(!current_txn->IsReadOnly());
 
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
@@ -472,7 +472,7 @@ void TimestampOrderingTransactionManager::PerformInsert(
 void TimestampOrderingTransactionManager::PerformUpdate(
     TransactionContext *const current_txn, const ItemPointer &location,
     const ItemPointer &new_location) {
-  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(!current_txn->IsReadOnly());
 
   ItemPointer old_location = location;
 
@@ -555,7 +555,7 @@ void TimestampOrderingTransactionManager::PerformUpdate(
 void TimestampOrderingTransactionManager::PerformUpdate(
     TransactionContext *const current_txn UNUSED_ATTRIBUTE,
     const ItemPointer &location) {
-  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(!current_txn->IsReadOnly());
 
   oid_t tile_group_id = location.block;
   UNUSED_ATTRIBUTE oid_t tuple_id = location.offset;
@@ -588,7 +588,7 @@ void TimestampOrderingTransactionManager::PerformUpdate(
 void TimestampOrderingTransactionManager::PerformDelete(
     TransactionContext *const current_txn, const ItemPointer &location,
     const ItemPointer &new_location) {
-  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(!current_txn->IsReadOnly());
 
   ItemPointer old_location = location;
 
@@ -673,7 +673,7 @@ void TimestampOrderingTransactionManager::PerformDelete(
 
 void TimestampOrderingTransactionManager::PerformDelete(
     TransactionContext *const current_txn, const ItemPointer &location) {
-  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(!current_txn->IsReadOnly());
 
   oid_t tile_group_id = location.block;
   oid_t tuple_id = location.offset;
@@ -712,7 +712,7 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
   //////////////////////////////////////////////////////////
   //// handle READ_ONLY
   //////////////////////////////////////////////////////////
-  if (current_txn->GetIsolationLevel() == IsolationLevelType::READ_ONLY) {
+  if (current_txn->IsReadOnly()) {
     EndTransaction(current_txn);
     return ResultType::SUCCESS;
   }
@@ -899,7 +899,7 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
 ResultType TimestampOrderingTransactionManager::AbortTransaction(
     TransactionContext *const current_txn) {
   // a pre-declared read-only transaction will never abort.
-  PELOTON_ASSERT(current_txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY);
+  PELOTON_ASSERT(!current_txn->IsReadOnly());
 
   LOG_TRACE("Aborting peloton txn : %" PRId64, current_txn->GetTransactionId());
   auto &manager = catalog::Manager::GetInstance();

--- a/src/concurrency/transaction_manager.cpp
+++ b/src/concurrency/transaction_manager.cpp
@@ -60,8 +60,8 @@ TransactionContext *TransactionManager::BeginTransaction(
     txn = new TransactionContext(thread_id, type, read_id);
   }
 
-  if(read_only){
-    txn->setReadOnly();
+  if (read_only) {
+    txn->SetReadOnly();
   }
 
   if (static_cast<StatsType>(settings::SettingsManager::GetInt(

--- a/src/concurrency/transaction_manager.cpp
+++ b/src/concurrency/transaction_manager.cpp
@@ -39,7 +39,7 @@ TransactionContext *TransactionManager::BeginTransaction(
     cid_t read_id = EpochManagerFactory::GetInstance().EnterEpoch(
         thread_id, TimestampType::SNAPSHOT_READ);
     txn = new TransactionContext(thread_id, type, read_id);
-
+    txn->setReadOnly();
   }
 
   if (type == IsolationLevelType::SNAPSHOT) {

--- a/src/concurrency/transaction_manager.cpp
+++ b/src/concurrency/transaction_manager.cpp
@@ -31,16 +31,18 @@ ConflictAvoidanceType TransactionManager::conflict_avoidance_ =
     ConflictAvoidanceType::ABORT;
 
 TransactionContext *TransactionManager::BeginTransaction(
-    const size_t thread_id, const IsolationLevelType type) {
+    const size_t thread_id, const IsolationLevelType type, bool read_only) {
   TransactionContext *txn = nullptr;
 
-  if (type == IsolationLevelType::READ_ONLY) {
+  if (read_only) {
     // transaction processing with decentralized epoch manager
     cid_t read_id = EpochManagerFactory::GetInstance().EnterEpoch(
         thread_id, TimestampType::SNAPSHOT_READ);
     txn = new TransactionContext(thread_id, type, read_id);
 
-  } else if (type == IsolationLevelType::SNAPSHOT) {
+  }
+
+  if (type == IsolationLevelType::SNAPSHOT) {
     // transaction processing with decentralized epoch manager
     // the DBMS must acquire
     cid_t read_id = EpochManagerFactory::GetInstance().EnterEpoch(

--- a/src/concurrency/transaction_manager.cpp
+++ b/src/concurrency/transaction_manager.cpp
@@ -34,14 +34,6 @@ TransactionContext *TransactionManager::BeginTransaction(
     const size_t thread_id, const IsolationLevelType type, bool read_only) {
   TransactionContext *txn = nullptr;
 
-  if (read_only) {
-    // transaction processing with decentralized epoch manager
-    cid_t read_id = EpochManagerFactory::GetInstance().EnterEpoch(
-        thread_id, TimestampType::SNAPSHOT_READ);
-    txn = new TransactionContext(thread_id, type, read_id);
-    txn->setReadOnly();
-  }
-
   if (type == IsolationLevelType::SNAPSHOT) {
     // transaction processing with decentralized epoch manager
     // the DBMS must acquire
@@ -66,6 +58,10 @@ TransactionContext *TransactionManager::BeginTransaction(
     cid_t read_id = EpochManagerFactory::GetInstance().EnterEpoch(
         thread_id, TimestampType::READ);
     txn = new TransactionContext(thread_id, type, read_id);
+  }
+
+  if(read_only){
+    txn->setReadOnly();
   }
 
   if (static_cast<StatsType>(settings::SettingsManager::GetInt(

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -93,7 +93,7 @@ void TransactionLevelGCManager::RecycleTransaction(
   epoch_manager.ExitEpoch(txn->GetThreadId(),
                           txn->GetEpochId());
 
-  if (txn->GetIsolationLevel() != IsolationLevelType::READ_ONLY && \
+  if (!txn->IsReadOnly() && \
       txn->GetResult() != ResultType::SUCCESS && txn->IsGCSetEmpty() != true) {
         txn->SetEpochId(epoch_manager.GetNextEpochId());
   }
@@ -148,7 +148,7 @@ int TransactionLevelGCManager::Unlink(const int &thread_id,
 
     // Deallocate the Transaction Context of transactions that don't involve
     // any garbage collection
-    if (txn_ctx->GetIsolationLevel() == IsolationLevelType::READ_ONLY || \
+    if (txn_ctx->IsReadOnly() || \
         txn_ctx->IsGCSetEmpty()) {
       delete txn_ctx;
       continue;

--- a/src/include/common/internal_types.h
+++ b/src/include/common/internal_types.h
@@ -422,7 +422,6 @@ enum class IsolationLevelType {
   SNAPSHOT = 2,          // snapshot isolation
   REPEATABLE_READS = 3,  // repeatable reads
   READ_COMMITTED = 4,    // read committed
-  READ_ONLY = 5          // read only
 };
 std::string IsolationLevelTypeToString(IsolationLevelType type);
 IsolationLevelType StringToIsolationLevelType(const std::string &str);

--- a/src/include/concurrency/transaction_context.h
+++ b/src/include/concurrency/transaction_context.h
@@ -269,7 +269,15 @@ class TransactionContext : public Printable {
    * @return     True if read only, False otherwise.
    */
   inline bool IsReadOnly() const {
-    return is_written_ == false && insert_count_ == 0;
+    return read_only_;
+  }
+
+  /**
+   * @brief      mark this context as read only
+   *
+   */
+  inline void setReadOnly() {
+    read_only_ = true;
   }
 
   /**
@@ -341,6 +349,8 @@ class TransactionContext : public Printable {
   IsolationLevelType isolation_level_;
 
   std::unique_ptr<trigger::TriggerSet> on_commit_triggers_;
+
+  bool read_only_ = false;
 };
 
 }  // namespace concurrency

--- a/src/include/concurrency/transaction_context.h
+++ b/src/include/concurrency/transaction_context.h
@@ -268,7 +268,7 @@ class TransactionContext : public Printable {
    *
    * @return     True if read only, False otherwise.
    */
-  inline bool IsReadOnly() const {
+  bool IsReadOnly() const {
     return read_only_;
   }
 
@@ -276,7 +276,7 @@ class TransactionContext : public Printable {
    * @brief      mark this context as read only
    *
    */
-  inline void setReadOnly() {
+  void SetReadOnly() {
     read_only_ = true;
   }
 
@@ -350,6 +350,7 @@ class TransactionContext : public Printable {
 
   std::unique_ptr<trigger::TriggerSet> on_commit_triggers_;
 
+  /** one default transaction is NOT 'read only' unless it is marked 'read only' explicitly*/
   bool read_only_ = false;
 };
 

--- a/src/include/concurrency/transaction_manager.h
+++ b/src/include/concurrency/transaction_manager.h
@@ -219,10 +219,10 @@ class TransactionManager {
   }
 
   TransactionContext *BeginTransaction(const IsolationLevelType type) {
-    return BeginTransaction(0, type);
+    return BeginTransaction(0, type, false);
   }
 
-  TransactionContext *BeginTransactionReadOnly() {
+  TransactionContext *BeginTransactionReadOnly(const IsolationLevelType type) {
     return BeginTransaction(0, type, true);
   }
 

--- a/src/include/concurrency/transaction_manager.h
+++ b/src/include/concurrency/transaction_manager.h
@@ -222,8 +222,13 @@ class TransactionManager {
     return BeginTransaction(0, type);
   }
 
+  TransactionContext *BeginTransactionReadOnly() {
+    return BeginTransaction(0, type, true);
+  }
+
   TransactionContext *BeginTransaction(const size_t thread_id = 0,
-                                const IsolationLevelType type = isolation_level_);
+                                const IsolationLevelType type = isolation_level_,
+                                bool read_only = false);
 
   /**
    * @brief      Ends a transaction.

--- a/src/include/concurrency/transaction_manager.h
+++ b/src/include/concurrency/transaction_manager.h
@@ -222,10 +222,6 @@ class TransactionManager {
     return BeginTransaction(0, type, false);
   }
 
-  TransactionContext *BeginTransactionReadOnly(const IsolationLevelType type) {
-    return BeginTransaction(0, type, true);
-  }
-
   TransactionContext *BeginTransaction(const size_t thread_id = 0,
                                 const IsolationLevelType type = isolation_level_,
                                 bool read_only = false);

--- a/test/common/internal_types_test.cpp
+++ b/test/common/internal_types_test.cpp
@@ -646,7 +646,7 @@ TEST_F(InternalTypesTests, IsolationLevelTypeTest) {
   std::vector<IsolationLevelType> list = {
       IsolationLevelType::INVALID,        IsolationLevelType::SERIALIZABLE,
       IsolationLevelType::SNAPSHOT,       IsolationLevelType::REPEATABLE_READS,
-      IsolationLevelType::READ_COMMITTED, IsolationLevelType::READ_ONLY};
+      IsolationLevelType::READ_COMMITTED};
 
   // Make sure that ToString and FromString work
   for (auto val : list) {

--- a/test/concurrency/serializable_transaction_test.cpp
+++ b/test/concurrency/serializable_transaction_test.cpp
@@ -76,6 +76,8 @@ TEST_F(SerializableTransactionTests, ReadOnlyTransactionTest) {
 
       //manually update snapshot epoch number, so later snapshot read must get a larger epoch than table creating txn
       //or it may read nothing
+      //wait one epoch. so that global epoch is guaranteed to increase
+      std::this_thread::sleep_for(std::chrono::milliseconds(EPOCH_LENGTH));
       concurrency::EpochManagerFactory::GetInstance().GetExpiredEpochId();
 
       TransactionScheduler scheduler(1, table, &txn_manager, {0});
@@ -127,6 +129,7 @@ TEST_F(SerializableTransactionTests, ConcurrentReadOnlyTransactionTest) {
       storage::DataTable *table = TestingTransactionUtil::CreateTable();
 
       //force snapshot epoch to be updated. it should be larger than table creation txn's epoch
+      std::this_thread::sleep_for(std::chrono::milliseconds(EPOCH_LENGTH));
       concurrency::EpochManagerFactory::GetInstance().GetExpiredEpochId();
 
       TransactionScheduler scheduler(2, table, &txn_manager, {1});

--- a/test/concurrency/serializable_transaction_test.cpp
+++ b/test/concurrency/serializable_transaction_test.cpp
@@ -111,6 +111,7 @@ TEST_F(SerializableTransactionTests, ConcurrentReadOnlyTransactionTest) {
       EXPECT_EQ(ResultType::SUCCESS, scheduler.schedules[1].txn_result);
 
       EXPECT_EQ(0, scheduler.schedules[1].results[0]);
+      //behaves like read committed
       EXPECT_EQ(2, scheduler.schedules[1].results[1]);
     }
   }

--- a/test/concurrency/serializable_transaction_test.cpp
+++ b/test/concurrency/serializable_transaction_test.cpp
@@ -111,7 +111,7 @@ TEST_F(SerializableTransactionTests, ConcurrentReadOnlyTransactionTest) {
       EXPECT_EQ(ResultType::SUCCESS, scheduler.schedules[1].txn_result);
 
       EXPECT_EQ(0, scheduler.schedules[1].results[0]);
-      EXPECT_EQ(0, scheduler.schedules[1].results[0]);
+      EXPECT_EQ(2, scheduler.schedules[1].results[1]);
     }
   }
 }

--- a/test/include/concurrency/testing_transaction_util.h
+++ b/test/include/concurrency/testing_transaction_util.h
@@ -241,7 +241,7 @@ class TransactionThread {
 
     if (cur_seq == 0) {
       if (schedule->declared_ro == true) {
-        txn = txn_manager->BeginTransactionReadOnly(IsolationLevelType::READ_COMMITTED);
+        txn = txn_manager->BeginTransactionReadOnly(IsolationLevelType::SNAPSHOT);
       } else {
         txn = txn_manager->BeginTransaction();
       }

--- a/test/include/concurrency/testing_transaction_util.h
+++ b/test/include/concurrency/testing_transaction_util.h
@@ -241,7 +241,7 @@ class TransactionThread {
 
     if (cur_seq == 0) {
       if (schedule->declared_ro == true) {
-        txn = txn_manager->BeginTransactionReadOnly();
+        txn = txn_manager->BeginTransactionReadOnly(IsolationLevelType::READ_COMMITTED);
       } else {
         txn = txn_manager->BeginTransaction();
       }

--- a/test/include/concurrency/testing_transaction_util.h
+++ b/test/include/concurrency/testing_transaction_util.h
@@ -242,7 +242,7 @@ class TransactionThread {
     if (cur_seq == 0) {
       if (schedule->declared_ro == true) {
         /** starts a read only transaction*/
-        txn = txn_manager->BeginTransaction(0, IsolationLevelType::SERIALIZABLE, true);
+        txn = txn_manager->BeginTransaction(0, IsolationLevelType::SNAPSHOT, true);
       } else {
         txn = txn_manager->BeginTransaction();
       }

--- a/test/include/concurrency/testing_transaction_util.h
+++ b/test/include/concurrency/testing_transaction_util.h
@@ -349,14 +349,14 @@ class TransactionScheduler {
  public:
   TransactionScheduler(size_t num_txn, storage::DataTable *datatable_,
                        concurrency::TransactionManager *txn_manager_,
-                       std::initializer_list<int> il = {})
+                       std::set<int> read_only_ = {})
       : txn_manager(txn_manager_),
         table(datatable_),
         time(0),
         concurrent(false) {
-    std::set<int> read_only(il);
+
     for (size_t i = 0; i < num_txn; i++) {
-      if (read_only.find(i) != read_only.end()) {
+      if (read_only_.find(i) != read_only_.end()) {
         schedules.emplace_back(i, true);
       } else {
         schedules.emplace_back(i, false);

--- a/test/include/concurrency/testing_transaction_util.h
+++ b/test/include/concurrency/testing_transaction_util.h
@@ -241,7 +241,8 @@ class TransactionThread {
 
     if (cur_seq == 0) {
       if (schedule->declared_ro == true) {
-        txn = txn_manager->BeginTransactionReadOnly(IsolationLevelType::SNAPSHOT);
+        /** starts a read only transaction*/
+        txn = txn_manager->BeginTransaction(0, IsolationLevelType::SNAPSHOT, true);
       } else {
         txn = txn_manager->BeginTransaction();
       }

--- a/test/include/concurrency/testing_transaction_util.h
+++ b/test/include/concurrency/testing_transaction_util.h
@@ -54,7 +54,7 @@
  *
  * See isolation_level_test.cpp for examples.
  */
-
+#include <initializer_list>
 #include "catalog/schema.h"
 #include "common/harness.h"
 #include "concurrency/transaction_context.h"
@@ -242,7 +242,7 @@ class TransactionThread {
     if (cur_seq == 0) {
       if (schedule->declared_ro == true) {
         /** starts a read only transaction*/
-        txn = txn_manager->BeginTransaction(0, IsolationLevelType::SNAPSHOT, true);
+        txn = txn_manager->BeginTransaction(0, IsolationLevelType::SERIALIZABLE, true);
       } else {
         txn = txn_manager->BeginTransaction();
       }
@@ -349,13 +349,14 @@ class TransactionScheduler {
  public:
   TransactionScheduler(size_t num_txn, storage::DataTable *datatable_,
                        concurrency::TransactionManager *txn_manager_,
-                       bool first_as_ro = false)
+                       std::initializer_list<int> il = {})
       : txn_manager(txn_manager_),
         table(datatable_),
         time(0),
         concurrent(false) {
+    std::set<int> read_only(il);
     for (size_t i = 0; i < num_txn; i++) {
-      if (first_as_ro && i == 0) {
+      if (read_only.find(i) != read_only.end()) {
         schedules.emplace_back(i, true);
       } else {
         schedules.emplace_back(i, false);

--- a/test/include/concurrency/testing_transaction_util.h
+++ b/test/include/concurrency/testing_transaction_util.h
@@ -241,7 +241,7 @@ class TransactionThread {
 
     if (cur_seq == 0) {
       if (schedule->declared_ro == true) {
-        txn = txn_manager->BeginTransaction(IsolationLevelType::READ_ONLY);
+        txn = txn_manager->BeginTransactionReadOnly();
       } else {
         txn = txn_manager->BeginTransaction();
       }


### PR DESCRIPTION
this is to #1313 

Details:
1.remove IsolationLevelType::READ_ONLY
2.add a flag in transactioncontext 
3.re-implement 'IsReadOnly' function. This is safe because the function has not been call anywhere before this modification.
4.substitute every usage of 'READ_ONLY' with IsReadOnly function call
5.add a new parameter to BeginTransaction and provide a short cut 'BeginTransactionReadOnly'
6.one invocation of BeginTransaction(READ_ONLY) is changed to 'BeginTransactionReadOnly(IsolationLevelType::READ_COMMITTED);'