### PR TITLE
Fix HashTable::BuildLazy if it contains zero emelemts

### DIFF
--- a/src/codegen/util/hash_table.cpp
+++ b/src/codegen/util/hash_table.cpp
@@ -191,6 +191,9 @@ char *HashTable::Insert(uint64_t hash) {
 }
 
 void HashTable::BuildLazy() {
+  // Early exit if no elements have been added (hash table is still valid)
+  if (num_elems_ == 0) return;
+
   // Grab entry head
   Entry *head = directory_[0];
 

--- a/test/codegen/hash_table_test.cpp
+++ b/test/codegen/hash_table_test.cpp
@@ -105,6 +105,33 @@ TEST_F(HashTableTest, CanInsertUniqueKeys) {
   }
 }
 
+TEST_F(HashTableTest, BuildEmptyHashTable) {
+  codegen::util::HashTable table{GetMemPool(), sizeof(Key), sizeof(Value)};
+
+  std::vector<Key> keys;
+
+  // Insert keys
+  for (uint32_t i = 0; i < 10; i++) {
+    Key k{1, i};
+    // do NOT insert into hash table
+
+    keys.emplace_back(k);
+  }
+
+  EXPECT_EQ(0, table.NumElements());
+
+  // Build lazy
+  table.BuildLazy();
+
+  // Lookups should succeed
+  for (const auto &key : keys) {
+    std::function<void(const Value &v)> f =
+        [](UNUSED_ATTRIBUTE const Value &v) {};
+    auto ret = table.TypedProbe(key.Hash(), key, f);
+    EXPECT_EQ(false, ret);
+  }
+}
+
 TEST_F(HashTableTest, CanInsertDuplicateKeys) {
   codegen::util::HashTable table{GetMemPool(), sizeof(Key), sizeof(Value)};
 


### PR DESCRIPTION
Avoids a call to `NextPowerOf2` with zero when the hash table doesn't contain any elements in the function `HashTable::BuildLazy`. Occurred when running TPC-H Q3 in Peloton. 