### PR TITLE
Inline tuple SpinLatch after TileGroupHeader refactor

### DIFF
--- a/src/include/storage/tile_group_header.h
+++ b/src/include/storage/tile_group_header.h
@@ -33,7 +33,7 @@ class TileGroup;
 //===--------------------------------------------------------------------===//
 
 struct TupleHeader {
-  std::unique_ptr<common::synchronization::SpinLatch> latch;
+  common::synchronization::SpinLatch latch;
   std::atomic<txn_id_t> txn_id;
   cid_t read_ts;
   cid_t begin_ts;
@@ -92,8 +92,6 @@ class TileGroupHeader : public Printable {
     // copy tuple header values
     for (oid_t tuple_slot_id = START_OID; tuple_slot_id < num_tuple_slots;
          tuple_slot_id++) {
-      tuple_headers_[tuple_slot_id].latch.reset(
-          new common::synchronization::SpinLatch);
       SetTransactionId(tuple_slot_id, other.GetTransactionId(tuple_slot_id));
       SetLastReaderCommitId(tuple_slot_id,
                             other.GetLastReaderCommitId(tuple_slot_id));
@@ -166,9 +164,9 @@ class TileGroupHeader : public Printable {
     return tile_group;
   }
 
-  inline common::synchronization::SpinLatch *GetSpinLatch(
+  inline common::synchronization::SpinLatch &GetSpinLatch(
       const oid_t &tuple_slot_id) const {
-    return tuple_headers_[tuple_slot_id].latch.get();
+    return tuple_headers_[tuple_slot_id].latch;
   }
 
   inline txn_id_t GetTransactionId(const oid_t &tuple_slot_id) const {

--- a/src/storage/tile_group_header.cpp
+++ b/src/storage/tile_group_header.cpp
@@ -42,8 +42,6 @@ TileGroupHeader::TileGroupHeader(const BackendType &backend_type,
   // Set MVCC Initial Value
   for (oid_t tuple_slot_id = START_OID; tuple_slot_id < num_tuple_slots;
        tuple_slot_id++) {
-    tuple_headers_[tuple_slot_id].latch.reset(
-        new common::synchronization::SpinLatch);
     SetTransactionId(tuple_slot_id, INVALID_TXN_ID);
     SetLastReaderCommitId(tuple_slot_id, INVALID_CID);
     SetBeginCommitId(tuple_slot_id, MAX_CID);


### PR DESCRIPTION
This addresses a good comment @pmenon brought up after merging #1423. I misinterpreted the old pointer casting and layout of the old headers, and made the SpinLatch field a pointer to a separately allocated SpinLatch. Instead, it should have been inlined in the header.

 This addresses a potential performance issue in the future of having to chase another pointer. Right now we see no difference in TPC-C and YCSB, but we should fix it now.