### PR TITLE
Read-Only TxnContext Interface; Read-Only (single-statement select, txn) optimizations

### DIFF
--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -623,6 +623,14 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
   //// handle other isolation levels
   //////////////////////////////////////////////////////////
 
+  auto &rw_set = current_txn->GetReadWriteSet();
+
+  // if no modifying queries, treat as read-only
+  if (rw_set.empty()) {
+    EndTransaction(current_txn);
+    return ResultType::SUCCESS;
+  }
+
   auto storage_manager = storage::StorageManager::GetInstance();
   auto &log_manager = logging::LogManager::GetInstance();
 
@@ -631,7 +639,6 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
   // generate transaction id.
   cid_t end_commit_id = current_txn->GetCommitId();
 
-  auto &rw_set = current_txn->GetReadWriteSet();
   auto &rw_object_set = current_txn->GetCreateDropSet();
 
   auto gc_set = current_txn->GetGCSetPtr();

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -171,10 +171,9 @@ void TimestampOrderingTransactionManager::YieldOwnership(
   tile_group_header->SetTransactionId(tuple_id, INITIAL_TXN_ID);
 }
 
-bool TimestampOrderingTransactionManager::PerformRead(TransactionContext *const current_txn,
-                                                      const ItemPointer &read_location,
-                                                      storage::TileGroupHeader *tile_group_header,
-                                                      bool acquire_ownership) {
+bool TimestampOrderingTransactionManager::PerformRead(
+    TransactionContext *const current_txn, const ItemPointer &read_location,
+    storage::TileGroupHeader *tile_group_header, bool acquire_ownership) {
   ItemPointer location = read_location;
 
   //////////////////////////////////////////////////////////
@@ -374,7 +373,8 @@ void TimestampOrderingTransactionManager::PerformInsert(
   oid_t tuple_id = location.offset;
 
   auto storage_manager = storage::StorageManager::GetInstance();
-  auto tile_group_header = storage_manager->GetTileGroup(tile_group_id)->GetHeader();
+  auto tile_group_header =
+      storage_manager->GetTileGroup(tile_group_id)->GetHeader();
   auto transaction_id = current_txn->GetTransactionId();
 
   // check MVCC info
@@ -420,9 +420,8 @@ void TimestampOrderingTransactionManager::PerformUpdate(
   // version.
   PELOTON_ASSERT(tile_group_header->GetTransactionId(old_location.offset) ==
                  transaction_id);
-  PELOTON_ASSERT(
-      tile_group_header->GetPrevItemPointer(old_location.offset).IsNull() ==
-      true);
+  PELOTON_ASSERT(tile_group_header->GetPrevItemPointer(old_location.offset)
+                     .IsNull() == true);
 
   // check whether the new version is empty.
   PELOTON_ASSERT(new_tile_group_header->GetTransactionId(new_location.offset) ==
@@ -529,9 +528,8 @@ void TimestampOrderingTransactionManager::PerformDelete(
   PELOTON_ASSERT(tile_group_header->GetTransactionId(old_location.offset) ==
                  transaction_id);
   // we must be deleting the latest version.
-  PELOTON_ASSERT(
-      tile_group_header->GetPrevItemPointer(old_location.offset).IsNull() ==
-      true);
+  PELOTON_ASSERT(tile_group_header->GetPrevItemPointer(old_location.offset)
+                     .IsNull() == true);
 
   // check whether the new version is empty.
   PELOTON_ASSERT(new_tile_group_header->GetTransactionId(new_location.offset) ==
@@ -588,7 +586,8 @@ void TimestampOrderingTransactionManager::PerformDelete(
   oid_t tuple_id = location.offset;
 
   auto storage_manager = storage::StorageManager::GetInstance();
-  auto tile_group_header = storage_manager->GetTileGroup(tile_group_id)->GetHeader();
+  auto tile_group_header =
+      storage_manager->GetTileGroup(tile_group_id)->GetHeader();
 
   PELOTON_ASSERT(tile_group_header->GetTransactionId(tuple_id) ==
                  current_txn->GetTransactionId());
@@ -660,7 +659,8 @@ ResultType TimestampOrderingTransactionManager::CommitTransaction(
     oid_t tile_group_id = item_ptr.block;
     oid_t tuple_slot = item_ptr.offset;
 
-    auto tile_group_header = storage_manager->GetTileGroup(tile_group_id)->GetHeader();
+    auto tile_group_header =
+        storage_manager->GetTileGroup(tile_group_id)->GetHeader();
 
     if (tuple_entry.second == RWType::READ_OWN) {
       // A read operation has acquired ownership but hasn't done any further
@@ -811,7 +811,8 @@ ResultType TimestampOrderingTransactionManager::AbortTransaction(
     ItemPointer item_ptr = tuple_entry.first;
     oid_t tile_group_id = item_ptr.block;
     oid_t tuple_slot = item_ptr.offset;
-    auto tile_group_header = storage_manager->GetTileGroup(tile_group_id)->GetHeader();
+    auto tile_group_header =
+        storage_manager->GetTileGroup(tile_group_id)->GetHeader();
 
     if (tuple_entry.second == RWType::READ_OWN) {
       // A read operation has acquired ownership but hasn't done any further

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -101,7 +101,6 @@ RWType TransactionContext::GetRWType(const ItemPointer &location) {
 }
 
 void TransactionContext::RecordRead(const ItemPointer &location) {
-
   auto rw_set_it = rw_set_.find(location);
   if (rw_set_it != rw_set_.end()) {
     UNUSED_ATTRIBUTE RWType rw_type = rw_set_it->second;

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -48,24 +48,26 @@ namespace concurrency {
  *    i : insert
  */
 
-TransactionContext::TransactionContext(const size_t thread_id,
+TransactionContext::TransactionContext(bool read_only, const size_t thread_id,
                                        const IsolationLevelType isolation,
                                        const cid_t &read_id) {
-  Init(thread_id, isolation, read_id);
+  Init(read_only, thread_id, isolation, read_id);
 }
 
-TransactionContext::TransactionContext(const size_t thread_id,
+TransactionContext::TransactionContext(bool read_only, const size_t thread_id,
                                        const IsolationLevelType isolation,
                                        const cid_t &read_id,
                                        const cid_t &commit_id) {
-  Init(thread_id, isolation, read_id, commit_id);
+  Init(read_only, thread_id, isolation, read_id, commit_id);
 }
 
 TransactionContext::~TransactionContext() {}
 
-void TransactionContext::Init(const size_t thread_id,
+void TransactionContext::Init(bool read_only, const size_t thread_id,
                               const IsolationLevelType isolation,
                               const cid_t &read_id, const cid_t &commit_id) {
+  read_only_ = read_only;
+
   read_id_ = read_id;
 
   // commit id can be set at a transaction's commit phase.

--- a/src/concurrency/transaction_manager.cpp
+++ b/src/concurrency/transaction_manager.cpp
@@ -102,8 +102,9 @@ bool TransactionManager::IsOccupied(TransactionContext *const current_txn,
                                     const void *position_ptr) {
   ItemPointer &position = *((ItemPointer *)position_ptr);
 
-  auto tile_group_header =
-      storage::StorageManager::GetInstance()->GetTileGroup(position.block)->GetHeader();
+  auto tile_group_header = storage::StorageManager::GetInstance()
+                               ->GetTileGroup(position.block)
+                               ->GetHeader();
   auto tuple_id = position.offset;
 
   txn_id_t tuple_txn_id = tile_group_header->GetTransactionId(tuple_id);

--- a/src/concurrency/transaction_manager.cpp
+++ b/src/concurrency/transaction_manager.cpp
@@ -32,7 +32,7 @@ ConflictAvoidanceType TransactionManager::conflict_avoidance_ =
     ConflictAvoidanceType::ABORT;
 
 TransactionContext *TransactionManager::BeginTransaction(
-    const size_t thread_id, const IsolationLevelType type, bool read_only) {
+    bool read_only, const size_t thread_id, const IsolationLevelType type) {
   TransactionContext *txn = nullptr;
 
   if (type == IsolationLevelType::SNAPSHOT) {
@@ -45,9 +45,10 @@ TransactionContext *TransactionManager::BeginTransaction(
       cid_t commit_id = EpochManagerFactory::GetInstance().EnterEpoch(
           thread_id, TimestampType::COMMIT);
 
-      txn = new TransactionContext(thread_id, type, read_id, commit_id);
+      txn = new TransactionContext(read_only, thread_id, type, read_id,
+                                   commit_id);
     } else {
-      txn = new TransactionContext(thread_id, type, read_id);
+      txn = new TransactionContext(read_only, thread_id, type, read_id);
     }
 
   } else {
@@ -58,11 +59,7 @@ TransactionContext *TransactionManager::BeginTransaction(
     // transaction processing with decentralized epoch manager
     cid_t read_id = EpochManagerFactory::GetInstance().EnterEpoch(
         thread_id, TimestampType::READ);
-    txn = new TransactionContext(thread_id, type, read_id);
-  }
-
-  if (read_only) {
-    txn->SetReadOnly();
+    txn = new TransactionContext(read_only, thread_id, type, read_id);
   }
 
   txn->SetTimestamp(function::DateFunctions::Now());

--- a/src/include/concurrency/transaction_context.h
+++ b/src/include/concurrency/transaction_context.h
@@ -45,10 +45,10 @@ class TransactionContext : public Printable {
 
  public:
   TransactionContext(const size_t thread_id, const IsolationLevelType isolation,
-              const cid_t &read_id);
+                     const cid_t &read_id);
 
   TransactionContext(const size_t thread_id, const IsolationLevelType isolation,
-              const cid_t &read_id, const cid_t &commit_id);
+                     const cid_t &read_id, const cid_t &commit_id);
 
   /**
    * @brief      Destroys the object.
@@ -116,8 +116,9 @@ class TransactionContext : public Printable {
    *
    * @return     The query strings.
    */
-  inline const std::vector<std::string>& GetQueryStrings() const {
-                                                      return query_strings_; }
+  inline const std::vector<std::string> &GetQueryStrings() const {
+    return query_strings_;
+  }
 
   /**
    * @brief      Sets the commit identifier.
@@ -132,7 +133,7 @@ class TransactionContext : public Printable {
    * @param[in]  epoch_id  The epoch identifier
    */
   inline void SetEpochId(const eid_t epoch_id) { epoch_id_ = epoch_id; }
-  
+
   /**
    * @brief      Sets the timestamp.
    *
@@ -145,18 +146,18 @@ class TransactionContext : public Printable {
    *
    * @param[in]  query_string  The query string
    */
-  inline void AddQueryString(const char* query_string) {
+  inline void AddQueryString(const char *query_string) {
     query_strings_.push_back(std::string(query_string));
   }
 
   void RecordCreate(oid_t database_oid, oid_t table_oid, oid_t index_oid) {
-    rw_object_set_.push_back(std::make_tuple(database_oid, table_oid,
-                                index_oid, DDLType::CREATE));
+    rw_object_set_.push_back(
+        std::make_tuple(database_oid, table_oid, index_oid, DDLType::CREATE));
   }
 
   void RecordDrop(oid_t database_oid, oid_t table_oid, oid_t index_oid) {
-    rw_object_set_.push_back(std::make_tuple(database_oid, table_oid,
-                                index_oid, DDLType::DROP));
+    rw_object_set_.push_back(
+        std::make_tuple(database_oid, table_oid, index_oid, DDLType::DROP));
   }
 
   void RecordRead(const ItemPointer &);
@@ -262,17 +263,13 @@ class TransactionContext : public Printable {
    *
    * @return     True if read only, False otherwise.
    */
-  bool IsReadOnly() const {
-    return read_only_;
-  }
+  bool IsReadOnly() const { return read_only_; }
 
   /**
    * @brief      mark this context as read only
    *
    */
-  void SetReadOnly() {
-    read_only_ = true;
-  }
+  void SetReadOnly() { read_only_ = true; }
 
   /**
    * @brief      Gets the isolation level.
@@ -328,8 +325,8 @@ class TransactionContext : public Printable {
   ReadWriteSet rw_set_;
   CreateDropSet rw_object_set_;
 
-  /** 
-   * this set contains data location that needs to be gc'd in the transaction. 
+  /**
+   * this set contains data location that needs to be gc'd in the transaction.
    */
   std::shared_ptr<GCSet> gc_set_;
   std::shared_ptr<GCObjectSet> gc_object_set_;
@@ -344,7 +341,8 @@ class TransactionContext : public Printable {
 
   std::unique_ptr<trigger::TriggerSet> on_commit_triggers_;
 
-  /** one default transaction is NOT 'read only' unless it is marked 'read only' explicitly*/
+  /** one default transaction is NOT 'read only' unless it is marked 'read only'
+   * explicitly*/
   bool read_only_ = false;
 };
 

--- a/src/include/concurrency/transaction_context.h
+++ b/src/include/concurrency/transaction_context.h
@@ -44,11 +44,12 @@ class TransactionContext : public Printable {
   TransactionContext(TransactionContext const &) = delete;
 
  public:
-  TransactionContext(const size_t thread_id, const IsolationLevelType isolation,
-                     const cid_t &read_id);
+  TransactionContext(bool read_only, const size_t thread_id,
+                     const IsolationLevelType isolation, const cid_t &read_id);
 
-  TransactionContext(const size_t thread_id, const IsolationLevelType isolation,
-                     const cid_t &read_id, const cid_t &commit_id);
+  TransactionContext(bool read_only, const size_t thread_id,
+                     const IsolationLevelType isolation, const cid_t &read_id,
+                     const cid_t &commit_id);
 
   /**
    * @brief      Destroys the object.
@@ -56,13 +57,14 @@ class TransactionContext : public Printable {
   ~TransactionContext();
 
  private:
-  void Init(const size_t thread_id, const IsolationLevelType isolation,
-            const cid_t &read_id) {
-    Init(thread_id, isolation, read_id, read_id);
+  void Init(bool read_only, const size_t thread_id,
+            const IsolationLevelType isolation, const cid_t &read_id) {
+    Init(read_only, thread_id, isolation, read_id, read_id);
   }
 
-  void Init(const size_t thread_id, const IsolationLevelType isolation,
-            const cid_t &read_id, const cid_t &commit_id);
+  void Init(bool read_only, const size_t thread_id,
+            const IsolationLevelType isolation, const cid_t &read_id,
+            const cid_t &commit_id);
 
  public:
   //===--------------------------------------------------------------------===//
@@ -264,12 +266,6 @@ class TransactionContext : public Printable {
    * @return     True if read only, False otherwise.
    */
   bool IsReadOnly() const { return read_only_; }
-
-  /**
-   * @brief      mark this context as read only
-   *
-   */
-  void SetReadOnly() { read_only_ = true; }
 
   /**
    * @brief      Gets the isolation level.

--- a/src/include/concurrency/transaction_manager.h
+++ b/src/include/concurrency/transaction_manager.h
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include <atomic>
@@ -58,8 +57,7 @@ class TransactionManager {
    */
   virtual ~TransactionManager() {}
 
-  void Init(const ProtocolType protocol,
-            const IsolationLevelType isolation, 
+  void Init(const ProtocolType protocol, const IsolationLevelType isolation,
             const ConflictAvoidanceType conflict) {
     protocol_ = protocol;
     isolation_level_ = isolation;
@@ -74,9 +72,8 @@ class TransactionManager {
    *
    * @return     True if occupied, False otherwise.
    */
-  bool IsOccupied(
-      TransactionContext *const current_txn,
-      const void *position_ptr);
+  bool IsOccupied(TransactionContext *const current_txn,
+                  const void *position_ptr);
 
   /**
    * @brief      Determines if visible.
@@ -103,10 +100,9 @@ class TransactionManager {
    *
    * @return     True if owner, False otherwise.
    */
-  virtual bool IsOwner(
-      TransactionContext *const current_txn,
-      const storage::TileGroupHeader *const tile_group_header,
-      const oid_t &tuple_id) = 0;
+  virtual bool IsOwner(TransactionContext *const current_txn,
+                       const storage::TileGroupHeader *const tile_group_header,
+                       const oid_t &tuple_id) = 0;
 
   /**
    * This method tests whether any other transaction has owned this version.
@@ -117,10 +113,9 @@ class TransactionManager {
    *
    * @return     True if owned, False otherwise.
    */
-  virtual bool IsOwned(
-      TransactionContext *const current_txn,
-      const storage::TileGroupHeader *const tile_group_header,
-      const oid_t &tuple_id) = 0;
+  virtual bool IsOwned(TransactionContext *const current_txn,
+                       const storage::TileGroupHeader *const tile_group_header,
+                       const oid_t &tuple_id) = 0;
 
   /**
    * Test whether the current transaction has created this version of the tuple.
@@ -132,9 +127,9 @@ class TransactionManager {
    * @return     True if written, False otherwise.
    */
   virtual bool IsWritten(
-    TransactionContext *const current_txn,
-    const storage::TileGroupHeader *const tile_group_header,
-    const oid_t &tuple_id) = 0;
+      TransactionContext *const current_txn,
+      const storage::TileGroupHeader *const tile_group_header,
+      const oid_t &tuple_id) = 0;
 
   /**
    * Test whether it can obtain ownership.
@@ -161,7 +156,7 @@ class TransactionManager {
    */
   virtual bool AcquireOwnership(
       TransactionContext *const current_txn,
-      const storage::TileGroupHeader *const tile_group_header, 
+      const storage::TileGroupHeader *const tile_group_header,
       const oid_t &tuple_id) = 0;
 
   /**
@@ -173,8 +168,8 @@ class TransactionManager {
    */
   virtual void YieldOwnership(
       TransactionContext *const current_txn,
-      // const oid_t &tile_group_id, 
-      const storage::TileGroupHeader *const tile_group_header, 
+      // const oid_t &tile_group_id,
+      const storage::TileGroupHeader *const tile_group_header,
       const oid_t &tuple_id) = 0;
 
   /**
@@ -186,14 +181,13 @@ class TransactionManager {
    * @param      index_entry_ptr  The index entry pointer
    */
   virtual void PerformInsert(TransactionContext *const current_txn,
-                             const ItemPointer &location, 
+                             const ItemPointer &location,
                              ItemPointer *index_entry_ptr = nullptr) = 0;
 
   virtual bool PerformRead(TransactionContext *const current_txn,
-                             const ItemPointer &location,
-                             storage::TileGroupHeader *tile_group_header,
-                             bool acquire_ownership) = 0;
-
+                           const ItemPointer &location,
+                           storage::TileGroupHeader *tile_group_header,
+                           bool acquire_ownership) = 0;
 
   virtual void PerformUpdate(TransactionContext *const current_txn,
                              const ItemPointer &old_location,
@@ -215,7 +209,8 @@ class TransactionManager {
    * @param      current_txn  The current transaction
    * @param[in]  result       The result
    */
-  void SetTransactionResult(TransactionContext *const current_txn, const ResultType result) {
+  void SetTransactionResult(TransactionContext *const current_txn,
+                            const ResultType result) {
     current_txn->SetResult(result);
   }
 
@@ -223,9 +218,9 @@ class TransactionManager {
     return BeginTransaction(0, type, false);
   }
 
-  TransactionContext *BeginTransaction(const size_t thread_id = 0,
-                                const IsolationLevelType type = isolation_level_,
-                                bool read_only = false);
+  TransactionContext *BeginTransaction(
+      const size_t thread_id = 0,
+      const IsolationLevelType type = isolation_level_, bool read_only = false);
 
   /**
    * @brief      Ends a transaction.
@@ -245,7 +240,8 @@ class TransactionManager {
   virtual ResultType CommitTransaction(
       TransactionContext *const current_txn) = 0;
 
-  virtual ResultType AbortTransaction(TransactionContext *const current_txn) = 0;
+  virtual ResultType AbortTransaction(
+      TransactionContext *const current_txn) = 0;
 
   /**
    * This function generates the maximum commit id of committed transactions.
@@ -263,15 +259,12 @@ class TransactionManager {
    *
    * @return     The isolation level.
    */
-  IsolationLevelType GetIsolationLevel() {
-    return isolation_level_;
-  }
+  IsolationLevelType GetIsolationLevel() { return isolation_level_; }
 
  protected:
   static ProtocolType protocol_;
   static IsolationLevelType isolation_level_;
   static ConflictAvoidanceType conflict_avoidance_;
-
 };
 }  // namespace storage
 }  // namespace peloton

--- a/src/include/concurrency/transaction_manager.h
+++ b/src/include/concurrency/transaction_manager.h
@@ -214,13 +214,19 @@ class TransactionManager {
     current_txn->SetResult(result);
   }
 
+  TransactionContext *BeginTransaction() { return BeginTransaction(false); }
+
+  TransactionContext *BeginTransaction(const size_t thread_id) {
+    return BeginTransaction(false, thread_id, isolation_level_);
+  }
+
   TransactionContext *BeginTransaction(const IsolationLevelType type) {
-    return BeginTransaction(0, type, false);
+    return BeginTransaction(false, 0, type);
   }
 
   TransactionContext *BeginTransaction(
-      const size_t thread_id = 0,
-      const IsolationLevelType type = isolation_level_, bool read_only = false);
+      bool read_only, const size_t thread_id = 0,
+      const IsolationLevelType type = isolation_level_);
 
   /**
    * @brief      Ends a transaction.

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -164,7 +164,9 @@ executor::ExecutionResult TrafficCop::ExecuteHelper(
     // new txn, reset result status
     curr_state.second = ResultType::SUCCESS;
     single_statement_txn_ = true;
-    txn = txn_manager.BeginTransaction(thread_id);
+    // txn is read-only for single-statement select
+    bool read_only = statement_->GetQueryType() == QueryType::QUERY_SELECT;
+    txn = txn_manager.BeginTransaction(read_only, thread_id);
     tcop_txn_state_.emplace(txn, ResultType::SUCCESS);
   }
 


### PR DESCRIPTION
#1396 
1. Removed default read_only=false from [TransactionManager::BeginTransaction](https://github.com/lmwnshn/peloton/commit/e506f17d043581af0e77369899edf01b0174bd94#diff-cb353f0475324594d1f1c27b15dd2247R228)
2. Removed [TransactionContext::SetReadOnly](https://github.com/lmwnshn/peloton/commit/e506f17d043581af0e77369899edf01b0174bd94#diff-4d5037ca29ea43576b5613d89b7f7f09L268)
3. Added read-only param to TransactionContext [constructors](https://github.com/lmwnshn/peloton/commit/e506f17d043581af0e77369899edf01b0174bd94#diff-4d5037ca29ea43576b5613d89b7f7f09L47)
4. Transactions with no modifying queries treated as [read-only](https://github.com/lmwnshn/peloton/commit/8b1531b98f0d40bcd13edad89de8f7fb2cac0871#diff-10269290aecfeb50f6ad7d6c0748819fR626)
  4.1 assumption: if transaction is marked read-only, then READ transactions are not added to ReadWriteSet

#1395 
Single-statement selects are marked as [read-only](https://github.com/lmwnshn/peloton/commit/467834ca5cf6ae3182755220c9a0b4906cf85cbc#diff-023fd34a4233a33e1d640a552340f34cR167)