### PR TITLE
Performance fix: replace WorkerPool sleeping with condition variable

### DIFF
--- a/src/include/threadpool/mono_queue_pool.h
+++ b/src/include/threadpool/mono_queue_pool.h
@@ -83,7 +83,11 @@ inline void MonoQueuePool::SubmitTask(const F &func) {
   if (!is_running_) {
     Startup();
   }
-  task_queue_.Enqueue(std::move(func));
+  {
+    std::lock_guard<std::mutex> lock(worker_pool_.cv_lock);
+    task_queue_.Enqueue(std::move(func));
+  }
+  worker_pool_.not_empty.notify_one();
 }
 
 inline MonoQueuePool &MonoQueuePool::GetInstance() {

--- a/src/include/threadpool/worker_pool.h
+++ b/src/include/threadpool/worker_pool.h
@@ -13,7 +13,9 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
 #include <functional>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -51,6 +53,9 @@ class WorkerPool {
    * @return The number of worker threads assigned to this pool
    */
   uint32_t NumWorkers() const { return num_workers_; }
+
+  std::mutex cv_lock;
+  std::condition_variable not_empty;
 
  private:
   // The name of this pool

--- a/src/threadpool/worker_pool.cpp
+++ b/src/threadpool/worker_pool.cpp
@@ -28,7 +28,7 @@ void WorkerFunc(std::string thread_name, std::atomic_bool *is_running,
 
   while (is_running->load() || !task_queue->IsEmpty()) {
     std::unique_lock<std::mutex> lock(*cv_lock);
-    not_empty->wait_for(lock, std::chrono::milliseconds(1),
+    not_empty->wait_for(lock, std::chrono::seconds(1),
                         [&] { return !task_queue->IsEmpty(); });
     std::function<void()> task;
     if (task_queue->Dequeue(task)) {


### PR DESCRIPTION
I couldn't stare at concurrency control logic anymore this afternoon, so I threw together a quick experiment replacing our WorkerPool's sleep with exponential backoff behavior for [C++11's std::condition_variable](https://en.cppreference.com/w/cpp/thread/condition_variable). This change applies to any WorkerPool's created by a MonoQueuePool, which is currently the query worker threads, the parallel worker threads for codegen, and Brain worker threads.

I benchmarked using the same configs from #1401:

TPC-C: 15 runs, 60 seconds each, 4 terminals, scale factor 4
YCSB (read-only): 15 runs, 60 seconds each, 4 terminals, scale factor 1000

|       | master μ | master σ | branch μ | branch σ |
|-------|----------|----------|---------------|---------------|
| TPC-C |   329       |    22      |     344          |     11          |
| YCSB  |   16580       |   167       |   18186            |     56          |

It seems 5-10% faster in limited testing.

Right now I'm interested in feedback about if this has already been explored, and any concerns others might have with using this approach. I'm mostly interested in scalability, and would like to see how this fares on something with multiple sockets and a lot of cores. I'm also wondering if this actually falls apart when we do get our TPS numbers up where they should be.