### PR TITLE
Skip adding READs to the RWSet

### DIFF
--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -224,8 +224,7 @@ bool TimestampOrderingTransactionManager::PerformRead(TransactionContext *const 
       return true;
 
     } else {
-      // if it's not select for update, then update read set and return true.
-      current_txn->RecordRead(location);
+      // if it's not select for update, then return true.
       return true;
     }
 
@@ -266,7 +265,6 @@ bool TimestampOrderingTransactionManager::PerformRead(TransactionContext *const 
       // a transaction can never read an uncommitted version.
       if (IsOwner(current_txn, tile_group_header, tuple_id) == false) {
         if (IsOwned(current_txn, tile_group_header, tuple_id) == false) {
-          current_txn->RecordRead(location);
           return true;
 
         } else {
@@ -339,8 +337,6 @@ bool TimestampOrderingTransactionManager::PerformRead(TransactionContext *const 
         // then attempt to set last reader cid.
         if (SetLastReaderCommitId(tile_group_header, tuple_id,
                                   current_txn->GetCommitId(), false) == true) {
-          // update read set.
-          current_txn->RecordRead(location);
           return true;
         } else {
           // if the tuple has been owned by some concurrent transactions,

--- a/src/concurrency/transaction_context.cpp
+++ b/src/concurrency/transaction_context.cpp
@@ -94,35 +94,20 @@ RWType TransactionContext::GetRWType(const ItemPointer &location) {
   return RWType::INVALID;
 }
 
-void TransactionContext::RecordRead(const ItemPointer &location) {
-  PELOTON_ASSERT(rw_set_.find(location) == rw_set_.end() ||
-                 (rw_set_[location] != RWType::DELETE &&
-                  rw_set_[location] != RWType::INS_DEL));
-  auto rw_set_it = rw_set_.find(location);
-  if (rw_set_it != rw_set_.end()) {
-    return;
-  }
-  rw_set_[location] = RWType::READ;
-}
-
 void TransactionContext::RecordReadOwn(const ItemPointer &location) {
   PELOTON_ASSERT(rw_set_.find(location) == rw_set_.end() ||
                  (rw_set_[location] != RWType::DELETE &&
                   rw_set_[location] != RWType::INS_DEL));
   rw_set_[location] = RWType::READ_OWN;
+  is_written_ = true;
 }
 
 void TransactionContext::RecordUpdate(const ItemPointer &location) {
   PELOTON_ASSERT(rw_set_.find(location) == rw_set_.end() ||
                  (rw_set_[location] != RWType::DELETE &&
                   rw_set_[location] != RWType::INS_DEL));
-  auto rw_set_it = rw_set_.find(location);
-  if (rw_set_it != rw_set_.end() && (rw_set_it->second == RWType::READ ||
-                                     rw_set_it->second == RWType::READ_OWN)) {
-    rw_set_it->second = RWType::UPDATE;
-    is_written_ = true;
-  }
-  PELOTON_ASSERT(is_written_);
+  rw_set_[location] = RWType::UPDATE;
+  is_written_ = true;
 }
 
 void TransactionContext::RecordInsert(const ItemPointer &location) {

--- a/src/include/concurrency/transaction_context.h
+++ b/src/include/concurrency/transaction_context.h
@@ -159,8 +159,6 @@ class TransactionContext : public Printable {
                                 index_oid, DDLType::DROP));
   }
 
-  void RecordRead(const ItemPointer &);
-
   void RecordReadOwn(const ItemPointer &);
 
   void RecordUpdate(const ItemPointer &);


### PR DESCRIPTION
Addresses point 2 in #1420. There's no reason to add READs to the RWSet in MVTO.