### PR TITLE
Settings refactoring

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -200,7 +200,8 @@ void Catalog::Bootstrap() {
   // TODO: change pg_proc to per database
   ProcCatalog::GetInstance(txn);
 
-  if (settings::SettingsManager::GetBool(settings::SettingId::brain)) {
+  if (settings::SettingsManager::GetInstance().GetBool(
+          settings::SettingId::brain)) {
     QueryHistoryCatalog::GetInstance(txn);
   }
 

--- a/src/catalog/settings_catalog.cpp
+++ b/src/catalog/settings_catalog.cpp
@@ -21,71 +21,96 @@
 namespace peloton {
 namespace catalog {
 
-SettingsCatalogObject::SettingsCatalogObject(executor::LogicalTile *tile,
-                                             int tuple_id)
+SettingsCatalogEntry::SettingsCatalogEntry(executor::LogicalTile *tile,
+                                           int tuple_id)
     : name_(tile->GetValue(tuple_id,
-        static_cast<int>(SettingsCatalog::ColumnId::NAME)).ToString()),
-      value_type_(StringToTypeId(tile->GetValue(tuple_id,
-        static_cast<int>(SettingsCatalog::ColumnId::VALUE_TYPE)).ToString())),
-      desc_(tile->GetValue(tuple_id,
-        static_cast<int>(SettingsCatalog::ColumnId::DESCRIPTION)).ToString()),
-      is_mutable_(tile->GetValue(tuple_id,
-        static_cast<int>(SettingsCatalog::ColumnId::IS_MUTABLE)).GetAs<bool>()),
-      is_persistent_(tile->GetValue(tuple_id,
-        static_cast<int>(SettingsCatalog::ColumnId::IS_PERSISTENT)).GetAs<bool>()) {
+                           static_cast<int>(SettingsCatalog::ColumnId::NAME))
+                .ToString()),
+      value_type_(StringToTypeId(
+          tile->GetValue(tuple_id, static_cast<int>(
+                                       SettingsCatalog::ColumnId::VALUE_TYPE))
+              .ToString())),
+      desc_(tile->GetValue(
+                      tuple_id,
+                      static_cast<int>(SettingsCatalog::ColumnId::DESCRIPTION))
+                .ToString()),
+      is_mutable_(
+          tile->GetValue(tuple_id, static_cast<int>(
+                                       SettingsCatalog::ColumnId::IS_MUTABLE))
+              .GetAs<bool>()),
+      is_persistent_(
+          tile->GetValue(
+                    tuple_id,
+                    static_cast<int>(SettingsCatalog::ColumnId::IS_PERSISTENT))
+              .GetAs<bool>()) {
   switch (value_type_) {
-  case type::TypeId::INTEGER:{
-    value_ = type::ValueFactory::GetIntegerValue(
-        std::stoi(tile->GetValue(tuple_id,
-            static_cast<int>(SettingsCatalog::ColumnId::VALUE)).ToString()));
-    default_value_ = type::ValueFactory::GetIntegerValue(
-        std::stoi(tile->GetValue(tuple_id,
-            static_cast<int>(SettingsCatalog::ColumnId::DEFAULT_VALUE)).ToString()));
-    min_value_ = type::ValueFactory::GetIntegerValue(
-        std::stoi(tile->GetValue(tuple_id,
-            static_cast<int>(SettingsCatalog::ColumnId::MIN_VALUE)).ToString()));
-    max_value_ = type::ValueFactory::GetIntegerValue(
-        std::stoi(tile->GetValue(tuple_id,
-            static_cast<int>(SettingsCatalog::ColumnId::MAX_VALUE)).ToString()));
-    break;
-  }
-  case type::TypeId::DECIMAL: {
-    value_ = type::ValueFactory::GetDecimalValue(
-        std::stof(tile->GetValue(tuple_id,
-            static_cast<int>(SettingsCatalog::ColumnId::VALUE)).ToString()));
-    default_value_ = type::ValueFactory::GetDecimalValue(
-        std::stof(tile->GetValue(tuple_id,
-            static_cast<int>(SettingsCatalog::ColumnId::DEFAULT_VALUE)).ToString()));
-    min_value_ = type::ValueFactory::GetDecimalValue(
-        std::stof(tile->GetValue(tuple_id,
-            static_cast<int>(SettingsCatalog::ColumnId::MIN_VALUE)).ToString()));
-    max_value_ = type::ValueFactory::GetDecimalValue(
-        std::stof(tile->GetValue(tuple_id,
-            static_cast<int>(SettingsCatalog::ColumnId::MAX_VALUE)).ToString()));
-    break;
-  }
-  case type::TypeId::BOOLEAN: {
-    value_ = type::ValueFactory::GetBooleanValue(
-        (tile->GetValue(tuple_id,
-            static_cast<int>(SettingsCatalog::ColumnId::VALUE)).ToString()
-                == "true")? true : false);
-    default_value_ = type::ValueFactory::GetBooleanValue(
-        (tile->GetValue(tuple_id,
-            static_cast<int>(SettingsCatalog::ColumnId::DEFAULT_VALUE)).ToString()
-                == "true")? true : false);
-    break;
-  }
-  case type::TypeId::VARCHAR: {
-    value_ = tile->GetValue(tuple_id,
-        static_cast<int>(SettingsCatalog::ColumnId::VALUE));
-    default_value_ = tile->GetValue(tuple_id,
-        static_cast<int>(SettingsCatalog::ColumnId::DEFAULT_VALUE));
-    break;
-  }
-  default:
-    LOG_ERROR("Unsupported type for setting value: %s",
-        TypeIdToString(value_type_).c_str());
-    PELOTON_ASSERT(false);
+    case type::TypeId::INTEGER: {
+      value_ = type::ValueFactory::GetIntegerValue(std::stoi(
+          tile->GetValue(tuple_id,
+                         static_cast<int>(SettingsCatalog::ColumnId::VALUE))
+              .ToString()));
+      default_value_ = type::ValueFactory::GetIntegerValue(std::stoi(
+          tile->GetValue(
+                    tuple_id,
+                    static_cast<int>(SettingsCatalog::ColumnId::DEFAULT_VALUE))
+              .ToString()));
+      min_value_ = type::ValueFactory::GetIntegerValue(std::stoi(
+          tile->GetValue(tuple_id,
+                         static_cast<int>(SettingsCatalog::ColumnId::MIN_VALUE))
+              .ToString()));
+      max_value_ = type::ValueFactory::GetIntegerValue(std::stoi(
+          tile->GetValue(tuple_id,
+                         static_cast<int>(SettingsCatalog::ColumnId::MAX_VALUE))
+              .ToString()));
+      break;
+    }
+    case type::TypeId::DECIMAL: {
+      value_ = type::ValueFactory::GetDecimalValue(std::stof(
+          tile->GetValue(tuple_id,
+                         static_cast<int>(SettingsCatalog::ColumnId::VALUE))
+              .ToString()));
+      default_value_ = type::ValueFactory::GetDecimalValue(std::stof(
+          tile->GetValue(
+                    tuple_id,
+                    static_cast<int>(SettingsCatalog::ColumnId::DEFAULT_VALUE))
+              .ToString()));
+      min_value_ = type::ValueFactory::GetDecimalValue(std::stof(
+          tile->GetValue(tuple_id,
+                         static_cast<int>(SettingsCatalog::ColumnId::MIN_VALUE))
+              .ToString()));
+      max_value_ = type::ValueFactory::GetDecimalValue(std::stof(
+          tile->GetValue(tuple_id,
+                         static_cast<int>(SettingsCatalog::ColumnId::MAX_VALUE))
+              .ToString()));
+      break;
+    }
+    case type::TypeId::BOOLEAN: {
+      value_ = type::ValueFactory::GetBooleanValue(
+          (tile->GetValue(tuple_id,
+                          static_cast<int>(SettingsCatalog::ColumnId::VALUE))
+               .ToString() == "true")
+              ? true
+              : false);
+      default_value_ = type::ValueFactory::GetBooleanValue(
+          (tile->GetValue(
+                     tuple_id,
+                     static_cast<int>(SettingsCatalog::ColumnId::DEFAULT_VALUE))
+               .ToString() == "true")
+              ? true
+              : false);
+      break;
+    }
+    case type::TypeId::VARCHAR: {
+      value_ = tile->GetValue(
+          tuple_id, static_cast<int>(SettingsCatalog::ColumnId::VALUE));
+      default_value_ = tile->GetValue(
+          tuple_id, static_cast<int>(SettingsCatalog::ColumnId::DEFAULT_VALUE));
+      break;
+    }
+    default:
+      LOG_ERROR("Unsupported type for setting value: %s",
+                TypeIdToString(value_type_).c_str());
+      PELOTON_ASSERT(false);
   }
 }
 
@@ -132,7 +157,7 @@ bool SettingsCatalog::InsertSetting(
   auto val2 =
       type::ValueFactory::GetVarcharValue(TypeIdToString(value_type), pool);
   auto val3 = type::ValueFactory::GetVarcharValue(description, pool);
-  auto val4= type::ValueFactory::GetVarcharValue(min_value, pool);
+  auto val4 = type::ValueFactory::GetVarcharValue(min_value, pool);
   auto val5 = type::ValueFactory::GetVarcharValue(max_value, pool);
   auto val6 = type::ValueFactory::GetVarcharValue(default_value, pool);
   auto val7 = type::ValueFactory::GetBooleanValue(is_mutable);
@@ -161,50 +186,50 @@ bool SettingsCatalog::DeleteSetting(const std::string &name,
   return DeleteWithIndexScan(index_offset, values, txn);
 }
 
-/** @brief      Update a setting object corresponding to a name
+/** @brief      Update a setting catalog entry corresponding to a name
  *              in the pg_settings.
  *  @param      name  name of the setting.
  *  @param      value  value for the updating.
  *  @param      txn  TransactionContext for getting the setting.
- *  @return     setting object.
+ *  @return     setting catalog entry.
  */
 bool SettingsCatalog::UpdateSettingValue(concurrency::TransactionContext *txn,
                                          const std::string &name,
                                          const std::string &value,
                                          bool set_default) {
-  std::vector<oid_t> update_columns({static_cast<int>(ColumnId::VALUE)});  // value
-  oid_t index_offset = static_cast<int>(IndexId::SECONDARY_KEY_0);  // Index of name
+  std::vector<oid_t> update_columns(
+      {static_cast<int>(ColumnId::VALUE)});  // value
+  oid_t index_offset =
+      static_cast<int>(IndexId::SECONDARY_KEY_0);  // Index of name
   // values to execute index scan
   std::vector<type::Value> scan_values;
   scan_values.push_back(type::ValueFactory::GetVarcharValue(name).Copy());
   // values to update
   std::vector<type::Value> update_values;
-  update_values.push_back(
-      type::ValueFactory::GetVarcharValue(value).Copy());
+  update_values.push_back(type::ValueFactory::GetVarcharValue(value).Copy());
 
   if (set_default) {
     update_columns.push_back(static_cast<oid_t>(ColumnId::DEFAULT_VALUE));
-    update_values.push_back(
-        type::ValueFactory::GetVarcharValue(value).Copy());
+    update_values.push_back(type::ValueFactory::GetVarcharValue(value).Copy());
   }
 
   return UpdateWithIndexScan(update_columns, update_values, scan_values,
                              index_offset, txn);
 }
 
-/** @brief      Get a setting object corresponding to a name
+/** @brief      Get a setting catalog entry corresponding to a name
  *              from the pg_settings.
  *  @param      name  name of the setting.
  *  @param      txn  TransactionContext for getting the setting.
- *  @return     setting object.
+ *  @return     setting catalog entry.
  */
-std::shared_ptr<SettingsCatalogObject> SettingsCatalog::GetSetting(
+std::shared_ptr<SettingsCatalogEntry> SettingsCatalog::GetSetting(
     const std::string &name, concurrency::TransactionContext *txn) {
   if (txn == nullptr) {
     throw CatalogException("Transaction is invalid!");
   }
 
-  std::vector<oid_t> column_ids(all_column_ids);
+  std::vector<oid_t> column_ids(all_column_ids_);
   oid_t index_offset = static_cast<int>(IndexId::SECONDARY_KEY_0);
   std::vector<type::Value> values;
   values.push_back(type::ValueFactory::GetVarcharValue(name, nullptr).Copy());
@@ -216,42 +241,40 @@ std::shared_ptr<SettingsCatalogObject> SettingsCatalog::GetSetting(
   if (result_tiles->size() != 0) {
     PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
     if ((*result_tiles)[0]->GetTupleCount() != 0) {
-      return std::make_shared<SettingsCatalogObject>((*result_tiles)[0].get());
+      return std::make_shared<SettingsCatalogEntry>((*result_tiles)[0].get());
     }
   }
 
   return nullptr;
 }
 
-/** @brief      Get all setting objects from the pg_settings.
+/** @brief      Get all setting catalog entries from the pg_settings.
  *  @param      txn TransactionContext for getting the settings.
- *  @return     unordered_map containing a name -> setting object
- *              mapping.
+ *  @return     unordered_map containing a name -> setting catalog
+ *              entry mapping.
  */
-std::unordered_map<std::string, std::shared_ptr<SettingsCatalogObject>>
-SettingsCatalog::GetSettings(
-    concurrency::TransactionContext *txn) {
+std::unordered_map<std::string, std::shared_ptr<SettingsCatalogEntry>>
+SettingsCatalog::GetSettings(concurrency::TransactionContext *txn) {
   if (txn == nullptr) {
     throw CatalogException("Transaction is invalid!");
   }
 
-  std::vector<oid_t> column_ids(all_column_ids);
+  std::vector<oid_t> column_ids(all_column_ids_);
 
-  auto result_tiles =
-      this->GetResultWithSeqScan(column_ids, nullptr, txn);
+  auto result_tiles = this->GetResultWithSeqScan(column_ids, nullptr, txn);
 
-  std::unordered_map<std::string, std::shared_ptr<SettingsCatalogObject>>
-    setting_objects;
+  std::unordered_map<std::string, std::shared_ptr<SettingsCatalogEntry>>
+      setting_entries;
   for (auto &tile : (*result_tiles)) {
     for (auto tuple_id : *tile) {
-      auto setting_object =
-          std::make_shared<SettingsCatalogObject>(tile.get(), tuple_id);
-      setting_objects.insert(
-          std::make_pair(setting_object->GetName(), setting_object));
+      auto setting_entry =
+          std::make_shared<SettingsCatalogEntry>(tile.get(), tuple_id);
+      setting_entries.insert(
+          std::make_pair(setting_entry->GetName(), setting_entry));
     }
   }
 
-  return setting_objects;
+  return setting_entries;
 }
 
 }  // namespace catalog

--- a/src/catalog/settings_catalog.cpp
+++ b/src/catalog/settings_catalog.cpp
@@ -21,6 +21,74 @@
 namespace peloton {
 namespace catalog {
 
+SettingsCatalogObject::SettingsCatalogObject(executor::LogicalTile *tile,
+                                             int tuple_id)
+    : name_(tile->GetValue(tuple_id,
+        static_cast<int>(SettingsCatalog::ColumnId::NAME)).ToString()),
+      value_type_(StringToTypeId(tile->GetValue(tuple_id,
+        static_cast<int>(SettingsCatalog::ColumnId::VALUE_TYPE)).ToString())),
+      desc_(tile->GetValue(tuple_id,
+        static_cast<int>(SettingsCatalog::ColumnId::DESCRIPTION)).ToString()),
+      is_mutable_(tile->GetValue(tuple_id,
+        static_cast<int>(SettingsCatalog::ColumnId::IS_MUTABLE)).GetAs<bool>()),
+      is_persistent_(tile->GetValue(tuple_id,
+        static_cast<int>(SettingsCatalog::ColumnId::IS_PERSISTENT)).GetAs<bool>()) {
+  switch (value_type_) {
+  case type::TypeId::INTEGER:{
+    value_ = type::ValueFactory::GetIntegerValue(
+        std::stoi(tile->GetValue(tuple_id,
+            static_cast<int>(SettingsCatalog::ColumnId::VALUE)).ToString()));
+    default_value_ = type::ValueFactory::GetIntegerValue(
+        std::stoi(tile->GetValue(tuple_id,
+            static_cast<int>(SettingsCatalog::ColumnId::DEFAULT_VALUE)).ToString()));
+    min_value_ = type::ValueFactory::GetIntegerValue(
+        std::stoi(tile->GetValue(tuple_id,
+            static_cast<int>(SettingsCatalog::ColumnId::MIN_VALUE)).ToString()));
+    max_value_ = type::ValueFactory::GetIntegerValue(
+        std::stoi(tile->GetValue(tuple_id,
+            static_cast<int>(SettingsCatalog::ColumnId::MAX_VALUE)).ToString()));
+    break;
+  }
+  case type::TypeId::DECIMAL: {
+    value_ = type::ValueFactory::GetDecimalValue(
+        std::stof(tile->GetValue(tuple_id,
+            static_cast<int>(SettingsCatalog::ColumnId::VALUE)).ToString()));
+    default_value_ = type::ValueFactory::GetDecimalValue(
+        std::stof(tile->GetValue(tuple_id,
+            static_cast<int>(SettingsCatalog::ColumnId::DEFAULT_VALUE)).ToString()));
+    min_value_ = type::ValueFactory::GetDecimalValue(
+        std::stof(tile->GetValue(tuple_id,
+            static_cast<int>(SettingsCatalog::ColumnId::MIN_VALUE)).ToString()));
+    max_value_ = type::ValueFactory::GetDecimalValue(
+        std::stof(tile->GetValue(tuple_id,
+            static_cast<int>(SettingsCatalog::ColumnId::MAX_VALUE)).ToString()));
+    break;
+  }
+  case type::TypeId::BOOLEAN: {
+    value_ = type::ValueFactory::GetBooleanValue(
+        (tile->GetValue(tuple_id,
+            static_cast<int>(SettingsCatalog::ColumnId::VALUE)).ToString()
+                == "true")? true : false);
+    default_value_ = type::ValueFactory::GetBooleanValue(
+        (tile->GetValue(tuple_id,
+            static_cast<int>(SettingsCatalog::ColumnId::DEFAULT_VALUE)).ToString()
+                == "true")? true : false);
+    break;
+  }
+  case type::TypeId::VARCHAR: {
+    value_ = tile->GetValue(tuple_id,
+        static_cast<int>(SettingsCatalog::ColumnId::VALUE));
+    default_value_ = tile->GetValue(tuple_id,
+        static_cast<int>(SettingsCatalog::ColumnId::DEFAULT_VALUE));
+    break;
+  }
+  default:
+    LOG_ERROR("Unsupported type for setting value: %s",
+        TypeIdToString(value_type_).c_str());
+    PELOTON_ASSERT(false);
+  }
+}
+
 SettingsCatalog &SettingsCatalog::GetInstance(
     concurrency::TransactionContext *txn) {
   static SettingsCatalog settings_catalog{txn};
@@ -64,7 +132,7 @@ bool SettingsCatalog::InsertSetting(
   auto val2 =
       type::ValueFactory::GetVarcharValue(TypeIdToString(value_type), pool);
   auto val3 = type::ValueFactory::GetVarcharValue(description, pool);
-  auto val4 = type::ValueFactory::GetVarcharValue(min_value, pool);
+  auto val4= type::ValueFactory::GetVarcharValue(min_value, pool);
   auto val5 = type::ValueFactory::GetVarcharValue(max_value, pool);
   auto val6 = type::ValueFactory::GetVarcharValue(default_value, pool);
   auto val7 = type::ValueFactory::GetBooleanValue(is_mutable);
@@ -93,30 +161,50 @@ bool SettingsCatalog::DeleteSetting(const std::string &name,
   return DeleteWithIndexScan(index_offset, values, txn);
 }
 
-std::string SettingsCatalog::GetSettingValue(
-    const std::string &name, concurrency::TransactionContext *txn) {
-  std::vector<oid_t> column_ids({static_cast<int>(ColumnId::VALUE)});
-  oid_t index_offset = static_cast<int>(IndexId::SECONDARY_KEY_0);
-  std::vector<type::Value> values;
-  values.push_back(type::ValueFactory::GetVarcharValue(name, nullptr).Copy());
+/** @brief      Update a setting object corresponding to a name
+ *              in the pg_settings.
+ *  @param      name  name of the setting.
+ *  @param      value  value for the updating.
+ *  @param      txn  TransactionContext for getting the setting.
+ *  @return     setting object.
+ */
+bool SettingsCatalog::UpdateSettingValue(concurrency::TransactionContext *txn,
+                                         const std::string &name,
+                                         const std::string &value,
+                                         bool set_default) {
+  std::vector<oid_t> update_columns({static_cast<int>(ColumnId::VALUE)});  // value
+  oid_t index_offset = static_cast<int>(IndexId::SECONDARY_KEY_0);  // Index of name
+  // values to execute index scan
+  std::vector<type::Value> scan_values;
+  scan_values.push_back(type::ValueFactory::GetVarcharValue(name).Copy());
+  // values to update
+  std::vector<type::Value> update_values;
+  update_values.push_back(
+      type::ValueFactory::GetVarcharValue(value).Copy());
 
-  auto result_tiles =
-      GetResultWithIndexScan(column_ids, index_offset, values, txn);
-
-  std::string config_value = "";
-  PELOTON_ASSERT(result_tiles->size() <= 1);
-  if (result_tiles->size() != 0) {
-    PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
-    if ((*result_tiles)[0]->GetTupleCount() != 0) {
-      config_value = (*result_tiles)[0]->GetValue(0, 0).ToString();
-    }
+  if (set_default) {
+    update_columns.push_back(static_cast<oid_t>(ColumnId::DEFAULT_VALUE));
+    update_values.push_back(
+        type::ValueFactory::GetVarcharValue(value).Copy());
   }
-  return config_value;
+
+  return UpdateWithIndexScan(update_columns, update_values, scan_values,
+                             index_offset, txn);
 }
 
-std::string SettingsCatalog::GetDefaultValue(
+/** @brief      Get a setting object corresponding to a name
+ *              from the pg_settings.
+ *  @param      name  name of the setting.
+ *  @param      txn  TransactionContext for getting the setting.
+ *  @return     setting object.
+ */
+std::shared_ptr<SettingsCatalogObject> SettingsCatalog::GetSetting(
     const std::string &name, concurrency::TransactionContext *txn) {
-  std::vector<oid_t> column_ids({static_cast<int>(ColumnId::VALUE)});
+  if (txn == nullptr) {
+    throw CatalogException("Transaction is invalid!");
+  }
+
+  std::vector<oid_t> column_ids(all_column_ids);
   oid_t index_offset = static_cast<int>(IndexId::SECONDARY_KEY_0);
   std::vector<type::Value> values;
   values.push_back(type::ValueFactory::GetVarcharValue(name, nullptr).Copy());
@@ -124,15 +212,46 @@ std::string SettingsCatalog::GetDefaultValue(
   auto result_tiles =
       GetResultWithIndexScan(column_ids, index_offset, values, txn);
 
-  std::string config_value = "";
   PELOTON_ASSERT(result_tiles->size() <= 1);
   if (result_tiles->size() != 0) {
     PELOTON_ASSERT((*result_tiles)[0]->GetTupleCount() <= 1);
     if ((*result_tiles)[0]->GetTupleCount() != 0) {
-      config_value = (*result_tiles)[0]->GetValue(0, 0).ToString();
+      return std::make_shared<SettingsCatalogObject>((*result_tiles)[0].get());
     }
   }
-  return config_value;
+
+  return nullptr;
+}
+
+/** @brief      Get all setting objects from the pg_settings.
+ *  @param      txn TransactionContext for getting the settings.
+ *  @return     unordered_map containing a name -> setting object
+ *              mapping.
+ */
+std::unordered_map<std::string, std::shared_ptr<SettingsCatalogObject>>
+SettingsCatalog::GetSettings(
+    concurrency::TransactionContext *txn) {
+  if (txn == nullptr) {
+    throw CatalogException("Transaction is invalid!");
+  }
+
+  std::vector<oid_t> column_ids(all_column_ids);
+
+  auto result_tiles =
+      this->GetResultWithSeqScan(column_ids, nullptr, txn);
+
+  std::unordered_map<std::string, std::shared_ptr<SettingsCatalogObject>>
+    setting_objects;
+  for (auto &tile : (*result_tiles)) {
+    for (auto tuple_id : *tile) {
+      auto setting_object =
+          std::make_shared<SettingsCatalogObject>(tile.get(), tuple_id);
+      setting_objects.insert(
+          std::make_pair(setting_object->GetName(), setting_object));
+    }
+  }
+
+  return setting_objects;
 }
 
 }  // namespace catalog

--- a/src/codegen/code_context.cpp
+++ b/src/codegen/code_context.cpp
@@ -298,7 +298,8 @@ bool CodeContext::Compile() {
   }
   pass_manager_->doFinalization();
 
-  if (settings::SettingsManager::GetBool(settings::SettingId::print_ir_stats)) {
+  if (settings::SettingsManager::GetInstance().GetBool(
+          settings::SettingId::print_ir_stats)) {
     char name[] = "inst count";
     InstructionCounts inst_count(*name);
     inst_count.runOnModule(GetModule());
@@ -314,7 +315,8 @@ bool CodeContext::Compile() {
   }
 
   // Log the module
-  if (settings::SettingsManager::GetBool(settings::SettingId::dump_ir)) {
+  if (settings::SettingsManager::GetInstance().GetBool(
+          settings::SettingId::dump_ir)) {
     LOG_DEBUG("%s\n", GetIR().c_str());
   }
 

--- a/src/codegen/operator/block_nested_loop_join_translator.cpp
+++ b/src/codegen/operator/block_nested_loop_join_translator.cpp
@@ -104,7 +104,7 @@ BlockNestedLoopJoinTranslator::BlockNestedLoopJoinTranslator(
   buffer_ = BufferAccessor(codegen, left_input_desc);
 
   // Determine the number of rows to buffer before flushing it through the join
-  auto max_buffer_size = settings::SettingsManager::GetDouble(
+  auto max_buffer_size = settings::SettingsManager::GetInstance().GetDouble(
       settings::SettingId::bnlj_buffer_size);
   auto row_size = buffer_.GetTupleSize();
   max_buf_rows_ =

--- a/src/codegen/pipeline.cpp
+++ b/src/codegen/pipeline.cpp
@@ -259,7 +259,7 @@ void Pipeline::MarkSource(OperatorTranslator *translator,
   PELOTON_ASSERT(translator == pipeline_.back());
 
   // Check parallel execution settings
-  bool parallel_exec_disabled = !settings::SettingsManager::GetBool(
+  bool parallel_exec_disabled = !settings::SettingsManager::GetInstance().GetBool(
                                     settings::SettingId::parallel_execution);
 
   // Check if the consumer supports parallel execution

--- a/src/concurrency/transaction_manager.cpp
+++ b/src/concurrency/transaction_manager.cpp
@@ -78,7 +78,8 @@ void TransactionManager::EndTransaction(TransactionContext *current_txn) {
 
   // log RWSet and result stats
   const auto &stats_type = static_cast<StatsType>(
-      settings::SettingsManager::GetInt(settings::SettingId::stats_mode));
+      settings::SettingsManager::GetInstance().GetInt(
+          settings::SettingId::stats_mode));
 
   // update stats
   if (stats_type != StatsType::INVALID) {
@@ -251,8 +252,9 @@ VisibilityType TransactionManager::IsVisible(
 
 void TransactionManager::RecordTransactionStats(
     const TransactionContext *const current_txn) const {
-  PELOTON_ASSERT(static_cast<StatsType>(settings::SettingsManager::GetInt(
-                     settings::SettingId::stats_mode)) != StatsType::INVALID);
+  PELOTON_ASSERT(static_cast<StatsType>(
+      settings::SettingsManager::GetInstance().GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID);
 
   auto stats_context = stats::BackendStatsContext::GetInstance();
   const auto &rw_set = current_txn->GetReadWriteSet();

--- a/src/executor/plan_executor.cpp
+++ b/src/executor/plan_executor.cpp
@@ -159,7 +159,7 @@ void PlanExecutor::ExecutePlan(
   LOG_TRACE("PlanExecutor Start (Txn ID=%" PRId64 ")", txn->GetTransactionId());
 
   bool codegen_enabled =
-      settings::SettingsManager::GetBool(settings::SettingId::codegen);
+      settings::SettingsManager::GetInstance().GetBool(settings::SettingId::codegen);
 
   try {
     if (codegen_enabled && codegen::QueryCompiler::IsSupported(*plan)) {

--- a/src/gc/transaction_level_gc_manager.cpp
+++ b/src/gc/transaction_level_gc_manager.cpp
@@ -131,7 +131,8 @@ int TransactionLevelGCManager::Unlink(const int &thread_id,
     }
 
     // Log the query into query_history_catalog
-    if (settings::SettingsManager::GetBool(settings::SettingId::brain)) {
+    if (settings::SettingsManager::GetInstance().GetBool(
+            settings::SettingId::brain)) {
       std::vector<std::string> query_strings = txn_ctx->GetQueryStrings();
       if (query_strings.size() != 0) {
         uint64_t timestamp = txn_ctx->GetTimestamp();

--- a/src/include/catalog/settings_catalog.h
+++ b/src/include/catalog/settings_catalog.h
@@ -17,6 +17,39 @@
 namespace peloton {
 namespace catalog {
 
+//===----------------------------------------------------------------------===//
+// In-memory representation of a row from the pg_settings table.
+//===----------------------------------------------------------------------===//
+class SettingsCatalogObject {
+ public:
+  SettingsCatalogObject(executor::LogicalTile *tile, int tuple_id = 0);
+
+  // Accessors
+  inline const std::string &GetName() { return name_; }
+  inline type::Value &GetValue() { return value_; }
+  inline type::TypeId GetValueType() { return value_type_; }
+  inline const std::string &GetDescription() { return desc_; }
+  inline type::Value &GetDefaultValue() { return default_value_; }
+  inline type::Value &GetMinValue() { return min_value_; }
+  inline type::Value &GetMaxValue() { return max_value_; }
+  inline bool IsMutable() { return is_mutable_; }
+  inline bool IsPersistent() { return is_persistent_; }
+
+ private:
+  // The fields of 'pg_settings' table
+  std::string name_;
+  type::Value value_;
+  type::TypeId value_type_;
+  std::string desc_;
+  type::Value default_value_;
+  type::Value min_value_;
+  type::Value max_value_;
+  bool is_mutable_, is_persistent_;
+};
+
+//===----------------------------------------------------------------------===//
+// The pg_settings catalog table.
+//===----------------------------------------------------------------------===//
 class SettingsCatalog : public AbstractCatalog {
  public:
   ~SettingsCatalog();
@@ -36,14 +69,20 @@ class SettingsCatalog : public AbstractCatalog {
 
   bool DeleteSetting(const std::string &name, concurrency::TransactionContext *txn);
 
+  bool UpdateSettingValue(concurrency::TransactionContext *txn,
+                          const std::string &name,
+                          const std::string &value,
+                          bool set_default);
+
   //===--------------------------------------------------------------------===//
   // Read-only Related API
   //===--------------------------------------------------------------------===//
-  std::string GetSettingValue(const std::string &name,
-                              concurrency::TransactionContext *txn);
+  std::shared_ptr<SettingsCatalogObject> GetSetting(
+      const std::string &name,
+      concurrency::TransactionContext *txn);
 
-  std::string GetDefaultValue(const std::string &name,
-                              concurrency::TransactionContext *txn);
+  std::unordered_map<std::string, std::shared_ptr<SettingsCatalogObject>>
+  GetSettings(concurrency::TransactionContext *txn);
 
   enum class ColumnId {
     NAME = 0,
@@ -57,6 +96,7 @@ class SettingsCatalog : public AbstractCatalog {
     IS_PERSISTENT = 8,
     // Add new columns here in creation order
   };
+  std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5, 6, 7, 8};
 
  private:
   SettingsCatalog(concurrency::TransactionContext *txn);

--- a/src/include/catalog/settings_catalog.h
+++ b/src/include/catalog/settings_catalog.h
@@ -20,9 +20,9 @@ namespace catalog {
 //===----------------------------------------------------------------------===//
 // In-memory representation of a row from the pg_settings table.
 //===----------------------------------------------------------------------===//
-class SettingsCatalogObject {
+class SettingsCatalogEntry {
  public:
-  SettingsCatalogObject(executor::LogicalTile *tile, int tuple_id = 0);
+  SettingsCatalogEntry(executor::LogicalTile *tile, int tuple_id = 0);
 
   // Accessors
   inline const std::string &GetName() { return name_; }
@@ -55,7 +55,8 @@ class SettingsCatalog : public AbstractCatalog {
   ~SettingsCatalog();
 
   // Global Singleton
-  static SettingsCatalog &GetInstance(concurrency::TransactionContext *txn = nullptr);
+  static SettingsCatalog &GetInstance(
+      concurrency::TransactionContext *txn = nullptr);
 
   //===--------------------------------------------------------------------===//
   // write Related API
@@ -67,21 +68,20 @@ class SettingsCatalog : public AbstractCatalog {
                      bool is_persistent, type::AbstractPool *pool,
                      concurrency::TransactionContext *txn);
 
-  bool DeleteSetting(const std::string &name, concurrency::TransactionContext *txn);
+  bool DeleteSetting(const std::string &name,
+                     concurrency::TransactionContext *txn);
 
   bool UpdateSettingValue(concurrency::TransactionContext *txn,
-                          const std::string &name,
-                          const std::string &value,
+                          const std::string &name, const std::string &value,
                           bool set_default);
 
   //===--------------------------------------------------------------------===//
   // Read-only Related API
   //===--------------------------------------------------------------------===//
-  std::shared_ptr<SettingsCatalogObject> GetSetting(
-      const std::string &name,
-      concurrency::TransactionContext *txn);
+  std::shared_ptr<SettingsCatalogEntry> GetSetting(
+      const std::string &name, concurrency::TransactionContext *txn);
 
-  std::unordered_map<std::string, std::shared_ptr<SettingsCatalogObject>>
+  std::unordered_map<std::string, std::shared_ptr<SettingsCatalogEntry>>
   GetSettings(concurrency::TransactionContext *txn);
 
   enum class ColumnId {
@@ -96,7 +96,7 @@ class SettingsCatalog : public AbstractCatalog {
     IS_PERSISTENT = 8,
     // Add new columns here in creation order
   };
-  std::vector<oid_t> all_column_ids = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<oid_t> all_column_ids_ = {0, 1, 2, 3, 4, 5, 6, 7, 8};
 
  private:
   SettingsCatalog(concurrency::TransactionContext *txn);

--- a/src/include/optimizer/optimizer_metadata.h
+++ b/src/include/optimizer/optimizer_metadata.h
@@ -31,7 +31,7 @@ class RuleSet;
 class OptimizerMetadata {
  public:
   OptimizerMetadata()
-      : timeout_limit(settings::SettingsManager::GetInt(
+      : timeout_limit(settings::SettingsManager::GetInstance().GetInt(
             settings::SettingId::task_execution_timeout)),
         timer(Timer<std::milli>()) {}
 

--- a/src/include/settings/settings_manager.h
+++ b/src/include/settings/settings_manager.h
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include <unordered_map>
@@ -23,7 +22,6 @@
 
 namespace peloton {
 namespace settings {
-
 
 // SettingsManager:
 // provide ability to define, get_value and set_value of setting parameters
@@ -69,7 +67,6 @@ class SettingsManager : public Printable {
   void ShowInfo();
 
  private:
-
   // local information storage
   // name, value, description, default_value, is_mutable, is_persistent
   struct Param {
@@ -81,20 +78,25 @@ class SettingsManager : public Printable {
     type::Value max_value;
     bool is_mutable, is_persistent;
 
-    Param(std::string name, const type::Value &value,
-          std::string desc, const type::Value &default_value,
-          type::Value min_value, type::Value max_value,
-          bool is_mutable, bool is_persistent)
-        : name(name), value(value), desc(desc),
-          default_value(default_value), min_value(min_value),
-          max_value(max_value), is_mutable(is_mutable),
+    Param(std::string name, const type::Value &value, std::string desc,
+          const type::Value &default_value, type::Value min_value,
+          type::Value max_value, bool is_mutable, bool is_persistent)
+        : name(name),
+          value(value),
+          desc(desc),
+          default_value(default_value),
+          min_value(min_value),
+          max_value(max_value),
+          is_mutable(is_mutable),
           is_persistent(is_persistent) {}
   };
 
   // internal map
   struct EnumClassHash {
-    template <typename T> std::size_t operator()(T t)
-    const { return static_cast<std::size_t>(t); }
+    template <typename T>
+    std::size_t operator()(T t) const {
+      return static_cast<std::size_t>(t);
+    }
   };
   std::unordered_map<SettingId, Param, EnumClassHash> settings_;
 
@@ -105,19 +107,15 @@ class SettingsManager : public Printable {
   SettingsManager();
 
   void DefineSetting(SettingId id, const std::string &name,
-                     const type::Value &value,
-                     const std::string &description,
+                     const type::Value &value, const std::string &description,
                      const type::Value &default_value,
-                     const type::Value &min_value,
-                     const type::Value &max_value,
+                     const type::Value &min_value, const type::Value &max_value,
                      bool is_mutable, bool is_persistent);
 
-  bool InsertCatalog(const Param &param,
-                     concurrency::TransactionContext *txn);
+  bool InsertCatalog(const Param &param, concurrency::TransactionContext *txn);
 
   bool UpdateCatalog(const std::string &name, const type::Value &value,
-                     bool set_default,
-                     concurrency::TransactionContext *txn);
+                     bool set_default, concurrency::TransactionContext *txn);
 };
 
 }  // namespace settings

--- a/src/include/settings/settings_manager.h
+++ b/src/include/settings/settings_manager.h
@@ -18,29 +18,51 @@
 #include "type/value.h"
 #include "common/exception.h"
 #include "common/printable.h"
+#include "concurrency/transaction_context.h"
 #include "settings/setting_id.h"
 
 namespace peloton {
 namespace settings {
+
 
 // SettingsManager:
 // provide ability to define, get_value and set_value of setting parameters
 // It stores information in an internal map as well as catalog pg_settings
 class SettingsManager : public Printable {
  public:
-  static int32_t GetInt(SettingId id);
-  static double GetDouble(SettingId id);
-  static bool GetBool(SettingId id);
-  static std::string GetString(SettingId id);
-
-  static void SetInt(SettingId id, int32_t value);
-  static void SetBool(SettingId id, bool value);
-  static void SetString(SettingId id, const std::string &value);
   static SettingsManager &GetInstance();
+
+  // Getter functions for setting value.
+  int32_t GetInt(SettingId id) const;
+  double GetDouble(SettingId id) const;
+  bool GetBool(SettingId id) const;
+  std::string GetString(SettingId id) const;
+  type::Value GetValue(SettingId id) const;
+
+  // Setter functions to update internal setting value.
+  // These can be called without txn before calling InitializeCatalog().
+  // If set_default is true, then set default_value in addition to value.
+  void SetInt(SettingId id, int32_t value, bool set_default = false,
+              concurrency::TransactionContext *txn = nullptr);
+  void SetDouble(SettingId id, double value, bool set_default = false,
+                 concurrency::TransactionContext *txn = nullptr);
+  void SetBool(SettingId id, bool value, bool set_default = false,
+               concurrency::TransactionContext *txn = nullptr);
+  void SetString(SettingId id, const std::string &value,
+                 bool set_default = false,
+                 concurrency::TransactionContext *txn = nullptr);
+  void SetValue(SettingId id, const type::Value &value,
+                bool set_default = false,
+                concurrency::TransactionContext *txn = nullptr);
+
+  // Reset a setting value to a default value
+  void ResetValue(SettingId id, concurrency::TransactionContext *txn);
 
   // Call this method in Catalog->Bootstrap
   // to store information into pg_settings
   void InitializeCatalog();
+
+  void UpdateSettingListFromCatalog(concurrency::TransactionContext *txn);
 
   const std::string GetInfo() const;
 
@@ -55,14 +77,18 @@ class SettingsManager : public Printable {
     type::Value value;
     std::string desc;
     type::Value default_value;
+    type::Value min_value;
+    type::Value max_value;
     bool is_mutable, is_persistent;
 
     Param(std::string name, const type::Value &value,
           std::string desc, const type::Value &default_value,
+          type::Value min_value, type::Value max_value,
           bool is_mutable, bool is_persistent)
         : name(name), value(value), desc(desc),
-          default_value(default_value),
-          is_mutable(is_mutable), is_persistent(is_persistent) {}
+          default_value(default_value), min_value(min_value),
+          max_value(max_value), is_mutable(is_mutable),
+          is_persistent(is_persistent) {}
   };
 
   // internal map
@@ -86,11 +112,12 @@ class SettingsManager : public Printable {
                      const type::Value &max_value,
                      bool is_mutable, bool is_persistent);
 
-  type::Value GetValue(SettingId id);
+  bool InsertCatalog(const Param &param,
+                     concurrency::TransactionContext *txn);
 
-  void SetValue(SettingId id, const type::Value &value);
-
-  bool InsertIntoCatalog(const Param &param);
+  bool UpdateCatalog(const std::string &name, const type::Value &value,
+                     bool set_default,
+                     concurrency::TransactionContext *txn);
 };
 
 }  // namespace settings

--- a/src/include/threadpool/mono_queue_pool.h
+++ b/src/include/threadpool/mono_queue_pool.h
@@ -87,9 +87,10 @@ inline void MonoQueuePool::SubmitTask(const F &func) {
 }
 
 inline MonoQueuePool &MonoQueuePool::GetInstance() {
-  int32_t task_queue_size = settings::SettingsManager::GetInt(
+  auto &settings_manager = settings::SettingsManager::GetInstance();
+  int32_t task_queue_size = settings_manager.GetInt(
       settings::SettingId::monoqueue_task_queue_size);
-  int32_t worker_pool_size = settings::SettingsManager::GetInt(
+  int32_t worker_pool_size = settings_manager.GetInt(
       settings::SettingId::monoqueue_worker_pool_size);
 
   PELOTON_ASSERT(task_queue_size > 0);
@@ -104,9 +105,10 @@ inline MonoQueuePool &MonoQueuePool::GetInstance() {
 }
 
 inline MonoQueuePool &MonoQueuePool::GetBrainInstance() {
-  int32_t task_queue_size = settings::SettingsManager::GetInt(
+  auto &settings_manager = settings::SettingsManager::GetInstance();
+  int32_t task_queue_size = settings_manager.GetInt(
       settings::SettingId::brain_task_queue_size);
-  int32_t worker_pool_size = settings::SettingsManager::GetInt(
+  int32_t worker_pool_size = settings_manager.GetInt(
       settings::SettingId::brain_worker_pool_size);
 
   PELOTON_ASSERT(task_queue_size > 0);
@@ -121,9 +123,10 @@ inline MonoQueuePool &MonoQueuePool::GetBrainInstance() {
 }
 
 inline MonoQueuePool &MonoQueuePool::GetExecutionInstance() {
-  int32_t task_queue_size = settings::SettingsManager::GetInt(
+  auto &settings_manager = settings::SettingsManager::GetInstance();
+  int32_t task_queue_size = settings_manager.GetInt(
       settings::SettingId::monoqueue_task_queue_size);
-  int32_t worker_pool_size = settings::SettingsManager::GetInt(
+  int32_t worker_pool_size = settings_manager.GetInt(
       settings::SettingId::monoqueue_worker_pool_size);
 
   PELOTON_ASSERT(task_queue_size > 0);

--- a/src/index/art_index.cpp
+++ b/src/index/art_index.cpp
@@ -65,7 +65,7 @@ bool ArtIndex::InsertEntry(const storage::Tuple *key, ItemPointer *value) {
   auto thread_info = container_.getThreadInfo();
   container_.insert(tree_key, reinterpret_cast<TID>(value), thread_info);
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+  if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
           settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexInserts(
         GetMetadata());
@@ -90,7 +90,7 @@ bool ArtIndex::DeleteEntry(const storage::Tuple *key, ItemPointer *value) {
   if (removed) {
     // Update stats
     DecreaseNumberOfTuplesBy(1);
-    if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+    if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
             settings::SettingId::stats_mode)) != StatsType::INVALID) {
       stats::BackendStatsContext::GetInstance()->IncrementIndexDeletes(
           1, GetMetadata());
@@ -114,7 +114,7 @@ bool ArtIndex::CondInsertEntry(const storage::Tuple *key, ItemPointer *value,
   if (inserted) {
     // Update stats
     IncreaseNumberOfTuplesBy(1);
-    if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+    if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
             settings::SettingId::stats_mode)) != StatsType::INVALID) {
       stats::BackendStatsContext::GetInstance()->IncrementIndexInserts(
           GetMetadata());
@@ -153,7 +153,7 @@ void ArtIndex::Scan(
   }
 
   // Update stats
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+  if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
           settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
         result.size(), GetMetadata());
@@ -225,7 +225,7 @@ void ArtIndex::ScanRange(const art::Key &start, const art::Key &end,
   }
 
   // Update stats
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+  if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
           settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
         result.size(), GetMetadata());

--- a/src/index/bwtree_index.cpp
+++ b/src/index/bwtree_index.cpp
@@ -60,7 +60,8 @@ bool BWTREE_INDEX_TYPE::InsertEntry(const storage::Tuple *key,
     ret = container.Insert(index_key, value, false);
   }
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexInserts(metadata);
   }
 
@@ -90,7 +91,8 @@ bool BWTREE_INDEX_TYPE::DeleteEntry(const storage::Tuple *key,
   // it is unnecessary for us to allocate memory
   bool ret = container.Delete(index_key, value);
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexDeletes(
         delete_count, metadata);
   }
@@ -126,7 +128,8 @@ bool BWTREE_INDEX_TYPE::CondInsertEntry(
     assert(ret == false);
   }
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexInserts(metadata);
   }
 
@@ -200,7 +203,8 @@ void BWTREE_INDEX_TYPE::Scan(
     }
   }  // if is full scan
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInstance().
+          GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
         result.size(), metadata);
   }
@@ -267,7 +271,8 @@ void BWTREE_INDEX_TYPE::ScanAllKeys(std::vector<ValueType> &result) {
     it++;
   }
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
         result.size(), metadata);
   }
@@ -283,7 +288,8 @@ void BWTREE_INDEX_TYPE::ScanKey(const storage::Tuple *key,
   // This function in BwTree fills a given vector
   container.GetValue(index_key, result);
 
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(settings::SettingId::stats_mode)) != StatsType::INVALID) {
+  if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
+          settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->IncrementIndexReads(
         result.size(), metadata);
   }

--- a/src/main/peloton/peloton.cpp
+++ b/src/main/peloton/peloton.cpp
@@ -81,10 +81,10 @@ int main(int argc, char *argv[]) {
   }
 
   try {
+    // Load build-in settings
+    auto &settings = peloton::settings::SettingsManager::GetInstance();
     // Print settings
-    if (peloton::settings::SettingsManager::GetBool(
-      peloton::settings::SettingId::display_settings)) {
-      auto &settings = peloton::settings::SettingsManager::GetInstance();
+    if (settings.GetBool(peloton::settings::SettingId::display_settings)) {
       settings.ShowInfo();
     }
   } catch (peloton::SettingsException &exception) {
@@ -93,7 +93,7 @@ int main(int argc, char *argv[]) {
   }
 
   int exit_code = 0;
-  if (peloton::settings::SettingsManager::GetBool(
+  if (peloton::settings::SettingsManager::GetInstance().GetBool(
       peloton::settings::SettingId::brain))
     exit_code =  RunPelotonBrain();
   else

--- a/src/network/peloton_server.cpp
+++ b/src/network/peloton_server.cpp
@@ -83,16 +83,18 @@ unsigned long PelotonServer::SSLIdFunction(void) {
 }
 
 void PelotonServer::LoadSSLFileSettings() {
-  private_key_file_ = DATA_DIR + settings::SettingsManager::GetString(
+  auto &settings_manager = settings::SettingsManager::GetInstance();
+  private_key_file_ = DATA_DIR + settings_manager.GetString(
                                      settings::SettingId::private_key_file);
-  certificate_file_ = DATA_DIR + settings::SettingsManager::GetString(
+  certificate_file_ = DATA_DIR + settings_manager.GetString(
                                      settings::SettingId::certificate_file);
-  root_cert_file_ = DATA_DIR + settings::SettingsManager::GetString(
+  root_cert_file_ = DATA_DIR + settings_manager.GetString(
                                    settings::SettingId::root_cert_file);
 }
 
 void PelotonServer::SSLInit() {
-  if (!settings::SettingsManager::GetBool(settings::SettingId::ssl)) {
+  if (!settings::SettingsManager::GetInstance().GetBool(
+          settings::SettingId::ssl)) {
     SetSSLLevel(SSLLevel::SSL_DISABLE);
     return;
   }
@@ -189,9 +191,10 @@ void PelotonServer::SSLInit() {
 }
 
 PelotonServer::PelotonServer() {
-  port_ = settings::SettingsManager::GetInt(settings::SettingId::port);
-  max_connections_ =
-      settings::SettingsManager::GetInt(settings::SettingId::max_connections);
+  auto &settings_manager = settings::SettingsManager::GetInstance();
+  port_ = settings_manager.GetInt(settings::SettingId::port);
+  max_connections_ = settings_manager.GetInt(
+          settings::SettingId::max_connections);
 
   // For logging purposes
   //  event_enable_debug_mode();
@@ -237,7 +240,7 @@ void PelotonServer::TrySslOperation(int (*func)(Ts...), Ts... arg) {
 PelotonServer &PelotonServer::SetupServer() {
   // This line is critical to performance for some reason
   evthread_use_pthreads();
-  if (settings::SettingsManager::GetString(
+  if (settings::SettingsManager::GetInstance().GetString(
           settings::SettingId::socket_family) != "AF_INET")
     throw ConnectionException("Unsupported socket family");
 
@@ -269,9 +272,10 @@ PelotonServer &PelotonServer::SetupServer() {
 }
 
 void PelotonServer::ServerLoop() {
-  if (settings::SettingsManager::GetBool(settings::SettingId::rpc_enabled)) {
-    int rpc_port =
-        settings::SettingsManager::GetInt(settings::SettingId::rpc_port);
+  auto &settings_manager = settings::SettingsManager::GetInstance();
+  if (settings_manager.GetBool(settings::SettingId::rpc_enabled)) {
+    int rpc_port = settings_manager.GetInt(
+        settings::SettingId::rpc_port);
     std::string address = "127.0.0.1:" + std::to_string(rpc_port);
     auto rpc_task = std::make_shared<PelotonRpcHandlerTask>(address.c_str());
     DedicatedThreadRegistry::GetInstance()

--- a/src/network/postgres_protocol_handler.cpp
+++ b/src/network/postgres_protocol_handler.cpp
@@ -383,7 +383,7 @@ void PostgresProtocolHandler::ExecParseMessage(InputPacket *pkt) {
   statement->SetParamTypes(param_types);
 
   // Stat
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+  if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
           settings::SettingId::stats_mode)) != StatsType::INVALID) {
     // Make a copy of param types for stat collection
     stats::QueryMetric::QueryParamBuf query_type_buf;
@@ -529,7 +529,7 @@ void PostgresProtocolHandler::ExecBindMessage(InputPacket *pkt) {
   }
 
   std::shared_ptr<stats::QueryMetric::QueryParams> param_stat(nullptr);
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+  if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
           settings::SettingId::stats_mode)) != StatsType::INVALID &&
       num_params > 0) {
     // Make a copy of format for stat collection

--- a/src/optimizer/plan_generator.cpp
+++ b/src/optimizer/plan_generator.cpp
@@ -91,7 +91,8 @@ void PlanGenerator::Visit(const PhysicalSeqScan *op) {
       op->table_->GetDatabaseOid(), op->table_->GetTableOid());
 
   // Check if we should do a parallel scan
-  bool parallel_exec_enabled = settings::SettingsManager::GetBool(
+  auto &setting_manager = settings::SettingsManager::GetInstance();
+  bool parallel_exec_enabled = setting_manager.GetBool(
       settings::SettingId::parallel_execution);
 
   bool parallel_scan = parallel_exec_enabled;
@@ -101,7 +102,7 @@ void PlanGenerator::Visit(const PhysicalSeqScan *op) {
     auto num_tilegroups = data_table->GetTileGroupCount();
     auto num_tuples = data_table->GetTupleCount();
     auto min_parallel_table_scan_size =
-        static_cast<uint32_t>(settings::SettingsManager::GetInt(
+        static_cast<uint32_t>(setting_manager.GetInt(
             settings::SettingId::min_parallel_table_scan_size));
     parallel_scan =
         (num_tilegroups > 1 && num_tuples > min_parallel_table_scan_size);
@@ -301,7 +302,7 @@ void PlanGenerator::Visit(const PhysicalInnerHashJoin *op) {
 
   auto join_plan = unique_ptr<planner::AbstractPlan>(new planner::HashJoinPlan(
       JoinType::INNER, move(join_predicate), move(proj_info), proj_schema,
-      left_keys, right_keys, settings::SettingsManager::GetBool(
+      left_keys, right_keys, settings::SettingsManager::GetInstance().GetBool(
                                  settings::SettingId::hash_join_bloom_filter)));
 
   join_plan->AddChild(move(children_plans_[0]));

--- a/src/optimizer/query_to_operator_transformer.cpp
+++ b/src/optimizer/query_to_operator_transformer.cpp
@@ -33,8 +33,9 @@ QueryToOperatorTransformer::QueryToOperatorTransformer(
     concurrency::TransactionContext *txn)
     : txn_(txn),
       get_id(0),
-      enable_predicate_push_down_(settings::SettingsManager::GetBool(
-          settings::SettingId::predicate_push_down)) {}
+      enable_predicate_push_down_(
+          settings::SettingsManager::GetInstance().GetBool(
+              settings::SettingId::predicate_push_down)) {}
 std::shared_ptr<OperatorExpression>
 QueryToOperatorTransformer::ConvertToOpExpression(parser::SQLStatement *op) {
   output_expr_ = nullptr;

--- a/src/traffic_cop/traffic_cop.cpp
+++ b/src/traffic_cop/traffic_cop.cpp
@@ -305,7 +305,8 @@ std::shared_ptr<Statement> TrafficCop::PrepareStatement(
     tcop_txn_state_.emplace(txn, ResultType::SUCCESS);
   }
 
-  if (settings::SettingsManager::GetBool(settings::SettingId::brain)) {
+  if (settings::SettingsManager::GetInstance().GetBool(
+          settings::SettingId::brain)) {
     tcop_txn_state_.top().first->AddQueryString(query_string.c_str());
   }
 
@@ -555,7 +556,7 @@ ResultType TrafficCop::ExecuteStatement(
     const std::vector<int> &result_format, std::vector<ResultValue> &result,
     size_t thread_id) {
   // TODO(Tianyi) Further simplify this API
-  if (static_cast<StatsType>(settings::SettingsManager::GetInt(
+  if (static_cast<StatsType>(settings::SettingsManager::GetInstance().GetInt(
           settings::SettingId::stats_mode)) != StatsType::INVALID) {
     stats::BackendStatsContext::GetInstance()->InitQueryMetric(
         statement, std::move(param_stats));

--- a/test/brain/query_logger_test.cpp
+++ b/test/brain/query_logger_test.cpp
@@ -22,7 +22,9 @@ namespace test {
 class QueryLoggerTests : public PelotonTest {
  protected:
   void SetUp() override {
-    settings::SettingsManager::SetBool(settings::SettingId::brain, true);
+    settings::SettingsManager::GetInstance().SetBool(
+        settings::SettingId::brain, true);
+
     PelotonInit::Initialize();
 
     // query to check that logging is done

--- a/test/statistics/stats_test.cpp
+++ b/test/statistics/stats_test.cpp
@@ -44,8 +44,12 @@ class StatsTests : public PelotonTest {};
 
 // Launch the aggregator thread manually
 void LaunchAggregator(int64_t stat_interval) {
-  settings::SettingsManager::SetInt(settings::SettingId::stats_mode,
-                                    static_cast<int>(StatsType::ENABLE));
+  auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
+  auto txn = txn_manager.BeginTransaction();
+  settings::SettingsManager::GetInstance()
+      .SetInt(settings::SettingId::stats_mode,
+              static_cast<int>(StatsType::ENABLE), txn);
+  txn_manager.CommitTransaction(txn);
 
   auto &aggregator =
       peloton::stats::StatsAggregator::GetInstance(stat_interval);


### PR DESCRIPTION
This PR refactors setting stuff in order to enable checkpoint manager to recover setting values. In addition,  added some convenient functions.

**- Fix Points of SettingsManager**

1. Change All set functions to non-static, and move all set/get functions to public.
1. Add `txn` argument into set functions in order that a caller of set functions can manage a necessary transaction by itself.
1. Add `set_default` argument into set functions. If this flag argument is true, then the default value is updated in addition to updating the setting value.
1. Add `Reset` public function to reset the setting value to default value.
1. Add `UpdateSettingListFromCatalog()` public function to update setting values in the manager from catalog for checkpoints.
1. Add/Modify two catalog management private functions: `InsertCatalog()`, `UpdateCatalog()`.

**- Fix Points of SettingsCatalog**

1. Add `SettingsCatalogEntry` class to acquire all setting information from catalog
1. Add `GetSetting()` and `GetSettings()` functions.
1. Delete other get functions.
1. Add `UpdateSettingValue()` function to update a setting value and a default value.

**- Related Issues**
1. Issues #1424