### PR TITLE
RWSet performance fixes, LockFreeArray performance fixes and tests

### DIFF
--- a/src/common/container/lock_free_array.cpp
+++ b/src/common/container/lock_free_array.cpp
@@ -73,23 +73,18 @@ ValueType LOCK_FREE_ARRAY_TYPE::FindValid(
     const std::size_t &offset, const ValueType &invalid_value) const {
   LOG_TRACE("Find Valid at %lu", offset);
 
-  std::size_t valid_array_itr = 0;
-  std::size_t array_itr;
-  auto lock_free_array_offset = lock_free_array.size();
-  for (array_itr = 0; array_itr < lock_free_array_offset; array_itr++) {
-    auto value = lock_free_array.at(array_itr);
-    if (value != invalid_value) {
-      // Check offset
-      if (valid_array_itr == offset) {
-        return value;
-      }
-
-      // Update valid value count
-      valid_array_itr++;
-    }
+  ValueType value = invalid_value;
+  if ((lock_free_array.size() > offset)) {
+    value = lock_free_array.at(offset);
+  } else {
+    return invalid_value;
   }
-
-  return invalid_value;
+  
+  if (value != invalid_value)
+    return value;
+  else {
+    return invalid_value;
+  }
 }
 
 template <typename ValueType>

--- a/src/common/container/lock_free_array.cpp
+++ b/src/common/container/lock_free_array.cpp
@@ -76,15 +76,9 @@ ValueType LOCK_FREE_ARRAY_TYPE::FindValid(
   ValueType value = invalid_value;
   if ((lock_free_array.size() > offset)) {
     value = lock_free_array.at(offset);
-  } else {
-    return invalid_value;
   }
-  
-  if (value != invalid_value)
-    return value;
-  else {
-    return invalid_value;
-  }
+
+  return value;
 }
 
 template <typename ValueType>

--- a/src/common/container/lock_free_array.cpp
+++ b/src/common/container/lock_free_array.cpp
@@ -36,7 +36,8 @@ template <typename ValueType>
 LOCK_FREE_ARRAY_TYPE::~LockFreeArray() { lock_free_array.clear(); }
 
 template <typename ValueType>
-void LOCK_FREE_ARRAY_TYPE::Update(const std::size_t &offset, const ValueType &value) {
+void LOCK_FREE_ARRAY_TYPE::Update(const std::size_t &offset,
+                                  const ValueType &value) {
   LOG_TRACE("Update at %lu", offset);
   PELOTON_ASSERT(lock_free_array.size() > offset);
   lock_free_array.at(offset) = value;

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -653,9 +653,6 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
   // 3. install a new tuple for insert operations.
   // Iterate through each item pointer in the read write set
 
-  // TODO (Pooja): This might be inefficient since we will have to get the
-  // tile_group_header for each entry. Check if this needs to be consolidated
-
   oid_t last_tile_group_id = INVALID_OID;
   storage::TileGroupHeader *tile_group_header = nullptr;
 
@@ -813,8 +810,6 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
   }
 
   // Iterate through each item pointer in the read write set
-  // TODO (Pooja): This might be inefficient since we will have to get the
-  // tile_group_header for each entry. Check if this needs to be consolidated
 
   oid_t last_tile_group_id = INVALID_OID;
   storage::TileGroupHeader *tile_group_header = nullptr;

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -667,6 +667,7 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
     if (tile_group_id != last_tile_group_id) {
       tile_group_header =
           storage_manager->GetTileGroup(tile_group_id)->GetHeader();
+      last_tile_group_id = tile_group_id;
     }
 
     if (tuple_entry.second == RWType::READ_OWN) {
@@ -826,6 +827,7 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
     if (tile_group_id != last_tile_group_id) {
       tile_group_header =
           storage_manager->GetTileGroup(tile_group_id)->GetHeader();
+      last_tile_group_id = tile_group_id;
     }
 
     if (tuple_entry.second == RWType::READ_OWN) {

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -665,7 +665,8 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
     oid_t tuple_slot = item_ptr.offset;
 
     if (tile_group_id != last_tile_group_id) {
-      tile_group_header = storage_manager->GetTileGroup(tile_group_id)->GetHeader();
+      tile_group_header =
+          storage_manager->GetTileGroup(tile_group_id)->GetHeader();
     }
 
     if (tuple_entry.second == RWType::READ_OWN) {
@@ -823,7 +824,8 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
     oid_t tuple_slot = item_ptr.offset;
 
     if (tile_group_id != last_tile_group_id) {
-      tile_group_header = storage_manager->GetTileGroup(tile_group_id)->GetHeader();
+      tile_group_header =
+          storage_manager->GetTileGroup(tile_group_id)->GetHeader();
     }
 
     if (tuple_entry.second == RWType::READ_OWN) {

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -655,12 +655,18 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
 
   // TODO (Pooja): This might be inefficient since we will have to get the
   // tile_group_header for each entry. Check if this needs to be consolidated
+
+  oid_t last_tile_group_id = INVALID_OID;
+  storage::TileGroupHeader *tile_group_header = nullptr;
+
   for (const auto &tuple_entry : rw_set) {
     ItemPointer item_ptr = tuple_entry.first;
     oid_t tile_group_id = item_ptr.block;
     oid_t tuple_slot = item_ptr.offset;
 
-    auto tile_group_header = storage_manager->GetTileGroup(tile_group_id)->GetHeader();
+    if (tile_group_id != last_tile_group_id) {
+      tile_group_header = storage_manager->GetTileGroup(tile_group_id)->GetHeader();
+    }
 
     if (tuple_entry.second == RWType::READ_OWN) {
       // A read operation has acquired ownership but hasn't done any further
@@ -807,11 +813,18 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
   // Iterate through each item pointer in the read write set
   // TODO (Pooja): This might be inefficient since we will have to get the
   // tile_group_header for each entry. Check if this needs to be consolidated
+
+  oid_t last_tile_group_id = INVALID_OID;
+  storage::TileGroupHeader *tile_group_header = nullptr;
+
   for (const auto &tuple_entry : rw_set) {
     ItemPointer item_ptr = tuple_entry.first;
     oid_t tile_group_id = item_ptr.block;
     oid_t tuple_slot = item_ptr.offset;
-    auto tile_group_header = storage_manager->GetTileGroup(tile_group_id)->GetHeader();
+
+    if (tile_group_id != last_tile_group_id) {
+      tile_group_header = storage_manager->GetTileGroup(tile_group_id)->GetHeader();
+    }
 
     if (tuple_entry.second == RWType::READ_OWN) {
       // A read operation has acquired ownership but hasn't done any further

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -93,7 +93,7 @@ RWType TransactionContext::GetRWType(const ItemPointer &location) {
 }
 
 void TransactionContext::RecordRead(const ItemPointer &location) {
-  PELOTON_ASSERT(rw_set_.count(location) == 0 ||
+  PELOTON_ASSERT(rw_set_.find(location) == rw_set_.end() ||
                  (rw_set_[location] != RWType::DELETE &&
                   rw_set_[location] != RWType::INS_DEL));
   auto rw_set_it = rw_set_.find(location);
@@ -104,14 +104,14 @@ void TransactionContext::RecordRead(const ItemPointer &location) {
 }
 
 void TransactionContext::RecordReadOwn(const ItemPointer &location) {
-  PELOTON_ASSERT(rw_set_.count(location) == 0 ||
+  PELOTON_ASSERT(rw_set_.find(location) == rw_set_.end() ||
                  (rw_set_[location] != RWType::DELETE &&
                   rw_set_[location] != RWType::INS_DEL));
   rw_set_[location] = RWType::READ_OWN;
 }
 
 void TransactionContext::RecordUpdate(const ItemPointer &location) {
-  PELOTON_ASSERT(rw_set_.count(location) == 0 ||
+  PELOTON_ASSERT(rw_set_.find(location) == rw_set_.end() ||
                  (rw_set_[location] != RWType::DELETE &&
                   rw_set_[location] != RWType::INS_DEL));
   auto rw_set_it = rw_set_.find(location);
@@ -122,12 +122,12 @@ void TransactionContext::RecordUpdate(const ItemPointer &location) {
 }
 
 void TransactionContext::RecordInsert(const ItemPointer &location) {
-  PELOTON_ASSERT(rw_set_.count(location) == 0);
+  PELOTON_ASSERT(rw_set_.find(location) == rw_set_.end());
   rw_set_[location] = RWType::INSERT;
 }
 
 bool TransactionContext::RecordDelete(const ItemPointer &location) {
-  PELOTON_ASSERT(rw_set_.count(location) == 0 ||
+  PELOTON_ASSERT(rw_set_.find(location) == rw_set_.end() ||
                  (rw_set_[location] != RWType::DELETE &&
                   rw_set_[location] != RWType::INS_DEL));
   auto rw_set_it = rw_set_.find(location);

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -114,7 +114,10 @@ void TransactionContext::RecordUpdate(const ItemPointer &location) {
   PELOTON_ASSERT(rw_set_.count(location) == 0 ||
                  (rw_set_[location] != RWType::DELETE &&
                   rw_set_[location] != RWType::INS_DEL));
-  rw_set_[location] = RWType::UPDATE;
+  auto rw_set_it = rw_set_.find(location);
+  if (rw_set_it != rw_set_.end() && (rw_set_it->second == RWType::READ || rw_set_it->second == RWType::READ_OWN)) {
+    rw_set_it->second = RWType::UPDATE;
+  }
 }
 
 void TransactionContext::RecordInsert(const ItemPointer &location) {

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -95,10 +95,11 @@ RWType TransactionContext::GetRWType(const ItemPointer &location) {
 void TransactionContext::RecordRead(const ItemPointer &location) {
   PELOTON_ASSERT(rw_set_.count(location) == 0 ||
       (rw_set_[location] != RWType::DELETE && rw_set_[location] != RWType::INS_DEL));
-
-  if (rw_set_.count(location) == 0) {
-    rw_set_[location] = RWType::READ;
+  auto rw_set_it = rw_set_.find(location);
+  if (rw_set_it != rw_set_.end()) {
+    return;
   }
+  rw_set_[location] = RWType::READ;
 }
 
 void TransactionContext::RecordReadOwn(const ItemPointer &location) {

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -115,10 +115,13 @@ void TransactionContext::RecordUpdate(const ItemPointer &location) {
                  (rw_set_[location] != RWType::DELETE &&
                   rw_set_[location] != RWType::INS_DEL));
   auto rw_set_it = rw_set_.find(location);
-  if (rw_set_it != rw_set_.end() && (rw_set_it->second == RWType::READ ||
-                                     rw_set_it->second == RWType::READ_OWN)) {
-    rw_set_it->second = RWType::UPDATE;
+  if (rw_set_it != rw_set_.end() {
+    if (rw_set_it->second == RWType::READ || rw_set_it->second == RWType::READ_OWN) {
+      rw_set_it->second = RWType::UPDATE;
+    }
+    return;
   }
+  rw_set_[location] = RWType::UPDATE;
 }
 
 void TransactionContext::RecordInsert(const ItemPointer &location) {

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -118,7 +118,7 @@ void TransactionContext::RecordUpdate(const ItemPointer &location) {
                   rw_set_[location] != RWType::INS_DEL));
   auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end() && (rw_set_it->second == RWType::READ ||
-                                  rw_set_it->second == RWType::READ_OWN)) {
+                                     rw_set_it->second == RWType::READ_OWN)) {
     rw_set_it->second = RWType::UPDATE;
     is_written_ = true;
   }

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -80,10 +80,6 @@ void TransactionContext::Init(const size_t thread_id,
 
   isolation_level_ = isolation;
 
-  is_written_ = false;
-
-  insert_count_ = 0;
-
   gc_set_.reset(new GCSet());
   gc_object_set_.reset(new GCObjectSet());
 
@@ -93,89 +89,48 @@ void TransactionContext::Init(const size_t thread_id,
 RWType TransactionContext::GetRWType(const ItemPointer &location) {
   RWType rw_type = RWType::INVALID;
 
-  auto rw_set_it = rw_set_.find(location);
+  const auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end()) {
-    return rw_set_it->second;
+    rw_type = rw_set_it->second;
   }
   return rw_type;
 }
 
 void TransactionContext::RecordRead(const ItemPointer &location) {
+  PELOTON_ASSERT(rw_set_.count(location) == 0 ||
+      (rw_set_[location] != RWType::DELETE && rw_set_[location] != RWType::INS_DEL));
 
-  auto rw_set_it = rw_set_.find(location);
-  if (rw_set_it != rw_set_.end()) {
-    UNUSED_ATTRIBUTE RWType rw_type = rw_set_it->second;
-    PELOTON_ASSERT(rw_type != RWType::DELETE && rw_type != RWType::INS_DEL);
-    return;
+  if (rw_set_.count(location) == 0) {
+    rw_set_[location] = RWType::READ;
   }
-  rw_set_.insert(rw_set_it, std::make_pair(location, RWType::READ));
 }
 
 void TransactionContext::RecordReadOwn(const ItemPointer &location) {
-  auto rw_set_it = rw_set_.find(location);
-  if (rw_set_it != rw_set_.end()) {
-    RWType rw_type = rw_set_it->second;
-    PELOTON_ASSERT(rw_type != RWType::DELETE && rw_type != RWType::INS_DEL);
-    if (rw_type == RWType::READ) {
-      rw_set_it->second = RWType::READ_OWN;
-    }
-  } else {
-    rw_set_.insert(rw_set_it, std::make_pair(location, RWType::READ_OWN));
-  }
+  PELOTON_ASSERT(rw_set_.count(location) == 0 ||
+      (rw_set_[location] != RWType::DELETE && rw_set_[location] != RWType::INS_DEL));
+  rw_set_[location] = RWType::READ_OWN;
 }
 
 void TransactionContext::RecordUpdate(const ItemPointer &location) {
-  auto rw_set_it = rw_set_.find(location);
-  if (rw_set_it != rw_set_.end()) {
-    RWType rw_type = rw_set_it->second;
-    if (rw_type == RWType::READ || rw_type == RWType::READ_OWN) {
-      is_written_ = true;
-      rw_set_it->second = RWType::UPDATE;
-    } else if (rw_type == RWType::UPDATE || rw_type == RWType::INSERT) {
-      return;
-    } else {
-      // DELETE or INS_DELETE
-      PELOTON_ASSERT(false);
-    }
-  } else {
-    rw_set_.insert(rw_set_it, std::make_pair(location, RWType::UPDATE));
-  }
+  PELOTON_ASSERT(rw_set_.count(location) == 0 ||
+      (rw_set_[location] != RWType::DELETE && rw_set_[location] != RWType::INS_DEL));
+  rw_set_[location] = RWType::UPDATE;
 }
 
 void TransactionContext::RecordInsert(const ItemPointer &location) {
-  auto rw_set_it = rw_set_.find(location);
-  if (rw_set_it != rw_set_.end()) {
-    PELOTON_ASSERT(false);
-    return;
-  }
-  rw_set_.insert(rw_set_it, std::make_pair(location, RWType::INSERT));
-  ++insert_count_;
+  PELOTON_ASSERT(rw_set_.count(location) == 0);
+  rw_set_[location] = RWType::INSERT;
 }
 
-bool TransactionContext::RecordDelete(const ItemPointer &location) {
-  auto rw_set_it = rw_set_.find(location);
-  if (rw_set_it != rw_set_.end()) {
-    RWType rw_type = rw_set_it->second;
-
-    if (rw_type == RWType::READ || rw_type == RWType::READ_OWN) {
-      rw_set_it->second = RWType::DELETE;
-      is_written_ = true;
-      return false;
-    } else if (rw_type == RWType::UPDATE) {
-      rw_set_it->second = RWType::DELETE;
-      return false;
-    } else if (rw_type == RWType::INSERT) {
-      rw_set_it->second = RWType::INS_DEL;
-      --insert_count_;
-      return true;
-    } else {
-      // DELETE and INS_DEL
-      PELOTON_ASSERT(false);
-      return false;
-    }
-  } else {
-    rw_set_.insert(rw_set_it, std::make_pair(location, RWType::DELETE));
-    return false;
+void TransactionContext::RecordDelete(const ItemPointer &location) {
+  PELOTON_ASSERT(rw_set_.count(location) == 0 ||
+      (rw_set_[location] != RWType::DELETE && rw_set_[location] != RWType::INS_DEL));
+  if (rw_set_[location] == RWType::INSERT) {
+    rw_set_[location] = RWType::INS_DEL;
+  }
+  else {
+    // READ, READ_OWN, UPDATE
+    rw_set_[location] = RWType::DELETE;
   }
 }
 

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -94,7 +94,8 @@ RWType TransactionContext::GetRWType(const ItemPointer &location) {
 
 void TransactionContext::RecordRead(const ItemPointer &location) {
   PELOTON_ASSERT(rw_set_.count(location) == 0 ||
-      (rw_set_[location] != RWType::DELETE && rw_set_[location] != RWType::INS_DEL));
+                 (rw_set_[location] != RWType::DELETE &&
+                  rw_set_[location] != RWType::INS_DEL));
   auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end()) {
     return;
@@ -104,13 +105,15 @@ void TransactionContext::RecordRead(const ItemPointer &location) {
 
 void TransactionContext::RecordReadOwn(const ItemPointer &location) {
   PELOTON_ASSERT(rw_set_.count(location) == 0 ||
-      (rw_set_[location] != RWType::DELETE && rw_set_[location] != RWType::INS_DEL));
+                 (rw_set_[location] != RWType::DELETE &&
+                  rw_set_[location] != RWType::INS_DEL));
   rw_set_[location] = RWType::READ_OWN;
 }
 
 void TransactionContext::RecordUpdate(const ItemPointer &location) {
   PELOTON_ASSERT(rw_set_.count(location) == 0 ||
-      (rw_set_[location] != RWType::DELETE && rw_set_[location] != RWType::INS_DEL));
+                 (rw_set_[location] != RWType::DELETE &&
+                  rw_set_[location] != RWType::INS_DEL));
   rw_set_[location] = RWType::UPDATE;
 }
 
@@ -121,12 +124,12 @@ void TransactionContext::RecordInsert(const ItemPointer &location) {
 
 void TransactionContext::RecordDelete(const ItemPointer &location) {
   PELOTON_ASSERT(rw_set_.count(location) == 0 ||
-      (rw_set_[location] != RWType::DELETE && rw_set_[location] != RWType::INS_DEL));
+                 (rw_set_[location] != RWType::DELETE &&
+                  rw_set_[location] != RWType::INS_DEL));
   auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end() && rw_set_it->second == RWType::INSERT) {
     rw_set_it->second = RWType::INS_DEL;
-  }
-  else {
+  } else {
     rw_set_[location] = RWType::DELETE;
   }
 }

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -122,11 +122,11 @@ void TransactionContext::RecordInsert(const ItemPointer &location) {
 void TransactionContext::RecordDelete(const ItemPointer &location) {
   PELOTON_ASSERT(rw_set_.count(location) == 0 ||
       (rw_set_[location] != RWType::DELETE && rw_set_[location] != RWType::INS_DEL));
-  if (rw_set_[location] == RWType::INSERT) {
-    rw_set_[location] = RWType::INS_DEL;
+  auto rw_set_it = rw_set_.find(location);
+  if (rw_set_it != rw_set_.end() && rw_set_it->second == RWType::INSERT) {
+    rw_set_it->second = RWType::INS_DEL;
   }
   else {
-    // READ, READ_OWN, UPDATE
     rw_set_[location] = RWType::DELETE;
   }
 }

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -115,7 +115,7 @@ void TransactionContext::RecordUpdate(const ItemPointer &location) {
                  (rw_set_[location] != RWType::DELETE &&
                   rw_set_[location] != RWType::INS_DEL));
   auto rw_set_it = rw_set_.find(location);
-  if (rw_set_it != rw_set_.end() {
+  if (rw_set_it != rw_set_.end()) {
     if (rw_set_it->second == RWType::READ || rw_set_it->second == RWType::READ_OWN) {
       rw_set_it->second = RWType::UPDATE;
     }

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -61,8 +61,6 @@ TransactionContext::TransactionContext(const size_t thread_id,
   Init(thread_id, isolation, read_id, commit_id);
 }
 
-TransactionContext::~TransactionContext() {}
-
 void TransactionContext::Init(const size_t thread_id,
                               const IsolationLevelType isolation,
                               const cid_t &read_id, const cid_t &commit_id) {
@@ -80,20 +78,18 @@ void TransactionContext::Init(const size_t thread_id,
 
   isolation_level_ = isolation;
 
-  gc_set_.reset(new GCSet());
-  gc_object_set_.reset(new GCObjectSet());
+  gc_set_ = std::make_shared<GCSet>();
+  gc_object_set_ = std::make_shared<GCObjectSet>();
 
   on_commit_triggers_.reset();
 }
 
 RWType TransactionContext::GetRWType(const ItemPointer &location) {
-  RWType rw_type = RWType::INVALID;
-
   const auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end()) {
-    rw_type = rw_set_it->second;
+    return rw_set_it->second;
   }
-  return rw_type;
+  return RWType::INVALID;
 }
 
 void TransactionContext::RecordRead(const ItemPointer &location) {

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -115,7 +115,8 @@ void TransactionContext::RecordUpdate(const ItemPointer &location) {
                  (rw_set_[location] != RWType::DELETE &&
                   rw_set_[location] != RWType::INS_DEL));
   auto rw_set_it = rw_set_.find(location);
-  if (rw_set_it != rw_set_.end() && (rw_set_it->second == RWType::READ || rw_set_it->second == RWType::READ_OWN)) {
+  if (rw_set_it != rw_set_.end() && (rw_set_it->second == RWType::READ ||
+                                     rw_set_it->second == RWType::READ_OWN)) {
     rw_set_it->second = RWType::UPDATE;
   }
 }

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -126,15 +126,17 @@ void TransactionContext::RecordInsert(const ItemPointer &location) {
   rw_set_[location] = RWType::INSERT;
 }
 
-void TransactionContext::RecordDelete(const ItemPointer &location) {
+bool TransactionContext::RecordDelete(const ItemPointer &location) {
   PELOTON_ASSERT(rw_set_.count(location) == 0 ||
                  (rw_set_[location] != RWType::DELETE &&
                   rw_set_[location] != RWType::INS_DEL));
   auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end() && rw_set_it->second == RWType::INSERT) {
     rw_set_it->second = RWType::INS_DEL;
+    return true;
   } else {
     rw_set_[location] = RWType::DELETE;
+    return false;
   }
 }
 

--- a/src/include/common/container/lock_free_array.h
+++ b/src/include/common/container/lock_free_array.h
@@ -12,13 +12,6 @@
 
 #pragma once
 #include "tbb/concurrent_vector.h"
-#include "tbb/tbb_allocator.h"
-#include <cstdlib>
-#include <cstring>
-#include <cstdio>
-#include <array>
-#include <atomic>
-#include <memory>
 
 namespace peloton {
 
@@ -35,33 +28,74 @@ class LockFreeArray {
   LockFreeArray();
   ~LockFreeArray();
 
-  // Update a item
-  bool Update(const std::size_t &offset, ValueType value);
+  /**
+   * Assigns the provided value to the provided offset.
+   *
+   * @param offset  Element offset to update
+   * @param value   Value to be assigned
+   */
+  void Update(const std::size_t &offset, const ValueType &value);
 
-  // Append an item
-  bool Append(ValueType value);
+  /**
+   * Appends an element to the end of the array
+   *
+   * @param value   Value to be appended
+   */
+  void Append(const ValueType &value);
 
-  // Get a item
+  /**
+   * Returns the element at the offset
+   *
+   * @returns   Element at offset
+   */
   ValueType Find(const std::size_t &offset) const;
 
-  // Get a valid item
+  /**
+   * Returns the element at the offset, or invalid_value if
+   * the element does not exist.
+   *
+   * @param offset          Element offset to access
+   * @param invalid_value   Sentinel value to return if element
+   *                        does not exist or offset out of range
+   * @returns               Element at offset or invalid_value
+   */
   ValueType FindValid(const std::size_t &offset,
                       const ValueType &invalid_value) const;
 
-  // Delete key from the lock_free_array
-  bool Erase(const std::size_t &offset, const ValueType &invalid_value);
+  /**
+   * Assigns the provided invalid_value to the provided offset.
+   *
+   * @param offset          Element offset to update
+   * @param invalid_value   Invalid value to be assigned
+   */
+  void Erase(const std::size_t &offset, const ValueType &invalid_value);
 
-  // Returns item count in the lock_free_array
+  /**
+   *
+   * @return Number of elements in the underlying structure
+   */
   size_t GetSize() const;
 
-  // Checks if the lock_free_array is empty
+  /**
+   *
+   * @return True if empty, false otherwise
+   */
   bool IsEmpty() const;
 
-  // Clear all elements and reset them to default value
+  /**
+   * Resets the underlying data structure to have 0 elements
+   */
   void Clear();
 
-  // Exists ?
-  bool Contains(const ValueType &value);
+  /**
+   *
+   * Check the lock-free array for the provided value.
+   * O(n) time complexity.
+   *
+   * @param value  value to search for
+   * @return       True if element present, false otherwise
+   */
+  bool Contains(const ValueType &value) const;
 
  private:
   // lock free array

--- a/src/include/concurrency/transaction_context.h
+++ b/src/include/concurrency/transaction_context.h
@@ -53,7 +53,7 @@ class TransactionContext : public Printable {
   /**
    * @brief      Destroys the object.
    */
-  ~TransactionContext();
+  ~TransactionContext() = default;
 
  private:
   void Init(const size_t thread_id, const IsolationLevelType isolation,

--- a/src/include/concurrency/transaction_context.h
+++ b/src/include/concurrency/transaction_context.h
@@ -338,6 +338,8 @@ class TransactionContext : public Printable {
 
   IsolationLevelType isolation_level_;
 
+  bool is_written_;
+
   std::unique_ptr<trigger::TriggerSet> on_commit_triggers_;
 
   /** one default transaction is NOT 'read only' unless it is marked 'read only' explicitly*/

--- a/src/include/concurrency/transaction_context.h
+++ b/src/include/concurrency/transaction_context.h
@@ -171,8 +171,9 @@ class TransactionContext : public Printable {
    * @brief      Delete the record.
    *
    * @param[in]  <unnamed>  The logical physical location of the record
+   * @return    true if INS_DEL, false if DELETE
    */
-  void RecordDelete(const ItemPointer &);
+  bool RecordDelete(const ItemPointer &);
 
   RWType GetRWType(const ItemPointer &);
 

--- a/src/include/concurrency/transaction_context.h
+++ b/src/include/concurrency/transaction_context.h
@@ -171,10 +171,8 @@ class TransactionContext : public Printable {
    * @brief      Delete the record.
    *
    * @param[in]  <unnamed>  The logical physical location of the record
-   *
-   * @return     Return true if we detect INS_DEL.
    */
-  bool RecordDelete(const ItemPointer &);
+  void RecordDelete(const ItemPointer &);
 
   RWType GetRWType(const ItemPointer &);
 
@@ -336,9 +334,6 @@ class TransactionContext : public Printable {
 
   /** result of the transaction */
   ResultType result_ = ResultType::SUCCESS;
-
-  bool is_written_;
-  size_t insert_count_;
 
   IsolationLevelType isolation_level_;
 

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1002,7 +1002,7 @@ std::shared_ptr<storage::TileGroup> DataTable::GetTileGroup(
   PELOTON_ASSERT(tile_group_offset < GetTileGroupCount());
 
   auto tile_group_id =
-      tile_groups_.FindValid(tile_group_offset, invalid_tile_group_id);
+      tile_groups_.Find(tile_group_offset);
 
   return GetTileGroupById(tile_group_id);
 }

--- a/src/storage/data_table.cpp
+++ b/src/storage/data_table.cpp
@@ -1002,7 +1002,7 @@ std::shared_ptr<storage::TileGroup> DataTable::GetTileGroup(
   PELOTON_ASSERT(tile_group_offset < GetTileGroupCount());
 
   auto tile_group_id =
-      tile_groups_.Find(tile_group_offset);
+      tile_groups_.FindValid(tile_group_offset, invalid_tile_group_id);
 
   return GetTileGroupById(tile_group_id);
 }

--- a/test/common/lock_free_array_test.cpp
+++ b/test/common/lock_free_array_test.cpp
@@ -96,8 +96,7 @@ TEST_F(LockFreeArrayTests, SharedPointerTest2) {
 }
 
 TEST_F(LockFreeArrayTests, FindValidAndEraseTest) {
-
-  typedef uint32_t  value_type;
+  typedef uint32_t value_type;
 
   {
     LockFreeArray<value_type> array;
@@ -105,7 +104,7 @@ TEST_F(LockFreeArrayTests, FindValidAndEraseTest) {
     value_type invalid_value = 6288;
 
     size_t const element_count = 3;
-    for (size_t element = 0; element < element_count; ++element ) {
+    for (size_t element = 0; element < element_count; ++element) {
       array.Append(element);
     }
 
@@ -120,12 +119,10 @@ TEST_F(LockFreeArrayTests, FindValidAndEraseTest) {
     // in range, erased
     EXPECT_EQ(invalid_value, array.FindValid(2, invalid_value));
   }
-
 }
 
 TEST_F(LockFreeArrayTests, ClearAndIsEmptyTest) {
-
-  typedef uint32_t  value_type;
+  typedef uint32_t value_type;
 
   {
     LockFreeArray<value_type> array;
@@ -133,7 +130,7 @@ TEST_F(LockFreeArrayTests, ClearAndIsEmptyTest) {
     EXPECT_TRUE(array.IsEmpty());
 
     size_t const element_count = 3;
-    for (size_t element = 0; element < element_count; ++element ) {
+    for (size_t element = 0; element < element_count; ++element) {
       array.Append(element);
     }
 
@@ -145,16 +142,12 @@ TEST_F(LockFreeArrayTests, ClearAndIsEmptyTest) {
 
     EXPECT_TRUE(array.IsEmpty());
 
-
     EXPECT_FALSE(array.Contains(2));
-
   }
-
 }
 
 TEST_F(LockFreeArrayTests, ContainsTest) {
-
-  typedef uint32_t  value_type;
+  typedef uint32_t value_type;
 
   {
     LockFreeArray<value_type> array;
@@ -162,7 +155,7 @@ TEST_F(LockFreeArrayTests, ContainsTest) {
     EXPECT_FALSE(array.Contains(2));
 
     size_t const element_count = 3;
-    for (size_t element = 0; element < element_count; ++element ) {
+    for (size_t element = 0; element < element_count; ++element) {
       array.Append(element);
     }
 
@@ -171,20 +164,17 @@ TEST_F(LockFreeArrayTests, ContainsTest) {
     array.Clear();
 
     EXPECT_FALSE(array.Contains(2));
-
   }
-
 }
 
 TEST_F(LockFreeArrayTests, UpdateTest) {
-
-  typedef uint32_t  value_type;
+  typedef uint32_t value_type;
 
   {
     LockFreeArray<value_type> array;
 
     size_t const element_count = 3;
-    for (size_t element = 0; element < element_count; ++element ) {
+    for (size_t element = 0; element < element_count; ++element) {
       array.Append(element);
     }
 
@@ -193,9 +183,7 @@ TEST_F(LockFreeArrayTests, UpdateTest) {
     array.Update(2, 6288);
 
     EXPECT_EQ(6288, array.Find(2));
-
   }
-
 }
 
 }  // namespace test

--- a/test/common/lock_free_array_test.cpp
+++ b/test/common/lock_free_array_test.cpp
@@ -34,8 +34,7 @@ TEST_F(LockFreeArrayTests, BasicTest) {
 
     size_t const element_count = 3;
     for (size_t element = 0; element < element_count; ++element ) {
-      auto status = array.Append(element);
-      EXPECT_TRUE(status);
+      array.Append(element);
     }
 
     auto array_size = array.GetSize();
@@ -55,8 +54,7 @@ TEST_F(LockFreeArrayTests, SharedPointerTest1) {
     size_t const element_count = 3;
     for (size_t element = 0; element < element_count; ++element ) {
       std::shared_ptr<oid_t> entry(new oid_t);
-      auto status = array.Append(entry);
-      EXPECT_TRUE(status);
+      array.Append(entry);
     }
 
     auto array_size = array.GetSize();
@@ -77,8 +75,7 @@ TEST_F(LockFreeArrayTests, SharedPointerTest2) {
       size_t const element_count = 10000;
       for (size_t element = 0; element < element_count; ++element ) {
         std::shared_ptr<oid_t> entry(new oid_t);
-        auto status = array.Append(entry);
-        EXPECT_TRUE(status);
+        array.Append(entry);
       }
     });
 
@@ -86,8 +83,7 @@ TEST_F(LockFreeArrayTests, SharedPointerTest2) {
     size_t const element_count = 10000;
     for (size_t element = 0; element < element_count; ++element ) {
       std::shared_ptr<oid_t> entry(new oid_t);
-      auto status = array.Append(entry);
-      EXPECT_TRUE(status);
+      array.Append(entry);
     }
     t0.join();
 
@@ -97,6 +93,109 @@ TEST_F(LockFreeArrayTests, SharedPointerTest2) {
 
 
   }
+}
+
+TEST_F(LockFreeArrayTests, FindValidAndEraseTest) {
+
+  typedef uint32_t  value_type;
+
+  {
+    LockFreeArray<value_type> array;
+
+    value_type invalid_value = 6288;
+
+    size_t const element_count = 3;
+    for (size_t element = 0; element < element_count; ++element ) {
+      array.Append(element);
+    }
+
+    // in range, valid
+    EXPECT_EQ(2, array.FindValid(2, invalid_value));
+
+    // out of range
+    EXPECT_EQ(invalid_value, array.FindValid(6, invalid_value));
+
+    array.Erase(2, invalid_value);
+
+    // in range, erased
+    EXPECT_EQ(invalid_value, array.FindValid(2, invalid_value));
+  }
+
+}
+
+TEST_F(LockFreeArrayTests, ClearAndIsEmptyTest) {
+
+  typedef uint32_t  value_type;
+
+  {
+    LockFreeArray<value_type> array;
+
+    EXPECT_TRUE(array.IsEmpty());
+
+    size_t const element_count = 3;
+    for (size_t element = 0; element < element_count; ++element ) {
+      array.Append(element);
+    }
+
+    EXPECT_TRUE(array.Contains(2));
+
+    EXPECT_FALSE(array.IsEmpty());
+
+    array.Clear();
+
+    EXPECT_TRUE(array.IsEmpty());
+
+
+    EXPECT_FALSE(array.Contains(2));
+
+  }
+
+}
+
+TEST_F(LockFreeArrayTests, ContainsTest) {
+
+  typedef uint32_t  value_type;
+
+  {
+    LockFreeArray<value_type> array;
+
+    EXPECT_FALSE(array.Contains(2));
+
+    size_t const element_count = 3;
+    for (size_t element = 0; element < element_count; ++element ) {
+      array.Append(element);
+    }
+
+    EXPECT_TRUE(array.Contains(2));
+
+    array.Clear();
+
+    EXPECT_FALSE(array.Contains(2));
+
+  }
+
+}
+
+TEST_F(LockFreeArrayTests, UpdateTest) {
+
+  typedef uint32_t  value_type;
+
+  {
+    LockFreeArray<value_type> array;
+
+    size_t const element_count = 3;
+    for (size_t element = 0; element < element_count; ++element ) {
+      array.Append(element);
+    }
+
+    EXPECT_EQ(2, array.Find(2));
+
+    array.Update(2, 6288);
+
+    EXPECT_EQ(6288, array.Find(2));
+
+  }
+
 }
 
 }  // namespace test

--- a/test/common/lock_free_array_test.cpp
+++ b/test/common/lock_free_array_test.cpp
@@ -101,23 +101,21 @@ TEST_F(LockFreeArrayTests, FindValidAndEraseTest) {
   {
     LockFreeArray<value_type> array;
 
-    value_type invalid_value = 6288;
-
     size_t const element_count = 3;
     for (size_t element = 0; element < element_count; ++element) {
       array.Append(element);
     }
 
     // in range, valid
-    EXPECT_EQ(2, array.FindValid(2, invalid_value));
+    EXPECT_EQ(2, array.FindValid(2, INVALID_OID));
 
     // out of range
-    EXPECT_EQ(invalid_value, array.FindValid(6, invalid_value));
+    EXPECT_EQ(INVALID_OID, array.FindValid(6, INVALID_OID));
 
-    array.Erase(2, invalid_value);
+    array.Erase(2, INVALID_OID);
 
     // in range, erased
-    EXPECT_EQ(invalid_value, array.FindValid(2, invalid_value));
+    EXPECT_EQ(INVALID_OID, array.FindValid(2, INVALID_OID));
   }
 }
 


### PR DESCRIPTION
**LockFreeArray:**
- Changed functions that unconditionally returned true to be void.
- Rewrote FindValid to no longer be O(n) lookups. This is used in DataTable:GetTileGroup() and should be fast.
- Added Doxygen comments.
- Added more tests.

**TimestampOrderingTransactionManger:**
- Keep track of last accessed tile_group_id and if it's the same avoid going to the StorageManager’s CuckooHashMap for the TileGroup.

**TransactionContext:**
- Simplified conditionals to what should be equivalent logic. Reduced lookups for Release mode, increased lookups in Debug mode (by moving lookups that only served for PELOTON_ASSERTs into individual lookups inside the ASSERTs)
- Removed the iterator hints since Intel docs show they're not used:
https://software.intel.com/en-us/node/506175
- Removed is_written_ and insert_count_ members and related logic since they were not used for anything.

@pervazea is going to help me out and grab callgrind numbers when he has time to demonstrate these improvements.