### PR TITLE
Resolves Clang warnings and LLVM assertion failure on Mac

### DIFF
--- a/src/codegen/code_context.cpp
+++ b/src/codegen/code_context.cpp
@@ -224,7 +224,7 @@ CodeContext::CodeContext()
   int64_type_ = llvm::Type::getInt64Ty(*context_);
   double_type_ = llvm::Type::getDoubleTy(*context_);
   void_type_ = llvm::Type::getVoidTy(*context_);
-  void_ptr_type_ = llvm::Type::getVoidTy(*context_)->getPointerTo();
+  void_ptr_type_ = llvm::Type::getInt8PtrTy(*context_);
   char_ptr_type_ = llvm::Type::getInt8PtrTy(*context_);
 }
 

--- a/src/codegen/function_builder.cpp
+++ b/src/codegen/function_builder.cpp
@@ -131,10 +131,13 @@ FunctionBuilder::FunctionBuilder(
           cc,
           ConstructFunction(cc, name, FunctionDeclaration::Visibility::External,
                             ret_type, args)) {}
-                            
+
 FunctionBuilder::~FunctionBuilder() {
   if (!finished_) {
-    PELOTON_ASSERT(false); // Missing call to FunctionBuilder::ReturnAndFinish()
+    LOG_ERROR(
+        "Missing call to FunctionBuilder::ReturnAndFinish() for function '%s'",
+        func_->getName().data());
+    PELOTON_ASSERT(false);
   }
 }
 

--- a/src/codegen/function_builder.cpp
+++ b/src/codegen/function_builder.cpp
@@ -137,7 +137,6 @@ FunctionBuilder::~FunctionBuilder() {
     LOG_ERROR(
         "Missing call to FunctionBuilder::ReturnAndFinish() for function '%s'",
         func_->getName().data());
-    PELOTON_ASSERT(false);
   }
 }
 

--- a/src/codegen/function_builder.cpp
+++ b/src/codegen/function_builder.cpp
@@ -134,7 +134,7 @@ FunctionBuilder::FunctionBuilder(
                             
 FunctionBuilder::~FunctionBuilder() {
   if (!finished_) {
-    throw Exception{"Missing call to FunctionBuilder::ReturnAndFinish()"};
+    PELOTON_ASSERT(false); // Missing call to FunctionBuilder::ReturnAndFinish()
   }
 }
 

--- a/src/codegen/lang/vectorized_loop.cpp
+++ b/src/codegen/lang/vectorized_loop.cpp
@@ -33,7 +33,9 @@ VectorizedLoop::VectorizedLoop(CodeGen &codegen, llvm::Value *num_elements,
 }
 
 VectorizedLoop::~VectorizedLoop() {
-  PELOTON_ASSERT(ended_ && "You didn't call lang::VectorizedLoop::LoopEnd()!");
+  if (!ended_) {
+    LOG_ERROR("You didn't call lang::VectorizedLoop::LoopEnd()!");
+  }
 }
 
 VectorizedLoop::Range VectorizedLoop::GetCurrentRange() const {

--- a/src/codegen/operator/table_scan_translator.cpp
+++ b/src/codegen/operator/table_scan_translator.cpp
@@ -216,7 +216,7 @@ void TableScanTranslator::ProduceParallel() const {
                                                   codegen.Int64Type()};
 
   // Parallel production
-  auto producer = [this, &codegen, &table](
+  auto producer = [this, &codegen](
       ConsumerContext &ctx, const std::vector<llvm::Value *> params) {
     PELOTON_ASSERT(params.size() == 2);
     llvm::Value *tilegroup_start = params[0];

--- a/src/codegen/util/sorter.cpp
+++ b/src/codegen/util/sorter.cpp
@@ -268,7 +268,7 @@ void Sorter::SortParallel(
           return !(cmp_func_(*l.first, *r.first) < 0);
         };
     for (auto &work : merge_work) {
-      work_pool.SubmitTask([&work, &latch, &heap_cmp, &comp] {
+      work_pool.SubmitTask([&work, &latch, &heap_cmp] {
         std::priority_queue<MergeWork::InputRange,
                             std::vector<MergeWork::InputRange>,
                             decltype(heap_cmp)> heap(heap_cmp,

--- a/test/codegen/hash_table_test.cpp
+++ b/test/codegen/hash_table_test.cpp
@@ -94,7 +94,7 @@ TEST_F(HashTableTest, CanInsertUniqueKeys) {
   // Lookup
   for (const auto &key : keys) {
     uint32_t count = 0;
-    std::function<void(const Value &v)> f = [&key, &count](const Value &v) {
+    std::function<void(const Value &v)> f = [&key, &count, &c1](const Value &v) {
       EXPECT_EQ(key.k2, v.v1)
           << "Value's [v1] found in table doesn't match insert key";
       EXPECT_EQ(c1, v.v4) << "Value's [v4] doesn't match constant";
@@ -136,7 +136,7 @@ TEST_F(HashTableTest, CanInsertDuplicateKeys) {
   // Lookup
   for (const auto &key : keys) {
     uint32_t count = 0;
-    std::function<void(const Value &v)> f = [&key, &count](const Value &v) {
+    std::function<void(const Value &v)> f = [&key, &count, &c1](const Value &v) {
       EXPECT_EQ(key.k2, v.v1)
           << "Value's [v1] found in table doesn't match insert key";
       EXPECT_EQ(c1, v.v4) << "Value's [v4] doesn't match constant";
@@ -183,7 +183,7 @@ TEST_F(HashTableTest, CanInsertLazilyWithDups) {
   // Lookups should succeed
   for (const auto &key : keys) {
     uint32_t count = 0;
-    std::function<void(const Value &v)> f = [&key, &count](const Value &v) {
+    std::function<void(const Value &v)> f = [&key, &count, &c1](const Value &v) {
       EXPECT_EQ(key.k2, v.v1)
           << "Value's [v1] found in table doesn't match insert key";
       EXPECT_EQ(c1, v.v4) << "Value's [v4] doesn't match constant";
@@ -219,7 +219,7 @@ TEST_F(HashTableTest, ParallelMerge) {
   };
 
   // Insert function
-  auto insert_fn = [&add_key, &exec_ctx, &to_insert](uint64_t tid) {
+  auto insert_fn = [&add_key, &exec_ctx](uint64_t tid) {
     // Get the local table for this thread
     auto *table = reinterpret_cast<codegen::util::HashTable *>(
         exec_ctx.GetThreadStates().AccessThreadState(tid));


### PR DESCRIPTION
Resolves the following introduced after merging PR #1304:

/peloton/src/codegen/function_builder.cpp:137:5: error: ‘~FunctionBuilder’ has a non-throwing exception specification but can still throw [-Werror,-Wexceptions]
/peloton/src/codegen/function_builder.cpp:135:18: note: destructor has a implicit non-throwing exception specification

/peloton/src/codegen/operator/table_scan_translator.cpp:219:37: error: lambda capture ‘table’ is not used [-Werror,-Wunused-lambda-capture]

/peloton/src/codegen/util/sorter.cpp:271:56: error: lambda capture ‘comp’ is not used [-Werror,-Wunused-lambda-capture]

/peloton/test/codegen/hash_table_test.cpp:100:17: error: variable ‘c1’ cannot be implicitly captured in a lambda with no capture-default specified
/peloton/test/codegen/hash_table_test.cpp:142:17: error: variable ‘c1’ cannot be implicitly captured in a lambda with no capture-default specified
/peloton/test/codegen/hash_table_test.cpp:189:17: error: variable ‘c1’ cannot be implicitly captured in a lambda with no capture-default specified
/peloton/test/codegen/hash_table_test.cpp:222:43: error: lambda capture ‘to_insert’ is not required to be captured for this use [-Werror,-Wunused-lambda-capture]

Assertion failed: (isValidElementType(EltTy) && “Invalid type for pointer element!“), function get, file /private/tmp/llvm@3.7-20170923-4009-1tn3kci/llvm-3.7.1.src/lib/IR/Type.cpp, line 740.