### PR TITLE
Fix warning for unused lambda capture on Clang 9.1

### DIFF
--- a/test/codegen/csv_scan_translator_test.cpp
+++ b/test/codegen/csv_scan_translator_test.cpp
@@ -36,7 +36,7 @@ class CSVScanTranslatorTest : public PelotonCodeGenTest {
 TEST_F(CSVScanTranslatorTest, IntCsvScan) {
   // The quoting character and a helper function to quote a given string
   const char quote = '"';
-  const auto quote_string = [quote](std::string s) {
+  const auto quote_string = [](std::string s) {
     return StringUtil::Format("%c%s%c", quote, s.c_str(), quote);
   };
 


### PR DESCRIPTION
Resolves the following warning introduced by #1371 on Clang 9.1:

../git/peloton/test/codegen/csv_scan_translator_test.cpp:39:30: error: lambda capture 'quote' is not required to be captured for this use [-Werror,-Wunused-lambda-capture]
  const auto quote_string = [quote](std::string s) {

I couldn't reproduce the warning on GCC 7.3, which makes me wonder if it's spurious on Clang's part. However, I ran make check with this proposed change under Clang 9.1 and GCC 7.3 and everything looked good. Hopefully it's the same story on Jenkins and Travis.