### PR TITLE
[15721] Compiled Catalog Query Access

### DIFF
--- a/src/catalog/column_catalog.cpp
+++ b/src/catalog/column_catalog.cpp
@@ -297,7 +297,6 @@ bool ColumnCatalog::DeleteColumns(oid_t table_oid,
                       ->GetTableCatalog();
   auto table_object = pg_table->GetTableObject(table_oid, txn);
     table_object->EvictAllColumnObjects();
-  }
   return result;
 }
 

--- a/src/catalog/column_stats_catalog.cpp
+++ b/src/catalog/column_stats_catalog.cpp
@@ -230,7 +230,7 @@ std::unique_ptr<std::vector<type::Value>> ColumnStatsCatalog::GetColumnStats(
   std::vector<codegen::WrappedTuple> result_tuples =
       GetResultWithCompiledSeqScan(column_ids, predicate, txn);
 
-  PL_ASSERT(result_tuples.size() <= 1);  // unique
+  PELOTON_ASSERT(result_tuples.size() <= 1);  // unique
   if (result_tuples.size() == 0) {
     return nullptr;
   }

--- a/src/catalog/column_stats_catalog.cpp
+++ b/src/catalog/column_stats_catalog.cpp
@@ -17,6 +17,8 @@
 #include "optimizer/stats/column_stats_collector.h"
 #include "storage/data_table.h"
 #include "storage/tuple.h"
+#include "expression/expression_util.h"
+#include "codegen/buffering_consumer.h"
 
 namespace peloton {
 namespace catalog {
@@ -63,8 +65,8 @@ bool ColumnStatsCatalog::InsertColumnStats(
     std::string most_common_freqs, std::string histogram_bounds,
     std::string column_name, bool has_index, type::AbstractPool *pool,
     concurrency::TransactionContext *txn) {
-  std::unique_ptr<storage::Tuple> tuple(
-      new storage::Tuple(catalog_table_->GetSchema(), true));
+  (void) pool;
+  std::vector<std::vector<ExpressionPtr>> tuples;
 
   auto val_db_id = type::ValueFactory::GetIntegerValue(database_id);
   auto val_table_id = type::ValueFactory::GetIntegerValue(table_id);
@@ -96,74 +98,156 @@ bool ColumnStatsCatalog::InsertColumnStats(
       type::ValueFactory::GetVarcharValue(column_name);
   type::Value val_has_index = type::ValueFactory::GetBooleanValue(has_index);
 
-  tuple->SetValue(ColumnId::DATABASE_ID, val_db_id, nullptr);
-  tuple->SetValue(ColumnId::TABLE_ID, val_table_id, nullptr);
-  tuple->SetValue(ColumnId::COLUMN_ID, val_column_id, nullptr);
-  tuple->SetValue(ColumnId::NUM_ROWS, val_num_row, nullptr);
-  tuple->SetValue(ColumnId::CARDINALITY, val_cardinality, nullptr);
-  tuple->SetValue(ColumnId::FRAC_NULL, val_frac_null, nullptr);
-  tuple->SetValue(ColumnId::MOST_COMMON_VALS, val_common_val, pool);
-  tuple->SetValue(ColumnId::MOST_COMMON_FREQS, val_common_freq, pool);
-  tuple->SetValue(ColumnId::HISTOGRAM_BOUNDS, val_hist_bounds, pool);
-  tuple->SetValue(ColumnId::COLUMN_NAME, val_column_name, pool);
-  tuple->SetValue(ColumnId::HAS_INDEX, val_has_index, nullptr);
+  tuples.push_back(std::vector<ExpressionPtr>());
+  auto &values = tuples[0];
+
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(val_db_id)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(val_table_id)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(val_column_id)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(val_num_row)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(val_cardinality)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(val_frac_null)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(val_common_val)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(val_common_freq)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(val_hist_bounds)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(val_column_name)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(val_has_index)));
 
   // Insert the tuple into catalog table
-  return InsertTuple(std::move(tuple), txn);
+  return InsertTupleWithCompiledPlan(&tuples, txn);
 }
 
 bool ColumnStatsCatalog::DeleteColumnStats(
     oid_t database_id, oid_t table_id, oid_t column_id,
     concurrency::TransactionContext *txn) {
-  oid_t index_offset = IndexId::SECONDARY_KEY_0;  // Secondary key index
+  std::vector<oid_t> column_ids(all_column_ids);
 
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetIntegerValue(database_id).Copy());
-  values.push_back(type::ValueFactory::GetIntegerValue(table_id).Copy());
-  values.push_back(type::ValueFactory::GetIntegerValue(column_id).Copy());
+  auto *db_oid_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                           ColumnId::DATABASE_ID);
+  db_oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                           catalog_table_->GetOid(),
+                           ColumnId::DATABASE_ID);
+  expression::AbstractExpression *db_oid_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(database_id).Copy());
+  expression::AbstractExpression *db_oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, db_oid_expr, db_oid_const_expr);
 
-  return DeleteWithIndexScan(index_offset, values, txn);
+  auto *tb_oid_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                           ColumnId::TABLE_ID);
+  tb_oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                           catalog_table_->GetOid(),
+                           ColumnId::TABLE_ID);
+  expression::AbstractExpression *tb_oid_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(table_id).Copy());
+  expression::AbstractExpression *tb_oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, tb_oid_expr, tb_oid_const_expr);
+
+  auto *col_id_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                           ColumnId::COLUMN_ID);
+  col_id_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                           catalog_table_->GetOid(),
+                           ColumnId::COLUMN_ID);
+  expression::AbstractExpression *col_id_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(column_id).Copy());
+  expression::AbstractExpression *col_oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, col_id_expr, col_id_const_expr);
+
+  expression::AbstractExpression *db_and_tb =
+      expression::ExpressionUtil::ConjunctionFactory(
+          ExpressionType::CONJUNCTION_AND, db_oid_equality_expr,
+          tb_oid_equality_expr);
+  expression::AbstractExpression *predicate =
+      expression::ExpressionUtil::ConjunctionFactory(
+          ExpressionType::CONJUNCTION_AND, db_and_tb, col_oid_equality_expr);
+
+
+
+  return DeleteWithCompiledSeqScan(column_ids, predicate, txn);
 }
 
 std::unique_ptr<std::vector<type::Value>> ColumnStatsCatalog::GetColumnStats(
     oid_t database_id, oid_t table_id, oid_t column_id,
     concurrency::TransactionContext *txn) {
-  std::vector<oid_t> column_ids(
-      {ColumnId::NUM_ROWS, ColumnId::CARDINALITY, ColumnId::FRAC_NULL,
-       ColumnId::MOST_COMMON_VALS, ColumnId::MOST_COMMON_FREQS,
-       ColumnId::HISTOGRAM_BOUNDS, ColumnId::COLUMN_NAME, ColumnId::HAS_INDEX});
-  oid_t index_offset = IndexId::SECONDARY_KEY_0;  // Secondary key index
 
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetIntegerValue(database_id).Copy());
-  values.push_back(type::ValueFactory::GetIntegerValue(table_id).Copy());
-  values.push_back(type::ValueFactory::GetIntegerValue(column_id).Copy());
+  std::vector<oid_t> column_ids(all_column_ids);
 
-  auto result_tiles =
-      GetResultWithIndexScan(column_ids, index_offset, values, txn);
+  auto *db_oid_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                                    ColumnId::DATABASE_ID);
+  db_oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                           catalog_table_->GetOid(),
+                           ColumnId::DATABASE_ID);
+  expression::AbstractExpression *db_oid_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(database_id).Copy());
+  expression::AbstractExpression *db_oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, db_oid_expr, db_oid_const_expr);
 
-  PELOTON_ASSERT(result_tiles->size() <= 1);  // unique
-  if (result_tiles->size() == 0) {
+  auto *tb_oid_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                                    ColumnId::TABLE_ID);
+  tb_oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                           catalog_table_->GetOid(),
+                           ColumnId::TABLE_ID);
+  expression::AbstractExpression *tb_oid_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(table_id).Copy());
+  expression::AbstractExpression *tb_oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, tb_oid_expr, tb_oid_const_expr);
+
+  auto *col_id_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                                    ColumnId::COLUMN_ID);
+  col_id_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                           catalog_table_->GetOid(),
+                           ColumnId::COLUMN_ID);
+  expression::AbstractExpression *col_id_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(column_id).Copy());
+  expression::AbstractExpression *col_oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, col_id_expr, col_id_const_expr);
+
+  expression::AbstractExpression *db_and_tb =
+      expression::ExpressionUtil::ConjunctionFactory(
+          ExpressionType::CONJUNCTION_AND, db_oid_equality_expr,
+          tb_oid_equality_expr);
+  expression::AbstractExpression *predicate =
+      expression::ExpressionUtil::ConjunctionFactory(
+          ExpressionType::CONJUNCTION_AND, db_and_tb, col_oid_equality_expr);
+
+  std::vector<codegen::WrappedTuple> result_tuples =
+      GetResultWithCompiledSeqScan(column_ids, predicate, txn);
+
+  PL_ASSERT(result_tuples.size() <= 1);  // unique
+  if (result_tuples.size() == 0) {
     return nullptr;
   }
 
-  auto tile = (*result_tiles)[0].get();
-  PELOTON_ASSERT(tile->GetTupleCount() <= 1);
-  if (tile->GetTupleCount() == 0) {
-    return nullptr;
-  }
+  codegen::WrappedTuple tuple = result_tuples[0];
 
   type::Value num_rows, cardinality, frac_null, most_common_vals,
       most_common_freqs, hist_bounds, column_name, has_index;
 
-  num_rows = tile->GetValue(0, ColumnStatsOffset::NUM_ROWS_OFF);
-  cardinality = tile->GetValue(0, ColumnStatsOffset::CARDINALITY_OFF);
-  frac_null = tile->GetValue(0, ColumnStatsOffset::FRAC_NULL_OFF);
-  most_common_vals = tile->GetValue(0, ColumnStatsOffset::COMMON_VALS_OFF);
-  most_common_freqs = tile->GetValue(0, ColumnStatsOffset::COMMON_FREQS_OFF);
-  hist_bounds = tile->GetValue(0, ColumnStatsOffset::HIST_BOUNDS_OFF);
-  column_name = tile->GetValue(0, ColumnStatsOffset::COLUMN_NAME_OFF);
-  has_index = tile->GetValue(0, ColumnStatsOffset::HAS_INDEX_OFF);
+  num_rows = tuple.GetValue(ColumnId::NUM_ROWS);
+  cardinality = tuple.GetValue(ColumnId::CARDINALITY);
+  frac_null = tuple.GetValue(ColumnId::FRAC_NULL);
+  most_common_vals = tuple.GetValue(ColumnId::MOST_COMMON_VALS);
+  most_common_freqs = tuple.GetValue(ColumnId::MOST_COMMON_FREQS);
+  hist_bounds = tuple.GetValue(ColumnId::HISTOGRAM_BOUNDS);
+  column_name = tuple.GetValue(ColumnId::COLUMN_NAME);
+  has_index = tuple.GetValue(ColumnId::HAS_INDEX);
 
   std::unique_ptr<std::vector<type::Value>> column_stats(
       new std::vector<type::Value>({num_rows, cardinality, frac_null,
@@ -176,28 +260,46 @@ std::unique_ptr<std::vector<type::Value>> ColumnStatsCatalog::GetColumnStats(
 // Return value: number of column stats
 size_t ColumnStatsCatalog::GetTableStats(
     oid_t database_id, oid_t table_id, concurrency::TransactionContext *txn,
-    std::map<oid_t, std::unique_ptr<std::vector<type::Value>>>
-        &column_stats_map) {
-  std::vector<oid_t> column_ids(
-      {ColumnId::COLUMN_ID, ColumnId::NUM_ROWS, ColumnId::CARDINALITY,
-       ColumnId::FRAC_NULL, ColumnId::MOST_COMMON_VALS,
-       ColumnId::MOST_COMMON_FREQS, ColumnId::HISTOGRAM_BOUNDS,
-       ColumnId::COLUMN_NAME, ColumnId::HAS_INDEX});
-  oid_t index_offset = IndexId::SECONDARY_KEY_1;  // Secondary key index
+    std::map<oid_t, std::unique_ptr<std::vector<type::Value>>> &
+        column_stats_map) {
+  std::vector<oid_t> column_ids(all_column_ids);
 
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetIntegerValue(database_id).Copy());
-  values.push_back(type::ValueFactory::GetIntegerValue(table_id).Copy());
+  auto *db_oid_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                                    ColumnId::DATABASE_ID);
+  db_oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                           catalog_table_->GetOid(),
+                           ColumnId::DATABASE_ID);
+  expression::AbstractExpression *db_oid_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(database_id).Copy());
+  expression::AbstractExpression *db_oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, db_oid_expr,
+          db_oid_const_expr);
 
-  auto result_tiles =
-      GetResultWithIndexScan(column_ids, index_offset, values, txn);
+  auto *tb_oid_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                                    ColumnId::TABLE_ID);
+  tb_oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                           catalog_table_->GetOid(),
+                           ColumnId::TABLE_ID);
+  expression::AbstractExpression *tb_oid_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(table_id).Copy());
+  expression::AbstractExpression *tb_oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, tb_oid_expr, tb_oid_const_expr);
 
-  PELOTON_ASSERT(result_tiles->size() <= 1);  // unique
-  if (result_tiles->size() == 0) {
-    return 0;
-  }
-  auto tile = (*result_tiles)[0].get();
-  size_t tuple_count = tile->GetTupleCount();
+  expression::AbstractExpression *predicate =
+      expression::ExpressionUtil::ConjunctionFactory(
+          ExpressionType::CONJUNCTION_AND, db_oid_equality_expr,
+          tb_oid_equality_expr);
+
+  std::vector<codegen::WrappedTuple> result_tuples =
+      GetResultWithCompiledSeqScan(column_ids, predicate, txn);
+
+  size_t tuple_count = result_tuples.size();
   LOG_DEBUG("Tuple count: %lu", tuple_count);
   if (tuple_count == 0) {
     return 0;
@@ -205,27 +307,22 @@ size_t ColumnStatsCatalog::GetTableStats(
 
   type::Value num_rows, cardinality, frac_null, most_common_vals,
       most_common_freqs, hist_bounds, column_name, has_index;
-  for (size_t tuple_id = 0; tuple_id < tuple_count; ++tuple_id) {
-    num_rows = tile->GetValue(tuple_id, 1 + ColumnStatsOffset::NUM_ROWS_OFF);
-    cardinality =
-        tile->GetValue(tuple_id, 1 + ColumnStatsOffset::CARDINALITY_OFF);
-    frac_null = tile->GetValue(tuple_id, 1 + ColumnStatsOffset::FRAC_NULL_OFF);
-    most_common_vals =
-        tile->GetValue(tuple_id, 1 + ColumnStatsOffset::COMMON_VALS_OFF);
-    most_common_freqs =
-        tile->GetValue(tuple_id, 1 + ColumnStatsOffset::COMMON_FREQS_OFF);
-    hist_bounds =
-        tile->GetValue(tuple_id, 1 + ColumnStatsOffset::HIST_BOUNDS_OFF);
-    column_name =
-        tile->GetValue(tuple_id, 1 + ColumnStatsOffset::COLUMN_NAME_OFF);
-    has_index = tile->GetValue(tuple_id, 1 + ColumnStatsOffset::HAS_INDEX_OFF);
+  for (auto tuple : result_tuples) {
+    num_rows = tuple.GetValue(ColumnId::NUM_ROWS);
+    cardinality = tuple.GetValue(ColumnId::CARDINALITY);
+    frac_null = tuple.GetValue(ColumnId::FRAC_NULL);
+    most_common_vals = tuple.GetValue(ColumnId::MOST_COMMON_VALS);
+    most_common_freqs = tuple.GetValue(ColumnId::MOST_COMMON_FREQS);
+    hist_bounds = tuple.GetValue(ColumnId::HISTOGRAM_BOUNDS);
+    column_name = tuple.GetValue(ColumnId::COLUMN_NAME);
+    has_index = tuple.GetValue(ColumnId::HAS_INDEX);
 
     std::unique_ptr<std::vector<type::Value>> column_stats(
         new std::vector<type::Value>({num_rows, cardinality, frac_null,
                                       most_common_vals, most_common_freqs,
                                       hist_bounds, column_name, has_index}));
 
-    oid_t column_id = tile->GetValue(tuple_id, 0).GetAs<int>();
+    oid_t column_id = tuple.GetValue(ColumnId::COLUMN_ID).GetAs<int>();
     column_stats_map[column_id] = std::move(column_stats);
   }
   return tuple_count;

--- a/src/catalog/database_catalog.cpp
+++ b/src/catalog/database_catalog.cpp
@@ -17,6 +17,8 @@
 #include "catalog/catalog.h"
 #include "catalog/system_catalogs.h"
 #include "concurrency/transaction_context.h"
+#include "expression/expression_util.h"
+#include "codegen/buffering_consumer.h"
 #include "executor/logical_tile.h"
 #include "storage/data_table.h"
 #include "storage/tuple.h"
@@ -36,6 +38,19 @@ DatabaseCatalogObject::DatabaseCatalogObject(
       valid_table_objects(false),
       txn(txn) {}
 
+DatabaseCatalogObject::DatabaseCatalogObject(
+    codegen::WrappedTuple wrapped_tuple, concurrency::TransactionContext *txn)
+    : database_oid(
+          wrapped_tuple.GetValue(DatabaseCatalog::ColumnId::DATABASE_OID)
+              .GetAs<oid_t>()),
+      database_name(
+          wrapped_tuple.GetValue(DatabaseCatalog::ColumnId::DATABASE_NAME)
+              .ToString()),
+      table_objects_cache(),
+      table_name_cache(),
+      valid_table_objects(false),
+      txn(txn) {}
+
 /* @brief   insert table catalog object into cache
  * @param   table_object
  * @return  false if table_name already exists in cache
@@ -49,14 +64,14 @@ bool DatabaseCatalogObject::InsertTableObject(
   // check if already in cache
   if (table_objects_cache.find(table_object->GetTableOid()) !=
       table_objects_cache.end()) {
-    LOG_DEBUG("Table %u already exists in cache!", table_object->GetTableOid());
+    LOG_TRACE("Table %u already exists in cache!", table_object->GetTableOid());
     return false;
   }
 
   std::string key =
       table_object->GetSchemaName() + "." + table_object->GetTableName();
   if (table_name_cache.find(key) != table_name_cache.end()) {
-    LOG_DEBUG("Table %s already exists in cache!",
+    LOG_TRACE("Table %s already exists in cache!",
               table_object->GetTableName().c_str());
     return false;
   }
@@ -294,29 +309,53 @@ bool DatabaseCatalog::InsertDatabase(oid_t database_oid,
                                      const std::string &database_name,
                                      type::AbstractPool *pool,
                                      concurrency::TransactionContext *txn) {
-  std::unique_ptr<storage::Tuple> tuple(
-      new storage::Tuple(catalog_table_->GetSchema(), true));
 
+  (void) pool;
+
+  std::vector<std::vector<ExpressionPtr>> tuples;
   auto val0 = type::ValueFactory::GetIntegerValue(database_oid);
   auto val1 = type::ValueFactory::GetVarcharValue(database_name, nullptr);
 
-  tuple->SetValue(ColumnId::DATABASE_OID, val0, pool);
-  tuple->SetValue(ColumnId::DATABASE_NAME, val1, pool);
+  auto constant_expr_0 = new expression::ConstantValueExpression(
+      val0);
+  auto constant_expr_1 = new expression::ConstantValueExpression(
+      val1);
 
-  // Insert the tuple
-  return InsertTuple(std::move(tuple), txn);
+  tuples.push_back(std::vector<ExpressionPtr>());
+  auto &values = tuples[0];
+  values.push_back(ExpressionPtr(constant_expr_0));
+  values.push_back(ExpressionPtr(constant_expr_1));
+
+  return InsertTupleWithCompiledPlan(&tuples, txn);
 }
 
 bool DatabaseCatalog::DeleteDatabase(oid_t database_oid,
                                      concurrency::TransactionContext *txn) {
-  oid_t index_offset = IndexId::PRIMARY_KEY;  // Index of database_oid
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetIntegerValue(database_oid).Copy());
+
+  // cache miss, get from pg_database
+  std::vector<oid_t> column_ids(all_column_ids);
+
+  auto *db_oid_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                           ColumnId::DATABASE_OID);
+
+  db_oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                           catalog_table_->GetOid(),
+                           ColumnId::DATABASE_OID);
+
+  expression::AbstractExpression *db_oid_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(database_oid).Copy());
+  expression::AbstractExpression *db_oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, db_oid_expr, db_oid_const_expr);
+
+  expression::AbstractExpression *predicate = db_oid_equality_expr;
 
   // evict cache
   txn->catalog_cache.EvictDatabaseObject(database_oid);
 
-  return DeleteWithIndexScan(index_offset, values, txn);
+  return DeleteWithCompiledSeqScan(column_ids, predicate, txn);
 }
 
 std::shared_ptr<DatabaseCatalogObject> DatabaseCatalog::GetDatabaseObject(
@@ -330,23 +369,35 @@ std::shared_ptr<DatabaseCatalogObject> DatabaseCatalog::GetDatabaseObject(
 
   // cache miss, get from pg_database
   std::vector<oid_t> column_ids(all_column_ids);
-  oid_t index_offset = IndexId::PRIMARY_KEY;  // Index of database_oid
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetIntegerValue(database_oid).Copy());
 
-  auto result_tiles =
-      GetResultWithIndexScan(column_ids, index_offset, values, txn);
+  auto *db_oid_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                       ColumnId::DATABASE_OID);
 
-  if (result_tiles->size() == 1 && (*result_tiles)[0]->GetTupleCount() == 1) {
+  db_oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                           catalog_table_->GetOid(),
+                           ColumnId::DATABASE_OID);
+
+  expression::AbstractExpression *db_oid_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(database_oid).Copy());
+  expression::AbstractExpression *db_oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, db_oid_expr, db_oid_const_expr);
+
+  expression::AbstractExpression *predicate = db_oid_equality_expr;
+  auto result_tuples = GetResultWithCompiledSeqScan(column_ids, predicate, txn);
+
+  if (result_tuples.size() == 1) {
     auto database_object =
-        std::make_shared<DatabaseCatalogObject>((*result_tiles)[0].get(), txn);
+        std::make_shared<DatabaseCatalogObject>(result_tuples[0], txn);
     // insert into cache
     bool success = txn->catalog_cache.InsertDatabaseObject(database_object);
     PELOTON_ASSERT(success == true);
     (void)success;
     return database_object;
   } else {
-    LOG_DEBUG("Found %lu database tiles with oid %u", result_tiles->size(),
+    LOG_TRACE("Found %lu database tiles with oid %u", result_tuples.size(),
               database_oid);
   }
 
@@ -367,29 +418,36 @@ std::shared_ptr<DatabaseCatalogObject> DatabaseCatalog::GetDatabaseObject(
   auto database_object = txn->catalog_cache.GetDatabaseObject(database_name);
   if (database_object) return database_object;
 
-  // cache miss, get from pg_database
   std::vector<oid_t> column_ids(all_column_ids);
-  oid_t index_offset = IndexId::SKEY_DATABASE_NAME;  // Index of database_name
-  std::vector<type::Value> values;
-  values.push_back(
-      type::ValueFactory::GetVarcharValue(database_name, nullptr).Copy());
 
-  auto result_tiles =
-      GetResultWithIndexScan(column_ids, index_offset, values, txn);
+  auto *db_name_expr =
+      new expression::TupleValueExpression(type::TypeId::VARCHAR, 0,
+                                       ColumnId::DATABASE_NAME);
+  db_name_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                              catalog_table_->GetOid(),
+                              ColumnId::DATABASE_NAME);
 
-  if (result_tiles->size() == 1 && (*result_tiles)[0]->GetTupleCount() == 1) {
+    expression::AbstractExpression *db_name_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetVarcharValue(database_name, nullptr).Copy());
+  expression::AbstractExpression *db_name_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, db_name_expr, db_name_const_expr);
+
+  std::vector<codegen::WrappedTuple> result_tuples =
+      GetResultWithCompiledSeqScan(column_ids, db_name_equality_expr, txn);
+
+  if (result_tuples.size() == 1) {
     auto database_object =
-        std::make_shared<DatabaseCatalogObject>((*result_tiles)[0].get(), txn);
-    if (database_object) {
-      // insert into cache
-      bool success = txn->catalog_cache.InsertDatabaseObject(database_object);
-      PELOTON_ASSERT(success == true);
-      (void)success;
-    }
+        std::make_shared<DatabaseCatalogObject>(result_tuples[0], txn);
+    // insert into cache
+    bool success = txn->catalog_cache.InsertDatabaseObject(database_object);
+    PELOTON_ASSERT(success == true);
+    (void)success;
     return database_object;
   }
 
-  // return empty object if not found
+    // return empty object if not found
   return nullptr;
 }
 

--- a/src/catalog/database_metrics_catalog.cpp
+++ b/src/catalog/database_metrics_catalog.cpp
@@ -14,6 +14,8 @@
 
 #include "executor/logical_tile.h"
 #include "storage/data_table.h"
+#include "expression/abstract_expression.h"
+#include "expression/expression_util.h"
 #include "type/value_factory.h"
 
 namespace peloton {
@@ -44,31 +46,47 @@ bool DatabaseMetricsCatalog::InsertDatabaseMetrics(
     oid_t database_oid, oid_t txn_committed, oid_t txn_aborted,
     oid_t time_stamp, type::AbstractPool *pool,
     concurrency::TransactionContext *txn) {
-  std::unique_ptr<storage::Tuple> tuple(
-      new storage::Tuple(catalog_table_->GetSchema(), true));
+  (void) pool;
+  std::vector<std::vector<ExpressionPtr>> tuples;
+  tuples.push_back(std::vector<ExpressionPtr>());
+  auto &values = tuples[0];
 
   auto val0 = type::ValueFactory::GetIntegerValue(database_oid);
   auto val1 = type::ValueFactory::GetIntegerValue(txn_committed);
   auto val2 = type::ValueFactory::GetIntegerValue(txn_aborted);
   auto val3 = type::ValueFactory::GetIntegerValue(time_stamp);
 
-  tuple->SetValue(ColumnId::DATABASE_OID, val0, pool);
-  tuple->SetValue(ColumnId::TXN_COMMITTED, val1, pool);
-  tuple->SetValue(ColumnId::TXN_ABORTED, val2, pool);
-  tuple->SetValue(ColumnId::TIME_STAMP, val3, pool);
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(
+      val0)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(
+      val1)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(
+      val2)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(
+      val3)));
+
 
   // Insert the tuple into catalog table
-  return InsertTuple(std::move(tuple), txn);
+  return InsertTupleWithCompiledPlan(&tuples, txn);
 }
 
 bool DatabaseMetricsCatalog::DeleteDatabaseMetrics(
     oid_t database_oid, concurrency::TransactionContext *txn) {
-  oid_t index_offset = IndexId::PRIMARY_KEY;  // Primary key index
+  std::vector<oid_t> column_ids(all_column_ids);
 
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetIntegerValue(database_oid).Copy());
-
-  return DeleteWithIndexScan(index_offset, values, txn);
+  auto *db_oid_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                                    ColumnId::DATABASE_OID);
+  db_oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                           catalog_table_->GetOid(),
+                           ColumnId::DATABASE_OID);
+  expression::AbstractExpression *db_oid_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(database_oid).Copy());
+  expression::AbstractExpression *predicate =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, db_oid_expr, db_oid_const_expr);
+  return DeleteWithCompiledSeqScan(column_ids, predicate, txn);
 }
 
 }  // namespace catalog

--- a/src/catalog/index_catalog.cpp
+++ b/src/catalog/index_catalog.cpp
@@ -84,13 +84,6 @@ IndexCatalogObject::IndexCatalogObject(codegen::WrappedTuple wrapped_tuple)
   LOG_TRACE("the size for indexed key is %lu", key_attrs.size());
 }
 
-IndexCatalog *IndexCatalog::GetInstance(storage::Database *pg_catalog,
-                                        type::AbstractPool *pool,
-                                        concurrency::TransactionContext *txn) {
-  static IndexCatalog index_catalog{pg_catalog, pool, txn};
-  return &index_catalog;
-}
-
 IndexCatalog::IndexCatalog(
     storage::Database *pg_catalog, UNUSED_ATTRIBUTE type::AbstractPool *pool,
     UNUSED_ATTRIBUTE concurrency::TransactionContext *txn)

--- a/src/catalog/index_metrics_catalog.cpp
+++ b/src/catalog/index_metrics_catalog.cpp
@@ -87,11 +87,11 @@ bool IndexMetricsCatalog::DeleteIndexMetrics(
 
   auto *oid_expr =
       new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
-                                           ColumnId::DATABASE_OID);
+                                           ColumnId::INDEX_OID);
 
   oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
                            catalog_table_->GetOid(),
-                           ColumnId::DATABASE_OID);
+                           ColumnId::INDEX_OID);
 
   expression::AbstractExpression *oid_const_expr =
       expression::ExpressionUtil::ConstantValueFactory(

--- a/src/catalog/index_metrics_catalog.cpp
+++ b/src/catalog/index_metrics_catalog.cpp
@@ -12,6 +12,7 @@
 
 #include "catalog/index_metrics_catalog.h"
 
+#include "expression/expression_util.h"
 #include "executor/logical_tile.h"
 #include "storage/data_table.h"
 #include "type/value_factory.h"
@@ -40,8 +41,10 @@ bool IndexMetricsCatalog::InsertIndexMetrics(
     oid_t table_oid, oid_t index_oid, int64_t reads, int64_t deletes,
     int64_t inserts, int64_t time_stamp, type::AbstractPool *pool,
     concurrency::TransactionContext *txn) {
-  std::unique_ptr<storage::Tuple> tuple(
-      new storage::Tuple(catalog_table_->GetSchema(), true));
+
+  (void) pool;
+  // Create the tuple first
+  std::vector<std::vector<ExpressionPtr>> tuples;
 
   auto val1 = type::ValueFactory::GetIntegerValue(table_oid);
   auto val2 = type::ValueFactory::GetIntegerValue(index_oid);
@@ -50,25 +53,57 @@ bool IndexMetricsCatalog::InsertIndexMetrics(
   auto val5 = type::ValueFactory::GetIntegerValue(inserts);
   auto val6 = type::ValueFactory::GetIntegerValue(time_stamp);
 
-  tuple->SetValue(ColumnId::TABLE_OID, val1, pool);
-  tuple->SetValue(ColumnId::INDEX_OID, val2, pool);
-  tuple->SetValue(ColumnId::READS, val3, pool);
-  tuple->SetValue(ColumnId::DELETES, val4, pool);
-  tuple->SetValue(ColumnId::INSERTS, val5, pool);
-  tuple->SetValue(ColumnId::TIME_STAMP, val6, pool);
 
-  // Insert the tuple
-  return InsertTuple(std::move(tuple), txn);
+  auto constant_expr_1 = new expression::ConstantValueExpression(
+      val1);
+  auto constant_expr_2 = new expression::ConstantValueExpression(
+      val2);
+  auto constant_expr_3 = new expression::ConstantValueExpression(
+      val3);
+  auto constant_expr_4 = new expression::ConstantValueExpression(
+      val4);
+  auto constant_expr_5 = new expression::ConstantValueExpression(
+      val5);
+  auto constant_expr_6 = new expression::ConstantValueExpression(
+      val6);
+
+  tuples.push_back(std::vector<ExpressionPtr>());
+  auto &values = tuples[0];
+  values.push_back(ExpressionPtr(constant_expr_1));
+  values.push_back(ExpressionPtr(constant_expr_2));
+  values.push_back(ExpressionPtr(constant_expr_3));
+  values.push_back(ExpressionPtr(constant_expr_4));
+  values.push_back(ExpressionPtr(constant_expr_5));
+  values.push_back(ExpressionPtr(constant_expr_6));
+
+  return InsertTupleWithCompiledPlan(&tuples, txn);
 }
 
 bool IndexMetricsCatalog::DeleteIndexMetrics(
     oid_t index_oid, concurrency::TransactionContext *txn) {
-  oid_t index_offset = IndexId::PRIMARY_KEY;  // Primary key index
 
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetIntegerValue(index_oid).Copy());
+  // cache miss, get from pg_database
+  std::vector<oid_t> column_ids(all_column_ids);
 
-  return DeleteWithIndexScan(index_offset, values, txn);
+  auto *oid_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                           ColumnId::DATABASE_OID);
+
+  oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                           catalog_table_->GetOid(),
+                           ColumnId::DATABASE_OID);
+
+  expression::AbstractExpression *oid_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(index_oid).Copy());
+  expression::AbstractExpression *oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, oid_expr, oid_const_expr);
+
+  expression::AbstractExpression *predicate = oid_equality_expr;
+
+  return DeleteWithCompiledSeqScan(column_ids, predicate, txn);
+
 }
 
 }  // namespace catalog

--- a/src/catalog/language_catalog.cpp
+++ b/src/catalog/language_catalog.cpp
@@ -115,7 +115,7 @@ std::unique_ptr<LanguageCatalogObject> LanguageCatalog::GetLanguageByOid(
       GetResultWithCompiledSeqScan(column_ids, oid_equality_expr, txn);
 
 
-  PL_ASSERT(result_tuples.size() <= 1);
+  PELOTON_ASSERT(result_tuples.size() <= 1);
 
   std::unique_ptr<LanguageCatalogObject> ret;
   if (result_tuples.size() == 1) {
@@ -145,7 +145,7 @@ std::unique_ptr<LanguageCatalogObject> LanguageCatalog::GetLanguageByName(
   std::vector<codegen::WrappedTuple> result_tuples =
       GetResultWithCompiledSeqScan(column_ids, name_equality_expr, txn);
 
-  PL_ASSERT(result_tuples.size() <= 1);
+  PELOTON_ASSERT(result_tuples.size() <= 1);
 
   std::unique_ptr<LanguageCatalogObject> ret;
   if (result_tuples.size() == 1) {

--- a/src/catalog/language_catalog.cpp
+++ b/src/catalog/language_catalog.cpp
@@ -16,6 +16,8 @@
 #include "executor/logical_tile.h"
 #include "storage/data_table.h"
 #include "type/value_factory.h"
+#include "codegen/buffering_consumer.h"
+#include "expression/expression_util.h"
 
 namespace peloton {
 namespace catalog {
@@ -23,6 +25,10 @@ namespace catalog {
 LanguageCatalogObject::LanguageCatalogObject(executor::LogicalTile *tuple)
     : lang_oid_(tuple->GetValue(0, 0).GetAs<oid_t>()),
       lang_name_(tuple->GetValue(0, 1).GetAs<const char *>()) {}
+
+LanguageCatalogObject::LanguageCatalogObject(codegen::WrappedTuple tuple)
+    : lang_oid_(tuple.GetValue(0).GetAs<oid_t>()),
+      lang_name_(tuple.GetValue(1).GetAs<const char *>()) {}
 
 LanguageCatalog &LanguageCatalog::GetInstance(
     concurrency::TransactionContext *txn) {
@@ -48,47 +54,72 @@ LanguageCatalog::LanguageCatalog(concurrency::TransactionContext *txn)
 bool LanguageCatalog::InsertLanguage(const std::string &lanname,
                                      type::AbstractPool *pool,
                                      concurrency::TransactionContext *txn) {
-  std::unique_ptr<storage::Tuple> tuple(
-      new storage::Tuple(catalog_table_->GetSchema(), true));
+  (void) pool;
+  std::vector<std::vector<ExpressionPtr>> tuples;
+  tuples.push_back(std::vector<ExpressionPtr>());
+  auto &values = tuples[0];
 
   oid_t language_oid = GetNextOid();
   auto val0 = type::ValueFactory::GetIntegerValue(language_oid);
   auto val1 = type::ValueFactory::GetVarcharValue(lanname);
 
-  tuple->SetValue(ColumnId::OID, val0, pool);
-  tuple->SetValue(ColumnId::LANNAME, val1, pool);
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(
+      val0)));
+  values.push_back(ExpressionPtr(new expression::ConstantValueExpression(
+      val1)));
 
   // Insert the tuple
-  return InsertTuple(std::move(tuple), txn);
+  return InsertTupleWithCompiledPlan(&tuples, txn);
 }
 
 // delete a language by name
 bool LanguageCatalog::DeleteLanguage(const std::string &lanname,
                                      concurrency::TransactionContext *txn) {
-  oid_t index_offset = IndexId::SECONDARY_KEY_0;
+  std::vector<oid_t> column_ids(all_column_ids);
 
-  std::vector<type::Value> values;
-  values.push_back(
-      type::ValueFactory::GetVarcharValue(lanname, nullptr).Copy());
+  auto *lan_name_expr =
+      new expression::TupleValueExpression(type::TypeId::VARCHAR, 0,
+                                                    ColumnId::LANNAME);
+  lan_name_expr->SetBoundOid(catalog_table_->GetDatabaseOid(), catalog_table_->GetOid(), ColumnId::LANNAME);
+      
+      expression::AbstractExpression *lan_name_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetVarcharValue(lanname, nullptr).Copy());
+  expression::AbstractExpression *lan_name_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, lan_name_expr,
+          lan_name_const_expr);
 
-  return DeleteWithIndexScan(index_offset, values, txn);
+  return DeleteWithCompiledSeqScan(column_ids, lan_name_equality_expr, txn);
 }
 
 std::unique_ptr<LanguageCatalogObject> LanguageCatalog::GetLanguageByOid(
     oid_t lang_oid, concurrency::TransactionContext *txn) const {
-  std::vector<oid_t> column_ids(all_column_ids);
-  oid_t index_offset = IndexId::PRIMARY_KEY;
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetIntegerValue(lang_oid).Copy());
 
-  auto result_tiles =
-      GetResultWithIndexScan(column_ids, index_offset, values, txn);
-  PELOTON_ASSERT(result_tiles->size() <= 1);
+  std::vector<oid_t> column_ids(all_column_ids);
+
+  auto *oid_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                        ColumnId::OID);
+  oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                        catalog_table_->GetOid(), ColumnId::OID);
+
+  expression::AbstractExpression *oid_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(lang_oid).Copy());
+  expression::AbstractExpression *oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, oid_expr, oid_const_expr);
+
+  std::vector<codegen::WrappedTuple> result_tuples =
+      GetResultWithCompiledSeqScan(column_ids, oid_equality_expr, txn);
+
+
+  PL_ASSERT(result_tuples.size() <= 1);
 
   std::unique_ptr<LanguageCatalogObject> ret;
-  if (result_tiles->size() == 1) {
-    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
-    ret.reset(new LanguageCatalogObject((*result_tiles)[0].get()));
+  if (result_tuples.size() == 1) {
+    ret.reset(new LanguageCatalogObject(result_tuples[0]));
   }
 
   return ret;
@@ -96,19 +127,29 @@ std::unique_ptr<LanguageCatalogObject> LanguageCatalog::GetLanguageByOid(
 
 std::unique_ptr<LanguageCatalogObject> LanguageCatalog::GetLanguageByName(
     const std::string &lang_name, concurrency::TransactionContext *txn) const {
-  std::vector<oid_t> column_ids(all_column_ids);
-  oid_t index_offset = IndexId::SECONDARY_KEY_0;
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetVarcharValue(lang_name).Copy());
 
-  auto result_tiles =
-      GetResultWithIndexScan(column_ids, index_offset, values, txn);
-  PELOTON_ASSERT(result_tiles->size() <= 1);
+  std::vector<oid_t> column_ids(all_column_ids);
+
+  auto *name_expr =
+      new expression::TupleValueExpression(type::TypeId::VARCHAR, 0,
+                                                    ColumnId::LANNAME);
+  name_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                          catalog_table_->GetOid(), ColumnId::LANNAME);
+  expression::AbstractExpression *name_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetVarcharValue(lang_name, nullptr).Copy());
+  expression::AbstractExpression *name_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, name_expr, name_const_expr);
+
+  std::vector<codegen::WrappedTuple> result_tuples =
+      GetResultWithCompiledSeqScan(column_ids, name_equality_expr, txn);
+
+  PL_ASSERT(result_tuples.size() <= 1);
 
   std::unique_ptr<LanguageCatalogObject> ret;
-  if (result_tiles->size() == 1) {
-    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
-    ret.reset(new LanguageCatalogObject((*result_tiles)[0].get()));
+  if (result_tuples.size() == 1) {
+    ret.reset(new LanguageCatalogObject(result_tuples[0]));
   }
 
   return ret;

--- a/src/catalog/schema.cpp
+++ b/src/catalog/schema.cpp
@@ -21,11 +21,10 @@ namespace peloton {
 namespace catalog {
 
 // Helper function for creating TupleSchema
-void Schema::CreateTupleSchema(
-    const std::vector<type::TypeId> &column_types,
-    const std::vector<oid_t> &column_lengths,
-    const std::vector<std::string> &column_names,
-    const std::vector<bool> &is_inlined) {
+void Schema::CreateTupleSchema(const std::vector<type::TypeId> &column_types,
+                               const std::vector<oid_t> &column_lengths,
+                               const std::vector<std::string> &column_names,
+                               const std::vector<bool> &is_inlined) {
   bool tup_is_inlined = true;
   oid_t num_columns = column_types.size();
   oid_t column_offset = 0;

--- a/src/catalog/settings_catalog.cpp
+++ b/src/catalog/settings_catalog.cpp
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "expression/expression_util.h"
+#include "codegen/buffering_consumer.h"
 #include "catalog/settings_catalog.h"
 #include "catalog/catalog.h"
 #include "executor/logical_tile.h"
@@ -55,9 +57,9 @@ bool SettingsCatalog::InsertSetting(
     const std::string &max_value, const std::string &default_value,
     bool is_mutable, bool is_persistent, type::AbstractPool *pool,
     concurrency::TransactionContext *txn) {
+  (void) pool;
   // Create the tuple first
-  std::unique_ptr<storage::Tuple> tuple(
-      new storage::Tuple(catalog_table_->GetSchema(), true));
+  std::vector<std::vector<ExpressionPtr>> tuples;
 
   auto val0 = type::ValueFactory::GetVarcharValue(name, pool);
   auto val1 = type::ValueFactory::GetVarcharValue(value, pool);
@@ -70,67 +72,120 @@ bool SettingsCatalog::InsertSetting(
   auto val7 = type::ValueFactory::GetBooleanValue(is_mutable);
   auto val8 = type::ValueFactory::GetBooleanValue(is_persistent);
 
-  tuple->SetValue(static_cast<int>(ColumnId::NAME), val0, pool);
-  tuple->SetValue(static_cast<int>(ColumnId::VALUE), val1, pool);
-  tuple->SetValue(static_cast<int>(ColumnId::VALUE_TYPE), val2, pool);
-  tuple->SetValue(static_cast<int>(ColumnId::DESCRIPTION), val3, pool);
-  tuple->SetValue(static_cast<int>(ColumnId::MIN_VALUE), val4, pool);
-  tuple->SetValue(static_cast<int>(ColumnId::MAX_VALUE), val5, pool);
-  tuple->SetValue(static_cast<int>(ColumnId::DEFAULT_VALUE), val6, pool);
-  tuple->SetValue(static_cast<int>(ColumnId::IS_MUTABLE), val7, pool);
-  tuple->SetValue(static_cast<int>(ColumnId::IS_PERSISTENT), val8, pool);
+  auto constant_expr_0 = new expression::ConstantValueExpression(
+    val0);
+  auto constant_expr_1 = new expression::ConstantValueExpression(
+    val1);
+  auto constant_expr_2 = new expression::ConstantValueExpression(
+    val2);
+  auto constant_expr_3 = new expression::ConstantValueExpression(
+    val3);
+  auto constant_expr_4 = new expression::ConstantValueExpression(
+    val4);
+  auto constant_expr_5 = new expression::ConstantValueExpression(
+    val5);
+  auto constant_expr_6 = new expression::ConstantValueExpression(
+    val6);
+  auto constant_expr_7 = new expression::ConstantValueExpression(
+    val7);
+  auto constant_expr_8 = new expression::ConstantValueExpression(
+    val8);
+
+  tuples.push_back(std::vector<ExpressionPtr>());
+  auto &values = tuples[0];
+  values.push_back(ExpressionPtr(constant_expr_0));
+  values.push_back(ExpressionPtr(constant_expr_1));
+  values.push_back(ExpressionPtr(constant_expr_2));
+  values.push_back(ExpressionPtr(constant_expr_3));
+  values.push_back(ExpressionPtr(constant_expr_4));
+  values.push_back(ExpressionPtr(constant_expr_5));
+  values.push_back(ExpressionPtr(constant_expr_6));
+  values.push_back(ExpressionPtr(constant_expr_7));
+  values.push_back(ExpressionPtr(constant_expr_8));
 
   // Insert the tuple
-  return InsertTuple(std::move(tuple), txn);
+  return InsertTupleWithCompiledPlan(&tuples, txn);
 }
 
 bool SettingsCatalog::DeleteSetting(const std::string &name,
                                     concurrency::TransactionContext *txn) {
-  oid_t index_offset = 0;
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetVarcharValue(name, nullptr).Copy());
+ std::vector<oid_t> column_ids(all_column_ids);
 
-  return DeleteWithIndexScan(index_offset, values, txn);
+ auto *name_expr =
+   new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                        static_cast<int>(ColumnId::NAME));
+ name_expr->SetBoundOid(catalog_table_->GetDatabaseOid(), catalog_table_->GetOid(), static_cast<int>(ColumnId::NAME));
+
+ expression::AbstractExpression *name_const_expr =
+   expression::ExpressionUtil::ConstantValueFactory(
+     type::ValueFactory::GetVarcharValue(name).Copy());
+ expression::AbstractExpression *name_equality_expr =
+   expression::ExpressionUtil::ComparisonFactory(
+     ExpressionType::COMPARE_EQUAL, name_expr, name_const_expr);
+
+ return DeleteWithCompiledSeqScan(column_ids, name_equality_expr, txn);
 }
 
 std::string SettingsCatalog::GetSettingValue(
     const std::string &name, concurrency::TransactionContext *txn) {
-  std::vector<oid_t> column_ids({static_cast<int>(ColumnId::VALUE)});
-  oid_t index_offset = static_cast<int>(IndexId::SECONDARY_KEY_0);
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetVarcharValue(name, nullptr).Copy());
+  std::vector<oid_t> column_ids(all_column_ids);
 
-  auto result_tiles =
-      GetResultWithIndexScan(column_ids, index_offset, values, txn);
+  auto *name_expr =
+      new expression::TupleValueExpression(type::TypeId::VARCHAR, 0,
+                                           static_cast<int>(ColumnId::NAME));
+
+  name_expr->SetBoundOid(
+      catalog_table_->GetDatabaseOid(),
+      catalog_table_->GetOid(),
+      static_cast<int>(ColumnId::NAME));
+
+  expression::AbstractExpression *name_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetVarcharValue(name, nullptr).Copy());
+  expression::AbstractExpression *name_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, name_expr, name_const_expr);
+
+  std::vector<codegen::WrappedTuple> result_tuples =
+      GetResultWithCompiledSeqScan(column_ids, name_equality_expr, txn);
 
   std::string config_value = "";
-  PELOTON_ASSERT(result_tiles->size() <= 1);
-  if (result_tiles->size() != 0) {
-    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
-    if ((*result_tiles)[0]->GetTupleCount() != 0) {
-      config_value = (*result_tiles)[0]->GetValue(0, 0).ToString();
-    }
+  PELOTON_ASSERT(result_tuples.size() <= 1);
+  if (result_tuples.size() != 0) {
+    config_value = (result_tuples[0]).GetValue(static_cast<int>(ColumnId::VALUE)).ToString();
   }
+
   return config_value;
 }
 
 std::string SettingsCatalog::GetDefaultValue(
     const std::string &name, concurrency::TransactionContext *txn) {
-  std::vector<oid_t> column_ids({static_cast<int>(ColumnId::VALUE)});
-  oid_t index_offset = static_cast<int>(IndexId::SECONDARY_KEY_0);
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetVarcharValue(name, nullptr).Copy());
+  std::vector<oid_t> column_ids(all_column_ids);
 
-  auto result_tiles =
-      GetResultWithIndexScan(column_ids, index_offset, values, txn);
+  auto *name_expr =
+      new expression::TupleValueExpression(
+          type::TypeId::VARCHAR, 0,
+          static_cast<int>(ColumnId::NAME));
+
+  name_expr->SetBoundOid(
+      catalog_table_->GetDatabaseOid(),
+      catalog_table_->GetOid(),
+      static_cast<int>(ColumnId::NAME));
+
+  expression::AbstractExpression *name_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetVarcharValue(name, nullptr).Copy());
+  expression::AbstractExpression *name_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, name_expr, name_const_expr);
+
+  std::vector<codegen::WrappedTuple> result_tuples =
+      GetResultWithCompiledSeqScan(column_ids, name_equality_expr, txn);
 
   std::string config_value = "";
-  PELOTON_ASSERT(result_tiles->size() <= 1);
-  if (result_tiles->size() != 0) {
-    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
-    if ((*result_tiles)[0]->GetTupleCount() != 0) {
-      config_value = (*result_tiles)[0]->GetValue(0, 0).ToString();
-    }
+  PELOTON_ASSERT(result_tuples.size() <= 1);
+  if (result_tuples.size() != 0) {
+    config_value = result_tuples[0].GetValue(static_cast<int>(ColumnId::DEFAULT_VALUE)).ToString();
   }
   return config_value;
 }

--- a/src/catalog/table_metrics_catalog.cpp
+++ b/src/catalog/table_metrics_catalog.cpp
@@ -86,11 +86,11 @@ bool TableMetricsCatalog::DeleteTableMetrics(
 
   auto *oid_expr =
       new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
-                                           ColumnId::DATABASE_OID);
+                                           ColumnId::TABLE_OID);
 
   oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
                         catalog_table_->GetOid(),
-                        ColumnId::DATABASE_OID);
+                        ColumnId::TABLE_OID);
 
   expression::AbstractExpression *oid_const_expr =
       expression::ExpressionUtil::ConstantValueFactory(

--- a/src/catalog/table_metrics_catalog.cpp
+++ b/src/catalog/table_metrics_catalog.cpp
@@ -13,6 +13,7 @@
 #include "catalog/table_metrics_catalog.h"
 
 #include "executor/logical_tile.h"
+#include "expression/expression_util.h"
 #include "storage/data_table.h"
 #include "type/value_factory.h"
 
@@ -40,8 +41,10 @@ bool TableMetricsCatalog::InsertTableMetrics(
     oid_t table_oid, int64_t reads, int64_t updates, int64_t deletes,
     int64_t inserts, int64_t time_stamp, type::AbstractPool *pool,
     concurrency::TransactionContext *txn) {
-  std::unique_ptr<storage::Tuple> tuple(
-      new storage::Tuple(catalog_table_->GetSchema(), true));
+
+  (void) pool;
+  // Create the tuple first
+  std::vector<std::vector<ExpressionPtr>> tuples;
 
   auto val1 = type::ValueFactory::GetIntegerValue(table_oid);
   auto val2 = type::ValueFactory::GetIntegerValue(reads);
@@ -50,25 +53,55 @@ bool TableMetricsCatalog::InsertTableMetrics(
   auto val5 = type::ValueFactory::GetIntegerValue(inserts);
   auto val6 = type::ValueFactory::GetIntegerValue(time_stamp);
 
-  tuple->SetValue(ColumnId::TABLE_OID, val1, pool);
-  tuple->SetValue(ColumnId::READS, val2, pool);
-  tuple->SetValue(ColumnId::UPDATES, val3, pool);
-  tuple->SetValue(ColumnId::DELETES, val4, pool);
-  tuple->SetValue(ColumnId::INSERTS, val5, pool);
-  tuple->SetValue(ColumnId::TIME_STAMP, val6, pool);
 
-  // Insert the tuple
-  return InsertTuple(std::move(tuple), txn);
+  auto constant_expr_1 = new expression::ConstantValueExpression(
+      val1);
+  auto constant_expr_2 = new expression::ConstantValueExpression(
+      val2);
+  auto constant_expr_3 = new expression::ConstantValueExpression(
+      val3);
+  auto constant_expr_4 = new expression::ConstantValueExpression(
+      val4);
+  auto constant_expr_5 = new expression::ConstantValueExpression(
+      val5);
+  auto constant_expr_6 = new expression::ConstantValueExpression(
+      val6);
+
+  tuples.push_back(std::vector<ExpressionPtr>());
+  auto &values = tuples[0];
+  values.push_back(ExpressionPtr(constant_expr_1));
+  values.push_back(ExpressionPtr(constant_expr_2));
+  values.push_back(ExpressionPtr(constant_expr_3));
+  values.push_back(ExpressionPtr(constant_expr_4));
+  values.push_back(ExpressionPtr(constant_expr_5));
+  values.push_back(ExpressionPtr(constant_expr_6));
+
+  return InsertTupleWithCompiledPlan(&tuples, txn);
 }
 
 bool TableMetricsCatalog::DeleteTableMetrics(
     oid_t table_oid, concurrency::TransactionContext *txn) {
-  oid_t index_offset = IndexId::PRIMARY_KEY;  // Primary key index
 
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetIntegerValue(table_oid).Copy());
+  std::vector<oid_t> column_ids(all_column_ids);
 
-  return DeleteWithIndexScan(index_offset, values, txn);
+  auto *oid_expr =
+      new expression::TupleValueExpression(type::TypeId::INTEGER, 0,
+                                           ColumnId::DATABASE_OID);
+
+  oid_expr->SetBoundOid(catalog_table_->GetDatabaseOid(),
+                        catalog_table_->GetOid(),
+                        ColumnId::DATABASE_OID);
+
+  expression::AbstractExpression *oid_const_expr =
+      expression::ExpressionUtil::ConstantValueFactory(
+          type::ValueFactory::GetIntegerValue(table_oid).Copy());
+  expression::AbstractExpression *oid_equality_expr =
+      expression::ExpressionUtil::ComparisonFactory(
+          ExpressionType::COMPARE_EQUAL, oid_expr, oid_const_expr);
+
+  expression::AbstractExpression *predicate = oid_equality_expr;
+
+  return DeleteWithCompiledSeqScan(column_ids, predicate, txn);
 }
 
 }  // namespace catalog

--- a/src/codegen/expression/comparison_translator.cpp
+++ b/src/codegen/expression/comparison_translator.cpp
@@ -34,6 +34,7 @@ codegen::Value ComparisonTranslator::DeriveValue(CodeGen &codegen,
   codegen::Value left = row.DeriveValue(codegen, *comparison.GetChild(0));
   codegen::Value right = row.DeriveValue(codegen, *comparison.GetChild(1));
 
+
   switch (comparison.GetExpressionType()) {
     case ExpressionType::COMPARE_EQUAL:
       return left.CompareEq(codegen, right);

--- a/src/include/catalog/abstract_catalog.h
+++ b/src/include/catalog/abstract_catalog.h
@@ -99,6 +99,11 @@ class AbstractCatalog {
                            std::vector<type::Value> scan_values,
                            oid_t index_offset,
                            concurrency::TransactionContext *txn);
+  bool  UpdateWithCompiledSeqScan( std::vector<oid_t> update_columns,
+                                   std::vector<type::Value> update_values,
+                                   std::vector<oid_t> column_offsets,
+                                   expression::AbstractExpression *predicate,
+                                   concurrency::TransactionContext *txn);
 
   void AddIndex(const std::vector<oid_t> &key_attrs, oid_t index_oid,
                 const std::string &index_name,

--- a/src/include/catalog/column.h
+++ b/src/include/catalog/column.h
@@ -33,9 +33,8 @@ class Column : public Printable {
     // Nothing to see...
   }
 
-  Column(type::TypeId value_type, size_t column_length,
-         std::string column_name, bool is_inlined = false,
-         oid_t column_offset = INVALID_OID)
+  Column(type::TypeId value_type, size_t column_length, std::string column_name,
+         bool is_inlined = false, oid_t column_offset = INVALID_OID)
       : column_name(column_name),
         column_type(value_type),
         fixed_length(INVALID_OID),

--- a/src/include/catalog/column_catalog.h
+++ b/src/include/catalog/column_catalog.h
@@ -41,6 +41,7 @@ namespace catalog {
 class ColumnCatalogObject {
  public:
   ColumnCatalogObject(executor::LogicalTile *tile, int tupleId = 0);
+  ColumnCatalogObject(codegen::WrappedTuple wrapped_tuple);
 
   inline oid_t GetTableOid() { return table_oid; }
   inline const std::string &GetColumnName() { return column_name; }

--- a/src/include/catalog/column_stats_catalog.h
+++ b/src/include/catalog/column_stats_catalog.h
@@ -107,6 +107,7 @@ class ColumnStatsCatalog : public AbstractCatalog {
 
  private:
   ColumnStatsCatalog(concurrency::TransactionContext *txn);
+  std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
   enum IndexId {
     SECONDARY_KEY_0 = 0,

--- a/src/include/catalog/constraint.h
+++ b/src/include/catalog/constraint.h
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include <string>
@@ -65,16 +64,15 @@ class Constraint : public Printable {
   // Todo: default union data structure,
   // For default constraint
   void addDefaultValue(const type::Value &value) {
-    if (constraint_type != ConstraintType::DEFAULT || default_value.get() != nullptr) {
+    if (constraint_type != ConstraintType::DEFAULT ||
+        default_value.get() != nullptr) {
       return;
     }
 
     default_value.reset(new peloton::type::Value(value));
   }
 
-  type::Value* getDefaultValue() {
-    return default_value.get();
-  }
+  type::Value *getDefaultValue() { return default_value.get(); }
 
   // Add check constrain
   void AddCheck(ExpressionType op, peloton::type::Value val) {

--- a/src/include/catalog/database_catalog.h
+++ b/src/include/catalog/database_catalog.h
@@ -32,7 +32,6 @@
 
 namespace peloton {
 namespace catalog {
-
 class TableCatalogObject;
 class IndexCatalogObject;
 
@@ -43,6 +42,8 @@ class DatabaseCatalogObject {
 
  public:
   DatabaseCatalogObject(executor::LogicalTile *tile,
+                        concurrency::TransactionContext *txn);
+  DatabaseCatalogObject(codegen::WrappedTuple wrapped_tuple,
                         concurrency::TransactionContext *txn);
 
   void EvictAllTableObjects();

--- a/src/include/catalog/database_metrics_catalog.h
+++ b/src/include/catalog/database_metrics_catalog.h
@@ -49,7 +49,8 @@ class DatabaseMetricsCatalog : public AbstractCatalog {
                              oid_t txn_aborted, oid_t time_stamp,
                              type::AbstractPool *pool,
                              concurrency::TransactionContext *txn);
-  bool DeleteDatabaseMetrics(oid_t database_oid, concurrency::TransactionContext *txn);
+  bool DeleteDatabaseMetrics(oid_t database_oid,
+                             concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
@@ -67,7 +68,7 @@ class DatabaseMetricsCatalog : public AbstractCatalog {
 
  private:
   DatabaseMetricsCatalog(concurrency::TransactionContext *txn);
-
+  std::vector<oid_t> all_column_ids = {0, 1, 2, 3};
   enum IndexId {
     PRIMARY_KEY = 0,
     // Add new indexes here in creation order

--- a/src/include/catalog/foreign_key.h
+++ b/src/include/catalog/foreign_key.h
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include <string>
@@ -28,12 +27,9 @@ namespace catalog {
 // Stores info about foreign key constraints, like the sink table id etc.
 class ForeignKey {
  public:
-  ForeignKey(oid_t source_table_id,
-             oid_t sink_table_id,
-             std::vector<oid_t> sink_col_ids,
-             std::vector<oid_t> source_col_ids,
-             FKConstrActionType update_action,
-             FKConstrActionType delete_action,
+  ForeignKey(oid_t source_table_id, oid_t sink_table_id,
+             std::vector<oid_t> sink_col_ids, std::vector<oid_t> source_col_ids,
+             FKConstrActionType update_action, FKConstrActionType delete_action,
              std::string constraint_name)
 
       : source_table_id(source_table_id),

--- a/src/include/catalog/index_catalog.h
+++ b/src/include/catalog/index_catalog.h
@@ -45,6 +45,7 @@ class IndexCatalogObject {
 
  public:
   IndexCatalogObject(executor::LogicalTile *tile, int tupleId = 0);
+  IndexCatalogObject(codegen::WrappedTuple wrapped_tuple);
 
   inline oid_t GetIndexOid() { return index_oid; }
   inline const std::string &GetIndexName() { return index_name; }
@@ -94,7 +95,6 @@ class IndexCatalog : public AbstractCatalog {
       const std::string &index_name, const std::string &schema_name,
       concurrency::TransactionContext *txn);
 
- private:
   std::shared_ptr<IndexCatalogObject> GetIndexObject(
       oid_t index_oid, concurrency::TransactionContext *txn);
 

--- a/src/include/catalog/index_metrics_catalog.h
+++ b/src/include/catalog/index_metrics_catalog.h
@@ -52,6 +52,7 @@ class IndexMetricsCatalog : public AbstractCatalog {
   bool DeleteIndexMetrics(oid_t index_oid,
                           concurrency::TransactionContext *txn);
 
+
   //===--------------------------------------------------------------------===//
   // Read-only Related API
   //===--------------------------------------------------------------------===//
@@ -67,6 +68,8 @@ class IndexMetricsCatalog : public AbstractCatalog {
     TIME_STAMP = 5,
     // Add new columns here in creation order
   };
+
+  std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5, 6};
 
   enum IndexId {
     PRIMARY_KEY = 0,

--- a/src/include/catalog/language_catalog.h
+++ b/src/include/catalog/language_catalog.h
@@ -39,6 +39,7 @@ namespace catalog {
 class LanguageCatalogObject {
  public:
   LanguageCatalogObject(executor::LogicalTile *tuple);
+  LanguageCatalogObject(codegen::WrappedTuple tuple);
 
   oid_t GetOid() const { return lang_oid_; }
 
@@ -54,7 +55,8 @@ class LanguageCatalog : public AbstractCatalog {
   ~LanguageCatalog();
 
   // Global Singleton
-  static LanguageCatalog &GetInstance(concurrency::TransactionContext *txn = nullptr);
+  static LanguageCatalog &GetInstance(
+      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API

--- a/src/include/catalog/proc_catalog.h
+++ b/src/include/catalog/proc_catalog.h
@@ -41,8 +41,10 @@ class LanguageCatalogObject;
 //===----------------------------------------------------------------------===//
 class ProcCatalogObject {
  public:
-  ProcCatalogObject(executor::LogicalTile *tile, concurrency::TransactionContext *txn);
-
+  ProcCatalogObject(executor::LogicalTile *tile,
+                    concurrency::TransactionContext *txn);
+  ProcCatalogObject(codegen::WrappedTuple wrapped_tuple,
+                    concurrency::TransactionContext *txn);
   // Accessors
 
   oid_t GetOid() const { return oid_; }
@@ -80,7 +82,8 @@ class ProcCatalog : public AbstractCatalog {
   ~ProcCatalog();
 
   // Global Singleton
-  static ProcCatalog &GetInstance(concurrency::TransactionContext *txn = nullptr);
+  static ProcCatalog &GetInstance(
+      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API

--- a/src/include/catalog/query_metrics_catalog.h
+++ b/src/include/catalog/query_metrics_catalog.h
@@ -88,7 +88,10 @@ class QueryMetricsCatalog : public AbstractCatalog {
     // Add new columns here in creation order
   };
 
- private:
+  std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5, 6,
+                                       7, 8, 9, 10, 11, 12};
+
+private:
   enum IndexId {
     PRIMARY_KEY = 0,
     // Add new indexes here in creation order

--- a/src/include/catalog/schema.h
+++ b/src/include/catalog/schema.h
@@ -191,7 +191,7 @@ class Schema : public Printable {
   }
 
   // Get the default value for the column
-  inline type::Value* GetDefaultValue(const oid_t column_id) const {
+  inline type::Value *GetDefaultValue(const oid_t column_id) const {
     for (auto constraint : columns[column_id].GetConstraints()) {
       if (constraint.GetType() == ConstraintType::DEFAULT) {
         return constraint.getDefaultValue();

--- a/src/include/catalog/settings_catalog.h
+++ b/src/include/catalog/settings_catalog.h
@@ -22,7 +22,8 @@ class SettingsCatalog : public AbstractCatalog {
   ~SettingsCatalog();
 
   // Global Singleton
-  static SettingsCatalog &GetInstance(concurrency::TransactionContext *txn = nullptr);
+  static SettingsCatalog &GetInstance(
+      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -34,7 +35,8 @@ class SettingsCatalog : public AbstractCatalog {
                      bool is_persistent, type::AbstractPool *pool,
                      concurrency::TransactionContext *txn);
 
-  bool DeleteSetting(const std::string &name, concurrency::TransactionContext *txn);
+  bool DeleteSetting(const std::string &name,
+                     concurrency::TransactionContext *txn);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
@@ -57,6 +59,8 @@ class SettingsCatalog : public AbstractCatalog {
     IS_PERSISTENT = 8,
     // Add new columns here in creation order
   };
+
+  std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5, 6, 7, 8};
 
  private:
   SettingsCatalog(concurrency::TransactionContext *txn);

--- a/src/include/catalog/table_catalog.h
+++ b/src/include/catalog/table_catalog.h
@@ -49,6 +49,8 @@ class TableCatalogObject {
  public:
   TableCatalogObject(executor::LogicalTile *tile,
                      concurrency::TransactionContext *txn, int tupleId = 0);
+  TableCatalogObject(codegen::WrappedTuple wrapped_tuple,
+                     concurrency::TransactionContext *txn);
 
  public:
   // Get indexes
@@ -126,6 +128,7 @@ class TableCatalog : public AbstractCatalog {
                concurrency::TransactionContext *txn);
 
   ~TableCatalog();
+
 
   inline oid_t GetNextOid() { return oid_++ | TABLE_OID_MASK; }
 

--- a/src/include/catalog/table_metrics_catalog.h
+++ b/src/include/catalog/table_metrics_catalog.h
@@ -52,6 +52,7 @@ class TableMetricsCatalog : public AbstractCatalog {
   bool DeleteTableMetrics(oid_t table_oid,
                           concurrency::TransactionContext *txn);
 
+
   //===--------------------------------------------------------------------===//
   // Read-only Related API
   //===--------------------------------------------------------------------===//
@@ -67,6 +68,8 @@ class TableMetricsCatalog : public AbstractCatalog {
     TIME_STAMP = 5,
     // Add new columns here in creation order
   };
+
+  std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5};
 
   enum IndexId {
     PRIMARY_KEY = 0,

--- a/src/include/catalog/trigger_catalog.h
+++ b/src/include/catalog/trigger_catalog.h
@@ -17,7 +17,7 @@
 // 0: oid (pkey)
 // 1: tgrelid   : table_oid
 // 2: tgname    : trigger_name
-// 3: tgfoid    : function_oid
+// 3: tgfoid    : function_name
 // 4: tgtype    : trigger_type
 // 5: tgargs    : function_arguemnts
 // 6: tgqual    : fire_condition
@@ -50,6 +50,7 @@ class TriggerCatalog : public AbstractCatalog {
   TriggerCatalog(const std::string &database_name,
                  concurrency::TransactionContext *txn);
   ~TriggerCatalog();
+
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -88,7 +89,7 @@ class TriggerCatalog : public AbstractCatalog {
     TRIGGER_OID = 0,
     TABLE_OID = 1,
     TRIGGER_NAME = 2,
-    FUNCTION_OID = 3,
+    FUNCTION_NAME = 3,
     TRIGGER_TYPE = 4,
     FUNCTION_ARGS = 5,
     FIRE_CONDITION = 6,
@@ -97,6 +98,8 @@ class TriggerCatalog : public AbstractCatalog {
 
  private:
   oid_t GetNextOid() { return oid_++ | TRIGGER_OID_MASK; }
+
+  std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5, 6, 7};
 
   enum IndexId {
     PRIMARY_KEY = 0,

--- a/src/include/catalog/zone_map_catalog.h
+++ b/src/include/catalog/zone_map_catalog.h
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include <map>
@@ -31,7 +30,8 @@ class ZoneMapCatalog : public AbstractCatalog {
   // am sorry to do this. When PelotonMain() becomes a reality, I will
   // fix this for sure.
 
-  static ZoneMapCatalog *GetInstance(concurrency::TransactionContext *txn = nullptr);
+  static ZoneMapCatalog *GetInstance(
+      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -54,7 +54,7 @@ class ZoneMapCatalog : public AbstractCatalog {
       oid_t database_id, oid_t table_id, oid_t tile_group_id, oid_t column_id,
       concurrency::TransactionContext *txn);
 
-  enum class ColumnId {
+  enum ColumnId {
     DATABASE_ID = 0,
     TABLE_ID = 1,
     TILE_GROUP_ID = 2,
@@ -64,11 +64,9 @@ class ZoneMapCatalog : public AbstractCatalog {
     TYPE = 6
   };
 
-  enum class ZoneMapOffset { 
-    MINIMUM_OFF = 0, 
-    MAXIMUM_OFF = 1, 
-    TYPE_OFF = 2 
-  };
+  enum ZoneMapOffset { MINIMUM_OFF = 0, MAXIMUM_OFF = 1, TYPE_OFF = 2 };
+
+  std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5, 6};
 
  private:
   ZoneMapCatalog(concurrency::TransactionContext *txn);

--- a/src/storage/zone_map_manager.cpp
+++ b/src/storage/zone_map_manager.cpp
@@ -199,6 +199,10 @@ ZoneMapManager::GetResultVectorAsZoneMap(
 bool ZoneMapManager::ShouldScanTileGroup(
     storage::PredicateInfo *parsed_predicates, int32_t num_predicates,
     storage::DataTable *table, int64_t tile_group_idx) {
+  // always scan the zone_map catalog to avoid chicken and egg problem
+  if (table->GetName() == ZONE_MAP_CATALOG_NAME) {
+    return true;
+  }
   for (int32_t i = 0; i < num_predicates; i++) {
     // Extract the col_id, operator and predicate_value
     int col_id = parsed_predicates[i].col_id;

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -119,26 +119,6 @@ TEST_F(CatalogTests, CreatingTable) {
                         ->GetColumnName());
   txn_manager.CommitTransaction(txn);
 }
-TEST_F(CatalogTests, IndexObject) {
-  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-  auto txn = txn_manager.BeginTransaction();
-
-  auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
-      "EMP_DB", "department_table", txn);
-  LOG_INFO("table name: %u", table_object->GetTableOid());
-  auto index_objects = table_object->GetIndexObjects();
-  for (auto it=index_objects.begin();it != index_objects.end();it++) {
-    auto index_obj = it->second;
-    LOG_INFO("index oid %u, %s, %u", index_obj->GetIndexOid(), index_obj->GetIndexName().c_str(), index_obj->GetTableOid());
-  }
-
-  auto index_oid = index_objects.begin()->second->GetIndexOid();
-  auto index_obj = catalog::IndexCatalog::GetInstance()->GetIndexObject(index_oid, txn);
-  EXPECT_NE(nullptr, index_obj);
-  // LOG_INFO("Found index oid %u, %s, %u", index_obj->GetIndexOid(), index_obj->GetIndexName().c_str(), index_obj->GetTableOid());
-
-  txn_manager.CommitTransaction(txn);
-}
 
 TEST_F(CatalogTests, TableObject) {
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
@@ -148,9 +128,6 @@ TEST_F(CatalogTests, TableObject) {
       "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn);
 
   auto index_objects = table_object->GetIndexObjects();
-  // auto index_oid = index_objects.begin()->second->GetIndexOid();
-  // auto index_obj = catalog::IndexCatalog::GetInstance()->GetIndexObject(index_oid, txn);
-  // LOG_INFO("index oid %u", index_oid);
 
   auto column_objects = table_object->GetColumnObjects();
 

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -62,248 +62,278 @@ TEST_F(CatalogTests, CreatingDatabase) {
   txn_manager.CommitTransaction(txn);
 }
 
-TEST_F(CatalogTests, CreatingTable) {
-  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-  auto txn = txn_manager.BeginTransaction();
-  auto id_column = catalog::Column(
-      type::TypeId::INTEGER, type::Type::GetTypeSize(type::TypeId::INTEGER),
-      "id", true);
-  id_column.AddConstraint(
-      catalog::Constraint(ConstraintType::PRIMARY, "primary_key"));
-  auto name_column = catalog::Column(type::TypeId::VARCHAR, 32, "name", true);
+TEST_F(CatalogTests, CreateThenDropTable) {
+ auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+ auto txn = txn_manager.BeginTransaction();
+ auto id_column = catalog::Column(
+   type::TypeId::INTEGER, type::Type::GetTypeSize(type::TypeId::INTEGER),
+   "id", true);
+ id_column.AddConstraint(
+   catalog::Constraint(ConstraintType::PRIMARY, "primary_key"));
+ auto name_column = catalog::Column(type::TypeId::VARCHAR, 32, "name", true);
 
-  std::unique_ptr<catalog::Schema> table_schema(
-      new catalog::Schema({id_column, name_column}));
-  std::unique_ptr<catalog::Schema> table_schema_2(
-      new catalog::Schema({id_column, name_column}));
-  std::unique_ptr<catalog::Schema> table_schema_3(
-      new catalog::Schema({id_column, name_column}));
+ std::unique_ptr<catalog::Schema> table_schema(
+   new catalog::Schema({id_column, name_column}));
 
-  catalog::Catalog::GetInstance()->CreateTable(
-      "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", std::move(table_schema), txn);
-  catalog::Catalog::GetInstance()->CreateTable("emp_db", DEFUALT_SCHEMA_NAME,
-                                               "department_table",
-                                               std::move(table_schema_2), txn);
-  catalog::Catalog::GetInstance()->CreateTable("emp_db", DEFUALT_SCHEMA_NAME,
-                                               "salary_table",
-                                               std::move(table_schema_3), txn);
-  // insert random tuple into DATABASE_METRICS_CATALOG and check
-  std::unique_ptr<type::AbstractPool> pool(new type::EphemeralPool());
-  catalog::DatabaseMetricsCatalog::GetInstance()->InsertDatabaseMetrics(
-      2, 3, 4, 5, pool.get(), txn);
+ catalog::Catalog::GetInstance()->CreateTable(
+   "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", std::move(table_schema), txn);
 
-  // inset meaningless tuple into QUERY_METRICS_CATALOG and check
-  stats::QueryMetric::QueryParamBuf param;
-  param.len = 1;
-  param.buf = (unsigned char *)pool->Allocate(1);
-  *param.buf = 'a';
-  auto database_object =
-      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
-  catalog::Catalog::GetInstance()
-      ->GetSystemCatalogs(database_object->GetDatabaseOid())
-      ->GetQueryMetricsCatalog()
-      ->InsertQueryMetrics("a query", database_object->GetDatabaseOid(), 1,
-                           param, param, param, 1, 1, 1, 1, 1, 1, 1, pool.get(),
-                           txn);
-  auto param1 = catalog::Catalog::GetInstance()
-                    ->GetSystemCatalogs(database_object->GetDatabaseOid())
-                    ->GetQueryMetricsCatalog()
-                    ->GetParamTypes("a query", txn);
-  EXPECT_EQ(1, param1.len);
-  EXPECT_EQ('a', *param1.buf);
-  // check colum object
-  EXPECT_EQ("name", catalog::Catalog::GetInstance()
-                        ->GetTableObject("emp_db", DEFUALT_SCHEMA_NAME,
-                                         "department_table", txn)
-                        ->GetColumnObject(1)
-                        ->GetColumnName());
-  txn_manager.CommitTransaction(txn);
+ auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
+   "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", txn);
+
+ EXPECT_NE(table_object, nullptr);
+ EXPECT_EQ(table_object->GetTableName(), "emp_table");
+
+ catalog::Catalog::GetInstance()->DropTable("emp_db", DEFUALT_SCHEMA_NAME,
+                                            "emp_table", txn);
+ auto table_object_1 = catalog::Catalog::GetInstance()->GetTableObject(
+   "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", txn);
+ EXPECT_EQ(nullptr, table_object_1);
+ txn_manager.CommitTransaction(txn);
 }
-
-TEST_F(CatalogTests, TableObject) {
-  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-  auto txn = txn_manager.BeginTransaction();
-
-  auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
-      "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn);
-
-  auto index_objects = table_object->GetIndexObjects();
-
-  auto column_objects = table_object->GetColumnObjects();
-
-  EXPECT_EQ(1, index_objects.size());
-  EXPECT_EQ(2, column_objects.size());
-
-  EXPECT_EQ(table_object->GetTableOid(), column_objects[0]->GetTableOid());
-  EXPECT_EQ("id", column_objects[0]->GetColumnName());
-  EXPECT_EQ(0, column_objects[0]->GetColumnId());
-  EXPECT_EQ(0, column_objects[0]->GetColumnOffset());
-  EXPECT_EQ(type::TypeId::INTEGER, column_objects[0]->GetColumnType());
-  EXPECT_TRUE(column_objects[0]->IsInlined());
-  EXPECT_TRUE(column_objects[0]->IsPrimary());
-  EXPECT_FALSE(column_objects[0]->IsNotNull());
-
-  EXPECT_EQ(table_object->GetTableOid(), column_objects[1]->GetTableOid());
-  EXPECT_EQ("name", column_objects[1]->GetColumnName());
-  EXPECT_EQ(1, column_objects[1]->GetColumnId());
-  EXPECT_EQ(4, column_objects[1]->GetColumnOffset());
-  EXPECT_EQ(type::TypeId::VARCHAR, column_objects[1]->GetColumnType());
-  EXPECT_TRUE(column_objects[1]->IsInlined());
-  EXPECT_FALSE(column_objects[1]->IsPrimary());
-  EXPECT_FALSE(column_objects[1]->IsNotNull());
-
-  // update pg_table SET version_oid = 1 where table_name = department_table
-  oid_t department_table_oid = table_object->GetTableOid();
-  auto pg_table = catalog::Catalog::GetInstance()
-                      ->GetSystemCatalogs(table_object->GetDatabaseOid())
-                      ->GetTableCatalog();
-  bool update_result = pg_table->UpdateVersionId(1, department_table_oid, txn);
-  // get version id after update, invalidate old cache
-  table_object = catalog::Catalog::GetInstance()->GetTableObject(
-      "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn);
-  uint32_t version_oid = table_object->GetVersionId();
-  EXPECT_NE(department_table_oid, INVALID_OID);
-  EXPECT_EQ(update_result, true);
-  EXPECT_EQ(version_oid, 1);
-
-  txn_manager.CommitTransaction(txn);
-}
-
-TEST_F(CatalogTests, TestingNamespace) {
-  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
-  // create namespaces emp_ns0 and emp_ns1
-  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery(
-                                     "create database default_database;"));
-  EXPECT_EQ(ResultType::SUCCESS,
-            TestingSQLUtil::ExecuteSQLQuery("create schema emp_ns0;"));
-  EXPECT_EQ(ResultType::SUCCESS,
-            TestingSQLUtil::ExecuteSQLQuery("create schema emp_ns1;"));
-
-  // create emp_table0 and emp_table1 in namespaces
-  EXPECT_EQ(ResultType::SUCCESS,
-            TestingSQLUtil::ExecuteSQLQuery(
-                "create table emp_ns0.emp_table0 (a int, b varchar);"));
-  EXPECT_EQ(ResultType::SUCCESS,
-            TestingSQLUtil::ExecuteSQLQuery(
-                "create table emp_ns0.emp_table1 (a int, b varchar);"));
-  EXPECT_EQ(ResultType::SUCCESS,
-            TestingSQLUtil::ExecuteSQLQuery(
-                "create table emp_ns1.emp_table0 (a int, b varchar);"));
-  EXPECT_EQ(ResultType::FAILURE,
-            TestingSQLUtil::ExecuteSQLQuery(
-                "create table emp_ns1.emp_table0 (a int, b varchar);"));
-
-  // insert values into emp_table0
-  EXPECT_EQ(ResultType::SUCCESS,
-            TestingSQLUtil::ExecuteSQLQuery(
-                "insert into emp_ns0.emp_table0 values (1, 'abc');"));
-  EXPECT_EQ(ResultType::SUCCESS,
-            TestingSQLUtil::ExecuteSQLQuery(
-                "insert into emp_ns0.emp_table0 values (2, 'abc');"));
-  EXPECT_EQ(ResultType::SUCCESS,
-            TestingSQLUtil::ExecuteSQLQuery(
-                "insert into emp_ns1.emp_table0 values (1, 'abc');"));
-
-  // select values from emp_table0 and emp_table1
-  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
-      "select * from emp_ns0.emp_table1;", {});
-  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
-      "select * from emp_ns0.emp_table0;", {"1|abc", "2|abc"});
-  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
-      "select * from emp_ns1.emp_table0;", {"1|abc"});
-  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("commit;"));
-  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
-  EXPECT_EQ(ResultType::FAILURE, TestingSQLUtil::ExecuteSQLQuery(
-                                     "select * from emp_ns1.emp_table1;"));
-  EXPECT_EQ(ResultType::ABORTED, TestingSQLUtil::ExecuteSQLQuery("commit;"));
-
-  // drop namespace emp_ns0 and emp_ns1
-  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
-  EXPECT_EQ(ResultType::SUCCESS,
-            TestingSQLUtil::ExecuteSQLQuery("drop schema emp_ns0;"));
-  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
-      "select * from emp_ns1.emp_table0;", {"1|abc"});
-  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("commit;"));
-  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
-  EXPECT_EQ(ResultType::FAILURE,
-            TestingSQLUtil::ExecuteSQLQuery("drop schema emp_ns0;"));
-  EXPECT_EQ(ResultType::FAILURE, TestingSQLUtil::ExecuteSQLQuery(
-                                     "select * from emp_ns0.emp_table1;"));
-  EXPECT_EQ(ResultType::ABORTED, TestingSQLUtil::ExecuteSQLQuery("commit;"));
-}
-
-TEST_F(CatalogTests, DroppingTable) {
-  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-  auto txn = txn_manager.BeginTransaction();
-  auto catalog = catalog::Catalog::GetInstance();
-  // NOTE: everytime we create a database, there will be 8 catalog tables inside
-  EXPECT_EQ(
-      11,
-      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
-  auto database_object =
-      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
-  EXPECT_NE(nullptr, database_object);
-  catalog::Catalog::GetInstance()->DropTable("emp_db", DEFUALT_SCHEMA_NAME,
-                                             "department_table", txn);
-
-  database_object =
-      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
-  EXPECT_NE(nullptr, database_object);
-  auto department_table_object =
-      database_object->GetTableObject("department_table", DEFUALT_SCHEMA_NAME);
-  EXPECT_EQ(
-      10,
-      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
-  txn_manager.CommitTransaction(txn);
-
-  EXPECT_EQ(nullptr, department_table_object);
-
-  // Try to drop again
-  txn = txn_manager.BeginTransaction();
-  EXPECT_THROW(catalog::Catalog::GetInstance()->DropTable(
-                   "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn),
-               CatalogException);
-  //
-  EXPECT_EQ(
-      10,
-      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
-  txn_manager.CommitTransaction(txn);
-
-  // Drop a table that does not exist
-  txn = txn_manager.BeginTransaction();
-  EXPECT_THROW(catalog::Catalog::GetInstance()->DropTable(
-                   "emp_db", DEFUALT_SCHEMA_NAME, "void_table", txn),
-               CatalogException);
-  EXPECT_EQ(
-      10,
-      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
-  txn_manager.CommitTransaction(txn);
-
-  // Drop the other table
-  txn = txn_manager.BeginTransaction();
-  catalog::Catalog::GetInstance()->DropTable("emp_db", DEFUALT_SCHEMA_NAME,
-                                             "emp_table", txn);
-  EXPECT_EQ(
-      9,
-      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
-  txn_manager.CommitTransaction(txn);
-}
-
-TEST_F(CatalogTests, DroppingDatabase) {
-  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-  auto txn = txn_manager.BeginTransaction();
-  catalog::Catalog::GetInstance()->DropDatabaseWithName("emp_db", txn);
-
-  EXPECT_THROW(
-      catalog::Catalog::GetInstance()->GetDatabaseWithName("emp_db", txn),
-      CatalogException);
-  txn_manager.CommitTransaction(txn);
-}
-
-TEST_F(CatalogTests, DroppingCatalog) {
-  auto catalog = catalog::Catalog::GetInstance();
-  EXPECT_NE(nullptr, catalog);
-}
+//
+//TEST_F(CatalogTests, CreatingTable) {
+//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+//  auto txn = txn_manager.BeginTransaction();
+//  auto id_column = catalog::Column(
+//      type::TypeId::INTEGER, type::Type::GetTypeSize(type::TypeId::INTEGER),
+//      "id", true);
+//  id_column.AddConstraint(
+//      catalog::Constraint(ConstraintType::PRIMARY, "primary_key"));
+//  auto name_column = catalog::Column(type::TypeId::VARCHAR, 32, "name", true);
+//
+//  std::unique_ptr<catalog::Schema> table_schema(
+//      new catalog::Schema({id_column, name_column}));
+//  std::unique_ptr<catalog::Schema> table_schema_2(
+//      new catalog::Schema({id_column, name_column}));
+//  std::unique_ptr<catalog::Schema> table_schema_3(
+//      new catalog::Schema({id_column, name_column}));
+//
+//  catalog::Catalog::GetInstance()->CreateTable(
+//      "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", std::move(table_schema), txn);
+//  catalog::Catalog::GetInstance()->CreateTable("emp_db", DEFUALT_SCHEMA_NAME,
+//                                               "department_table",
+//                                               std::move(table_schema_2), txn);
+//  catalog::Catalog::GetInstance()->CreateTable("emp_db", DEFUALT_SCHEMA_NAME,
+//                                               "salary_table",
+//                                               std::move(table_schema_3), txn);
+//  // insert random tuple into DATABASE_METRICS_CATALOG and check
+//  std::unique_ptr<type::AbstractPool> pool(new type::EphemeralPool());
+//  catalog::DatabaseMetricsCatalog::GetInstance()->InsertDatabaseMetrics(
+//      2, 3, 4, 5, pool.get(), txn);
+//
+//  // inset meaningless tuple into QUERY_METRICS_CATALOG and check
+//  stats::QueryMetric::QueryParamBuf param;
+//  param.len = 1;
+//  param.buf = (unsigned char *)pool->Allocate(1);
+//  *param.buf = 'a';
+//  auto database_object =
+//      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
+//  catalog::Catalog::GetInstance()
+//      ->GetSystemCatalogs(database_object->GetDatabaseOid())
+//      ->GetQueryMetricsCatalog()
+//      ->InsertQueryMetrics("a query", database_object->GetDatabaseOid(), 1,
+//                           param, param, param, 1, 1, 1, 1, 1, 1, 1, pool.get(),
+//                           txn);
+//  auto param1 = catalog::Catalog::GetInstance()
+//                    ->GetSystemCatalogs(database_object->GetDatabaseOid())
+//                    ->GetQueryMetricsCatalog()
+//                    ->GetParamTypes("a query", txn);
+//  EXPECT_EQ(1, param1.len);
+//  EXPECT_EQ('a', *param1.buf);
+//  // check colum object
+//  EXPECT_EQ("name", catalog::Catalog::GetInstance()
+//                        ->GetTableObject("emp_db", DEFUALT_SCHEMA_NAME,
+//                                         "department_table", txn)
+//                        ->GetColumnObject(1)
+//                        ->GetColumnName());
+//  txn_manager.CommitTransaction(txn);
+//}
+//
+//TEST_F(CatalogTests, TableObject) {
+//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+//  auto txn = txn_manager.BeginTransaction();
+//
+//  auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
+//      "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn);
+//
+//  auto index_objects = table_object->GetIndexObjects();
+//
+//  auto column_objects = table_object->GetColumnObjects();
+//
+//  EXPECT_EQ(1, index_objects.size());
+//  EXPECT_EQ(2, column_objects.size());
+//
+//  EXPECT_EQ(table_object->GetTableOid(), column_objects[0]->GetTableOid());
+//  EXPECT_EQ("id", column_objects[0]->GetColumnName());
+//  EXPECT_EQ(0, column_objects[0]->GetColumnId());
+//  EXPECT_EQ(0, column_objects[0]->GetColumnOffset());
+//  EXPECT_EQ(type::TypeId::INTEGER, column_objects[0]->GetColumnType());
+//  EXPECT_TRUE(column_objects[0]->IsInlined());
+//  EXPECT_TRUE(column_objects[0]->IsPrimary());
+//  EXPECT_FALSE(column_objects[0]->IsNotNull());
+//
+//  EXPECT_EQ(table_object->GetTableOid(), column_objects[1]->GetTableOid());
+//  EXPECT_EQ("name", column_objects[1]->GetColumnName());
+//  EXPECT_EQ(1, column_objects[1]->GetColumnId());
+//  EXPECT_EQ(4, column_objects[1]->GetColumnOffset());
+//  EXPECT_EQ(type::TypeId::VARCHAR, column_objects[1]->GetColumnType());
+//  EXPECT_TRUE(column_objects[1]->IsInlined());
+//  EXPECT_FALSE(column_objects[1]->IsPrimary());
+//  EXPECT_FALSE(column_objects[1]->IsNotNull());
+//
+//  // update pg_table SET version_oid = 1 where table_name = department_table
+//  oid_t department_table_oid = table_object->GetTableOid();
+//  auto pg_table = catalog::Catalog::GetInstance()
+//                      ->GetSystemCatalogs(table_object->GetDatabaseOid())
+//                      ->GetTableCatalog();
+//  bool update_result = pg_table->UpdateVersionId(1, department_table_oid, txn);
+//  // get version id after update, invalidate old cache
+//  table_object = catalog::Catalog::GetInstance()->GetTableObject(
+//      "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn);
+//  uint32_t version_oid = table_object->GetVersionId();
+//  EXPECT_NE(department_table_oid, INVALID_OID);
+//  EXPECT_EQ(update_result, true);
+//  EXPECT_EQ(version_oid, 1);
+//
+//  txn_manager.CommitTransaction(txn);
+//}
+//
+//TEST_F(CatalogTests, TestingNamespace) {
+//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
+//  // create namespaces emp_ns0 and emp_ns1
+//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery(
+//                                     "create database default_database;"));
+//  EXPECT_EQ(ResultType::SUCCESS,
+//            TestingSQLUtil::ExecuteSQLQuery("create schema emp_ns0;"));
+//  EXPECT_EQ(ResultType::SUCCESS,
+//            TestingSQLUtil::ExecuteSQLQuery("create schema emp_ns1;"));
+//
+//  // create emp_table0 and emp_table1 in namespaces
+//  EXPECT_EQ(ResultType::SUCCESS,
+//            TestingSQLUtil::ExecuteSQLQuery(
+//                "create table emp_ns0.emp_table0 (a int, b varchar);"));
+//  EXPECT_EQ(ResultType::SUCCESS,
+//            TestingSQLUtil::ExecuteSQLQuery(
+//                "create table emp_ns0.emp_table1 (a int, b varchar);"));
+//  EXPECT_EQ(ResultType::SUCCESS,
+//            TestingSQLUtil::ExecuteSQLQuery(
+//                "create table emp_ns1.emp_table0 (a int, b varchar);"));
+//  EXPECT_EQ(ResultType::FAILURE,
+//            TestingSQLUtil::ExecuteSQLQuery(
+//                "create table emp_ns1.emp_table0 (a int, b varchar);"));
+//
+//  // insert values into emp_table0
+//  EXPECT_EQ(ResultType::SUCCESS,
+//            TestingSQLUtil::ExecuteSQLQuery(
+//                "insert into emp_ns0.emp_table0 values (1, 'abc');"));
+//  EXPECT_EQ(ResultType::SUCCESS,
+//            TestingSQLUtil::ExecuteSQLQuery(
+//                "insert into emp_ns0.emp_table0 values (2, 'abc');"));
+//  EXPECT_EQ(ResultType::SUCCESS,
+//            TestingSQLUtil::ExecuteSQLQuery(
+//                "insert into emp_ns1.emp_table0 values (1, 'abc');"));
+//
+//  // select values from emp_table0 and emp_table1
+//  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
+//      "select * from emp_ns0.emp_table1;", {});
+//  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
+//      "select * from emp_ns0.emp_table0;", {"1|abc", "2|abc"});
+//  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
+//      "select * from emp_ns1.emp_table0;", {"1|abc"});
+//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("commit;"));
+//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
+//  EXPECT_EQ(ResultType::FAILURE, TestingSQLUtil::ExecuteSQLQuery(
+//                                     "select * from emp_ns1.emp_table1;"));
+//  EXPECT_EQ(ResultType::ABORTED, TestingSQLUtil::ExecuteSQLQuery("commit;"));
+//
+//  // drop namespace emp_ns0 and emp_ns1
+//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
+//  EXPECT_EQ(ResultType::SUCCESS,
+//            TestingSQLUtil::ExecuteSQLQuery("drop schema emp_ns0;"));
+//  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
+//      "select * from emp_ns1.emp_table0;", {"1|abc"});
+//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("commit;"));
+//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
+//  EXPECT_EQ(ResultType::FAILURE,
+//            TestingSQLUtil::ExecuteSQLQuery("drop schema emp_ns0;"));
+//  EXPECT_EQ(ResultType::FAILURE, TestingSQLUtil::ExecuteSQLQuery(
+//                                     "select * from emp_ns0.emp_table1;"));
+//  EXPECT_EQ(ResultType::ABORTED, TestingSQLUtil::ExecuteSQLQuery("commit;"));
+//}
+//
+//TEST_F(CatalogTests, DroppingTable) {
+//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+//  auto txn = txn_manager.BeginTransaction();
+//  auto catalog = catalog::Catalog::GetInstance();
+//  // NOTE: everytime we create a database, there will be 8 catalog tables inside
+//  EXPECT_EQ(
+//      11,
+//      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
+//  auto database_object =
+//      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
+//  EXPECT_NE(nullptr, database_object);
+//  catalog::Catalog::GetInstance()->DropTable("emp_db", DEFUALT_SCHEMA_NAME,
+//                                             "department_table", txn);
+//
+//  database_object =
+//      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
+//  EXPECT_NE(nullptr, database_object);
+//  auto department_table_object =
+//      database_object->GetTableObject("department_table", DEFUALT_SCHEMA_NAME);
+//  EXPECT_EQ(
+//      10,
+//      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
+//  txn_manager.CommitTransaction(txn);
+//
+//  EXPECT_EQ(nullptr, department_table_object);
+//
+//  // Try to drop again
+//  txn = txn_manager.BeginTransaction();
+//  EXPECT_THROW(catalog::Catalog::GetInstance()->DropTable(
+//                   "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn),
+//               CatalogException);
+//  //
+//  EXPECT_EQ(
+//      10,
+//      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
+//  txn_manager.CommitTransaction(txn);
+//
+//  // Drop a table that does not exist
+//  txn = txn_manager.BeginTransaction();
+//  EXPECT_THROW(catalog::Catalog::GetInstance()->DropTable(
+//                   "emp_db", DEFUALT_SCHEMA_NAME, "void_table", txn),
+//               CatalogException);
+//  EXPECT_EQ(
+//      10,
+//      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
+//  txn_manager.CommitTransaction(txn);
+//
+//  // Drop the other table
+//  txn = txn_manager.BeginTransaction();
+//  catalog::Catalog::GetInstance()->DropTable("emp_db", DEFUALT_SCHEMA_NAME,
+//                                             "emp_table", txn);
+//  EXPECT_EQ(
+//      9,
+//      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
+//  txn_manager.CommitTransaction(txn);
+//}
+//
+//TEST_F(CatalogTests, DroppingDatabase) {
+//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+//  auto txn = txn_manager.BeginTransaction();
+//  catalog::Catalog::GetInstance()->DropDatabaseWithName("emp_db", txn);
+//
+//  EXPECT_THROW(
+//      catalog::Catalog::GetInstance()->GetDatabaseWithName("emp_db", txn),
+//      CatalogException);
+//  txn_manager.CommitTransaction(txn);
+//}
+//
+//TEST_F(CatalogTests, DroppingCatalog) {
+//  auto catalog = catalog::Catalog::GetInstance();
+//  EXPECT_NE(nullptr, catalog);
+//}
 
 }  // namespace test
 }  // namespace peloton

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -61,279 +61,279 @@ TEST_F(CatalogTests, CreatingDatabase) {
                           ->GetDBName());
   txn_manager.CommitTransaction(txn);
 }
+//
+//TEST_F(CatalogTests, CreateThenDropTable) {
+// auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+// auto txn = txn_manager.BeginTransaction();
+// auto id_column = catalog::Column(
+//   type::TypeId::INTEGER, type::Type::GetTypeSize(type::TypeId::INTEGER),
+//   "id", true);
+// id_column.AddConstraint(
+//   catalog::Constraint(ConstraintType::PRIMARY, "primary_key"));
+// auto name_column = catalog::Column(type::TypeId::VARCHAR, 32, "name", true);
+//
+// std::unique_ptr<catalog::Schema> table_schema(
+//   new catalog::Schema({id_column, name_column}));
+//
+// catalog::Catalog::GetInstance()->CreateTable(
+//   "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", std::move(table_schema), txn);
+//
+// auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
+//   "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", txn);
+//
+// EXPECT_NE(table_object, nullptr);
+// EXPECT_EQ(table_object->GetTableName(), "emp_table");
+//
+// catalog::Catalog::GetInstance()->DropTable("emp_db", DEFUALT_SCHEMA_NAME,
+//                                            "emp_table", txn);
+// auto table_object_1 = catalog::Catalog::GetInstance()->GetTableObject(
+//   "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", txn);
+// EXPECT_EQ(nullptr, table_object_1);
+// txn_manager.CommitTransaction(txn);
+//}
+//
+TEST_F(CatalogTests, CreatingTable) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  auto id_column = catalog::Column(
+      type::TypeId::INTEGER, type::Type::GetTypeSize(type::TypeId::INTEGER),
+      "id", true);
+  id_column.AddConstraint(
+      catalog::Constraint(ConstraintType::PRIMARY, "primary_key"));
+  auto name_column = catalog::Column(type::TypeId::VARCHAR, 32, "name", true);
 
-TEST_F(CatalogTests, CreateThenDropTable) {
- auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
- auto txn = txn_manager.BeginTransaction();
- auto id_column = catalog::Column(
-   type::TypeId::INTEGER, type::Type::GetTypeSize(type::TypeId::INTEGER),
-   "id", true);
- id_column.AddConstraint(
-   catalog::Constraint(ConstraintType::PRIMARY, "primary_key"));
- auto name_column = catalog::Column(type::TypeId::VARCHAR, 32, "name", true);
+  std::unique_ptr<catalog::Schema> table_schema(
+      new catalog::Schema({id_column, name_column}));
+  std::unique_ptr<catalog::Schema> table_schema_2(
+      new catalog::Schema({id_column, name_column}));
+  std::unique_ptr<catalog::Schema> table_schema_3(
+      new catalog::Schema({id_column, name_column}));
 
- std::unique_ptr<catalog::Schema> table_schema(
-   new catalog::Schema({id_column, name_column}));
+  catalog::Catalog::GetInstance()->CreateTable(
+      "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", std::move(table_schema), txn);
+  catalog::Catalog::GetInstance()->CreateTable("emp_db", DEFUALT_SCHEMA_NAME,
+                                               "department_table",
+                                               std::move(table_schema_2), txn);
+  catalog::Catalog::GetInstance()->CreateTable("emp_db", DEFUALT_SCHEMA_NAME,
+                                               "salary_table",
+                                               std::move(table_schema_3), txn);
+  // insert random tuple into DATABASE_METRICS_CATALOG and check
+  std::unique_ptr<type::AbstractPool> pool(new type::EphemeralPool());
+  catalog::DatabaseMetricsCatalog::GetInstance()->InsertDatabaseMetrics(
+      2, 3, 4, 5, pool.get(), txn);
 
- catalog::Catalog::GetInstance()->CreateTable(
-   "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", std::move(table_schema), txn);
-
- auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
-   "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", txn);
-
- EXPECT_NE(table_object, nullptr);
- EXPECT_EQ(table_object->GetTableName(), "emp_table");
-
- catalog::Catalog::GetInstance()->DropTable("emp_db", DEFUALT_SCHEMA_NAME,
-                                            "emp_table", txn);
- auto table_object_1 = catalog::Catalog::GetInstance()->GetTableObject(
-   "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", txn);
- EXPECT_EQ(nullptr, table_object_1);
- txn_manager.CommitTransaction(txn);
+  // inset meaningless tuple into QUERY_METRICS_CATALOG and check
+  stats::QueryMetric::QueryParamBuf param;
+  param.len = 1;
+  param.buf = (unsigned char *)pool->Allocate(1);
+  *param.buf = 'a';
+  auto database_object =
+      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
+  catalog::Catalog::GetInstance()
+      ->GetSystemCatalogs(database_object->GetDatabaseOid())
+      ->GetQueryMetricsCatalog()
+      ->InsertQueryMetrics("a query", database_object->GetDatabaseOid(), 1,
+                           param, param, param, 1, 1, 1, 1, 1, 1, 1, pool.get(),
+                           txn);
+  auto param1 = catalog::Catalog::GetInstance()
+                    ->GetSystemCatalogs(database_object->GetDatabaseOid())
+                    ->GetQueryMetricsCatalog()
+                    ->GetParamTypes("a query", txn);
+  EXPECT_EQ(1, param1.len);
+  EXPECT_EQ('a', *param1.buf);
+  // check colum object
+  EXPECT_EQ("name", catalog::Catalog::GetInstance()
+                        ->GetTableObject("emp_db", DEFUALT_SCHEMA_NAME,
+                                         "department_table", txn)
+                        ->GetColumnObject(1)
+                        ->GetColumnName());
+  txn_manager.CommitTransaction(txn);
 }
-//
-//TEST_F(CatalogTests, CreatingTable) {
-//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-//  auto txn = txn_manager.BeginTransaction();
-//  auto id_column = catalog::Column(
-//      type::TypeId::INTEGER, type::Type::GetTypeSize(type::TypeId::INTEGER),
-//      "id", true);
-//  id_column.AddConstraint(
-//      catalog::Constraint(ConstraintType::PRIMARY, "primary_key"));
-//  auto name_column = catalog::Column(type::TypeId::VARCHAR, 32, "name", true);
-//
-//  std::unique_ptr<catalog::Schema> table_schema(
-//      new catalog::Schema({id_column, name_column}));
-//  std::unique_ptr<catalog::Schema> table_schema_2(
-//      new catalog::Schema({id_column, name_column}));
-//  std::unique_ptr<catalog::Schema> table_schema_3(
-//      new catalog::Schema({id_column, name_column}));
-//
-//  catalog::Catalog::GetInstance()->CreateTable(
-//      "emp_db", DEFUALT_SCHEMA_NAME, "emp_table", std::move(table_schema), txn);
-//  catalog::Catalog::GetInstance()->CreateTable("emp_db", DEFUALT_SCHEMA_NAME,
-//                                               "department_table",
-//                                               std::move(table_schema_2), txn);
-//  catalog::Catalog::GetInstance()->CreateTable("emp_db", DEFUALT_SCHEMA_NAME,
-//                                               "salary_table",
-//                                               std::move(table_schema_3), txn);
-//  // insert random tuple into DATABASE_METRICS_CATALOG and check
-//  std::unique_ptr<type::AbstractPool> pool(new type::EphemeralPool());
-//  catalog::DatabaseMetricsCatalog::GetInstance()->InsertDatabaseMetrics(
-//      2, 3, 4, 5, pool.get(), txn);
-//
-//  // inset meaningless tuple into QUERY_METRICS_CATALOG and check
-//  stats::QueryMetric::QueryParamBuf param;
-//  param.len = 1;
-//  param.buf = (unsigned char *)pool->Allocate(1);
-//  *param.buf = 'a';
-//  auto database_object =
-//      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
-//  catalog::Catalog::GetInstance()
-//      ->GetSystemCatalogs(database_object->GetDatabaseOid())
-//      ->GetQueryMetricsCatalog()
-//      ->InsertQueryMetrics("a query", database_object->GetDatabaseOid(), 1,
-//                           param, param, param, 1, 1, 1, 1, 1, 1, 1, pool.get(),
-//                           txn);
-//  auto param1 = catalog::Catalog::GetInstance()
-//                    ->GetSystemCatalogs(database_object->GetDatabaseOid())
-//                    ->GetQueryMetricsCatalog()
-//                    ->GetParamTypes("a query", txn);
-//  EXPECT_EQ(1, param1.len);
-//  EXPECT_EQ('a', *param1.buf);
-//  // check colum object
-//  EXPECT_EQ("name", catalog::Catalog::GetInstance()
-//                        ->GetTableObject("emp_db", DEFUALT_SCHEMA_NAME,
-//                                         "department_table", txn)
-//                        ->GetColumnObject(1)
-//                        ->GetColumnName());
-//  txn_manager.CommitTransaction(txn);
-//}
-//
-//TEST_F(CatalogTests, TableObject) {
-//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-//  auto txn = txn_manager.BeginTransaction();
-//
-//  auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
-//      "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn);
-//
-//  auto index_objects = table_object->GetIndexObjects();
-//
-//  auto column_objects = table_object->GetColumnObjects();
-//
-//  EXPECT_EQ(1, index_objects.size());
-//  EXPECT_EQ(2, column_objects.size());
-//
-//  EXPECT_EQ(table_object->GetTableOid(), column_objects[0]->GetTableOid());
-//  EXPECT_EQ("id", column_objects[0]->GetColumnName());
-//  EXPECT_EQ(0, column_objects[0]->GetColumnId());
-//  EXPECT_EQ(0, column_objects[0]->GetColumnOffset());
-//  EXPECT_EQ(type::TypeId::INTEGER, column_objects[0]->GetColumnType());
-//  EXPECT_TRUE(column_objects[0]->IsInlined());
-//  EXPECT_TRUE(column_objects[0]->IsPrimary());
-//  EXPECT_FALSE(column_objects[0]->IsNotNull());
-//
-//  EXPECT_EQ(table_object->GetTableOid(), column_objects[1]->GetTableOid());
-//  EXPECT_EQ("name", column_objects[1]->GetColumnName());
-//  EXPECT_EQ(1, column_objects[1]->GetColumnId());
-//  EXPECT_EQ(4, column_objects[1]->GetColumnOffset());
-//  EXPECT_EQ(type::TypeId::VARCHAR, column_objects[1]->GetColumnType());
-//  EXPECT_TRUE(column_objects[1]->IsInlined());
-//  EXPECT_FALSE(column_objects[1]->IsPrimary());
-//  EXPECT_FALSE(column_objects[1]->IsNotNull());
-//
-//  // update pg_table SET version_oid = 1 where table_name = department_table
-//  oid_t department_table_oid = table_object->GetTableOid();
-//  auto pg_table = catalog::Catalog::GetInstance()
-//                      ->GetSystemCatalogs(table_object->GetDatabaseOid())
-//                      ->GetTableCatalog();
-//  bool update_result = pg_table->UpdateVersionId(1, department_table_oid, txn);
-//  // get version id after update, invalidate old cache
-//  table_object = catalog::Catalog::GetInstance()->GetTableObject(
-//      "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn);
-//  uint32_t version_oid = table_object->GetVersionId();
-//  EXPECT_NE(department_table_oid, INVALID_OID);
-//  EXPECT_EQ(update_result, true);
-//  EXPECT_EQ(version_oid, 1);
-//
-//  txn_manager.CommitTransaction(txn);
-//}
-//
-//TEST_F(CatalogTests, TestingNamespace) {
-//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
-//  // create namespaces emp_ns0 and emp_ns1
-//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery(
-//                                     "create database default_database;"));
-//  EXPECT_EQ(ResultType::SUCCESS,
-//            TestingSQLUtil::ExecuteSQLQuery("create schema emp_ns0;"));
-//  EXPECT_EQ(ResultType::SUCCESS,
-//            TestingSQLUtil::ExecuteSQLQuery("create schema emp_ns1;"));
-//
-//  // create emp_table0 and emp_table1 in namespaces
-//  EXPECT_EQ(ResultType::SUCCESS,
-//            TestingSQLUtil::ExecuteSQLQuery(
-//                "create table emp_ns0.emp_table0 (a int, b varchar);"));
-//  EXPECT_EQ(ResultType::SUCCESS,
-//            TestingSQLUtil::ExecuteSQLQuery(
-//                "create table emp_ns0.emp_table1 (a int, b varchar);"));
-//  EXPECT_EQ(ResultType::SUCCESS,
-//            TestingSQLUtil::ExecuteSQLQuery(
-//                "create table emp_ns1.emp_table0 (a int, b varchar);"));
-//  EXPECT_EQ(ResultType::FAILURE,
-//            TestingSQLUtil::ExecuteSQLQuery(
-//                "create table emp_ns1.emp_table0 (a int, b varchar);"));
-//
-//  // insert values into emp_table0
-//  EXPECT_EQ(ResultType::SUCCESS,
-//            TestingSQLUtil::ExecuteSQLQuery(
-//                "insert into emp_ns0.emp_table0 values (1, 'abc');"));
-//  EXPECT_EQ(ResultType::SUCCESS,
-//            TestingSQLUtil::ExecuteSQLQuery(
-//                "insert into emp_ns0.emp_table0 values (2, 'abc');"));
-//  EXPECT_EQ(ResultType::SUCCESS,
-//            TestingSQLUtil::ExecuteSQLQuery(
-//                "insert into emp_ns1.emp_table0 values (1, 'abc');"));
-//
-//  // select values from emp_table0 and emp_table1
-//  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
-//      "select * from emp_ns0.emp_table1;", {});
-//  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
-//      "select * from emp_ns0.emp_table0;", {"1|abc", "2|abc"});
-//  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
-//      "select * from emp_ns1.emp_table0;", {"1|abc"});
-//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("commit;"));
-//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
-//  EXPECT_EQ(ResultType::FAILURE, TestingSQLUtil::ExecuteSQLQuery(
-//                                     "select * from emp_ns1.emp_table1;"));
-//  EXPECT_EQ(ResultType::ABORTED, TestingSQLUtil::ExecuteSQLQuery("commit;"));
-//
-//  // drop namespace emp_ns0 and emp_ns1
-//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
-//  EXPECT_EQ(ResultType::SUCCESS,
-//            TestingSQLUtil::ExecuteSQLQuery("drop schema emp_ns0;"));
-//  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
-//      "select * from emp_ns1.emp_table0;", {"1|abc"});
-//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("commit;"));
-//  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
-//  EXPECT_EQ(ResultType::FAILURE,
-//            TestingSQLUtil::ExecuteSQLQuery("drop schema emp_ns0;"));
-//  EXPECT_EQ(ResultType::FAILURE, TestingSQLUtil::ExecuteSQLQuery(
-//                                     "select * from emp_ns0.emp_table1;"));
-//  EXPECT_EQ(ResultType::ABORTED, TestingSQLUtil::ExecuteSQLQuery("commit;"));
-//}
-//
-//TEST_F(CatalogTests, DroppingTable) {
-//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-//  auto txn = txn_manager.BeginTransaction();
-//  auto catalog = catalog::Catalog::GetInstance();
-//  // NOTE: everytime we create a database, there will be 8 catalog tables inside
-//  EXPECT_EQ(
-//      11,
-//      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
-//  auto database_object =
-//      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
-//  EXPECT_NE(nullptr, database_object);
-//  catalog::Catalog::GetInstance()->DropTable("emp_db", DEFUALT_SCHEMA_NAME,
-//                                             "department_table", txn);
-//
-//  database_object =
-//      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
-//  EXPECT_NE(nullptr, database_object);
-//  auto department_table_object =
-//      database_object->GetTableObject("department_table", DEFUALT_SCHEMA_NAME);
-//  EXPECT_EQ(
-//      10,
-//      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
-//  txn_manager.CommitTransaction(txn);
-//
-//  EXPECT_EQ(nullptr, department_table_object);
-//
-//  // Try to drop again
-//  txn = txn_manager.BeginTransaction();
-//  EXPECT_THROW(catalog::Catalog::GetInstance()->DropTable(
-//                   "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn),
-//               CatalogException);
-//  //
-//  EXPECT_EQ(
-//      10,
-//      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
-//  txn_manager.CommitTransaction(txn);
-//
-//  // Drop a table that does not exist
-//  txn = txn_manager.BeginTransaction();
-//  EXPECT_THROW(catalog::Catalog::GetInstance()->DropTable(
-//                   "emp_db", DEFUALT_SCHEMA_NAME, "void_table", txn),
-//               CatalogException);
-//  EXPECT_EQ(
-//      10,
-//      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
-//  txn_manager.CommitTransaction(txn);
-//
-//  // Drop the other table
-//  txn = txn_manager.BeginTransaction();
-//  catalog::Catalog::GetInstance()->DropTable("emp_db", DEFUALT_SCHEMA_NAME,
-//                                             "emp_table", txn);
-//  EXPECT_EQ(
-//      9,
-//      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
-//  txn_manager.CommitTransaction(txn);
-//}
-//
-//TEST_F(CatalogTests, DroppingDatabase) {
-//  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
-//  auto txn = txn_manager.BeginTransaction();
-//  catalog::Catalog::GetInstance()->DropDatabaseWithName("emp_db", txn);
-//
-//  EXPECT_THROW(
-//      catalog::Catalog::GetInstance()->GetDatabaseWithName("emp_db", txn),
-//      CatalogException);
-//  txn_manager.CommitTransaction(txn);
-//}
-//
-//TEST_F(CatalogTests, DroppingCatalog) {
-//  auto catalog = catalog::Catalog::GetInstance();
-//  EXPECT_NE(nullptr, catalog);
-//}
+
+TEST_F(CatalogTests, TableObject) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+
+  auto table_object = catalog::Catalog::GetInstance()->GetTableObject(
+      "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn);
+
+  auto index_objects = table_object->GetIndexObjects();
+
+  auto column_objects = table_object->GetColumnObjects();
+
+  EXPECT_EQ(1, index_objects.size());
+  EXPECT_EQ(2, column_objects.size());
+
+  EXPECT_EQ(table_object->GetTableOid(), column_objects[0]->GetTableOid());
+  EXPECT_EQ("id", column_objects[0]->GetColumnName());
+  EXPECT_EQ(0, column_objects[0]->GetColumnId());
+  EXPECT_EQ(0, column_objects[0]->GetColumnOffset());
+  EXPECT_EQ(type::TypeId::INTEGER, column_objects[0]->GetColumnType());
+  EXPECT_TRUE(column_objects[0]->IsInlined());
+  EXPECT_TRUE(column_objects[0]->IsPrimary());
+  EXPECT_FALSE(column_objects[0]->IsNotNull());
+
+  EXPECT_EQ(table_object->GetTableOid(), column_objects[1]->GetTableOid());
+  EXPECT_EQ("name", column_objects[1]->GetColumnName());
+  EXPECT_EQ(1, column_objects[1]->GetColumnId());
+  EXPECT_EQ(4, column_objects[1]->GetColumnOffset());
+  EXPECT_EQ(type::TypeId::VARCHAR, column_objects[1]->GetColumnType());
+  EXPECT_TRUE(column_objects[1]->IsInlined());
+  EXPECT_FALSE(column_objects[1]->IsPrimary());
+  EXPECT_FALSE(column_objects[1]->IsNotNull());
+
+  // update pg_table SET version_oid = 1 where table_name = department_table
+  oid_t department_table_oid = table_object->GetTableOid();
+  auto pg_table = catalog::Catalog::GetInstance()
+                      ->GetSystemCatalogs(table_object->GetDatabaseOid())
+                      ->GetTableCatalog();
+  bool update_result = pg_table->UpdateVersionId(1, department_table_oid, txn);
+  // get version id after update, invalidate old cache
+  table_object = catalog::Catalog::GetInstance()->GetTableObject(
+      "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn);
+  uint32_t version_oid = table_object->GetVersionId();
+  EXPECT_NE(department_table_oid, INVALID_OID);
+  EXPECT_EQ(update_result, true);
+  EXPECT_EQ(version_oid, 1);
+
+  txn_manager.CommitTransaction(txn);
+}
+
+TEST_F(CatalogTests, TestingNamespace) {
+  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
+  // create namespaces emp_ns0 and emp_ns1
+  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery(
+                                     "create database default_database;"));
+  EXPECT_EQ(ResultType::SUCCESS,
+            TestingSQLUtil::ExecuteSQLQuery("create schema emp_ns0;"));
+  EXPECT_EQ(ResultType::SUCCESS,
+            TestingSQLUtil::ExecuteSQLQuery("create schema emp_ns1;"));
+
+  // create emp_table0 and emp_table1 in namespaces
+  EXPECT_EQ(ResultType::SUCCESS,
+            TestingSQLUtil::ExecuteSQLQuery(
+                "create table emp_ns0.emp_table0 (a int, b varchar);"));
+  EXPECT_EQ(ResultType::SUCCESS,
+            TestingSQLUtil::ExecuteSQLQuery(
+                "create table emp_ns0.emp_table1 (a int, b varchar);"));
+  EXPECT_EQ(ResultType::SUCCESS,
+            TestingSQLUtil::ExecuteSQLQuery(
+                "create table emp_ns1.emp_table0 (a int, b varchar);"));
+  EXPECT_EQ(ResultType::FAILURE,
+            TestingSQLUtil::ExecuteSQLQuery(
+                "create table emp_ns1.emp_table0 (a int, b varchar);"));
+
+  // insert values into emp_table0
+  EXPECT_EQ(ResultType::SUCCESS,
+            TestingSQLUtil::ExecuteSQLQuery(
+                "insert into emp_ns0.emp_table0 values (1, 'abc');"));
+  EXPECT_EQ(ResultType::SUCCESS,
+            TestingSQLUtil::ExecuteSQLQuery(
+                "insert into emp_ns0.emp_table0 values (2, 'abc');"));
+  EXPECT_EQ(ResultType::SUCCESS,
+            TestingSQLUtil::ExecuteSQLQuery(
+                "insert into emp_ns1.emp_table0 values (1, 'abc');"));
+
+  // select values from emp_table0 and emp_table1
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
+      "select * from emp_ns0.emp_table1;", {});
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
+      "select * from emp_ns0.emp_table0;", {"1|abc", "2|abc"});
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
+      "select * from emp_ns1.emp_table0;", {"1|abc"});
+  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("commit;"));
+  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
+  EXPECT_EQ(ResultType::FAILURE, TestingSQLUtil::ExecuteSQLQuery(
+                                     "select * from emp_ns1.emp_table1;"));
+  EXPECT_EQ(ResultType::ABORTED, TestingSQLUtil::ExecuteSQLQuery("commit;"));
+
+  // drop namespace emp_ns0 and emp_ns1
+  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
+  EXPECT_EQ(ResultType::SUCCESS,
+            TestingSQLUtil::ExecuteSQLQuery("drop schema emp_ns0;"));
+  TestingSQLUtil::ExecuteSQLQueryAndCheckResult(
+      "select * from emp_ns1.emp_table0;", {"1|abc"});
+  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("commit;"));
+  EXPECT_EQ(ResultType::SUCCESS, TestingSQLUtil::ExecuteSQLQuery("begin;"));
+  EXPECT_EQ(ResultType::FAILURE,
+            TestingSQLUtil::ExecuteSQLQuery("drop schema emp_ns0;"));
+  EXPECT_EQ(ResultType::FAILURE, TestingSQLUtil::ExecuteSQLQuery(
+                                     "select * from emp_ns0.emp_table1;"));
+  EXPECT_EQ(ResultType::ABORTED, TestingSQLUtil::ExecuteSQLQuery("commit;"));
+}
+
+TEST_F(CatalogTests, DroppingTable) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  auto catalog = catalog::Catalog::GetInstance();
+  // NOTE: everytime we create a database, there will be 8 catalog tables inside
+  EXPECT_EQ(
+      11,
+      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
+  auto database_object =
+      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
+  EXPECT_NE(nullptr, database_object);
+  catalog::Catalog::GetInstance()->DropTable("emp_db", DEFUALT_SCHEMA_NAME,
+                                             "department_table", txn);
+
+  database_object =
+      catalog::Catalog::GetInstance()->GetDatabaseObject("emp_db", txn);
+  EXPECT_NE(nullptr, database_object);
+  auto department_table_object =
+      database_object->GetTableObject("department_table", DEFUALT_SCHEMA_NAME);
+  EXPECT_EQ(
+      10,
+      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
+  txn_manager.CommitTransaction(txn);
+
+  EXPECT_EQ(nullptr, department_table_object);
+
+  // Try to drop again
+  txn = txn_manager.BeginTransaction();
+  EXPECT_THROW(catalog::Catalog::GetInstance()->DropTable(
+                   "emp_db", DEFUALT_SCHEMA_NAME, "department_table", txn),
+               CatalogException);
+  //
+  EXPECT_EQ(
+      10,
+      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
+  txn_manager.CommitTransaction(txn);
+
+  // Drop a table that does not exist
+  txn = txn_manager.BeginTransaction();
+  EXPECT_THROW(catalog::Catalog::GetInstance()->DropTable(
+                   "emp_db", DEFUALT_SCHEMA_NAME, "void_table", txn),
+               CatalogException);
+  EXPECT_EQ(
+      10,
+      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
+  txn_manager.CommitTransaction(txn);
+
+  // Drop the other table
+  txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropTable("emp_db", DEFUALT_SCHEMA_NAME,
+                                             "emp_table", txn);
+  EXPECT_EQ(
+      9,
+      (int)catalog->GetDatabaseObject("emp_db", txn)->GetTableObjects().size());
+  txn_manager.CommitTransaction(txn);
+}
+
+TEST_F(CatalogTests, DroppingDatabase) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName("emp_db", txn);
+
+  EXPECT_THROW(
+      catalog::Catalog::GetInstance()->GetDatabaseWithName("emp_db", txn),
+      CatalogException);
+  txn_manager.CommitTransaction(txn);
+}
+
+TEST_F(CatalogTests, DroppingCatalog) {
+  auto catalog = catalog::Catalog::GetInstance();
+  EXPECT_NE(nullptr, catalog);
+}
 
 }  // namespace test
 }  // namespace peloton

--- a/test/codegen/testing_codegen_util.cpp
+++ b/test/codegen/testing_codegen_util.cpp
@@ -269,6 +269,13 @@ ExpressionPtr PelotonCodeGenTest::ColRefExpr(type::TypeId type,
   return ExpressionPtr{expr};
 }
 
+ExpressionPtr PelotonCodeGenTest::ColRefExpr(storage::DataTable &table ,type::TypeId type,
+                                             uint32_t col_id) {
+  auto *expr = new expression::TupleValueExpression(type, 0, col_id);
+  expr->SetBoundOid(table.GetDatabaseOid(), table.GetOid(), col_id);
+  return ExpressionPtr{expr};
+}
+
 ExpressionPtr PelotonCodeGenTest::ColRefExpr(type::TypeId type, bool left,
                                              uint32_t col_id) {
   return ExpressionPtr{

--- a/test/codegen/zone_map_scan_test.cpp
+++ b/test/codegen/zone_map_scan_test.cpp
@@ -84,10 +84,11 @@ TEST_F(ZoneMapScanTest, ScanNoPredicates) {
 TEST_F(ZoneMapScanTest, SimplePredicate) {
   // SELECT a, b, c FROM table where a >= 20;
   // 1) Setup the predicate
+      auto &table = GetTestTable(TestTableId());
   ExpressionPtr a_gt_20 =
-      CmpGteExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(20));
+      CmpGteExpr(ColRefExpr(table ,type::TypeId::INTEGER, 0), ConstIntExpr(20));
   // 2) Setup the scan plan node
-  auto &table = GetTestTable(TestTableId());
+
   planner::SeqScanPlan scan{&table, a_gt_20.release(), {0, 1, 2}};
   // 3) Do binding
   planner::BindingContext context;
@@ -104,10 +105,11 @@ TEST_F(ZoneMapScanTest, SimplePredicate) {
 TEST_F(ZoneMapScanTest, PredicateOnNonOutputColumn) {
   // SELECT b FROM table where a >= 40;
   // 1) Setup the predicate
+      auto &table = GetTestTable(TestTableId());
   ExpressionPtr a_gt_40 =
-      CmpGteExpr(ColRefExpr(type::TypeId::INTEGER, 0), ConstIntExpr(40));
+      CmpGteExpr(ColRefExpr(table, type::TypeId::INTEGER, 0), ConstIntExpr(40));
   // 2) Setup the scan plan node
-  auto &table = GetTestTable(TestTableId());
+
   planner::SeqScanPlan scan{&table, a_gt_40.release(), {0, 1}};
   // 3) Do binding
   planner::BindingContext context;

--- a/test/include/codegen/testing_codegen_util.h
+++ b/test/include/codegen/testing_codegen_util.h
@@ -101,6 +101,9 @@ class PelotonCodeGenTest : public PelotonTest {
   ExpressionPtr ConstDecimalExpr(double val);
 
   ExpressionPtr ColRefExpr(type::TypeId type, uint32_t col_id);
+
+  ExpressionPtr ColRefExpr(storage::DataTable &table ,type::TypeId type,
+                                                 uint32_t col_id);
   ExpressionPtr ColRefExpr(type::TypeId type, bool left, uint32_t col_id);
 
   ExpressionPtr CmpExpr(ExpressionType cmp_type, ExpressionPtr &&left,

--- a/test/optimizer/old_optimizer_test.cpp
+++ b/test/optimizer/old_optimizer_test.cpp
@@ -12,6 +12,8 @@
 #include "binder/bind_node_visitor.h"
 #include <common/harness.h>
 #include "catalog/catalog.h"
+#include "catalog/table_catalog.h"
+#include "catalog/index_catalog.h"
 #include "common/statement.h"
 #include "concurrency/transaction_manager_factory.h"
 #include "executor/create_executor.h"
@@ -173,6 +175,7 @@ TEST_F(OldOptimizerTests, UpdateDelWithIndexScanTest) {
   auto target_table_ = catalog::Catalog::GetInstance()->GetTableWithName(
       DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, "department_table", txn);
   // Expected 1 , Primary key index + created index
+
   EXPECT_EQ(target_table_->GetIndexCount(), 2);
   txn_manager.CommitTransaction(txn);
 

--- a/test/trigger/trigger_test.cpp
+++ b/test/trigger/trigger_test.cpp
@@ -151,7 +151,7 @@ class TriggerTests : public PelotonTest {
             DEFAULT_DB_NAME, DEFUALT_SCHEMA_NAME, table_name, txn);
     txn_manager.CommitTransaction(txn);
     EXPECT_EQ(trigger_number, target_table->GetTriggerNumber());
-    trigger::Trigger *new_trigger = target_table->GetTriggerByIndex(0);
+    trigger::Trigger *new_trigger = target_table->GetTriggerByIndex(trigger_number-1);
     EXPECT_EQ(trigger_name, new_trigger->GetTriggerName());
   }
 };


### PR DESCRIPTION
We enabled complied catalog lookup in the first pull request. Based upon this, we further support complied insert and delete queries for all catalogs. We also fix bugs for the following issues:

* #1298 Need to manually bind the tuple value expression so that equality checks will work correctly.

* Sequential scan assumes that the output columns should start at offset 0 otherwise PerformBinding will not correctly find the corresponding column attributes.

* ZoneMapCatalog needs special care to avoid chicken and egg problem. Each sequential plan needs to check the zone map to know whether to scan the tile or not, but checking the zone map requires ZoneMap catalog access which leads to an infinity loop. So we ensure in the ZoneMap catalog manager that if the scanning table is ZoneMap catalog then it will just scan it without checking the ZoneMap