### PR TITLE
Fix for optimizer rule bug

### DIFF
--- a/src/optimizer/group_expression.cpp
+++ b/src/optimizer/group_expression.cpp
@@ -87,8 +87,14 @@ hash_t GroupExpression::Hash() const {
 bool GroupExpression::operator==(const GroupExpression &r) {
   bool eq = (op == r.Op());
 
-  for (size_t i = 0; i < child_groups.size(); ++i) {
-    eq = eq && (child_groups[i] == r.child_groups[i]);
+  auto left_groups = child_groups;
+  auto right_groups = r.child_groups;
+
+  std::sort(left_groups.begin(), left_groups.end());
+
+  std::sort(right_groups.begin(), right_groups.end());
+  for (size_t i = 0; i < left_groups.size(); ++i) {
+    eq = eq && (left_groups[i] == right_groups[i]);
   }
 
   return eq;

--- a/src/optimizer/group_expression.cpp
+++ b/src/optimizer/group_expression.cpp
@@ -95,7 +95,7 @@ bool GroupExpression::operator==(const GroupExpression &r) {
 }
 
 void GroupExpression::SetRuleExplored(Rule *rule) {
-  rule_mask_.set(rule->GetRuleIdx()) = true;
+  rule_mask_.set(rule->GetRuleIdx(), true);
 }
 
 bool GroupExpression::HasRuleExplored(Rule *rule) {

--- a/src/optimizer/memo.cpp
+++ b/src/optimizer/memo.cpp
@@ -43,8 +43,6 @@ GroupExpression *Memo::InsertExpression(std::shared_ptr<GroupExpression> gexpr,
   auto it = group_expressions_.find(gexpr.get());
 
   if (it != group_expressions_.end()) {
-    PELOTON_ASSERT(target_group == UNDEFINED_GROUP ||
-           target_group == (*it)->GetGroupID());
     gexpr->SetGroupID((*it)->GetGroupID());
     return *it;
   } else {

--- a/test/optimizer/optimizer_rule_test.cpp
+++ b/test/optimizer/optimizer_rule_test.cpp
@@ -261,5 +261,32 @@ TEST_F(OptimizerRuleTests, SimpleAssociativeRuleTest2) {
   delete root_context;
 }
 
+TEST_F(OptimizerRuleTests, RuleBitmapTest) {
+  Optimizer optimizer;
+  auto &memo = optimizer.GetMetadata().memo;
+
+  auto dummy_operator = std::make_shared<OperatorExpression>(LogicalGet::make());
+  auto dummy_group = memo.InsertExpression(optimizer.GetMetadata().MakeGroupExpression(dummy_operator), false);
+
+  auto rule1 = new InnerJoinCommutativity();
+  auto rule2 = new GetToSeqScan();
+
+  EXPECT_FALSE(dummy_group->HasRuleExplored(rule1));
+  EXPECT_FALSE(dummy_group->HasRuleExplored(rule2));
+
+  dummy_group->SetRuleExplored(rule1);
+
+  EXPECT_TRUE(dummy_group->HasRuleExplored(rule1));
+  EXPECT_FALSE(dummy_group->HasRuleExplored(rule2));
+
+  dummy_group->SetRuleExplored(rule2);
+
+  EXPECT_TRUE(dummy_group->HasRuleExplored(rule1));
+  EXPECT_TRUE(dummy_group->HasRuleExplored(rule2));
+
+  delete rule1;
+  delete rule2;
+}
+
 }  // namespace test
 }  // namespace peloton

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -131,7 +131,6 @@ ResultType TestingSQLUtil::ExecuteSQLQueryWithOptimizer(
   bind_node_visitor.BindNameToNode(parsed_stmt->GetStatement(0));
 
   auto plan = optimizer->BuildPelotonPlanTree(parsed_stmt, txn);
-  PrintPlan(plan.get());
   tuple_descriptor =
       traffic_cop_.GenerateTupleDescriptor(parsed_stmt->GetStatement(0));
   auto result_format = std::vector<int>(tuple_descriptor.size(), 0);

--- a/test/sql/testing_sql_util.cpp
+++ b/test/sql/testing_sql_util.cpp
@@ -98,6 +98,21 @@ ResultType TestingSQLUtil::ExecuteSQLQuery(
   return status;
 }
 
+void PrintPlan(planner::AbstractPlan *plan, int level = 0) {
+  auto spacing = std::string(level, '\t');
+  if (plan->GetPlanNodeType() == PlanNodeType::SEQSCAN) {
+    auto scan = dynamic_cast<planner::AbstractScan *>(plan);
+    LOG_INFO("%s%s(%s)", spacing.c_str(), scan->GetInfo().c_str(),
+              scan->GetTable()->GetName().c_str());
+  } else {
+    LOG_INFO("%s%s", spacing.c_str(), plan->GetInfo().c_str());
+  }
+  for (size_t i = 0; i < plan->GetChildren().size(); i++) {
+    PrintPlan(plan->GetChildren()[i].get(), level + 1);
+  }
+  return;
+}
+
 // Execute a SQL query end-to-end with the specific optimizer
 ResultType TestingSQLUtil::ExecuteSQLQueryWithOptimizer(
     std::unique_ptr<optimizer::AbstractOptimizer> &optimizer,
@@ -116,6 +131,7 @@ ResultType TestingSQLUtil::ExecuteSQLQueryWithOptimizer(
   bind_node_visitor.BindNameToNode(parsed_stmt->GetStatement(0));
 
   auto plan = optimizer->BuildPelotonPlanTree(parsed_stmt, txn);
+  PrintPlan(plan.get());
   tuple_descriptor =
       traffic_cop_.GenerateTupleDescriptor(parsed_stmt->GetStatement(0));
   auto result_format = std::vector<int>(tuple_descriptor.size(), 0);


### PR DESCRIPTION
Fixes false positive in rule checking (#1234). The error was being caused by incorrect use of `bitmap.set` function. I also added a plan printing helper function. Lastly, I improved our group expression equality function. While it's not a complete fix to #1354, it helps. 

@apavlo For some reason PR #1245 never got checked in (it says merged but the changes aren't in the code), so I'm submitting this one. We never merged in my PR for the class (#1344), however, that also included the bug fixes we found during the semester. I'm gonna add those in separate PRs like this one.
