### PR TITLE
Performance Fixes: pass TileGroupHeader*, avoid RW set lookups

### DIFF
--- a/src/codegen/transaction_runtime.cpp
+++ b/src/codegen/transaction_runtime.cpp
@@ -56,7 +56,7 @@ uint32_t TransactionRuntime::PerformVectorizedRead(
     ItemPointer location{tile_group_idx, selection_vector[idx]};
 
     // Perform the read
-    bool can_read = txn_manager.PerformRead(&txn, location);
+    bool can_read = txn_manager.PerformRead(&txn, location, tile_group_header, false);
 
     // Update the selection vector and output position
     selection_vector[out_idx] = selection_vector[idx];

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -93,7 +93,7 @@ void TransactionContext::Init(const size_t thread_id,
 RWType TransactionContext::GetRWType(const ItemPointer &location) {
   RWType rw_type = RWType::INVALID;
 
-  const auto rw_set_it = rw_set_.find(location);
+  auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end()) {
     return rw_set_it->second;
   }
@@ -102,7 +102,7 @@ RWType TransactionContext::GetRWType(const ItemPointer &location) {
 
 void TransactionContext::RecordRead(const ItemPointer &location) {
 
-  const auto rw_set_it = rw_set_.find(location);
+  auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end()) {
     UNUSED_ATTRIBUTE RWType rw_type = rw_set_it->second;
     PELOTON_ASSERT(rw_type != RWType::DELETE && rw_type != RWType::INS_DEL);
@@ -112,7 +112,7 @@ void TransactionContext::RecordRead(const ItemPointer &location) {
 }
 
 void TransactionContext::RecordReadOwn(const ItemPointer &location) {
-  const auto rw_set_it = rw_set_.find(location);
+  auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end()) {
     RWType rw_type = rw_set_it->second;
     PELOTON_ASSERT(rw_type != RWType::DELETE && rw_type != RWType::INS_DEL);
@@ -125,7 +125,7 @@ void TransactionContext::RecordReadOwn(const ItemPointer &location) {
 }
 
 void TransactionContext::RecordUpdate(const ItemPointer &location) {
-  const auto rw_set_it = rw_set_.find(location);
+  auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end()) {
     RWType rw_type = rw_set_it->second;
     if (rw_type == RWType::READ || rw_type == RWType::READ_OWN) {
@@ -143,7 +143,7 @@ void TransactionContext::RecordUpdate(const ItemPointer &location) {
 }
 
 void TransactionContext::RecordInsert(const ItemPointer &location) {
-  const auto rw_set_it = rw_set_.find(location);
+  auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end()) {
     PELOTON_ASSERT(false);
     return;
@@ -153,7 +153,7 @@ void TransactionContext::RecordInsert(const ItemPointer &location) {
 }
 
 bool TransactionContext::RecordDelete(const ItemPointer &location) {
-  const auto rw_set_it = rw_set_.find(location);
+  auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end()) {
     RWType rw_type = rw_set_it->second;
 

--- a/src/executor/hybrid_scan_executor.cpp
+++ b/src/executor/hybrid_scan_executor.cpp
@@ -230,7 +230,9 @@ bool HybridScanExecutor::SeqScanUtil() {
             predicate_->Evaluate(&tuple, nullptr, executor_context_).IsTrue();
         if (eval == true) {
           position_list.push_back(tuple_id);
-          auto res = transaction_manager.PerformRead(current_txn, location,
+          auto res = transaction_manager.PerformRead(current_txn,
+                                                     location,
+                                                     tile_group_header,
                                                      acquire_owner);
           if (!res) {
             transaction_manager.SetTransactionResult(current_txn,
@@ -389,7 +391,9 @@ bool HybridScanExecutor::ExecPrimaryIndexLookup() {
 
       if (visibility == VisibilityType::OK) {
         visible_tuples[tuple_location.block].push_back(tuple_location.offset);
-        auto res = transaction_manager.PerformRead(current_txn, tuple_location,
+        auto res = transaction_manager.PerformRead(current_txn,
+                                                   tuple_location,
+                                                   tile_group_header,
                                                    acquire_owner);
         if (!res) {
           transaction_manager.SetTransactionResult(current_txn,

--- a/src/executor/index_scan_executor.cpp
+++ b/src/executor/index_scan_executor.cpp
@@ -254,8 +254,10 @@ bool IndexScanExecutor::ExecPrimaryIndexLookup() {
         // if passed evaluation, then perform write.
         if (eval == true) {
           LOG_TRACE("perform read operation");
-          auto res = transaction_manager.PerformRead(
-              current_txn, tuple_location, acquire_owner);
+          auto res = transaction_manager.PerformRead(current_txn,
+                                                     tuple_location,
+                                                     tile_group_header,
+                                                     acquire_owner);
           if (!res) {
             LOG_TRACE("read nothing");
             transaction_manager.SetTransactionResult(current_txn,
@@ -519,8 +521,10 @@ bool IndexScanExecutor::ExecSecondaryIndexLookup() {
         }
         // if passed evaluation, then perform write.
         if (eval == true) {
-          auto res = transaction_manager.PerformRead(
-              current_txn, tuple_location, acquire_owner);
+          auto res = transaction_manager.PerformRead(current_txn,
+                                                     tuple_location,
+                                                     tile_group_header,
+                                                     acquire_owner);
           if (!res) {
             transaction_manager.SetTransactionResult(current_txn,
                                                      ResultType::FAILURE);

--- a/src/executor/seq_scan_executor.cpp
+++ b/src/executor/seq_scan_executor.cpp
@@ -172,7 +172,9 @@ bool SeqScanExecutor::DExecute() {
           // if the tuple is visible, then perform predicate evaluation.
           if (predicate_ == nullptr) {
             position_list.push_back(tuple_id);
-            auto res = transaction_manager.PerformRead(current_txn, location,
+            auto res = transaction_manager.PerformRead(current_txn,
+                                                       location,
+                                                       tile_group_header,
                                                        acquire_owner);
             if (!res) {
               transaction_manager.SetTransactionResult(current_txn,
@@ -188,7 +190,9 @@ bool SeqScanExecutor::DExecute() {
             LOG_TRACE("Evaluation result: %s", eval.GetInfo().c_str());
             if (eval.IsTrue()) {
               position_list.push_back(tuple_id);
-              auto res = transaction_manager.PerformRead(current_txn, location,
+              auto res = transaction_manager.PerformRead(current_txn,
+                                                         location,
+                                                         tile_group_header,
                                                          acquire_owner);
               if (!res) {
                 transaction_manager.SetTransactionResult(current_txn,

--- a/src/include/concurrency/timestamp_ordering_transaction_manager.h
+++ b/src/include/concurrency/timestamp_ordering_transaction_manager.h
@@ -170,11 +170,13 @@ class TimestampOrderingTransactionManager : public TransactionManager {
    *
    * @param      current_txn        The current transaction
    * @param[in]  location           The location of the tuple to be read
+   * @param[in]  tile_group_header  Pointer to the tile group header
    * @param[in]  acquire_ownership  The acquire ownership
    */
   virtual bool PerformRead(TransactionContext *const current_txn,
                            const ItemPointer &location,
-                           bool acquire_ownership = false);
+                           storage::TileGroupHeader *tile_group_header,
+                           bool acquire_ownership);
 
   /**
    * @brief      Perform an update operation

--- a/src/include/concurrency/transaction_manager.h
+++ b/src/include/concurrency/transaction_manager.h
@@ -190,8 +190,9 @@ class TransactionManager {
                              ItemPointer *index_entry_ptr = nullptr) = 0;
 
   virtual bool PerformRead(TransactionContext *const current_txn,
-                           const ItemPointer &location,
-                           bool acquire_ownership = false) = 0;
+                             const ItemPointer &location,
+                             storage::TileGroupHeader *tile_group_header,
+                             bool acquire_ownership) = 0;
 
 
   virtual void PerformUpdate(TransactionContext *const current_txn,

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -661,7 +661,10 @@ bool DataTable::CheckForeignKeySrcAndCascade(
                 // we can
                 // delete it later
                 bool ret =
-                    transaction_manager.PerformRead(current_txn, *ptr, true);
+                    transaction_manager.PerformRead(current_txn,
+                                                    *ptr,
+                                                    src_tile_group_header,
+                                                    true);
 
                 if (ret == false) {
                   if (src_is_owner) {


### PR DESCRIPTION
 * add TileGroupHeader* as argument to ReadRecord to avoid lookup with GetTileGroup()
 * rewrite access to RW set in TransactionContext::Record* functions to avoid duplicated lookups