### PR TITLE
TileGroupHeader refactor

### DIFF
--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -307,7 +307,7 @@ bool TimestampOrderingTransactionManager::PerformRead(TransactionContext *const 
       PELOTON_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id) == true);
       PELOTON_ASSERT(tile_group_header->GetLastReaderCommitId(tuple_id) ==
                          current_txn->GetCommitId() ||
-          tile_group_header->GetLastReaderCommitId(tuple_id) == 0);
+                     tile_group_header->GetLastReaderCommitId(tuple_id) == 0);
       return true;
 
     } else {
@@ -331,7 +331,7 @@ bool TimestampOrderingTransactionManager::PerformRead(TransactionContext *const 
         // then perform read directly.
         PELOTON_ASSERT(tile_group_header->GetLastReaderCommitId(tuple_id) ==
                            current_txn->GetCommitId() ||
-            tile_group_header->GetLastReaderCommitId(tuple_id) == 0);
+                       tile_group_header->GetLastReaderCommitId(tuple_id) == 0);
 
         // this version must already be in the read/write set.
         // so no need to update read set.
@@ -493,9 +493,8 @@ void TimestampOrderingTransactionManager::PerformDelete(
 
   auto transaction_id = current_txn->GetTransactionId();
 
-  PELOTON_ASSERT(
-      tile_group_header->GetLastReaderCommitId(old_location.offset) ==
-      current_txn->GetCommitId());
+  PELOTON_ASSERT(tile_group_header->GetLastReaderCommitId(
+                     old_location.offset) == current_txn->GetCommitId());
 
   // if we can perform delete, then we must have already locked the older
   // version.

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -27,30 +27,13 @@
 namespace peloton {
 namespace concurrency {
 
-common::synchronization::SpinLatch *
-TimestampOrderingTransactionManager::GetSpinLatchField(
-    const storage::TileGroupHeader *const tile_group_header,
-    const oid_t &tuple_id) {
-  return (
-      common::synchronization::SpinLatch
-          *)(tile_group_header->GetReservedFieldRef(tuple_id) + LOCK_OFFSET);
-}
-
-cid_t TimestampOrderingTransactionManager::GetLastReaderCommitId(
-    const storage::TileGroupHeader *const tile_group_header,
-    const oid_t &tuple_id) {
-  return *(cid_t *)(tile_group_header->GetReservedFieldRef(tuple_id) +
-                    LAST_READER_OFFSET);
-}
-
 bool TimestampOrderingTransactionManager::SetLastReaderCommitId(
     const storage::TileGroupHeader *const tile_group_header,
     const oid_t &tuple_id, const cid_t &current_cid, const bool is_owner) {
   // get the pointer to the last_reader_cid field.
-  cid_t *ts_ptr = (cid_t *)(tile_group_header->GetReservedFieldRef(tuple_id) +
-                            LAST_READER_OFFSET);
+  cid_t read_ts = tile_group_header->GetLastReaderCommitId(tuple_id);
 
-  GetSpinLatchField(tile_group_header, tuple_id)->Lock();
+  tile_group_header->GetSpinLatch(tuple_id)->Lock();
 
   txn_id_t tuple_txn_id = tile_group_header->GetTransactionId(tuple_id);
 
@@ -58,27 +41,18 @@ bool TimestampOrderingTransactionManager::SetLastReaderCommitId(
     // if the write lock has already been acquired by some concurrent
     // transactions,
     // then return without setting the last_reader_cid.
-    GetSpinLatchField(tile_group_header, tuple_id)->Unlock();
+    tile_group_header->GetSpinLatch(tuple_id)->Unlock();
     return false;
   } else {
     // if current_cid is larger than the current value of last_reader_cid field,
     // then set last_reader_cid to current_cid.
-    if (*ts_ptr < current_cid) {
-      *ts_ptr = current_cid;
+    if (read_ts < current_cid) {
+      tile_group_header->SetLastReaderCommitId(tuple_id, current_cid);
     }
 
-    GetSpinLatchField(tile_group_header, tuple_id)->Unlock();
+    tile_group_header->GetSpinLatch(tuple_id)->Unlock();
     return true;
   }
-}
-
-void TimestampOrderingTransactionManager::InitTupleReserved(
-    const storage::TileGroupHeader *const tile_group_header,
-    const oid_t tuple_id) {
-  auto reserved_area = tile_group_header->GetReservedFieldRef(tuple_id);
-
-  new ((reserved_area + LOCK_OFFSET)) common::synchronization::SpinLatch();
-  *(cid_t *)(reserved_area + LAST_READER_OFFSET) = 0;
 }
 
 TimestampOrderingTransactionManager &
@@ -138,25 +112,25 @@ bool TimestampOrderingTransactionManager::AcquireOwnership(
   // to acquire the ownership,
   // we must guarantee that no transaction that has read
   // the tuple has a larger timestamp than the current transaction.
-  GetSpinLatchField(tile_group_header, tuple_id)->Lock();
+  tile_group_header->GetSpinLatch(tuple_id)->Lock();
   // change timestamp
-  cid_t last_reader_cid = GetLastReaderCommitId(tile_group_header, tuple_id);
+  cid_t last_reader_cid = tile_group_header->GetLastReaderCommitId(tuple_id);
 
   // must compare last_reader_cid with a transaction's commit_id
   // (rather than read_id).
   // consider a transaction that is executed under snapshot isolation.
   // in this case, commit_id is not equal to read_id.
   if (last_reader_cid > current_txn->GetCommitId()) {
-    GetSpinLatchField(tile_group_header, tuple_id)->Unlock();
+    tile_group_header->GetSpinLatch(tuple_id)->Unlock();
 
     return false;
   } else {
     if (tile_group_header->SetAtomicTransactionId(tuple_id, txn_id) == false) {
-      GetSpinLatchField(tile_group_header, tuple_id)->Unlock();
+      tile_group_header->GetSpinLatch(tuple_id)->Unlock();
 
       return false;
     } else {
-      GetSpinLatchField(tile_group_header, tuple_id)->Unlock();
+      tile_group_header->GetSpinLatch(tuple_id)->Unlock();
 
       return true;
     }
@@ -328,9 +302,9 @@ bool TimestampOrderingTransactionManager::PerformRead(TransactionContext *const 
 
       // if we have already owned the version.
       PELOTON_ASSERT(IsOwner(current_txn, tile_group_header, tuple_id) == true);
-      PELOTON_ASSERT(GetLastReaderCommitId(tile_group_header, tuple_id) ==
+      PELOTON_ASSERT(tile_group_header->GetLastReaderCommitId(tuple_id) ==
                          current_txn->GetCommitId() ||
-                     GetLastReaderCommitId(tile_group_header, tuple_id) == 0);
+          tile_group_header->GetLastReaderCommitId(tuple_id) == 0);
       return true;
 
     } else {
@@ -352,9 +326,9 @@ bool TimestampOrderingTransactionManager::PerformRead(TransactionContext *const 
       } else {
         // if the current transaction has already owned this tuple,
         // then perform read directly.
-        PELOTON_ASSERT(GetLastReaderCommitId(tile_group_header, tuple_id) ==
+        PELOTON_ASSERT(tile_group_header->GetLastReaderCommitId(tuple_id) ==
                            current_txn->GetCommitId() ||
-                       GetLastReaderCommitId(tile_group_header, tuple_id) == 0);
+            tile_group_header->GetLastReaderCommitId(tuple_id) == 0);
 
         // this version must already be in the read/write set.
         // so no need to update read set.
@@ -390,8 +364,6 @@ void TimestampOrderingTransactionManager::PerformInsert(
 
   // Add the new tuple into the insert set
   current_txn->RecordInsert(location);
-
-  InitTupleReserved(tile_group_header, tuple_id);
 
   // Write down the head pointer's address in tile group header
   tile_group_header->SetIndirection(tuple_id, index_entry_ptr);
@@ -445,8 +417,6 @@ void TimestampOrderingTransactionManager::PerformUpdate(
   // we should guarantee that the newer version is all set before linking the
   // newer version to older version.
   COMPILER_MEMORY_FENCE;
-
-  InitTupleReserved(new_tile_group_header, new_location.offset);
 
   // we must be updating the latest version.
   // Set the header information for the new version
@@ -521,7 +491,7 @@ void TimestampOrderingTransactionManager::PerformDelete(
   auto transaction_id = current_txn->GetTransactionId();
 
   PELOTON_ASSERT(
-      GetLastReaderCommitId(tile_group_header, old_location.offset) ==
+      tile_group_header->GetLastReaderCommitId(old_location.offset) ==
       current_txn->GetCommitId());
 
   // if we can perform delete, then we must have already locked the older
@@ -553,8 +523,6 @@ void TimestampOrderingTransactionManager::PerformDelete(
   // we should guarantee that the newer version is all set before linking the
   // newer version to older version.
   COMPILER_MEMORY_FENCE;
-
-  InitTupleReserved(new_tile_group_header, new_location.offset);
 
   // we must be deleting the latest version.
   // Set the header information for the new version

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -35,7 +35,6 @@ bool TransactionLevelGCManager::ResetTuple(const ItemPointer &location) {
   auto tile_group_header = tile_group->GetHeader();
 
   // Reset the header
-  tile_group_header->SetSpinLatch(location.offset);
   tile_group_header->SetTransactionId(location.offset, INVALID_TXN_ID);
   tile_group_header->SetLastReaderCommitId(location.offset, INVALID_CID);
   tile_group_header->SetBeginCommitId(location.offset, MAX_CID);

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -35,14 +35,14 @@ bool TransactionLevelGCManager::ResetTuple(const ItemPointer &location) {
   auto tile_group_header = tile_group->GetHeader();
 
   // Reset the header
+  tile_group_header->SetSpinLatch(location.offset);
   tile_group_header->SetTransactionId(location.offset, INVALID_TXN_ID);
+  tile_group_header->SetLastReaderCommitId(location.offset, INVALID_CID);
   tile_group_header->SetBeginCommitId(location.offset, MAX_CID);
   tile_group_header->SetEndCommitId(location.offset, MAX_CID);
-  tile_group_header->SetPrevItemPointer(location.offset, INVALID_ITEMPOINTER);
   tile_group_header->SetNextItemPointer(location.offset, INVALID_ITEMPOINTER);
-
-  PELOTON_MEMSET(tile_group_header->GetReservedFieldRef(location.offset), 0,
-                 storage::TileGroupHeader::GetReservedSize());
+  tile_group_header->SetPrevItemPointer(location.offset, INVALID_ITEMPOINTER);
+  tile_group_header->SetIndirection(location.offset, nullptr);
 
   // Reclaim the varlen pool
   CheckAndReclaimVarlenColumns(tile_group, location.offset);

--- a/src/include/concurrency/timestamp_ordering_transaction_manager.h
+++ b/src/include/concurrency/timestamp_ordering_transaction_manager.h
@@ -238,9 +238,7 @@ class TimestampOrderingTransactionManager : public TransactionManager {
    */
   virtual ResultType AbortTransaction(TransactionContext *const current_txn);
 
-
-private:
-
+ private:
   /**
    * @brief      Sets the last reader commit identifier.
    *
@@ -253,9 +251,7 @@ private:
    */
   bool SetLastReaderCommitId(
       const storage::TileGroupHeader *const tile_group_header,
-      const oid_t &tuple_id, 
-      const cid_t &current_cid, 
-      const bool is_owner);
+      const oid_t &tuple_id, const cid_t &current_cid, const bool is_owner);
 };
 }
 }

--- a/src/include/concurrency/timestamp_ordering_transaction_manager.h
+++ b/src/include/concurrency/timestamp_ordering_transaction_manager.h
@@ -240,38 +240,6 @@ class TimestampOrderingTransactionManager : public TransactionManager {
 
 
 private:
-  static const int LOCK_OFFSET = 0;
-  static const int LAST_READER_OFFSET = (LOCK_OFFSET + 8);
-
-  /**
-   * @brief      Gets the spin latch field.
-   * 
-   * Timestamp ordering requires a spinlock field for protecting the atomic access
-   * to txn_id field and last_reader_cid field.
-   *
-   * @param[in]  tile_group_header  The tile group header
-   * @param[in]  tuple_id           The tuple identifier
-   *
-   * @return     The spin latch field.
-   */
-  common::synchronization::SpinLatch *GetSpinLatchField(
-      const storage::TileGroupHeader *const tile_group_header,
-      const oid_t &tuple_id);
-
-  /**
-   * @brief      Gets the last reader commit identifier.
-   * 
-   * In timestamp ordering, the last_reader_cid records the timestamp of the last
-   * transaction that reads the tuple.
-   *
-   * @param[in]  tile_group_header  The tile group header
-   * @param[in]  tuple_id           The tuple identifier
-   *
-   * @return     The last reader commit identifier.
-   */
-  cid_t GetLastReaderCommitId(
-      const storage::TileGroupHeader *const tile_group_header,
-      const oid_t &tuple_id);
 
   /**
    * @brief      Sets the last reader commit identifier.
@@ -288,16 +256,6 @@ private:
       const oid_t &tuple_id, 
       const cid_t &current_cid, 
       const bool is_owner);
-
-  /**
-   * Initialize reserved area of a tuple.
-   *
-   * @param[in]  tile_group_header  The tile group header
-   * @param[in]  tuple_id           The tuple identifier
-   */
-  void InitTupleReserved(
-      const storage::TileGroupHeader *const tile_group_header,
-      const oid_t tuple_id);
 };
 }
 }

--- a/src/include/storage/tile_group_header.h
+++ b/src/include/storage/tile_group_header.h
@@ -28,6 +28,17 @@ namespace storage {
 
 class TileGroup;
 
+struct TupleHeader {
+  std::unique_ptr<common::synchronization::SpinLatch> latch;
+  std::atomic<txn_id_t> txn_id;
+  cid_t read_ts;
+  cid_t begin_ts;
+  cid_t end_ts;
+  ItemPointer next;
+  ItemPointer prev;
+  ItemPointer *indirection;
+} __attribute__ ((aligned (64)));
+
 //===--------------------------------------------------------------------===//
 // Tile Group Header
 //===--------------------------------------------------------------------===//
@@ -63,8 +74,6 @@ class TileGroup;
  *  TxnID != INITIAL_TXN_ID, BeginTS == MAX_CID, EndTS == INVALID_CID --> to-be-installed deleted version
  */
 
-#define TUPLE_HEADER_LOCATION data + (tuple_slot_id * header_entry_size)
-
 class TileGroupHeader : public Printable {
   TileGroupHeader() = delete;
 
@@ -75,21 +84,30 @@ class TileGroupHeader : public Printable {
     // check for self-assignment
     if (&other == this) return *this;
 
-    header_size = other.header_size;
-
-    // copy over all the data
-    PELOTON_MEMCPY(data, other.data, header_size);
-
+    backend_type = other.backend_type;
+    tile_group = other.tile_group;
     num_tuple_slots = other.num_tuple_slots;
-    oid_t val = other.next_tuple_slot;
-    next_tuple_slot = val;
+    next_tuple_slot.store(other.next_tuple_slot);
+    immutable = other.immutable;
+
+    // copy tuple header values
+    for (oid_t tuple_slot_id = START_OID; tuple_slot_id < num_tuple_slots;
+         tuple_slot_id++) {
+      SetSpinLatch(tuple_slot_id);
+      SetTransactionId(tuple_slot_id, other.GetTransactionId(tuple_slot_id));
+      SetLastReaderCommitId(tuple_slot_id, other.GetLastReaderCommitId(tuple_slot_id));
+      SetBeginCommitId(tuple_slot_id, other.GetBeginCommitId(tuple_slot_id));
+      SetEndCommitId(tuple_slot_id, other.GetEndCommitId(tuple_slot_id));
+      SetNextItemPointer(tuple_slot_id, other.GetNextItemPointer(tuple_slot_id));
+      SetPrevItemPointer(tuple_slot_id, other.GetPrevItemPointer(tuple_slot_id));
+      SetIndirection(tuple_slot_id, other.GetIndirection(tuple_slot_id));
+    }
 
     return *this;
   }
 
-  ~TileGroupHeader();
+  ~TileGroupHeader() = default;
 
-  // this function is only called by DataTable::GetEmptyTupleSlot().
   oid_t GetNextEmptyTupleSlot() {
     if (next_tuple_slot >= num_tuple_slots) {
       return INVALID_OID;
@@ -145,36 +163,36 @@ class TileGroupHeader : public Printable {
     return tile_group;
   }
 
-  // it is possible that some other transactions are modifying the txn_id,
-  // but the current transaction reads the txn_id.
-  // the returned value seems to be uncertain.
+  inline common::synchronization::SpinLatch *GetSpinLatch(const oid_t &tuple_slot_id) const {
+    return tuple_headers_[tuple_slot_id].latch.get();
+  }
+
   inline txn_id_t GetTransactionId(const oid_t &tuple_slot_id) const {
-    return *((txn_id_t *)(TUPLE_HEADER_LOCATION));
+    return tuple_headers_[tuple_slot_id].txn_id;
+  }
+
+  inline cid_t GetLastReaderCommitId(const oid_t &tuple_slot_id) const {
+    return tuple_headers_[tuple_slot_id].read_ts;
   }
 
   inline cid_t GetBeginCommitId(const oid_t &tuple_slot_id) const {
-    return *((cid_t *)(TUPLE_HEADER_LOCATION + begin_cid_offset));
+    return tuple_headers_[tuple_slot_id].begin_ts;
   }
 
   inline cid_t GetEndCommitId(const oid_t &tuple_slot_id) const {
-    return *((cid_t *)(TUPLE_HEADER_LOCATION + end_cid_offset));
+    return tuple_headers_[tuple_slot_id].end_ts;
   }
 
   inline ItemPointer GetNextItemPointer(const oid_t &tuple_slot_id) const {
-    return *((ItemPointer *)(TUPLE_HEADER_LOCATION + next_pointer_offset));
+    return tuple_headers_[tuple_slot_id].next;
   }
 
   inline ItemPointer GetPrevItemPointer(const oid_t &tuple_slot_id) const {
-    return *((ItemPointer *)(TUPLE_HEADER_LOCATION + prev_pointer_offset));
+    return tuple_headers_[tuple_slot_id].prev;
   }
 
   inline ItemPointer *GetIndirection(const oid_t &tuple_slot_id) const {
-    return *(ItemPointer **)(TUPLE_HEADER_LOCATION + indirection_offset);
-  }
-
-  // constraint: at most 16 bytes.
-  inline char *GetReservedFieldRef(const oid_t &tuple_slot_id) const {
-    return (char *)(TUPLE_HEADER_LOCATION + reserved_field_offset);
+    return tuple_headers_[tuple_slot_id].indirection;
   }
 
   // Setters
@@ -182,49 +200,50 @@ class TileGroupHeader : public Printable {
   inline void SetTileGroup(TileGroup *tile_group) {
     this->tile_group = tile_group;
   }
+
+  inline void SetSpinLatch(const oid_t &tuple_slot_id) const {
+    tuple_headers_[tuple_slot_id].latch.reset(new common::synchronization::SpinLatch);
+  }
+
   inline void SetTransactionId(const oid_t &tuple_slot_id,
                                const txn_id_t &transaction_id) const {
-    *((txn_id_t *)(TUPLE_HEADER_LOCATION)) = transaction_id;
+    tuple_headers_[tuple_slot_id].txn_id = transaction_id;
+  }
+
+  inline void SetLastReaderCommitId(const oid_t &tuple_slot_id,
+                               const cid_t &read_cid) const {
+    tuple_headers_[tuple_slot_id].read_ts = read_cid;
   }
 
   inline void SetBeginCommitId(const oid_t &tuple_slot_id,
                                const cid_t &begin_cid) {
-    *((cid_t *)(TUPLE_HEADER_LOCATION + begin_cid_offset)) = begin_cid;
+    tuple_headers_[tuple_slot_id].begin_ts = begin_cid;
   }
 
   inline void SetEndCommitId(const oid_t &tuple_slot_id,
                              const cid_t &end_cid) const {
-    *((cid_t *)(TUPLE_HEADER_LOCATION + end_cid_offset)) = end_cid;
+    tuple_headers_[tuple_slot_id].end_ts = end_cid;
   }
 
   inline void SetNextItemPointer(const oid_t &tuple_slot_id,
                                  const ItemPointer &item) const {
-    *((ItemPointer *)(TUPLE_HEADER_LOCATION + next_pointer_offset)) = item;
+    tuple_headers_[tuple_slot_id].next = item;
   }
 
   inline void SetPrevItemPointer(const oid_t &tuple_slot_id,
                                  const ItemPointer &item) const {
-    *((ItemPointer *)(TUPLE_HEADER_LOCATION + prev_pointer_offset)) = item;
+    tuple_headers_[tuple_slot_id].prev = item;
   }
 
   inline void SetIndirection(const oid_t &tuple_slot_id,
-                             const ItemPointer *indirection) const {
-    *((const ItemPointer **)(TUPLE_HEADER_LOCATION + indirection_offset)) =
-        indirection;
-  }
-
-  inline txn_id_t SetAtomicTransactionId(const oid_t &tuple_slot_id,
-                                         const txn_id_t &old_txn_id,
-                                         const txn_id_t &new_txn_id) const {
-    txn_id_t *txn_id_ptr = (txn_id_t *)(TUPLE_HEADER_LOCATION);
-    return __sync_val_compare_and_swap(txn_id_ptr, old_txn_id, new_txn_id);
+                             ItemPointer *indirection) const {
+    tuple_headers_[tuple_slot_id].indirection = indirection;
   }
 
   inline bool SetAtomicTransactionId(const oid_t &tuple_slot_id,
                                      const txn_id_t &transaction_id) const {
-    txn_id_t *txn_id_ptr = (txn_id_t *)(TUPLE_HEADER_LOCATION);
-    return __sync_bool_compare_and_swap(txn_id_ptr, INITIAL_TXN_ID,
-                                        transaction_id);
+    auto old_val = INITIAL_TXN_ID;
+    return tuple_headers_[tuple_slot_id].txn_id.compare_exchange_strong(old_val, transaction_id);
   }
 
   /*
@@ -250,33 +269,12 @@ class TileGroupHeader : public Printable {
   // Getter for spin lock
   common::synchronization::SpinLatch &GetHeaderLock() { return tile_header_lock; }
 
-  // Sync the contents
-  void Sync();
-
   //===--------------------------------------------------------------------===//
   // Utilities
   //===--------------------------------------------------------------------===//
 
   // Get a string representation for debugging
   const std::string GetInfo() const;
-
-  static inline size_t GetReservedSize() { return reserved_size; }
-
-  // header entry size is the size of the layout described above
-  static const size_t reserved_size = 16;
-  static const size_t header_entry_size = sizeof(txn_id_t) + 2 * sizeof(cid_t) +
-                                          2 * sizeof(ItemPointer) +
-                                          sizeof(ItemPointer *) + reserved_size;
-  static const size_t txn_id_offset = 0;
-  static const size_t begin_cid_offset = txn_id_offset + sizeof(txn_id_t);
-  static const size_t end_cid_offset = begin_cid_offset + sizeof(cid_t);
-  static const size_t next_pointer_offset = end_cid_offset + sizeof(cid_t);
-  static const size_t prev_pointer_offset =
-      next_pointer_offset + sizeof(ItemPointer);
-  static const size_t indirection_offset =
-      prev_pointer_offset + sizeof(ItemPointer);
-  static const size_t reserved_field_offset =
-      indirection_offset + sizeof(ItemPointer);
 
  private:
   //===--------------------------------------------------------------------===//
@@ -289,10 +287,7 @@ class TileGroupHeader : public Printable {
   // Associated tile_group
   TileGroup *tile_group;
 
-  size_t header_size;
-
-  // set of fixed-length tuple slots
-  char *data;
+  std::unique_ptr<TupleHeader[]> tuple_headers_;
 
   // number of tuple slots allocated
   oid_t num_tuple_slots;

--- a/src/include/storage/tile_group_header.h
+++ b/src/include/storage/tile_group_header.h
@@ -28,6 +28,10 @@ namespace storage {
 
 class TileGroup;
 
+//===--------------------------------------------------------------------===//
+// Tuple Header
+//===--------------------------------------------------------------------===//
+
 struct TupleHeader {
   std::unique_ptr<common::synchronization::SpinLatch> latch;
   std::atomic<txn_id_t> txn_id;
@@ -39,6 +43,19 @@ struct TupleHeader {
   ItemPointer *indirection;
 } __attribute__((aligned(64)));
 
+/**
+ *  FIELD DESCRIPTIONS:
+ *  ===================
+ *  latch: Tuple header latch used to acquire ownership or update read_ts
+ *  txn_id: serve as a write lock on the tuple version
+ *  read_ts: the last txn to read this tuple
+ *  begin_ts: the lower bound of the version visibility range.
+ *  end_ts: the upper bound of the version visibility range.
+ *  next: the pointer pointing to the next (older) version in the version chain.
+ *  prev: the pointer pointing to the prev (newer) version in the version chain.
+ *  indirection: the pointer pointing to the index entry that holds the address of the version chain header.
+*/
+
 //===--------------------------------------------------------------------===//
 // Tile Group Header
 //===--------------------------------------------------------------------===//
@@ -47,24 +64,6 @@ struct TupleHeader {
  *
  * This contains information related to MVCC.
  * It is shared by all tiles in a tile group.
- *
- *  Layout :
- *
- *  -----------------------------------------------------------------------------
- *  | TxnID (8 bytes)  | BeginTimeStamp (8 bytes) | EndTimeStamp (8 bytes) |
- *  | NextItemPointer (8 bytes) | PrevItemPointer (8 bytes) |
- *  | Indirection (8 bytes) | ReservedField (16 bytes)
- *  -----------------------------------------------------------------------------
- *
- *  FIELD DESCRIPTIONS:
- *  ===================
- *  TxnID: serve as a write lock on the tuple version.
- *  BeginTimeStamp: the lower bound of the version visibility range.
- *  EndTimeStamp: the upper bound of the version visibility range.
- *  NextItemPointer: the pointer pointing to the next (older) version in the version chain.
- *  PrevItemPointer: the pointer pointing to the prev (newer) version in the version chain.
- *  Indirection: the pointer pointing to the index entry that holds the address of the version chain header.
- *  ReservedField: unused space for future usage.
  *
  *  STATUS:
  *  ===================

--- a/src/include/storage/tile_group_header.h
+++ b/src/include/storage/tile_group_header.h
@@ -37,7 +37,7 @@ struct TupleHeader {
   ItemPointer next;
   ItemPointer prev;
   ItemPointer *indirection;
-} __attribute__ ((aligned (64)));
+} __attribute__((aligned(64)));
 
 //===--------------------------------------------------------------------===//
 // Tile Group Header
@@ -95,11 +95,14 @@ class TileGroupHeader : public Printable {
          tuple_slot_id++) {
       SetSpinLatch(tuple_slot_id);
       SetTransactionId(tuple_slot_id, other.GetTransactionId(tuple_slot_id));
-      SetLastReaderCommitId(tuple_slot_id, other.GetLastReaderCommitId(tuple_slot_id));
+      SetLastReaderCommitId(tuple_slot_id,
+                            other.GetLastReaderCommitId(tuple_slot_id));
       SetBeginCommitId(tuple_slot_id, other.GetBeginCommitId(tuple_slot_id));
       SetEndCommitId(tuple_slot_id, other.GetEndCommitId(tuple_slot_id));
-      SetNextItemPointer(tuple_slot_id, other.GetNextItemPointer(tuple_slot_id));
-      SetPrevItemPointer(tuple_slot_id, other.GetPrevItemPointer(tuple_slot_id));
+      SetNextItemPointer(tuple_slot_id,
+                         other.GetNextItemPointer(tuple_slot_id));
+      SetPrevItemPointer(tuple_slot_id,
+                         other.GetPrevItemPointer(tuple_slot_id));
       SetIndirection(tuple_slot_id, other.GetIndirection(tuple_slot_id));
     }
 
@@ -163,7 +166,8 @@ class TileGroupHeader : public Printable {
     return tile_group;
   }
 
-  inline common::synchronization::SpinLatch *GetSpinLatch(const oid_t &tuple_slot_id) const {
+  inline common::synchronization::SpinLatch *GetSpinLatch(
+      const oid_t &tuple_slot_id) const {
     return tuple_headers_[tuple_slot_id].latch.get();
   }
 
@@ -202,7 +206,8 @@ class TileGroupHeader : public Printable {
   }
 
   inline void SetSpinLatch(const oid_t &tuple_slot_id) const {
-    tuple_headers_[tuple_slot_id].latch.reset(new common::synchronization::SpinLatch);
+    tuple_headers_[tuple_slot_id].latch.reset(
+        new common::synchronization::SpinLatch);
   }
 
   inline void SetTransactionId(const oid_t &tuple_slot_id,
@@ -211,7 +216,7 @@ class TileGroupHeader : public Printable {
   }
 
   inline void SetLastReaderCommitId(const oid_t &tuple_slot_id,
-                               const cid_t &read_cid) const {
+                                    const cid_t &read_cid) const {
     tuple_headers_[tuple_slot_id].read_ts = read_cid;
   }
 
@@ -243,7 +248,8 @@ class TileGroupHeader : public Printable {
   inline bool SetAtomicTransactionId(const oid_t &tuple_slot_id,
                                      const txn_id_t &transaction_id) const {
     auto old_val = INITIAL_TXN_ID;
-    return tuple_headers_[tuple_slot_id].txn_id.compare_exchange_strong(old_val, transaction_id);
+    return tuple_headers_[tuple_slot_id].txn_id.compare_exchange_strong(
+        old_val, transaction_id);
   }
 
   /*

--- a/src/include/storage/tile_group_header.h
+++ b/src/include/storage/tile_group_header.h
@@ -205,11 +205,6 @@ class TileGroupHeader : public Printable {
     this->tile_group = tile_group;
   }
 
-  inline void SetSpinLatch(const oid_t &tuple_slot_id) const {
-    tuple_headers_[tuple_slot_id].latch.reset(
-        new common::synchronization::SpinLatch);
-  }
-
   inline void SetTransactionId(const oid_t &tuple_slot_id,
                                const txn_id_t &transaction_id) const {
     tuple_headers_[tuple_slot_id].txn_id = transaction_id;

--- a/src/include/storage/tile_group_header.h
+++ b/src/include/storage/tile_group_header.h
@@ -93,7 +93,8 @@ class TileGroupHeader : public Printable {
     // copy tuple header values
     for (oid_t tuple_slot_id = START_OID; tuple_slot_id < num_tuple_slots;
          tuple_slot_id++) {
-      SetSpinLatch(tuple_slot_id);
+      tuple_headers_[tuple_slot_id].latch.reset(
+          new common::synchronization::SpinLatch);
       SetTransactionId(tuple_slot_id, other.GetTransactionId(tuple_slot_id));
       SetLastReaderCommitId(tuple_slot_id,
                             other.GetLastReaderCommitId(tuple_slot_id));

--- a/src/storage/tile_group_header.cpp
+++ b/src/storage/tile_group_header.cpp
@@ -37,7 +37,6 @@ TileGroupHeader::TileGroupHeader(const BackendType &backend_type,
       num_tuple_slots(tuple_count),
       next_tuple_slot(0),
       tile_header_lock() {
-
   tuple_headers_.reset(new TupleHeader[tuple_count]);
 
   // Set MVCC Initial Value

--- a/src/storage/tile_group_header.cpp
+++ b/src/storage/tile_group_header.cpp
@@ -34,42 +34,27 @@ TileGroupHeader::TileGroupHeader(const BackendType &backend_type,
                                  const int &tuple_count)
     : backend_type(backend_type),
       tile_group(nullptr),
-      data(nullptr),
       num_tuple_slots(tuple_count),
       next_tuple_slot(0),
       tile_header_lock() {
-  header_size = num_tuple_slots * header_entry_size;
 
-  // allocate storage space for header
-  // auto &storage_manager = storage::StorageManager::GetInstance();
-  // data = reinterpret_cast<char *>(
-  // storage_manager.Allocate(backend_type, header_size));
-  data = new char[header_size];
-  PELOTON_ASSERT(data != nullptr);
-
-  // zero out the data
-  PELOTON_MEMSET(data, 0, header_size);
+  tuple_headers_.reset(new TupleHeader[tuple_count]);
 
   // Set MVCC Initial Value
   for (oid_t tuple_slot_id = START_OID; tuple_slot_id < num_tuple_slots;
        tuple_slot_id++) {
+    SetSpinLatch(tuple_slot_id);
     SetTransactionId(tuple_slot_id, INVALID_TXN_ID);
+    SetLastReaderCommitId(tuple_slot_id, INVALID_CID);
     SetBeginCommitId(tuple_slot_id, MAX_CID);
     SetEndCommitId(tuple_slot_id, MAX_CID);
     SetNextItemPointer(tuple_slot_id, INVALID_ITEMPOINTER);
     SetPrevItemPointer(tuple_slot_id, INVALID_ITEMPOINTER);
+    SetIndirection(tuple_slot_id, nullptr);
   }
 
   // Initially immutabile flag to false initially.
   immutable = false;
-}
-
-TileGroupHeader::~TileGroupHeader() {
-  // reclaim the space
-  // auto &storage_manager = storage::StorageManager::GetInstance();
-  // storage_manager.Release(backend_type, data);
-  delete[] data;
-  data = nullptr;
 }
 
 //===--------------------------------------------------------------------===//
@@ -164,12 +149,6 @@ const std::string TileGroupHeader::GetInfo() const {
   }
 
   return os.str();
-}
-
-void TileGroupHeader::Sync() {
-  // Sync the tile group data
-  // auto &storage_manager = storage::StorageManager::GetInstance();
-  // storage_manager.Sync(backend_type, data, header_size);
 }
 
 void TileGroupHeader::PrintVisibility(txn_id_t txn_id, cid_t at_cid) {

--- a/src/storage/tile_group_header.cpp
+++ b/src/storage/tile_group_header.cpp
@@ -42,7 +42,8 @@ TileGroupHeader::TileGroupHeader(const BackendType &backend_type,
   // Set MVCC Initial Value
   for (oid_t tuple_slot_id = START_OID; tuple_slot_id < num_tuple_slots;
        tuple_slot_id++) {
-    SetSpinLatch(tuple_slot_id);
+    tuple_headers_[tuple_slot_id].latch.reset(
+        new common::synchronization::SpinLatch);
     SetTransactionId(tuple_slot_id, INVALID_TXN_ID);
     SetLastReaderCommitId(tuple_slot_id, INVALID_CID);
     SetBeginCommitId(tuple_slot_id, MAX_CID);


### PR DESCRIPTION
This is just a refactor of the TileGroupHeader to make it a bit more modifiable/maintainable. I got rid of the char array that used hardcoded pointer arithmetic to access tuple "fields". Made each tuple header slot be a struct of fields, and made an array of those to represent all of the tuples in the TileGroup. These are all managed by smart pointers now.

There's also no "reserved" area in a tuple header anymore, since it was full anyway for other purposes (spin latch and last reader) so I broke those out into proper fields.