### PR TITLE
Set LastReaderCommitId on new versions

### DIFF
--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -358,6 +358,7 @@ void TimestampOrderingTransactionManager::PerformInsert(
   PELOTON_ASSERT(tile_group_header->GetEndCommitId(tuple_id) == MAX_CID);
 
   tile_group_header->SetTransactionId(tuple_id, transaction_id);
+  tile_group_header->SetLastReaderCommitId(tuple_id, current_txn->GetCommitId());
 
   // no need to set next item pointer.
 
@@ -412,6 +413,7 @@ void TimestampOrderingTransactionManager::PerformUpdate(
   new_tile_group_header->SetNextItemPointer(new_location.offset, old_location);
 
   new_tile_group_header->SetTransactionId(new_location.offset, transaction_id);
+  new_tile_group_header->SetLastReaderCommitId(new_location.offset, current_txn->GetCommitId());
 
   // we should guarantee that the newer version is all set before linking the
   // newer version to older version.
@@ -515,6 +517,7 @@ void TimestampOrderingTransactionManager::PerformDelete(
   new_tile_group_header->SetNextItemPointer(new_location.offset, old_location);
 
   new_tile_group_header->SetTransactionId(new_location.offset, transaction_id);
+  new_tile_group_header->SetLastReaderCommitId(new_location.offset, current_txn->GetCommitId());
 
   new_tile_group_header->SetEndCommitId(new_location.offset, INVALID_CID);
 

--- a/src/concurrency/timestamp_ordering_transaction_manager.cpp
+++ b/src/concurrency/timestamp_ordering_transaction_manager.cpp
@@ -358,7 +358,8 @@ void TimestampOrderingTransactionManager::PerformInsert(
   PELOTON_ASSERT(tile_group_header->GetEndCommitId(tuple_id) == MAX_CID);
 
   tile_group_header->SetTransactionId(tuple_id, transaction_id);
-  tile_group_header->SetLastReaderCommitId(tuple_id, current_txn->GetCommitId());
+  tile_group_header->SetLastReaderCommitId(tuple_id,
+                                           current_txn->GetCommitId());
 
   // no need to set next item pointer.
 
@@ -413,7 +414,8 @@ void TimestampOrderingTransactionManager::PerformUpdate(
   new_tile_group_header->SetNextItemPointer(new_location.offset, old_location);
 
   new_tile_group_header->SetTransactionId(new_location.offset, transaction_id);
-  new_tile_group_header->SetLastReaderCommitId(new_location.offset, current_txn->GetCommitId());
+  new_tile_group_header->SetLastReaderCommitId(new_location.offset,
+                                               current_txn->GetCommitId());
 
   // we should guarantee that the newer version is all set before linking the
   // newer version to older version.
@@ -517,7 +519,8 @@ void TimestampOrderingTransactionManager::PerformDelete(
   new_tile_group_header->SetNextItemPointer(new_location.offset, old_location);
 
   new_tile_group_header->SetTransactionId(new_location.offset, transaction_id);
-  new_tile_group_header->SetLastReaderCommitId(new_location.offset, current_txn->GetCommitId());
+  new_tile_group_header->SetLastReaderCommitId(new_location.offset,
+                                               current_txn->GetCommitId());
 
   new_tile_group_header->SetEndCommitId(new_location.offset, INVALID_CID);
 


### PR DESCRIPTION
Addresses points 5 and 6 of #1420. MVTO should set the Last Reader timestamp to be the version creator's timestamp.[1] This was previously not done, and could trigger an assertion failure in Debug mode.

[1]A. Silberschatz, H. Korth and S. Sudarshan, _Database System Concepts_, 6th ed. New York: McGraw Hill, 2011, p. 690.