### PR TITLE
Handle EXPLAIN in the optimizer and executor

### DIFF
--- a/src/binder/bind_node_visitor.cpp
+++ b/src/binder/bind_node_visitor.cpp
@@ -191,7 +191,9 @@ void BindNodeVisitor::Visit(parser::AnalyzeStatement *node) {
   node->TryBindDatabaseName(default_database_name_);
 }
 
-// void BindNodeVisitor::Visit(const parser::ConstantValueExpression *) {}
+void BindNodeVisitor::Visit(parser::ExplainStatement *node) {
+  node->default_database_name = default_database_name_;
+}
 
 void BindNodeVisitor::Visit(expression::TupleValueExpression *expr) {
   if (!expr->GetIsBound()) {

--- a/src/common/internal_types.cpp
+++ b/src/common/internal_types.cpp
@@ -1391,6 +1391,9 @@ std::string PlanNodeTypeToString(PlanNodeType type) {
     case PlanNodeType::ANALYZE: {
       return ("ANALYZE");
     }
+    case PlanNodeType::EXPLAIN: {
+      return ("EXPLAIN");
+    }
     default: {
       throw ConversionException(
           StringUtil::Format("No string conversion for PlanNodeType value '%d'",

--- a/src/executor/explain_executor.cpp
+++ b/src/executor/explain_executor.cpp
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// explain_executor.cpp
+//
+// Identification: src/executor/explain_executor.cpp
+//
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <vector>
+
+#include "binder/bind_node_visitor.h"
+#include "catalog/catalog.h"
+#include "catalog/column.h"
+#include "catalog/schema.h"
+#include "concurrency/transaction_manager_factory.h"
+#include "common/logger.h"
+#include "executor/explain_executor.h"
+#include "executor/executor_context.h"
+#include "executor/logical_tile_factory.h"
+#include "optimizer/optimizer.h"
+#include "storage/tile.h"
+#include "type/type.h"
+
+namespace peloton {
+namespace executor {
+
+bool ExplainExecutor::DInit() {
+  LOG_TRACE("Initializing explain executor...");
+  LOG_TRACE("Explain executor initialized!");
+  return true;
+}
+
+bool ExplainExecutor::DExecute() {
+  LOG_TRACE("Executing Explain...");
+
+  const planner::ExplainPlan &node = GetPlanNode<planner::ExplainPlan>();
+
+  parser::SQLStatement *sql_stmt = node.GetSQLStatement();
+
+  // LOG_TRACE("Analyzing column size %lu", target_columns.size());
+
+  auto current_txn = executor_context_->GetTransaction();
+
+  auto bind_node_visitor =
+      binder::BindNodeVisitor(current_txn, node.GetDatabaseName());
+
+  // Bind, optimize and return the plan as a string
+  bind_node_visitor.BindNameToNode(sql_stmt);
+  std::unique_ptr<optimizer::Optimizer> optimizer(new optimizer::Optimizer());
+  std::unique_ptr<parser::SQLStatementList> stmt_list(
+      new parser::SQLStatementList(sql_stmt));
+  auto plan = optimizer->BuildPelotonPlanTree(stmt_list, current_txn);
+  const catalog::Schema schema({catalog::Column(
+      type::TypeId::VARCHAR, type::Type::GetTypeSize(type::TypeId::VARCHAR),
+      "Query Plan")});
+  std::shared_ptr<storage::Tile> dest_tile(
+      storage::TileFactory::GetTempTile(schema, 1));
+  std::unique_ptr<storage::Tuple> buffer(new storage::Tuple(&schema, true));
+  buffer->SetValue(0, type::ValueFactory::GetVarcharValue(plan->GetInfo()));
+  dest_tile->InsertTuple(0, buffer.get());
+  SetOutput(LogicalTileFactory::WrapTiles({dest_tile}));
+
+  LOG_TRACE("Explain finished!");
+  return false;
+}
+
+}  // namespace executor
+}  // namespace peloton

--- a/src/executor/explain_executor.cpp
+++ b/src/executor/explain_executor.cpp
@@ -41,7 +41,7 @@ bool ExplainExecutor::DExecute() {
 
   parser::SQLStatement *sql_stmt = node.GetSQLStatement();
 
-  // LOG_TRACE("Analyzing column size %lu", target_columns.size());
+  LOG_TRACE("EXPLAIN : %s", sql_stmt->GetInfo().c_str());
 
   auto current_txn = executor_context_->GetTransaction();
 
@@ -65,7 +65,7 @@ bool ExplainExecutor::DExecute() {
   SetOutput(LogicalTileFactory::WrapTiles({dest_tile}));
 
   LOG_TRACE("Explain finished!");
-  return false;
+  return true;
 }
 
 }  // namespace executor

--- a/src/executor/explain_executor.cpp
+++ b/src/executor/explain_executor.cpp
@@ -64,8 +64,8 @@ bool ExplainExecutor::DExecute() {
   dest_tile->InsertTuple(0, buffer.get());
   SetOutput(LogicalTileFactory::WrapTiles({dest_tile}));
 
-  LOG_TRACE("Explain finished!");
-  return true;
+  LOG_TRACE("Explain finished!, plan : %s", plan->GetInfo().c_str());
+  return false;
 }
 
 }  // namespace executor

--- a/src/executor/explain_executor.cpp
+++ b/src/executor/explain_executor.cpp
@@ -64,7 +64,7 @@ bool ExplainExecutor::DExecute() {
   dest_tile->InsertTuple(0, buffer.get());
   SetOutput(LogicalTileFactory::WrapTiles({dest_tile}));
 
-  LOG_TRACE("Explain finished!, plan : %s", plan->GetInfo().c_str());
+  LOG_DEBUG("Explain finished!, plan : %s", plan->GetInfo().c_str());
   return false;
 }
 

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -339,7 +339,7 @@ executor::AbstractExecutor *BuildExecutorTree(
     case PlanNodeType::EXPLAIN:
       child_executor = 
           new executor::ExplainExecutor(plan, executor_context);
-
+      break;
     default:
       LOG_ERROR("Unsupported plan node type : %s",
                 PlanNodeTypeToString(plan_node_type).c_str());

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -336,6 +336,9 @@ executor::AbstractExecutor *BuildExecutorTree(
       child_executor =
           new executor::PopulateIndexExecutor(plan, executor_context);
       break;
+    case PlanNodeType::EXPLAIN:
+      child_executor = 
+          new executor::ExplainExecutor(plan, executor_context);
 
     default:
       LOG_ERROR("Unsupported plan node type : %s",

--- a/src/include/binder/bind_node_visitor.h
+++ b/src/include/binder/bind_node_visitor.h
@@ -67,6 +67,7 @@ class BindNodeVisitor : public SqlNodeVisitor {
   void Visit(parser::UpdateStatement *) override;
   void Visit(parser::CopyStatement *) override;
   void Visit(parser::AnalyzeStatement *) override;
+  void Visit(parser::ExplainStatement *) override;
 
   void Visit(expression::CaseExpression *expr) override;
   void Visit(expression::SubqueryExpression *expr) override;

--- a/src/include/common/internal_types.h
+++ b/src/include/common/internal_types.h
@@ -596,6 +596,7 @@ enum class PlanNodeType {
   RESULT = 70,
   COPY = 71,
   CREATE_FUNC = 72,
+  EXPLAIN = 73,
 
   // Test
   MOCK = 80

--- a/src/include/executor/executors.h
+++ b/src/include/executor/executors.h
@@ -21,6 +21,7 @@
 #include "executor/copy_executor.h"
 #include "executor/create_executor.h"
 #include "executor/create_function_executor.h"
+#include "executor/explain_executor.h"
 #include "executor/delete_executor.h"
 #include "executor/drop_executor.h"
 #include "executor/hash_executor.h"

--- a/src/include/executor/explain_executor.h
+++ b/src/include/executor/explain_executor.h
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// explain_executor.h
+//
+// Identification: src/include/executor/explain_executor.h
+//
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "executor/abstract_executor.h"
+#include "planner/explain_plan.h"
+
+namespace peloton {
+
+namespace storage {
+class DataTable;
+}
+
+namespace executor {
+
+class ExplainExecutor : public AbstractExecutor {
+ public:
+  ExplainExecutor(const ExplainExecutor &) = delete;
+  ExplainExecutor &operator=(const ExplainExecutor &) = delete;
+  ExplainExecutor(ExplainExecutor &&) = delete;
+  ExplainExecutor &operator=(ExplainExecutor &&) = delete;
+
+  ExplainExecutor(const planner::AbstractPlan *node,
+                  ExecutorContext *executor_context)
+      : AbstractExecutor(node, executor_context) {}
+
+  ~ExplainExecutor() {}
+
+ protected:
+  bool DInit();
+
+  bool DExecute();
+};
+
+}  // namespace executor
+}  // namespace peloton

--- a/src/include/network/postgres_protocol_handler.h
+++ b/src/include/network/postgres_protocol_handler.h
@@ -31,10 +31,6 @@
 
 namespace peloton {
 
-namespace parser {
-class ExplainStatement;
-}  // namespace parser
-
 namespace network {
 
 typedef std::vector<std::unique_ptr<OutputPacket>> ResponseBuffer;
@@ -164,10 +160,6 @@ class PostgresProtocolHandler : public ProtocolHandler {
 
   /* Execute a Simple query protocol message */
   ProcessResult ExecQueryMessage(InputPacket *pkt, const size_t thread_id);
-
-  /* Execute a EXPLAIN query message */
-  ResultType ExecQueryExplain(const std::string &query,
-                              parser::ExplainStatement &explain_stmt);
 
   /* Process the PARSE message of the extended query protocol */
   void ExecParseMessage(InputPacket *pkt);

--- a/src/include/network/postgres_protocol_handler.h
+++ b/src/include/network/postgres_protocol_handler.h
@@ -215,9 +215,6 @@ class PostgresProtocolHandler : public ProtocolHandler {
   //  Portals
   std::unordered_map<std::string, std::shared_ptr<Portal>> portals_;
 
-  // packets ready for read
-  size_t pkt_cntr_;
-
   // Manage parameter types for unnamed statement
   stats::QueryMetric::QueryParamBuf unnamed_stmt_param_types_;
 

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -38,9 +38,9 @@ class TransactionContext;
 }
 
 namespace test {
-  class OptimizerRuleTests_SimpleAssociativeRuleTest_Test;
-  class OptimizerRuleTests_SimpleAssociativeRuleTest2_Test;
-} 
+class OptimizerRuleTests_SimpleAssociativeRuleTest_Test;
+class OptimizerRuleTests_SimpleAssociativeRuleTest2_Test;
+}
 
 namespace optimizer {
 
@@ -60,8 +60,10 @@ class Optimizer : public AbstractOptimizer {
   friend class BindingIterator;
   friend class GroupBindingIterator;
 
-  friend class ::peloton::test::OptimizerRuleTests_SimpleAssociativeRuleTest_Test;
-  friend class ::peloton::test::OptimizerRuleTests_SimpleAssociativeRuleTest2_Test; 
+  friend class ::peloton::test::
+      OptimizerRuleTests_SimpleAssociativeRuleTest_Test;
+  friend class ::peloton::test::
+      OptimizerRuleTests_SimpleAssociativeRuleTest2_Test;
 
  public:
   Optimizer(const Optimizer &) = delete;
@@ -83,27 +85,25 @@ class Optimizer : public AbstractOptimizer {
   OptimizerMetadata &GetMetadata() { return metadata_; }
 
   /* For test purposes only */
-  std::shared_ptr<GroupExpression> TestInsertQueryTree(parser::SQLStatement *tree,
-  concurrency::TransactionContext *txn) {
+  std::shared_ptr<GroupExpression> TestInsertQueryTree(
+      parser::SQLStatement *tree, concurrency::TransactionContext *txn) {
     return InsertQueryTree(tree, txn);
   }
   /* For test purposes only */
   void TestExecuteTaskStack(OptimizerTaskStack &task_stack, int root_group_id,
-                        std::shared_ptr<OptimizeContext> root_context) {
+                            std::shared_ptr<OptimizeContext> root_context) {
     return ExecuteTaskStack(task_stack, root_group_id, root_context);
   }
 
  private:
-  /* HandleDDLStatement - Check and handle DDL statment (currently only support
+  /* HandleUtilStatement - Check and handle Util statment (currently only
+   *support
    *CREATE), set
-   * is_ddl_stmt to false if there is no DDL statement.
-   *
    * tree: a peloton query tree representing a select query
-   * return: the DDL plan if it is a DDL statement
+   * return: the util plan if it is a util statement
    */
-  std::unique_ptr<planner::AbstractPlan> HandleDDLStatement(
-      parser::SQLStatement *tree, bool &is_ddl_stmt,
-      concurrency::TransactionContext *txn);
+  std::unique_ptr<planner::AbstractPlan> HandleUtilStatement(
+      parser::SQLStatement *tree, concurrency::TransactionContext *txn);
 
   /* TransformQueryTree - create an initial operator tree for the given query
    * to be used in performing optimization.

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -44,6 +44,11 @@ class OptimizerRuleTests_SimpleAssociativeRuleTest2_Test;
 
 namespace optimizer {
 
+struct UtilPlanStatus {
+  bool has_plan = false;
+  std::unique_ptr<planner::AbstractPlan> util_plan;
+};
+
 struct QueryInfo {
   QueryInfo(std::vector<expression::AbstractExpression *> &exprs,
             std::shared_ptr<PropertySet> &props)
@@ -100,10 +105,11 @@ class Optimizer : public AbstractOptimizer {
    *support
    *CREATE), set
    * tree: a peloton query tree representing a select query
-   * return: the util plan if it is a util statement
+   * return: the util plan if it is a util statement, if the sql type
+   * is not util statements then return with has_plan set to false
    */
-  std::unique_ptr<planner::AbstractPlan> HandleUtilStatement(
-      parser::SQLStatement *tree, concurrency::TransactionContext *txn);
+  UtilPlanStatus HandleUtilStatement(parser::SQLStatement *tree,
+                                     concurrency::TransactionContext *txn);
 
   /* TransformQueryTree - create an initial operator tree for the given query
    * to be used in performing optimization.

--- a/src/include/parser/explain_statement.h
+++ b/src/include/parser/explain_statement.h
@@ -28,6 +28,10 @@ class ExplainStatement : public SQLStatement {
 
   void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
+  const std::string GetInfo(int num_indent) const override;
+
+  const std::string GetInfo() const override;
+
   std::unique_ptr<parser::SQLStatement> real_sql_stmt;
 
   /**

--- a/src/include/parser/explain_statement.h
+++ b/src/include/parser/explain_statement.h
@@ -29,6 +29,12 @@ class ExplainStatement : public SQLStatement {
   void Accept(SqlNodeVisitor *v) override { v->Visit(this); }
 
   std::unique_ptr<parser::SQLStatement> real_sql_stmt;
+
+  /**
+   * @brief Should be set by the binder, used in the executor to bind the stmt
+   * being explained
+   */
+  std::string default_database_name;
 };
 
 }  // namespace parser

--- a/src/include/planner/explain_plan.h
+++ b/src/include/planner/explain_plan.h
@@ -39,21 +39,32 @@ class ExplainPlan : public AbstractPlan {
   ExplainPlan(ExplainPlan &&) = delete;
   ExplainPlan &operator=(ExplainPlan &&) = delete;
 
-  explicit ExplainPlan(parser::SQLStatement *sql_stmt) : sql_stmt(sql_stmt){};
+  explicit ExplainPlan(parser::SQLStatement *sql_stmt,
+                       std::string default_database_name)
+      : sql_stmt_(sql_stmt), default_database_name_(default_database_name){};
 
   inline PlanNodeType GetPlanNodeType() const { return PlanNodeType::EXPLAIN; }
 
   const std::string GetInfo() const { return "Explain table"; }
 
   inline std::unique_ptr<AbstractPlan> Copy() const {
-    return std::unique_ptr<AbstractPlan>(new ExplainPlan(sql_stmt));
+    return std::unique_ptr<AbstractPlan>(
+        new ExplainPlan(sql_stmt_, default_database_name_));
   }
+
+  parser::SQLStatement *GetSQLStatement() const { return sql_stmt_; }
+
+  std::string GetDatabaseName() const { return default_database_name_; }
 
  private:
   /**
    * @brief The SQL statement to explain (owned by the AST)
    */
-  parser::SQLStatement *sql_stmt;
+  parser::SQLStatement *sql_stmt_;
+  /**
+   * @brief The database name to be used in the binder
+   */
+  std::string default_database_name_;
 };
 
 }  // namespace planner

--- a/src/include/planner/explain_plan.h
+++ b/src/include/planner/explain_plan.h
@@ -5,7 +5,7 @@
 //
 // explain_plan.h
 //
-// Identification: src/include/planner/analyze_plan.h
+// Identification: src/include/planner/explain_plan.h
 //
 // Copyright (c) 2015-18, Carnegie Mellon University Database Group
 //

--- a/src/include/planner/explain_plan.h
+++ b/src/include/planner/explain_plan.h
@@ -1,0 +1,60 @@
+
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// explain_plan.h
+//
+// Identification: src/include/planner/analyze_plan.h
+//
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "planner/abstract_plan.h"
+
+#include <memory>
+
+namespace peloton {
+namespace storage {
+class DataTable;
+}
+namespace parser {
+class AnalyzeStatement;
+}
+namespace catalog {
+class Schema;
+}
+namespace concurrency {
+class TransactionContext;
+}
+
+namespace planner {
+class ExplainPlan : public AbstractPlan {
+ public:
+  ExplainPlan(const ExplainPlan &) = delete;
+  ExplainPlan &operator=(const ExplainPlan &) = delete;
+  ExplainPlan(ExplainPlan &&) = delete;
+  ExplainPlan &operator=(ExplainPlan &&) = delete;
+
+  explicit ExplainPlan(parser::SQLStatement *sql_stmt) : sql_stmt(sql_stmt){};
+
+  inline PlanNodeType GetPlanNodeType() const { return PlanNodeType::EXPLAIN; }
+
+  const std::string GetInfo() const { return "Explain table"; }
+
+  inline std::unique_ptr<AbstractPlan> Copy() const {
+    return std::unique_ptr<AbstractPlan>(new ExplainPlan(sql_stmt));
+  }
+
+ private:
+  /**
+   * @brief The SQL statement to explain (owned by the AST)
+   */
+  parser::SQLStatement *sql_stmt;
+};
+
+}  // namespace planner
+}  // namespace peloton

--- a/src/include/planner/explain_plan.h
+++ b/src/include/planner/explain_plan.h
@@ -19,9 +19,6 @@
 #include <memory>
 
 namespace peloton {
-namespace concurrency {
-class TransactionContext;
-}
 
 namespace planner {
 class ExplainPlan : public AbstractPlan {
@@ -31,34 +28,31 @@ class ExplainPlan : public AbstractPlan {
   ExplainPlan(ExplainPlan &&) = delete;
   ExplainPlan &operator=(ExplainPlan &&) = delete;
 
-  explicit ExplainPlan(std::unique_ptr<parser::SQLStatement> sql_stmt,
-                       std::string default_database_name)
-      : sql_stmt_(sql_stmt.release()),
-        default_database_name_(default_database_name){};
-
-  explicit ExplainPlan(std::shared_ptr<parser::SQLStatement> sql_stmt,
+  explicit ExplainPlan(parser::SQLStatement *sql_stmt,
                        std::string default_database_name)
       : sql_stmt_(sql_stmt), default_database_name_(default_database_name){};
 
   inline PlanNodeType GetPlanNodeType() const { return PlanNodeType::EXPLAIN; }
 
-  const std::string GetInfo() const { return std::string("Explain") + sql_stmt_->GetInfo(); }
+  const std::string GetInfo() const {
+    return std::string("Explain") + sql_stmt_->GetInfo();
+  }
 
   inline std::unique_ptr<AbstractPlan> Copy() const {
-    // FIXME: support deep copy for sql statement, then use a unique_ptr here
     return std::unique_ptr<AbstractPlan>(
         new ExplainPlan(sql_stmt_, default_database_name_));
   }
 
-  parser::SQLStatement *GetSQLStatement() const { return sql_stmt_.get(); }
+  parser::SQLStatement *GetSQLStatement() const { return sql_stmt_; }
 
   std::string GetDatabaseName() const { return default_database_name_; }
 
  private:
   /**
-   * @brief The SQL statement to explain (owned by the AST)
+   * @brief The SQL statement to explain, the it should be owned by the
+   * explain ast
    */
-  std::shared_ptr<parser::SQLStatement> sql_stmt_;
+  parser::SQLStatement *sql_stmt_;
   /**
    * @brief The database name to be used in the binder
    */

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -104,7 +104,6 @@ class TrafficCop {
 
   ResultType CommitQueryHelper();
 
-  void ExecuteStatementPlanGetResult();
 
   ResultType ExecuteStatementGetResult();
 
@@ -135,8 +134,6 @@ class TrafficCop {
     param_values_ = std::move(param_values);
   }
 
-  std::vector<type::Value> &GetParamVal() { return param_values_; }
-
   std::string &GetErrorMessage() { return error_message_; }
 
   void SetQueuing(bool is_queuing) { is_queuing_ = is_queuing; }
@@ -148,10 +145,6 @@ class TrafficCop {
   void SetDefaultDatabaseName(std::string default_database_name) {
     default_database_name_ = std::move(default_database_name);
   }
-
-  // TODO: this member variable should be in statement_ after parser part
-  // finished
-  std::string query_;
 
  private:
   bool is_queuing_;

--- a/src/include/traffic_cop/traffic_cop.h
+++ b/src/include/traffic_cop/traffic_cop.h
@@ -65,12 +65,16 @@ class TrafficCop {
   void Reset();
 
   // Execute a statement
-  ResultType ExecuteStatement(
-      const std::shared_ptr<Statement> &statement,
-      const std::vector<type::Value> &params, const bool unnamed,
-      std::shared_ptr<stats::QueryMetric::QueryParams> param_stats,
-      const std::vector<int> &result_format, std::vector<ResultValue> &result,
-      size_t thread_id = 0);
+  ResultType ExecuteStatement(std::shared_ptr<stats::QueryMetric::QueryParams> param_stats,
+                                          const std::vector<int> &result_format,
+                                          size_t thread_id);
+
+  ResultType ExecuteStatement(const std::shared_ptr<Statement> &statement,
+                              const std::vector<type::Value> &params,
+                              std::shared_ptr<stats::QueryMetric::QueryParams> param_stats,
+                              const std::vector<int> &result_format,
+                              std::vector<ResultValue> &result,
+                              size_t thread_id);
 
   // Helper to handle txn-specifics for the plan-tree of a statement.
   executor::ExecutionResult ExecuteHelper(
@@ -155,8 +159,6 @@ class TrafficCop {
   std::string error_message_;
 
   std::vector<type::Value> param_values_;
-
-  std::vector<ResultValue> results_;
 
   // This save currnet statement in the traffic cop
   std::shared_ptr<Statement> statement_;

--- a/src/network/connection_handle.cpp
+++ b/src/network/connection_handle.cpp
@@ -692,7 +692,6 @@ Transition ConnectionHandle::GetResult() {
     PELOTON_ASSERT(false);
   }
   protocol_handler_->GetResult();
-  traffic_cop_.SetQueuing(false);
   return Transition::PROCEED;
 }
 }  // namespace network

--- a/src/network/postgres_protocol_handler.cpp
+++ b/src/network/postgres_protocol_handler.cpp
@@ -859,7 +859,6 @@ void PostgresProtocolHandler::ExecExecuteMessageGetResult(ResultType status) {
 }
 
 void PostgresProtocolHandler::GetResult() {
-  traffic_cop_->ExecuteStatementPlanGetResult();
   auto status = traffic_cop_->ExecuteStatementGetResult();
   switch (protocol_type_) {
     case NetworkProtocolType::POSTGRES_JDBC:

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -225,7 +225,10 @@ unique_ptr<planner::AbstractPlan> Optimizer::HandleUtilStatement(
       auto *explain_parse_tree =
           reinterpret_cast<parser::ExplainStatement *>(tree);
       util_plan.reset(
-          new planner::ExplainPlan(std::move(explain_parse_tree->real_sql_stmt),
+          // TODO(boweic): not releasing this unique_ptr here would cause a
+          // double delete which I still don't know why is happening.
+          // I believe no one should take the ownership of the pointer here
+          new planner::ExplainPlan(explain_parse_tree->real_sql_stmt.release(),
                                    explain_parse_tree->default_database_name));
     }
     default:

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -222,8 +222,10 @@ unique_ptr<planner::AbstractPlan> Optimizer::HandleUtilStatement(
     case StatementType::EXPLAIN: {
       LOG_TRACE("Adding Explain plan...");
       // Pass the sql statement to explain to the plan node
-      util_plan.reset(new planner::ExplainPlan(
-          static_cast<parser::ExplainStatement *>(tree)->real_sql_stmt.get()));
+      auto *explain_parse_tree = static_cast<parser::ExplainStatement *>(tree);
+      util_plan.reset(
+          new planner::ExplainPlan(explain_parse_tree->real_sql_stmt.get(),
+                                   explain_parse_tree->default_database_name));
     }
     default:
       break;

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -222,9 +222,10 @@ unique_ptr<planner::AbstractPlan> Optimizer::HandleUtilStatement(
     case StatementType::EXPLAIN: {
       LOG_TRACE("Adding Explain plan...");
       // Pass the sql statement to explain to the plan node
-      auto *explain_parse_tree = static_cast<parser::ExplainStatement *>(tree);
+      auto *explain_parse_tree =
+          reinterpret_cast<parser::ExplainStatement *>(tree);
       util_plan.reset(
-          new planner::ExplainPlan(explain_parse_tree->real_sql_stmt.get(),
+          new planner::ExplainPlan(std::move(explain_parse_tree->real_sql_stmt),
                                    explain_parse_tree->default_database_name));
     }
     default:

--- a/src/parser/explain_statement.cpp
+++ b/src/parser/explain_statement.cpp
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// explain_statement.cpp
+//
+// Identification: src/parser/explain_statement.cpp
+//
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "parser/explain_statement.h"
+#include "parser/select_statement.h"
+
+namespace peloton {
+namespace parser {
+
+const std::string ExplainStatement::GetInfo(int num_indent) const {
+  std::ostringstream os;
+  os << StringUtil::Indent(num_indent) << "ExplainStatement:\n";
+  os << real_sql_stmt->GetInfo(num_indent + 1);
+  return os.str();
+}
+
+const std::string ExplainStatement::GetInfo() const {
+  std::ostringstream os;
+
+  os << "SQLStatement[EXPLAIN]\n";
+
+  os << GetInfo(1);
+
+  return os.str();
+}
+
+}  // namespace parser
+}  // namespace peloton

--- a/src/planner/analyze_plan.cpp
+++ b/src/planner/analyze_plan.cpp
@@ -4,7 +4,7 @@
 //
 // analyze_plan.cpp
 //
-// Identification: src/planner/Analyze_plan.cpp
+// Identification: src/planner/analyze_plan.cpp
 //
 // Copyright (c) 2015-16, Carnegie Mellon University Database Group
 //

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -44,7 +44,7 @@ void TrafficCop::Reset() {
   // clear out the stack
   swap(tcop_txn_state_, new_tcop_txn_state);
   optimizer_->Reset();
-  results_.clear();
+  result_.clear();
   param_values_.clear();
   setRowsAffected(0);
 }
@@ -543,12 +543,18 @@ FieldInfo TrafficCop::GetColumnFieldForValueType(std::string column_name,
                          field_size);
 }
 
-ResultType TrafficCop::ExecuteStatement(
-    const std::shared_ptr<Statement> &statement,
-    const std::vector<type::Value> &params, UNUSED_ATTRIBUTE bool unnamed,
-    std::shared_ptr<stats::QueryMetric::QueryParams> param_stats,
-    const std::vector<int> &result_format, std::vector<ResultValue> &result,
-    size_t thread_id) {
+ResultType TrafficCop::ExecuteStatement(std::shared_ptr<stats::QueryMetric::QueryParams> param_stats,
+                                        const std::vector<int> &result_format,
+                                        size_t thread_id) {
+  return ExecuteStatement(statement_, param_values_, param_stats, result_format, result_, thread_id);
+}
+
+ResultType TrafficCop::ExecuteStatement(const std::shared_ptr<Statement> &statement,
+                                        const std::vector<type::Value> &params,
+                                        std::shared_ptr<stats::QueryMetric::QueryParams> param_stats,
+                                        const std::vector<int> &result_format,
+                                        std::vector<ResultValue> &result,
+                                        size_t thread_id) {
   // TODO(Tianyi) Further simplify this API
   if (static_cast<StatsType>(settings::SettingsManager::GetInt(
           settings::SettingId::stats_mode)) != StatsType::INVALID) {

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -325,7 +325,8 @@ std::shared_ptr<Statement> TrafficCop::PrepareStatement(
         planner::PlanUtil::GetTablesReferenced(plan.get());
     statement->SetReferencedTables(table_oids);
 
-    if (query_type == QueryType::QUERY_SELECT) {
+    if (query_type == QueryType::QUERY_SELECT ||
+        query_type == QueryType::QUERY_EXPLAIN) {
       auto tuple_descriptor = GenerateTupleDescriptor(
           statement->GetStmtParseTreeList()->GetStatement(0));
       statement->SetTupleDescriptor(tuple_descriptor);
@@ -365,8 +366,8 @@ void TrafficCop::ProcessInvalidStatement() {
 }
 
 bool TrafficCop::BindParamsForCachePlan(
-    const std::vector<std::unique_ptr<expression::AbstractExpression>>
-        &parameters,
+    const std::vector<std::unique_ptr<expression::AbstractExpression>> &
+        parameters,
     const size_t thread_id UNUSED_ATTRIBUTE) {
   if (tcop_txn_state_.empty()) {
     single_statement_txn_ = true;

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -91,9 +91,8 @@ void SetupTables(std::string database_name) {
                                             result, result_format);
     if (traffic_cop.GetQueuing()) {
       TestingSQLUtil::ContinueAfterComplete();
-      traffic_cop.ExecuteStatementPlanGetResult();
+      traffic_cop.ExecuteStatementGetResult();
       status = traffic_cop.p_status_;
-      traffic_cop.SetQueuing(false);
     }
     LOG_INFO("Table create result: %s",
              ResultTypeToString(status.m_result).c_str());

--- a/test/executor/copy_test.cpp
+++ b/test/executor/copy_test.cpp
@@ -97,9 +97,8 @@ TEST_F(CopyTests, Copying) {
 
     if (traffic_cop.GetQueuing()) {
       TestingSQLUtil::ContinueAfterComplete();
-      traffic_cop.ExecuteStatementPlanGetResult();
+      traffic_cop.ExecuteStatementGetResult();
       status = traffic_cop.p_status_;
-      traffic_cop.SetQueuing(false);
     }
 
     EXPECT_EQ(status.m_result, peloton::ResultType::SUCCESS);

--- a/test/executor/create_index_test.cpp
+++ b/test/executor/create_index_test.cpp
@@ -104,9 +104,8 @@ TEST_F(CreateIndexTests, CreatingIndex) {
 
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
 
   LOG_INFO("Statement executed. Result: %s",
@@ -152,9 +151,8 @@ TEST_F(CreateIndexTests, CreatingIndex) {
 
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -194,9 +192,8 @@ TEST_F(CreateIndexTests, CreatingIndex) {
 
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/executor/delete_test.cpp
+++ b/test/executor/delete_test.cpp
@@ -84,9 +84,8 @@ void ShowTable(std::string database_name, std::string table_name) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   traffic_cop.CommitQueryHelper();
 }
@@ -165,9 +164,8 @@ TEST_F(DeleteTests, VariousOperations) {
       statement->GetPlanTree(), params, result, result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -206,9 +204,8 @@ TEST_F(DeleteTests, VariousOperations) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -247,9 +244,8 @@ TEST_F(DeleteTests, VariousOperations) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -290,9 +286,8 @@ TEST_F(DeleteTests, VariousOperations) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -328,9 +323,8 @@ TEST_F(DeleteTests, VariousOperations) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -368,9 +362,8 @@ TEST_F(DeleteTests, VariousOperations) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/executor/update_test.cpp
+++ b/test/executor/update_test.cpp
@@ -231,9 +231,8 @@ TEST_F(UpdateTests, UpdatingOld) {
       statement->GetPlanTree(), params, result, result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -275,9 +274,8 @@ TEST_F(UpdateTests, UpdatingOld) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -320,9 +318,8 @@ TEST_F(UpdateTests, UpdatingOld) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -359,9 +356,8 @@ TEST_F(UpdateTests, UpdatingOld) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -401,9 +397,8 @@ TEST_F(UpdateTests, UpdatingOld) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/network/explain_test.cpp
+++ b/test/network/explain_test.cpp
@@ -56,18 +56,13 @@ void *ExplainTest(int port) {
     txn1.exec("CREATE TABLE template(id INT);");
     txn1.commit();
 
-    // Execute EXPLAIN directly
+    // Try execute EXPLAIN 
     pqxx::work txn2(C);
-    pqxx::result result1 = txn2.exec("EXPLAIN SELECT * from template;");
+    pqxx::result result = txn2.exec("EXPLAIN SELECT * from template;");
     txn2.commit();
-    EXPECT_EQ(result1.size(), 1);
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(std::string(result[0][0].c_str()), std::string("SeqScan()"));
 
-    // Execute EXPLAIN through PREPARE statement
-    pqxx::work txn3(C);
-    txn3.exec("PREPARE func AS EXPLAIN SELECT * from template;");
-    pqxx::result result2 = txn3.exec("EXECUTE func");
-    txn3.commit();
-    EXPECT_EQ(result2.size(), 1);
   } catch (const std::exception &e) {
     LOG_INFO("[ExplainTest] Exception occurred: %s", e.what());
     EXPECT_TRUE(false);

--- a/test/network/explain_test.cpp
+++ b/test/network/explain_test.cpp
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// explain_test.cpp
+//
+// Identification: test/network/explain_test.cpp
+//
+// Copyright (c) 2016-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include "common/harness.h"
+#include "gtest/gtest.h"
+#include "common/logger.h"
+#include "network/peloton_server.h"
+#include "network/protocol_handler_factory.h"
+#include "network/connection_handle_factory.h"
+#include "util/string_util.h"
+#include <pqxx/pqxx> /* libpqxx is used to instantiate C++ client */
+#include "network/postgres_protocol_handler.h"
+
+namespace peloton {
+namespace test {
+
+//===--------------------------------------------------------------------===//
+// Explain Tests
+//===--------------------------------------------------------------------===//
+
+class ExplainTests : public PelotonTest {};
+
+/**
+ * Explain Test
+ * Test how the network layer handle explain
+ */
+void *ExplainTest(int port) {
+  try {
+    // forcing the factory to generate psql protocol handler
+    pqxx::connection C(
+        StringUtil::Format("host=127.0.0.1 port=%d user=default_database "
+                           "sslmode=disable application_name=psql",
+                           port));
+    pqxx::work txn1(C);
+    peloton::network::ConnectionHandle *conn =
+        peloton::network::ConnectionHandleFactory::GetInstance()
+            .ConnectionHandleAt(peloton::network::PelotonServer::recent_connfd)
+            .get();
+
+    network::PostgresProtocolHandler *handler =
+        dynamic_cast<network::PostgresProtocolHandler *>(
+            conn->GetProtocolHandler().get());
+    EXPECT_NE(handler, nullptr);
+
+    // create table and insert some data
+    txn1.exec("DROP TABLE IF EXISTS template;");
+    txn1.exec("CREATE TABLE template(id INT);");
+    txn1.commit();
+
+    // Execute EXPLAIN directly
+    pqxx::work txn2(C);
+    pqxx::result result1 = txn2.exec("EXPLAIN SELECT * from template;");
+    txn2.commit();
+    EXPECT_EQ(result1.size(), 1);
+
+    // Execute EXPLAIN through PREPARE statement
+    pqxx::work txn3(C);
+    txn3.exec("PREPARE func AS EXPLAIN SELECT * from template;");
+    pqxx::result result2 = txn3.exec("EXECUTE func");
+    txn3.commit();
+    EXPECT_EQ(result2.size(), 1);
+  } catch (const std::exception &e) {
+    LOG_INFO("[ExplainTest] Exception occurred: %s", e.what());
+    EXPECT_TRUE(false);
+  }
+
+  LOG_INFO("[ExplainTest] Client has closed");
+  return NULL;
+}
+
+TEST_F(ExplainTests, ExplainTest) {
+  peloton::PelotonInit::Initialize();
+  LOG_INFO("Server initialized");
+  peloton::network::PelotonServer server;
+
+  int port = 15721;
+  try {
+    server.SetPort(port);
+    server.SetupServer();
+  } catch (peloton::ConnectionException &exception) {
+    LOG_INFO("[LaunchServer] exception when launching server");
+  }
+  std::thread serverThread([&]() { server.ServerLoop(); });
+
+  // server & client running correctly
+  ExplainTest(port);
+
+  server.Close();
+  serverThread.join();
+  LOG_INFO("Peloton is shutting down");
+  peloton::PelotonInit::Shutdown();
+  LOG_INFO("Peloton has shut down");
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/optimizer/old_optimizer_test.cpp
+++ b/test/optimizer/old_optimizer_test.cpp
@@ -91,9 +91,8 @@ TEST_F(OldOptimizerTests, UpdateDelWithIndexScanTest) {
       statement->GetPlanTree(), params, result, result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_TRACE("Statement executed. Result: %s",
             ResultTypeToString(status.m_result).c_str());
@@ -128,9 +127,8 @@ TEST_F(OldOptimizerTests, UpdateDelWithIndexScanTest) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_TRACE("Statement executed. Result: %s",
             ResultTypeToString(status.m_result).c_str());
@@ -160,9 +158,8 @@ TEST_F(OldOptimizerTests, UpdateDelWithIndexScanTest) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_TRACE("Statement executed. Result: %s",
             ResultTypeToString(status.m_result).c_str());

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -110,9 +110,8 @@ TEST_F(OptimizerTests, HashJoinTest) {
       statement->GetPlanTree(), params, result, result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -146,9 +145,8 @@ TEST_F(OptimizerTests, HashJoinTest) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -182,9 +180,8 @@ TEST_F(OptimizerTests, HashJoinTest) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -212,9 +209,8 @@ TEST_F(OptimizerTests, HashJoinTest) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());
@@ -241,9 +237,8 @@ TEST_F(OptimizerTests, HashJoinTest) {
                                      result_format);
   if (traffic_cop.GetQueuing()) {
     TestingSQLUtil::ContinueAfterComplete();
-    traffic_cop.ExecuteStatementPlanGetResult();
+    traffic_cop.ExecuteStatementGetResult();
     status = traffic_cop.p_status_;
-    traffic_cop.SetQueuing(false);
   }
   LOG_INFO("Statement executed. Result: %s",
            ResultTypeToString(status.m_result).c_str());

--- a/test/sql/explain_sql_test.cpp
+++ b/test/sql/explain_sql_test.cpp
@@ -60,7 +60,7 @@ TEST_F(ExplainSQLTests, ExplainSelectTest) {
       optimizer, query, result, tuple_descriptor, rows_changed, error_message);
 
   EXPECT_EQ(result.size(), 1);
-  EXPECT_EQ(result[0], "");
+  EXPECT_EQ(result[0], "SeqScan()");
 
   // Free the database
   txn = txn_manager.BeginTransaction();

--- a/test/sql/explain_sql_test.cpp
+++ b/test/sql/explain_sql_test.cpp
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+//                         Peloton
+//
+// explain_sql_test.cpp
+//
+// Identification: test/sql/explain_sql_test.cpp
+//
+// Copyright (c) 2015-18, Carnegie Mellon University Database Group
+//
+//===----------------------------------------------------------------------===//
+
+#include <memory>
+
+#include "catalog/catalog.h"
+#include "catalog/column_stats_catalog.h"
+#include "common/harness.h"
+#include "common/internal_types.h"
+#include "concurrency/transaction_manager_factory.h"
+#include "executor/create_executor.h"
+#include "optimizer/optimizer.h"
+#include "planner/create_plan.h"
+#include "sql/testing_sql_util.h"
+
+namespace peloton {
+namespace test {
+
+class ExplainSQLTests : public PelotonTest {};
+
+void CreateAndLoadTable() {
+  // Create a table first
+  TestingSQLUtil::ExecuteSQLQuery(
+      "CREATE TABLE test(a INT PRIMARY KEY, b INT, c INT, d VARCHAR);");
+
+  // Insert tuples into table
+  TestingSQLUtil::ExecuteSQLQuery(
+      "INSERT INTO test VALUES (1, 22, 333, 'abcd');");
+  TestingSQLUtil::ExecuteSQLQuery(
+      "INSERT INTO test VALUES (2, 22, 333, 'abc');");
+  TestingSQLUtil::ExecuteSQLQuery(
+      "INSERT INTO test VALUES (3, 11, 222, 'abcd');");
+}
+
+TEST_F(ExplainSQLTests, ExplainSelectTest) {
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->CreateDatabase(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+
+  CreateAndLoadTable();
+  std::unique_ptr<optimizer::AbstractOptimizer> optimizer(
+      new optimizer::Optimizer());
+  const std::string query = "EXPLAIN SELECT * FROM test";
+  std::vector<ResultValue> result;
+  std::vector<FieldInfo> tuple_descriptor;
+  int rows_changed;
+  std::string error_message;
+  // Execute explain
+  TestingSQLUtil::ExecuteSQLQueryWithOptimizer(
+      optimizer, query, result, tuple_descriptor, rows_changed, error_message);
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0], "");
+
+  // Free the database
+  txn = txn_manager.BeginTransaction();
+  catalog::Catalog::GetInstance()->DropDatabaseWithName(DEFAULT_DB_NAME, txn);
+  txn_manager.CommitTransaction(txn);
+}
+
+}  // namespace test
+}  // namespace peloton

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -87,9 +87,7 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(
                                               0);
   if (traffic_cop_.GetQueuing()) {
     ContinueAfterComplete();
-    traffic_cop_.ExecuteStatementPlanGetResult();
     status = traffic_cop_.ExecuteStatementGetResult();
-    traffic_cop_.SetQueuing(false);
   }
   if (status == ResultType::SUCCESS) {
     tuple_descriptor = statement->GetTupleDescriptor();
@@ -128,11 +126,11 @@ ResultType TestingSQLUtil::ExecuteSQLQueryWithOptimizer(
     counter_.store(1);
     auto status =
         traffic_cop_.ExecuteHelper(plan, params, result, result_format);
+
     if (traffic_cop_.GetQueuing()) {
-      TestingSQLUtil::ContinueAfterComplete();
-      traffic_cop_.ExecuteStatementPlanGetResult();
+      ContinueAfterComplete();
+      traffic_cop_.ExecuteStatementGetResult();
       status = traffic_cop_.p_status_;
-      traffic_cop_.SetQueuing(false);
     }
     rows_changed = status.m_processed;
     LOG_INFO("Statement executed. Result: %s",
@@ -191,9 +189,7 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(const std::string query,
                                               0);
   if (traffic_cop_.GetQueuing()) {
     ContinueAfterComplete();
-    traffic_cop_.ExecuteStatementPlanGetResult();
     status = traffic_cop_.ExecuteStatementGetResult();
-    traffic_cop_.SetQueuing(false);
   }
   if (status == ResultType::SUCCESS) {
     tuple_descriptor = statement->GetTupleDescriptor();
@@ -232,10 +228,9 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(const std::string query) {
                                               0);
   if (traffic_cop_.GetQueuing()) {
     ContinueAfterComplete();
-    traffic_cop_.ExecuteStatementPlanGetResult();
     status = traffic_cop_.ExecuteStatementGetResult();
-    traffic_cop_.SetQueuing(false);
   }
+
   if (status == ResultType::SUCCESS) {
     tuple_descriptor = statement->GetTupleDescriptor();
   }

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -76,12 +76,15 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(
   }
   // ExecuteStatment
   std::vector<type::Value> param_values;
-  bool unnamed = false;
   std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
   // SetTrafficCopCounter();
   counter_.store(1);
-  auto status = traffic_cop_.ExecuteStatement(statement, param_values, unnamed,
-                                              nullptr, result_format, result);
+  auto status = traffic_cop_.ExecuteStatement(statement,
+                                              param_values,
+                                              nullptr,
+                                              result_format,
+                                              result,
+                                              0);
   if (traffic_cop_.GetQueuing()) {
     ContinueAfterComplete();
     traffic_cop_.ExecuteStatementPlanGetResult();
@@ -177,12 +180,15 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(const std::string query,
   }
   // ExecuteStatment
   std::vector<type::Value> param_values;
-  bool unnamed = false;
   std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
   // SetTrafficCopCounter();
   counter_.store(1);
-  auto status = traffic_cop_.ExecuteStatement(statement, param_values, unnamed,
-                                              nullptr, result_format, result);
+  auto status = traffic_cop_.ExecuteStatement(statement,
+                                              param_values,
+                                              nullptr,
+                                              result_format,
+                                              result,
+                                              0);
   if (traffic_cop_.GetQueuing()) {
     ContinueAfterComplete();
     traffic_cop_.ExecuteStatementPlanGetResult();
@@ -216,12 +222,14 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(const std::string query) {
   }
   // ExecuteStatment
   std::vector<type::Value> param_values;
-  bool unnamed = false;
   std::vector<int> result_format(statement->GetTupleDescriptor().size(), 0);
-  // SetTrafficCopCounter();
   counter_.store(1);
-  auto status = traffic_cop_.ExecuteStatement(statement, param_values, unnamed,
-                                              nullptr, result_format, result);
+  auto status = traffic_cop_.ExecuteStatement(statement,
+                                              param_values,
+                                              nullptr,
+                                              result_format,
+                                              result,
+                                              0);
   if (traffic_cop_.GetQueuing()) {
     ContinueAfterComplete();
     traffic_cop_.ExecuteStatementPlanGetResult();


### PR DESCRIPTION
This PR moves the handling logic of `EXPLAIN` from the network layer to the execution layer. One reason for this is we don't want to duplicate the logic for different protocols, e.g. psql and JDBC, as it is mentioned in #1350.

Two test cases are added, one of which is a SQL test for the functionality of the `EXPLAIN` executor. Since we also touch the network layer, an end-to-end test is also added to make sure we didn't break anything in the network layer.